### PR TITLE
[Bug] [FileSink] Flink file sink cannot work in stream mode

### DIFF
--- a/docs/en/flink/configuration/sink-plugins/File.md
+++ b/docs/en/flink/configuration/sink-plugins/File.md
@@ -8,15 +8,18 @@ Write data to the file system
 
 ## Options
 
-| name           | type   | required | default value |
-| -------------- | ------ | -------- | ------------- |
-| format         | string | yes      | -             |
-| path           | string | yes      | -             |
-| path_time_format | string | no       | yyyyMMddHHmmss |
-| write_mode     | string | no       | -             |
-| common-options | string | no       | -             |
-| parallelism    | int    | no       | -             |
-
+| name              | type   | required | default value  |
+|-------------------|--------| -------- |----------------|
+| format            | string | yes      | -              |
+| path              | string | yes      | -              |
+| path_time_format  | string | no       | yyyyMMddHHmmss |
+| write_mode        | string | no       | -              |
+| common-options    | string | no       | -              |
+| parallelism       | int    | no       | -              |
+| rollover_interval | long   | no       | 1              |
+| max_part_size     | long   | no       | 1024          |
+| prefix            | string | no       | seatunnel      |
+| suffix            | string | no       | .ext           |
 
 ### format [string]
 
@@ -51,7 +54,7 @@ See [Java SimpleDateFormat](https://docs.oracle.com/javase/tutorial/i18n/format/
 
 - OVERWRITE
 
-    - Overwrite, delete and then write if the path exists
+  - Overwrite, delete and then write if the path exists
 
 ### common options [string]
 
@@ -61,6 +64,21 @@ Sink plugin common parameters, please refer to [Sink Plugin](./sink-plugin.md) f
 
 The parallelism of an individual operator, for FileSink
 
+### rollover_interval [long]
+
+The new file part rollover interval, unit min.
+
+### max_part_size [long]
+
+The max size of each file part, unit MB.
+
+### prefix [string]
+
+The prefix of each file part.
+
+### suffix [string]
+
+The suffix of each file part.
 
 ## Examples
 

--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/TypesafeConfigUtils.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/TypesafeConfigUtils.java
@@ -91,4 +91,18 @@ public final class TypesafeConfigUtils {
 
         return config;
     }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getConfig(final Config config, final String configKey, final T defaultValue) {
+        if (defaultValue.getClass().equals(Long.class)) {
+            return config.hasPath(configKey) ? (T) Long.valueOf(config.getString(configKey)) : defaultValue;
+        }
+        if (defaultValue.getClass().equals(Integer.class)) {
+            return config.hasPath(configKey) ? (T) Integer.valueOf(config.getString(configKey)) : defaultValue;
+        }
+        if (defaultValue.getClass().equals(String.class)) {
+            return config.hasPath(configKey) ? (T) config.getString(configKey) : defaultValue;
+        }
+        throw new RuntimeException("Unsupported config type, configKey: " + configKey);
+    }
 }

--- a/seatunnel-common/src/test/java/org/apache/seatunnel/common/config/TypesafeConfigUtilsTest.java
+++ b/seatunnel-common/src/test/java/org/apache/seatunnel/common/config/TypesafeConfigUtilsTest.java
@@ -76,11 +76,19 @@ public class TypesafeConfigUtilsTest {
     }
 
     public Config getConfig() {
-        Map<String, String> configMap = new HashMap<>();
+        Map<String, Object> configMap = new HashMap<>();
         configMap.put("test.t0", "v0");
         configMap.put("test.t1", "v1");
         configMap.put("k0", "v2");
         configMap.put("k1", "v3");
+        configMap.put("l1", Long.parseLong("100"));
         return ConfigFactory.parseMap(configMap);
+    }
+
+    @Test
+    public void testGetConfig() {
+        Config config = getConfig();
+        Assert.assertEquals(Long.parseLong("100"), (long) TypesafeConfigUtils.getConfig(config, "l1", Long.parseLong("101")));
+        Assert.assertEquals(Long.parseLong("100"), (long) TypesafeConfigUtils.getConfig(config, "l2", Long.parseLong("100")));
     }
 }


### PR DESCRIPTION
## Purpose of this pull request

close #1527 

This pr remove directly use PrintStream to write record to file, see flink doc https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/datastream/streamfile_sink/#row-encoded-formats

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
