### PR TITLE
[Dependency]Upgrade log4j-core to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <maven-helper-plugin.version>3.2.0</maven-helper-plugin.version>
         <maven-license-maven-plugin>1.20</maven-license-maven-plugin>
         <influxdb-java.version>2.22</influxdb-java.version>
-        <log4j-core.version>2.15.0</log4j-core.version>
+        <log4j-core.version>2.17.1</log4j-core.version>
         <scalastyle-maven-plugin.version>1.0.0</scalastyle-maven-plugin.version>
         <docker-maven-plugin.version>0.38.0</docker-maven-plugin.version>
         <p3c-pmd.version>1.3.0</p3c-pmd.version>

--- a/seatunnel-dist/release-docs/LICENSE
+++ b/seatunnel-dist/release-docs/LICENSE
@@ -418,7 +418,7 @@ The text of each license is the standard Apache 2.0 license.
      (Apache License, Version 2.0) Apache Log4j API (org.apache.logging.log4j:log4j-api:2.11.1 - https://logging.apache.org/log4j/2.x/log4j-api/)
      (Apache License, Version 2.0) Apache Log4j API (org.apache.logging.log4j:log4j-api:2.15.0 - https://logging.apache.org/log4j/2.x/log4j-api/)
      (Apache License, Version 2.0) Apache Log4j API (org.apache.logging.log4j:log4j-api:2.8.1 - https://logging.apache.org/log4j/2.x/log4j-api/)
-     (Apache License, Version 2.0) Apache Log4j Core (org.apache.logging.log4j:log4j-core:2.15.0 - https://logging.apache.org/log4j/2.x/log4j-core/)
+     (Apache License, Version 2.0) Apache Log4j Core (org.apache.logging.log4j:log4j-core:2.17.1 - https://logging.apache.org/log4j/2.x/log4j-core/)
      (Apache License, Version 2.0) Apache Log4j JUL Adapter (org.apache.logging.log4j:log4j-jul:2.15.0 - https://logging.apache.org/log4j/2.x/log4j-jul/)
      (Apache License, Version 2.0) Apache Log4j SLF4J Binding (org.apache.logging.log4j:log4j-slf4j-impl:2.15.0 - https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/)
      (Apache License, Version 2.0) Apache POI (org.apache.poi:poi-ooxml-schemas:4.1.2 - http://poi.apache.org/)

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -466,7 +466,7 @@ log4j-1.2.17.jar
 log4j-api-2.11.1.jar
 log4j-api-2.15.0.jar
 log4j-api-2.8.1.jar
-log4j-core-2.15.0.jar
+log4j-core-2.17.1.jar
 log4j-jul-2.15.0.jar
 log4j-slf4j-impl-2.15.0.jar
 logging-interceptor-4.9.1.jar


### PR DESCRIPTION
There are two versions of log4j-api, 1.X and 2.X, I am not sure about compatibility, if possible, it is best to unify.