### PR TITLE
[Improve]Change the connection method of scm to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:apache/incubator-seatunnel.git</connection>
-        <developerConnection>scm:git:git@github.com:apache/incubator-seatunnel.git</developerConnection>
+        <connection>scm:git:https://github.com/apache/incubator-seatunnel.git</connection>
+        <developerConnection>scm:git:https://github.com/apache/incubator-seatunnel.git</developerConnection>
         <url>https://github.com/apache/incubator-seatunnel</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
I'm not sure where the problem is, when I use mvn release plugin, when he automatically executes `git checkout -b ${version} git@github.com:apache/incubator-seatunnel.git` it gives an error of no permissions ( I can't remember the full context), but I was able to use git locally at the time. 

When I switched to https, everything worked fine.