### PR TITLE
[hotfix][docs] Corrected typo in kafka source plugins description

### DIFF
--- a/docs/en/flink/configuration/source-plugins/Kafka.md
+++ b/docs/en/flink/configuration/source-plugins/Kafka.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-To consumer data from `Kafka` , the supported `Kafka version >= 0.10.0` .
+To consume data from `Kafka` , the supported `Kafka version >= 0.10.0` .
 
 ## Options
 

--- a/docs/en/spark/configuration/source-plugins/KafkaStream.md
+++ b/docs/en/spark/configuration/source-plugins/KafkaStream.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-To consumer data from `Kafka` , the supported `Kafka version >= 0.10.0` .
+To consume data from `Kafka` , the supported `Kafka version >= 0.10.0` .
 
 ## Options
 


### PR DESCRIPTION
## Purpose of this pull request

Changed description from `To consumer data from...`, to `To consume data from...`. This is a documentation update so no tests were added or updated.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
