### PR TITLE
[donot-merge][ci] Migrate check-license into license.yml

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -31,13 +31,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-license:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check License Header
-        uses: apache/skywalking-eyes@main
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: License Checker
+name: License
 
 on:
   push:
@@ -30,8 +30,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
+  check-license:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check License Header
+        uses: apache/skywalking-eyes@main
+  auto-license:
+    name: Auto License
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
* Move skywalking-eyes to make sure all file types expect
  `*.md` run the license checker
* Change license.yml name and make it more meaningful

ref: https://github.com/apache/incubator-seatunnel/pull/1613#issuecomment-1082600623
