### PR TITLE
[hotfix][connector-clickhouse][docs] Updated bulk size desc

### DIFF
--- a/docs/en/connector/sink/Clickhouse.md
+++ b/docs/en/connector/sink/Clickhouse.md
@@ -34,7 +34,7 @@ Engine Supported and plugin name
 
 ### bulk_size [number]
 
-The number of data written through [Clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-jdbc) each time, the `default is 20000` .
+The number of rows written through [Clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-jdbc) each time, the `default is 20000` .
 
 ### database [string]
 


### PR DESCRIPTION
## Purpose of this pull request

Updated bulk_size description from `number of data written` to `number of rows written`.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
