### PR TITLE
[hotfix][docs] Updated conf template to indicate it is for stream processing

### DIFF
--- a/config/spark.streaming.conf.template
+++ b/config/spark.streaming.conf.template
@@ -16,7 +16,7 @@
 #
 
 ######
-###### This config file is a demonstration of batch processing in seatunnel config
+###### This config file is a demonstration of stream processing in seatunnel config
 ######
 
 env {


### PR DESCRIPTION
## Purpose of this pull request

The spark **streaming** config template indicates it is 

<code>...demonstration of **batch** processing...</code>
 
Corrected it to indicate it is 

<code>...demonstration of **stream** processing...</code>

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
