### PR TITLE
[doc] Add hint only spark supported for Mesos cluster

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ Feel free to ping committers for the review!
 
 * [ ] Code changed are covered with tests, or it does not need tests for reason:
 * [ ] If any new Jar binary package adding in you PR, please add License Notice according
-  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
+  [New License Guide](../docs/en/development/new-license.md)
 * [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ Feel free to ping committers for the review!
 
 * [ ] Code changed are covered with tests, or it does not need tests for reason:
 * [ ] If any new Jar binary package adding in you PR, please add License Notice according
-  [New License Guide](../docs/en/development/new-license.md)
+  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
 * [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -104,7 +104,7 @@ bin/start-seatunnel-flink.sh \
 </TabItem>
 </Tabs>
 
-### Mesos Cluster
+### Mesos Cluster(Spark Only)
 
 Mesos cluster deployment only support Spark engine for now.
 


### PR DESCRIPTION
Same as `Local Mode`, `Mesos Cluster` mode is only for Spark cluster