### PR TITLE
[Improvement][flink-connector-kafka] rename kafkasink/add semantic/simplify code

### DIFF
--- a/docs/en/flink/configuration/sink-plugins/Kafka.md
+++ b/docs/en/flink/configuration/sink-plugins/Kafka.md
@@ -13,6 +13,7 @@ Write data to Kafka
 | producer.bootstrap.servers | string | yes      | -             |
 | topic                      | string | yes      | -             |
 | producer.*                 | string | no       | -             |
+| semantic                   | string | no       | -             |
 | common-options             | string | no       | -             |
 
 ### producer.bootstrap.servers [string]
@@ -29,6 +30,9 @@ In addition to the above mandatory parameters that must be specified by the `Kaf
 
 The way to specify the parameter is to add the prefix `producer.` to the original parameter name. For example, the way to specify `request.timeout.ms` is: `producer.request.timeout.ms = 60000` . If these non-essential parameters are not specified, they will use the default values given in the official Kafka documentation.
 
+### semantic [string]
+Semantics that can be chosen. exactly_once/at_least_once/none, default is at_least_once
+
 ### common options [string]
 
 Sink plugin common parameters, please refer to [Sink Plugin](./sink-plugin.md) for details
@@ -36,7 +40,7 @@ Sink plugin common parameters, please refer to [Sink Plugin](./sink-plugin.md) f
 ## Examples
 
 ```bash
-   KafkaTable {
+   KafkaSink {
      producer.bootstrap.servers = "127.0.0.1:9092"
      topics = test_sink
    }

--- a/docs/en/flink/configuration/sink-plugins/Kafka.md
+++ b/docs/en/flink/configuration/sink-plugins/Kafka.md
@@ -33,6 +33,14 @@ The way to specify the parameter is to add the prefix `producer.` to the origina
 ### semantic [string]
 Semantics that can be chosen. exactly_once/at_least_once/none, default is at_least_once
 
+In exactly_once, flink producer will write all messages in a Kafka transaction that will be committed to Kafka on a checkpoint.
+
+In at_least_once, flink producer will wait for all outstanding messages in the Kafka buffers to be acknowledged by the Kafka producer on a checkpoint.
+
+NONE does not provide any guarantees: messages may be lost in case of issues on the Kafka broker and messages may be duplicated in case of a Flink failure.
+
+please refer to [Flink Kafka Fault Tolerance](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/connectors/datastream/kafka/#fault-tolerance)
+
 ### common options [string]
 
 Sink plugin common parameters, please refer to [Sink Plugin](./sink-plugin.md) for details

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/resources/META-INF/services/org.apache.seatunnel.flink.BaseFlinkSink
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/resources/META-INF/services/org.apache.seatunnel.flink.BaseFlinkSink
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.seatunnel.flink.kafka.sink.KafkaTable
+org.apache.seatunnel.flink.kafka.sink.KafkaSink


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

1、add FlinkKafkaProducer params  semantic.  Semantics that can be chosen. exactly_once/at_least_once/none, default is at_least_once
2、rename kafkatable to kafkasink，it more suitable
3、simplify code

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/developement/NewLicenseGuide.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
