### PR TITLE
[hotfix][hbase][docs] Corrected staging_dir attribute

### DIFF
--- a/docs/en/spark/configuration/sink-plugins/Hbase.md
+++ b/docs/en/spark/configuration/sink-plugins/Hbase.md
@@ -24,7 +24,7 @@ The address of the `zookeeper` cluster, the format is: `host01:2181,host02:2181,
 
 The structure of the `hbase` table is defined by `catalog` , the name of the `hbase` table and its `namespace` , which `columns` are used as `rowkey`, and the correspondence between `column family` and `columns` can be defined by `catalog` `hbase table catalog`
 
-### stagging_dir [string]
+### staging_dir [string]
 
 A path on `HDFS` that will generate data that needs to be loaded into `hbase` . After the data is loaded, the data file will be deleted and the directory is still there.
 


### PR DESCRIPTION

## Purpose of this pull request

Corrected `stagging_dir` attribute and changed it to `staging_dir`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
