### PR TITLE
[hotfix] [checkstyle] Fix Import order of java in checkstyle

### DIFF
--- a/tools/checkstyle/checkStyle.xml
+++ b/tools/checkstyle/checkStyle.xml
@@ -83,8 +83,8 @@
     <module name="TreeWalker">
         <module name="ImportOrder">
             <property name="severity" value="error"/>
-            <property name="staticGroups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,/^java\./,scala"/>
-            <property name="groups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,/^java\./,scala"/>
+            <property name="staticGroups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,java,scala"/>
+            <property name="groups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,java,scala"/>
             <property name="separated" value="true"/>
             <property name="sortStaticImportsAlphabetically" value="true"/>
             <property name="option" value="top"/>


### PR DESCRIPTION
## Purpose of this pull request

When I import the checkstyle in IDEA, and find the import order of java.* is not in our expected.
for example:
```java
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

import java.io.File;
import java.util.ArrayList;
import java.util.Iterator;
import java.util.List;
import java.util.Objects;
import java.util.ServiceConfigurationError;
import java.util.ServiceLoader;
```
when I format it will look like below
```java
import java.io.File;
import java.util.ArrayList;
import java.util.Iterator;
import java.util.List;
import java.util.Objects;
import java.util.ServiceConfigurationError;
import java.util.ServiceLoader;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
```

My checkstyle version is 9.2.
I find this was caused by the ImportOrder in checkstyle.xml.
Maybe this is the right config.
```xml
<property name="staticGroups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,java,scala"/>
<property name="groups" value="org.apache.seatunnel,org.apache.seatunnel.shade,*,javax,java,scala"/>
```


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
