### PR TITLE
[Bug][Package]Incorrect binary package license file

### DIFF
--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -38,8 +38,7 @@
             </excludes>
 
             <includes>
-                <include>README.MD</include>
-                <include>LICENSE</include>
+                <include>README.md</include>
                 <include>bin/**</include>
                 <include>plugins/**</include>
                 <include>config/**</include>
@@ -95,7 +94,7 @@
         </fileSet>
         <!--Licenses And NOTICE-->
         <fileSet>
-            <directory>${basedir}/release-docs</directory>
+            <directory>release-docs</directory>
             <outputDirectory>.</outputDirectory>
         </fileSet>
         <!-- DISCLAIMER -->


### PR DESCRIPTION
fix readme name error
<img width="252" alt="image" src="https://user-images.githubusercontent.com/16631152/157213818-68c08293-f2ca-4a92-a676-af9ae5064cb9.png">

- The LICENSE was covered, so the license in the root directory was used. 

- Due to the wrong suffix of the readme, it was not packaged.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/16631152/157213241-9f6ffd58-fc95-4dac-aa8d-27d9d6f3794a.png">
