### PR TITLE
[hotfix][connector-redis][docs] Updated required value in attribute tables for those with default values

### DIFF
--- a/docs/en/connector/sink/Redis.md
+++ b/docs/en/connector/sink/Redis.md
@@ -15,18 +15,18 @@ Engine Supported and plugin name
 
 ## Options
 
-| name      | type   | required  | default value |
-|-----------|--------|-----------|---------------|
-| host      | string | yes       | "localhost"   |
-| port      | int    | yes       | 6379          |
-| auth      | string | no        |               |
-| db_num    | int    | no        | 0             |
-| data_type | string | no        | "KV"          |
-| hash_name | string | no        |               |
-| list_name | string | no        |               |
-| set_name  | string | no        |               |
-| zset_name | string | no        |               |
-| timeout   | int    | no        | 2000          |
+| name      | type   | required | default value |
+|-----------|--------|----------|---------------|
+| host      | string | no       | "localhost"   |
+| port      | int    | no       | 6379          |
+| auth      | string | no       |               |
+| db_num    | int    | no       | 0             |
+| data_type | string | no       | "KV"          |
+| hash_name | string | no       |               |
+| list_name | string | no       |               |
+| set_name  | string | no       |               |
+| zset_name | string | no       |               |
+| timeout   | int    | no       | 2000          |
 
 ### host [string]
 

--- a/docs/en/connector/source/Redis.md
+++ b/docs/en/connector/source/Redis.md
@@ -17,8 +17,8 @@ Engine Supported and plugin name
 
 | name                | type     | required | default value |
 |---------------------|----------|----------|---------------|
-| host                | string   | yes      | "localhost"   |
-| port                | int      | yes      | 6379          |
+| host                | string   | no       | "localhost"   |
+| port                | int      | no       | 6379          |
 | auth                | string   | no       |               |
 | db_num              | int      | no       | 0             |
 | keys_or_key_pattern | string   | yes      |               |


### PR DESCRIPTION
## Purpose of this pull request

Set `required` column value to `no` for those with `default value` (eg: `host` and `port`).

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
