### PR TITLE
[Feature][Refactor] ISSUE-1465 - Refactored code to remove embedded config literals

### DIFF
--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/Config.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/Config.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.flink;
+
+/**
+ * Jdbc source {@link org.apache.seatunnel.flink.source.JdbcSource} and
+ * sink {@link org.apache.seatunnel.flink.sink.JdbcSink} configuration parameters
+ */
+public interface Config {
+
+    /** Parallelism of the source or sink */
+    String PARALLELISM = "parallelism";
+
+    /** Jdbc driver for source or sink */
+    String DRIVER = "driver";
+
+    /** Jdbc Url for source or sink */
+    String URL = "url";
+
+    /** Jdbc username for source or sink */
+    String USERNAME = "username";
+
+    /** Jdbc query for source or sink */
+    String QUERY = "query";
+
+    /** Jdbc password for source or sink */
+    String PASSWORD = "password";
+
+    /** Jdbc fetch size for source */
+    String SOURCE_FETCH_SIZE = "fetch_size";
+
+    /** Jdbc batch size for sink */
+    String SINK_BATCH_SIZE = "batch_size";
+
+    /** Jdbc batch interval for sink */
+    String SINK_BATCH_INTERVAL = "batch_interval";
+
+    /** Jdbc max batch retries for sink */
+    String SINK_BATCH_MAX_RETRIES = "batch_max_retries";
+
+}

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/sink/JdbcSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/sink/JdbcSink.java
@@ -17,6 +17,15 @@
 
 package org.apache.seatunnel.flink.sink;
 
+import static org.apache.seatunnel.flink.Config.DRIVER;
+import static org.apache.seatunnel.flink.Config.PASSWORD;
+import static org.apache.seatunnel.flink.Config.QUERY;
+import static org.apache.seatunnel.flink.Config.SINK_BATCH_INTERVAL;
+import static org.apache.seatunnel.flink.Config.SINK_BATCH_MAX_RETRIES;
+import static org.apache.seatunnel.flink.Config.SINK_BATCH_SIZE;
+import static org.apache.seatunnel.flink.Config.URL;
+import static org.apache.seatunnel.flink.Config.USERNAME;
+
 import org.apache.seatunnel.common.config.CheckConfigUtil;
 import org.apache.seatunnel.common.config.CheckResult;
 import org.apache.seatunnel.flink.FlinkEnvironment;
@@ -73,26 +82,26 @@ public class JdbcSink implements FlinkStreamSink<Row, Row>, FlinkBatchSink<Row, 
 
     @Override
     public CheckResult checkConfig() {
-        return CheckConfigUtil.checkAllExists(config, "driver", "url", "username", "query");
+        return CheckConfigUtil.checkAllExists(config, DRIVER, URL, USERNAME, QUERY);
     }
 
     @Override
     public void prepare(FlinkEnvironment env) {
-        driverName = config.getString("driver");
-        dbUrl = config.getString("url");
-        username = config.getString("username");
-        query = config.getString("query");
-        if (config.hasPath("password")) {
-            password = config.getString("password");
+        driverName = config.getString(DRIVER);
+        dbUrl = config.getString(URL);
+        username = config.getString(USERNAME);
+        query = config.getString(QUERY);
+        if (config.hasPath(PASSWORD)) {
+            password = config.getString(PASSWORD);
         }
-        if (config.hasPath("batch_size")) {
-            batchSize = config.getInt("batch_size");
+        if (config.hasPath(SINK_BATCH_SIZE)) {
+            batchSize = config.getInt(SINK_BATCH_SIZE);
         }
-        if (config.hasPath("batch_interval")) {
-            batchIntervalMs = config.getLong("batch_interval");
+        if (config.hasPath(SINK_BATCH_INTERVAL)) {
+            batchIntervalMs = config.getLong(SINK_BATCH_INTERVAL);
         }
-        if (config.hasPath("batch_max_retries")) {
-            maxRetries = config.getInt("batch_max_retries");
+        if (config.hasPath(SINK_BATCH_MAX_RETRIES)) {
+            maxRetries = config.getInt(SINK_BATCH_MAX_RETRIES);
         }
     }
 

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/source/JdbcSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/source/JdbcSource.java
@@ -17,6 +17,13 @@
 
 package org.apache.seatunnel.flink.source;
 
+import static org.apache.seatunnel.flink.Config.DRIVER;
+import static org.apache.seatunnel.flink.Config.PARALLELISM;
+import static org.apache.seatunnel.flink.Config.PASSWORD;
+import static org.apache.seatunnel.flink.Config.QUERY;
+import static org.apache.seatunnel.flink.Config.SOURCE_FETCH_SIZE;
+import static org.apache.seatunnel.flink.Config.URL;
+import static org.apache.seatunnel.flink.Config.USERNAME;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_DEC_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_INT_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.BOOLEAN_TYPE_INFO;
@@ -72,7 +79,6 @@ public class JdbcSource implements FlinkBatchSource<Row> {
     private Set<String> fields;
 
     private static final Pattern COMPILE = Pattern.compile("select (.+) from (.+).*");
-    private static final String PARALLELISM = "parallelism";
 
     private HashMap<String, TypeInformation> informationMapping = new HashMap<>();
 
@@ -129,15 +135,15 @@ public class JdbcSource implements FlinkBatchSource<Row> {
 
     @Override
     public CheckResult checkConfig() {
-        return CheckConfigUtil.checkAllExists(config, "driver", "url", "username", "query");
+        return CheckConfigUtil.checkAllExists(config, DRIVER, URL, USERNAME, QUERY);
     }
 
     @Override
     public void prepare(FlinkEnvironment env) {
-        driverName = config.getString("driver");
-        dbUrl = config.getString("url");
-        username = config.getString("username");
-        String query = config.getString("query");
+        driverName = config.getString(DRIVER);
+        dbUrl = config.getString(URL);
+        username = config.getString(USERNAME);
+        String query = config.getString(QUERY);
         Matcher matcher = COMPILE.matcher(query);
         if (matcher.find()) {
             String var = matcher.group(1);
@@ -153,11 +159,11 @@ public class JdbcSource implements FlinkBatchSource<Row> {
                 fields = vars;
             }
         }
-        if (config.hasPath("password")) {
-            password = config.getString("password");
+        if (config.hasPath(PASSWORD)) {
+            password = config.getString(PASSWORD);
         }
-        if (config.hasPath("fetch_size")) {
-            fetchSize = config.getInt("fetch_size");
+        if (config.hasPath(SOURCE_FETCH_SIZE)) {
+            fetchSize = config.getInt(SOURCE_FETCH_SIZE);
         }
 
         jdbcInputFormat = JdbcInputFormat.buildJdbcInputFormat()


### PR DESCRIPTION

## Purpose of this pull request

The seatunnel flink jdbc connector has embedded literals for config parameters.  Refactored the literals to a config class for reusability, readability and maintainability.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
