### PR TITLE
[SeaTunnel #1094][pom] make scala-maven-plugin can skip attach javadocs jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,13 +492,15 @@
                                 <goal>testCompile</goal>
                             </goals>
                         </execution>
-
                         <!-- attach javadocs and sources , -javadoc.jar, sources.jar, to pass mvn deploy-->
                         <execution>
                             <id>attach-javadocs</id>
                             <goals>
                                 <goal>doc-jar</goal>
                             </goals>
+                            <configuration>
+                                <skip>${maven.javadoc.skip}</skip>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>attach-sources</id>
@@ -506,7 +508,6 @@
                                 <goal>add-source</goal>
                             </goals>
                         </execution>
-
                     </executions>
                 </plugin>
                 <!-- java/scala compiler (End) -->


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

close #1094
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
