### PR TITLE
[hotfix] Remove Hdfs Impl class name in META-INF

### DIFF
--- a/seatunnel-connectors/seatunnel-connector-spark-file/src/main/resources/META-INF/services/org.apache.seatunnel.spark.BaseSparkSink
+++ b/seatunnel-connectors/seatunnel-connector-spark-file/src/main/resources/META-INF/services/org.apache.seatunnel.spark.BaseSparkSink
@@ -1,2 +1,1 @@
 org.apache.seatunnel.spark.sink.File
-org.apache.seatunnel.spark.sink.Hdfs


### PR DESCRIPTION
## Purpose of this pull request

Remove Hdfs Impl class name in META-INF

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
