### PR TITLE
[Fix][Doc] Fix the wrong link of Hive sink in Spark Connector Plugins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,30 +62,30 @@ processing plug-in, because the whole system is easy to expand.
 
 ## Plugins supported by SeaTunnel
 
-| <div style="width: 130pt">Spark Connector Plugins | <div style="width: 80pt">Database Type | <div style="width: 50pt">Source | <div style="width: 50pt">Sink                        |
-|:------------------------:|:--------------:|:------------------------------------------------------------------:|:-------------------------------------------------------------------:|
-|Batch                     |Fake            |[doc](./docs/en/spark/configuration/source-plugins/Fake.md)         |                                                                     |
-|                          |ElasticSearch   |[doc](./docs/en/spark/configuration/source-plugins/Elasticsearch.md)|[doc](./docs/en/spark/configuration/sink-plugins/Elasticsearch.md)   |
-|                          |File            |[doc](./docs/en/spark/configuration/source-plugins/File.md)         |[doc](./docs/en/spark/configuration/sink-plugins/File.md)            |
-|                          |Hive            |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)         |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)          |
-|                          |Hudi            |[doc](./docs/en/spark/configuration/source-plugins/Hudi.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Hudi.md)            |
-|                          |Jdbc            |[doc](./docs/en/spark/configuration/source-plugins/Jdbc.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Jdbc.md)            |
-|                          |MongoDB         |[doc](./docs/en/spark/configuration/source-plugins/MongoDB.md)      |[doc](./docs/en/spark/configuration/sink-plugins/MongoDB.md)         |
-|                          |neo4j           |[doc](./docs/en/spark/configuration/source-plugins/neo4j.md)        |                                                                     |
-|                          |Phoenix         |[doc](./docs/en/spark/configuration/source-plugins/Phoenix.md)      |[doc](./docs/en/spark/configuration/sink-plugins/Phoenix.md)         |
-|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Redis.md)           |
-|                          |Tidb            |[doc](./docs/en/spark/configuration/source-plugins/Tidb.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Tidb.md)            |
-|                          |Clickhouse      |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Clickhouse.md)      |  
-|                          |Doris           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Doris.md)           |
-|                          |Email           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Email.md)           |
-|                          |Hbase           |[doc](./docs/en/spark/configuration/source-plugins/Hbase.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Hbase.md)           |
-|                          |Kafka           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Kafka.md)           |
-|                          |Console         |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Console.md)         |
-|                          |Kudu            |[doc](./docs/en/spark/configuration/source-plugins/Kudu.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Kudu.md)            |
-|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Redis.md)           |
-|Stream                    |FakeStream      |[doc](./docs/en/spark/configuration/source-plugins/FakeStream.md)   |                                                                     |
-|                          |KafkaStream     |[doc](./docs/en/spark/configuration/source-plugins/KafkaStream.md)  |                                                                     |
-|                          |SocketStream    |[doc](./docs/en/spark/configuration/source-plugins/SocketStream.md) |                                                                     |
+| <div style="width: 130pt">Spark Connector Plugins | <div style="width: 80pt">Database Type | <div style="width: 50pt">Source |                   <div style="width: 50pt">Sink                    |
+|:------------------------:|:--------------:|:------------------------------------------------------------------:|:------------------------------------------------------------------:|
+|Batch                     |Fake            |[doc](./docs/en/spark/configuration/source-plugins/Fake.md)         |                                                                    |
+|                          |ElasticSearch   |[doc](./docs/en/spark/configuration/source-plugins/Elasticsearch.md)| [doc](./docs/en/spark/configuration/sink-plugins/Elasticsearch.md) |
+|                          |File            |[doc](./docs/en/spark/configuration/source-plugins/File.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/File.md)      |
+|                          |Hive            |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Hive.md)      |
+|                          |Hudi            |[doc](./docs/en/spark/configuration/source-plugins/Hudi.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Hudi.md)      |
+|                          |Jdbc            |[doc](./docs/en/spark/configuration/source-plugins/Jdbc.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Jdbc.md)      |
+|                          |MongoDB         |[doc](./docs/en/spark/configuration/source-plugins/MongoDB.md)      |    [doc](./docs/en/spark/configuration/sink-plugins/MongoDB.md)    |
+|                          |neo4j           |[doc](./docs/en/spark/configuration/source-plugins/neo4j.md)        |                                                                    |
+|                          |Phoenix         |[doc](./docs/en/spark/configuration/source-plugins/Phoenix.md)      |    [doc](./docs/en/spark/configuration/sink-plugins/Phoenix.md)    |
+|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Redis.md)     |
+|                          |Tidb            |[doc](./docs/en/spark/configuration/source-plugins/Tidb.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Tidb.md)      |
+|                          |Clickhouse      |                                                                    |  [doc](./docs/en/spark/configuration/sink-plugins/Clickhouse.md)   |  
+|                          |Doris           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Doris.md)     |
+|                          |Email           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Email.md)     |
+|                          |Hbase           |[doc](./docs/en/spark/configuration/source-plugins/Hbase.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Hbase.md)     |
+|                          |Kafka           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Kafka.md)     |
+|                          |Console         |                                                                    |    [doc](./docs/en/spark/configuration/sink-plugins/Console.md)    |
+|                          |Kudu            |[doc](./docs/en/spark/configuration/source-plugins/Kudu.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Kudu.md)      |
+|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Redis.md)     |
+|Stream                    |FakeStream      |[doc](./docs/en/spark/configuration/source-plugins/FakeStream.md)   |                                                                    |
+|                          |KafkaStream     |[doc](./docs/en/spark/configuration/source-plugins/KafkaStream.md)  |                                                                    |
+|                          |SocketStream    |[doc](./docs/en/spark/configuration/source-plugins/SocketStream.md) |                                                                    |
 
 | <div style="width: 130pt">Flink Connector Plugins | <div style="width: 80pt">Database Type  | <div style="width: 50pt">Source | <div style="width: 50pt">Sink                                                                |
 |:------------------------:|:--------------:|:------------------------------------------------------------------:|:-------------------------------------------------------------------:|

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -59,30 +59,30 @@ Source[数据源输入] -> Transform[数据处理] -> Sink[结果输出]
 
 ## SeaTunnel 支持的插件
 
-| <div style="width: 130pt">Spark Connector Plugins | <div style="width: 80pt">Database Type | <div style="width: 50pt">Source | <div style="width: 50pt">Sink                        |
-|:------------------------:|:--------------:|:------------------------------------------------------------------:|:-------------------------------------------------------------------:|
-|Batch                     |Fake            |[doc](./docs/en/spark/configuration/source-plugins/Fake.md)         |                                                                     |
-|                          |ElasticSearch   |[doc](./docs/en/spark/configuration/source-plugins/Elasticsearch.md)|[doc](./docs/en/spark/configuration/sink-plugins/Elasticsearch.md)   |
-|                          |File            |[doc](./docs/en/spark/configuration/source-plugins/File.md)         |[doc](./docs/en/spark/configuration/sink-plugins/File.md)            |
-|                          |Hive            |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)         |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)          |
-|                          |Hudi            |[doc](./docs/en/spark/configuration/source-plugins/Hudi.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Hudi.md)            |
-|                          |Jdbc            |[doc](./docs/en/spark/configuration/source-plugins/Jdbc.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Jdbc.md)            |
-|                          |MongoDB         |[doc](./docs/en/spark/configuration/source-plugins/MongoDB.md)      |[doc](./docs/en/spark/configuration/sink-plugins/MongoDB.md)         |
-|                          |neo4j           |[doc](./docs/en/spark/configuration/source-plugins/neo4j.md)        |                                                                     |
-|                          |Phoenix         |[doc](./docs/en/spark/configuration/source-plugins/Phoenix.md)      |[doc](./docs/en/spark/configuration/sink-plugins/Phoenix.md)         |
-|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Redis.md)           |
-|                          |Tidb            |[doc](./docs/en/spark/configuration/source-plugins/Tidb.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Tidb.md)            |
-|                          |Clickhouse      |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Clickhouse.md)      |  
-|                          |Doris           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Doris.md)           |
-|                          |Email           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Email.md)           |
-|                          |Hbase           |[doc](./docs/en/spark/configuration/source-plugins/Hbase.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Hbase.md)           |
-|                          |Kafka           |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Kafka.md)           |
-|                          |Console         |                                                                    |[doc](./docs/en/spark/configuration/sink-plugins/Console.md)         |
-|                          |Kudu            |[doc](./docs/en/spark/configuration/source-plugins/Kudu.md)         |[doc](./docs/en/spark/configuration/sink-plugins/Kudu.md)            |
-|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |[doc](./docs/en/spark/configuration/sink-plugins/Redis.md)           |
-|Stream                    |FakeStream      |[doc](./docs/en/spark/configuration/source-plugins/FakeStream.md)   |                                                                     |
-|                          |KafkaStream     |[doc](./docs/en/spark/configuration/source-plugins/KafkaStream.md)  |                                                                     |
-|                          |SocketStream    |[doc](./docs/en/spark/configuration/source-plugins/SocketStream.md) |                                                                     |
+| <div style="width: 130pt">Spark Connector Plugins | <div style="width: 80pt">Database Type | <div style="width: 50pt">Source |                   <div style="width: 50pt">Sink                    |
+|:------------------------:|:--------------:|:------------------------------------------------------------------:|:------------------------------------------------------------------:|
+|Batch                     |Fake            |[doc](./docs/en/spark/configuration/source-plugins/Fake.md)         |                                                                    |
+|                          |ElasticSearch   |[doc](./docs/en/spark/configuration/source-plugins/Elasticsearch.md)| [doc](./docs/en/spark/configuration/sink-plugins/Elasticsearch.md) |
+|                          |File            |[doc](./docs/en/spark/configuration/source-plugins/File.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/File.md)      |
+|                          |Hive            |[doc](./docs/en/spark/configuration/source-plugins/Hive.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Hive.md)      |
+|                          |Hudi            |[doc](./docs/en/spark/configuration/source-plugins/Hudi.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Hudi.md)      |
+|                          |Jdbc            |[doc](./docs/en/spark/configuration/source-plugins/Jdbc.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Jdbc.md)      |
+|                          |MongoDB         |[doc](./docs/en/spark/configuration/source-plugins/MongoDB.md)      |    [doc](./docs/en/spark/configuration/sink-plugins/MongoDB.md)    |
+|                          |neo4j           |[doc](./docs/en/spark/configuration/source-plugins/neo4j.md)        |                                                                    |
+|                          |Phoenix         |[doc](./docs/en/spark/configuration/source-plugins/Phoenix.md)      |    [doc](./docs/en/spark/configuration/sink-plugins/Phoenix.md)    |
+|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Redis.md)     |
+|                          |Tidb            |[doc](./docs/en/spark/configuration/source-plugins/Tidb.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Tidb.md)      |
+|                          |Clickhouse      |                                                                    |  [doc](./docs/en/spark/configuration/sink-plugins/Clickhouse.md)   |  
+|                          |Doris           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Doris.md)     |
+|                          |Email           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Email.md)     |
+|                          |Hbase           |[doc](./docs/en/spark/configuration/source-plugins/Hbase.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Hbase.md)     |
+|                          |Kafka           |                                                                    |     [doc](./docs/en/spark/configuration/sink-plugins/Kafka.md)     |
+|                          |Console         |                                                                    |    [doc](./docs/en/spark/configuration/sink-plugins/Console.md)    |
+|                          |Kudu            |[doc](./docs/en/spark/configuration/source-plugins/Kudu.md)         |     [doc](./docs/en/spark/configuration/sink-plugins/Kudu.md)      |
+|                          |Redis           |[doc](./docs/en/spark/configuration/source-plugins/Redis.md)        |     [doc](./docs/en/spark/configuration/sink-plugins/Redis.md)     |
+|Stream                    |FakeStream      |[doc](./docs/en/spark/configuration/source-plugins/FakeStream.md)   |                                                                    |
+|                          |KafkaStream     |[doc](./docs/en/spark/configuration/source-plugins/KafkaStream.md)  |                                                                    |
+|                          |SocketStream    |[doc](./docs/en/spark/configuration/source-plugins/SocketStream.md) |                                                                    |
 
 | <div style="width: 130pt">Flink Connector Plugins | <div style="width: 80pt">Database Type  | <div style="width: 50pt">Source | <div style="width: 50pt">Sink                                                                |
 |:------------------------:|:--------------:|:------------------------------------------------------------------:|:-------------------------------------------------------------------:|


### PR DESCRIPTION
… on READDE.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
The  link about Hive sink in Spark Connector Plugins on README is wrong, which incorrectly refer to the link Hive source. This pr fix this.
## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
