### PR TITLE
[Improve] Use the correct init size for StringTemplate

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/StringTemplate.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/StringTemplate.java
@@ -37,7 +37,7 @@ public class StringTemplate {
         final SimpleDateFormat sdf = new SimpleDateFormat(timeFormat);
         final String formattedDate = sdf.format(new Date());
 
-        final Map<String, String> valuesMap = new HashMap(5);
+        final Map<String, String> valuesMap = new HashMap(3);
         valuesMap.put("uuid", UUID.randomUUID().toString());
         valuesMap.put("now", formattedDate);
         valuesMap.put(timeFormat, formattedDate);


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This is a minor improvement that using the correct init size instead for `StringTemplate`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
