### PR TITLE
[Improve]Modify Doris sink default parameter value

### DIFF
--- a/docs/en/flink/configuration/sink-plugins/Doris.md
+++ b/docs/en/flink/configuration/sink-plugins/Doris.md
@@ -43,11 +43,13 @@ Doris password
 
 ##### batch_size [int]
 
-Maximum number of lines in a single write Doris,default value is 100.
+Maximum number of lines in a single write Doris,default value is 5000.
 
 ##### interval [int]
 
 The flush interval millisecond, after which the asynchronous thread will write the data in the cache to Doris.Set to 0 to turn off periodic writing.
+
+Default value ：5000
 
 ##### max_retries [int]
 
@@ -75,4 +77,4 @@ DorisSink {
 	 doris.column_separator="\t"
      doris.columns="id,user_name,user_name_cn,create_time,last_login_time"
 }
- ```
+```

--- a/docs/en/spark/configuration/sink-plugins/Doris.md
+++ b/docs/en/spark/configuration/sink-plugins/Doris.md
@@ -29,6 +29,9 @@ Doris user name
 Doris user's password
 ##### batch_size [string]
 Doris number of submissions per batch
+
+Default value：5000
+
 ##### doris. [string]
 Doris stream_load properties,you can use 'doris.' prefix + stream_load properties
 [More Doris stream_load Configurations](https://doris.apache.org/administrator-guide/load-data/stream-load-manual.html)

--- a/docs/zh-CN/flink/configuration/sink-plugins/Doris.md
+++ b/docs/zh-CN/flink/configuration/sink-plugins/Doris.md
@@ -40,11 +40,13 @@ Doris 密码
 
 ##### batch_size [int]
 
-单次写Doris的最大行数,默认值100
+单次写 Doris 的最大行数,默认值 : 5000
 
 ##### interval [int]
 
 flush 间隔时间(毫秒)，超过该时间后异步线程将 缓存中数据写入Doris。设置为0表示关闭定期写入。
+
+默认值：5000（毫秒）即5秒一个批次
 
 ##### max_retries [int]
 
@@ -67,4 +69,4 @@ DorisSink {
 	 doris.column_separator="\t"
      doris.columns="id,user_name,user_name_cn,create_time,last_login_time"
 }
- ```
+```

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/sink/DorisSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/sink/DorisSink.java
@@ -44,8 +44,8 @@ import java.util.concurrent.TimeUnit;
 public class DorisSink implements FlinkStreamSink, FlinkBatchSink {
 
     private static final long serialVersionUID = 4747849769146047770L;
-    private static final int DEFAULT_BATCH_SIZE = 100;
-    private static final long DEFAULT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
+    private static final int DEFAULT_BATCH_SIZE = 5000;
+    private static final long DEFAULT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(5);
     private static final String PARALLELISM = "parallelism";
 
     private Config config;

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-doris/src/main/scala/org/apache/seatunnel/spark/sink/Doris.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-doris/src/main/scala/org/apache/seatunnel/spark/sink/Doris.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.{Dataset, Row}
 class Doris extends SparkBatchSink with Serializable {
 
   var apiUrl: String = _
-  var batch_size: Int = 100
+  var batch_size: Int = 5000
   var column_separator: String = "\t"
   var propertiesMap = new mutable.HashMap[String, String]()
 


### PR DESCRIPTION
Now the default parameters of Doris sink, if users are not familiar with Doris, using the default parameters will cause Doris write blocking during high-frequency writing. This is because Doris BE compacts the tablet version and generates a backlog.
This parameter value is recommended to be around 5000 items per batch. Flink uses two parameters, one is 5000 items, and the other is the default 5-second interval. Which condition comes first and which is executed

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
