### PR TITLE
[ci] Run auto license only if commit message contains keyword

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -41,6 +41,9 @@ jobs:
     name: Auto License
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Have a buggy in https://github.com/apache/incubator-seatunnel/pull/1642, Can trigger when commit message contains
+    # keyword `[ci-auto-license]`.
+    if: "contains(toJSON(github.event.commits.*.message), '[ci-auto-license]')"
     env:
       MAVEN_OPTS: -Xmx2G -Xms2G
     steps:


### PR DESCRIPTION
This path makes ci `Auto License` only run if commit message
contains keyword `'[ci-auto-license]'`. It seems it have buggy
in https://github.com/apache/incubator-seatunnel/pull/1642
