### PR TITLE
[Chore] Remove the useless qualifier of SparkBatchExecution

### DIFF
--- a/seatunnel-apis/seatunnel-api-spark/src/main/java/org/apache/seatunnel/spark/batch/SparkBatchExecution.java
+++ b/seatunnel-apis/seatunnel-api-spark/src/main/java/org/apache/seatunnel/spark/batch/SparkBatchExecution.java
@@ -92,17 +92,17 @@ public class SparkBatchExecution implements Execution<SparkBatchSource, BaseSpar
 
     @Override
     public void start(List<SparkBatchSource> sources, List<BaseSparkTransform> transforms, List<SparkBatchSink> sinks) {
-        sources.forEach(source -> SparkBatchExecution.registerInputTempView(source, environment));
+        sources.forEach(source -> registerInputTempView(source, environment));
         if (!sources.isEmpty()) {
             Dataset<Row> ds = sources.get(0).getData(environment);
             for (BaseSparkTransform transform : transforms) {
                 if (ds.takeAsList(1).size() > 0) {
-                    ds = SparkBatchExecution.transformProcess(environment, transform, ds);
-                    SparkBatchExecution.registerTransformTempView(transform, ds);
+                    ds = transformProcess(environment, transform, ds);
+                    registerTransformTempView(transform, ds);
                 }
             }
             for (SparkBatchSink sink : sinks) {
-                SparkBatchExecution.sinkProcess(environment, sink, ds);
+                sinkProcess(environment, sink, ds);
             }
         }
     }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This patch removed the useless qualifier of `SparkBatchExecution`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
