### PR TITLE
[hotfix][doris][docs] Fixed name of sink plugin

### DIFF
--- a/docs/en/spark/configuration/sink-plugins/Doris.md
+++ b/docs/en/spark/configuration/sink-plugins/Doris.md
@@ -1,6 +1,6 @@
-# Doirs
+# Doris
 
-> Sink plugin: Doirs [Spark]
+> Sink plugin: Doris [Spark]
 
 ### Description:
 Use Spark Batch Engine ETL Data to Doris.


### PR DESCRIPTION

## Purpose of this pull request

The name of sink is spelled as `Doirs`. Corrected the name to `Doris`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
