### PR TITLE
[hotfix][directory] recover plugins directory

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,6 @@
+# Introduction of plugins directory
+This directory used to store some plugin configuration files. 
+
+- `json/files/schemas/` is the default schema store directory for [Json transform plugin](https://seatunnel.apache.org/docs/transform/json#schema_dir-string).
+
+If you use spark cluster mode, this directory will be sent to the executor by `--files`.

--- a/plugins/json/files/schemas/seatunnel-schema-demo.json
+++ b/plugins/json/files/schemas/seatunnel-schema-demo.json
@@ -1,0 +1,4 @@
+{
+  "project":"seatunnel",
+  "group":"apache"
+}

--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -40,6 +40,7 @@
                 <include>README.md</include>
                 <include>bin/**</include>
                 <include>config/**</include>
+                <include>plugins/**</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-json/src/main/scala/org/apache/seatunnel/spark/transform/Json.scala
+++ b/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-json/src/main/scala/org/apache/seatunnel/spark/transform/Json.scala
@@ -96,9 +96,7 @@ class Json extends BaseSparkTransform {
       Map(
         "source_field" -> "raw_message",
         "target_field" -> Constants.ROW_ROOT,
-        "schema_dir" -> Paths
-          .get(Common.pluginFilesDir("json").toString, "schemas")
-          .toString,
+        "schema_dir" -> Paths.get(Common.pluginFilesDir("json").toString, "schemas").toString,
         "schema_file" -> ""))
     config = config.withFallback(defaultConfig)
     val schemaFile = config.getString("schema_file")


### PR DESCRIPTION
## Purpose of this pull request
I find the `plugins` is still used in seatunnel, so recover this directory and add a README.md to introduce.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
