### PR TITLE
[doc] Fix dead link to start

### DIFF
--- a/.dlc.json
+++ b/.dlc.json
@@ -14,6 +14,9 @@
     },
     {
       "pattern": "^https://json.org/"
+    },
+    {
+      "pattern": "^/docs/category"
     }
   ],
   "timeout": "10s",

--- a/docs/en/deployment.mdx
+++ b/docs/en/deployment.mdx
@@ -4,8 +4,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This section will show you how to submit your SeaTunnel application in all kinds of cluster engine. If you still not installation
-<!-- markdown-link-check-disable-next-line -->
-SeaTunnel you could go to see [quick start](/category/start) about how to prepare and change SeaTunnel configuration firstly.
+SeaTunnel you could go to see [quick start](/docs/category/start) about how to prepare and change SeaTunnel configuration firstly.
 
 ## Deployment in All Kind of Engine
 

--- a/docs/en/intro/about.md
+++ b/docs/en/intro/about.md
@@ -69,5 +69,4 @@ SeaTunnel enriches the <a href="https://landscape.cncf.io/landscape=observabilit
 
 ## What's More
 
-<!-- markdown-link-check-disable-next-line -->
-You can see [Quick Start](/category/start) for the next step.
+You can see [Quick Start](/docs/category/start) for the next step.


### PR DESCRIPTION
This patch fix the dead link about `/category/start`
and the correct url is `/docs/category/start`
