### PR TITLE
[hotfix][influxdb][docs] Corrected database attribute

### DIFF
--- a/docs/en/flink/configuration/sink-plugins/InfluxDb.md
+++ b/docs/en/flink/configuration/sink-plugins/InfluxDb.md
@@ -31,9 +31,9 @@ The username of InfluxDB Server.
 
 The password of InfluxDB Server.
 
-### datasource [`String`]
+### database [`String`]
 
-The DataSource name in InfluxDB.
+The database name in InfluxDB.
 
 ### measurement [`String`]
 

--- a/docs/en/flink/configuration/source-plugins/InfluxDb.md
+++ b/docs/en/flink/configuration/source-plugins/InfluxDb.md
@@ -31,9 +31,9 @@ The username of InfluxDB Server.
 
 The password of InfluxDB Server.
 
-### datasource [`String`]
+### database [`String`]
 
-The DataSource name in InfluxDB.
+The database name in InfluxDB.
 
 ### measurement [`String`]
 


### PR DESCRIPTION

## Purpose of this pull request

The fourth influxdb attribute in table shows `database` but the description name is `datasource`.  Corrected attribute name to match the table and code.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
