### PR TITLE
[Bug] [core] Cannot load plugin due to plugin name is not class name

### DIFF
--- a/seatunnel-apis/seatunnel-api-base/src/main/java/org/apache/seatunnel/plugin/Plugin.java
+++ b/seatunnel-apis/seatunnel-api-base/src/main/java/org/apache/seatunnel/plugin/Plugin.java
@@ -71,4 +71,12 @@ public interface Plugin<T extends RuntimeEnv> extends Serializable, AutoCloseabl
 
     }
 
+    /**
+     * Return the plugin name, this is used in seatunnel conf DSL.
+     *
+     * @return plugin name.
+     */
+    default String getPluginName() {
+        return this.getClass().getSimpleName();
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-console/src/main/java/org/apache/seatunnel/flink/console/sink/ConsoleSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-console/src/main/java/org/apache/seatunnel/flink/console/sink/ConsoleSink.java
@@ -94,4 +94,10 @@ public class ConsoleSink extends RichOutputFormat<Row> implements FlinkBatchSink
     public void close() {
 
     }
+
+    @Override
+    public String getPluginName() {
+        return "ConsoleSink";
+    }
+
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/doris/sink/DorisSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/doris/sink/DorisSink.java
@@ -100,7 +100,7 @@ public class DorisSink implements FlinkStreamSink, FlinkBatchSink {
 
     @Override
     public String getPluginName() {
-        return "doris";
+        return "DorisSink";
     }
 
     @Override

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/doris/sink/DorisSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-doris/src/main/java/org/apache/seatunnel/flink/doris/sink/DorisSink.java
@@ -99,6 +99,11 @@ public class DorisSink implements FlinkStreamSink, FlinkBatchSink {
     }
 
     @Override
+    public String getPluginName() {
+        return "doris";
+    }
+
+    @Override
     public DataSink<Row> outputBatch(FlinkEnvironment env, DataSet<Row> dataSet) {
         batchIntervalMs = 0;
         BatchTableEnvironment tableEnvironment = env.getBatchTableEnvironment();

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/sink/DruidSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/sink/DruidSink.java
@@ -78,4 +78,9 @@ public class DruidSink implements FlinkBatchSink {
         this.timestampFormat = config.hasPath(TIMESTAMP_FORMAT) ? config.getString(TIMESTAMP_FORMAT) : null;
         this.timestampMissingValue = config.hasPath(TIMESTAMP_MISSING_VALUE) ? config.getString(TIMESTAMP_MISSING_VALUE) : null;
     }
+
+    @Override
+    public String getPluginName() {
+        return "druid";
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/sink/DruidSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/sink/DruidSink.java
@@ -81,6 +81,6 @@ public class DruidSink implements FlinkBatchSink {
 
     @Override
     public String getPluginName() {
-        return "druid";
+        return "DruidSink";
     }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/source/DruidSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/source/DruidSource.java
@@ -130,7 +130,7 @@ public class DruidSource implements FlinkBatchSource {
 
     @Override
     public String getPluginName() {
-        return "druid";
+        return "DruidSource";
     }
 
     private RowTypeInfo getRowTypeInfo(String jdbcURL, String datasource, Collection<String> userColumns) {

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/source/DruidSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-druid/src/main/java/org/apache/seatunnel/flink/druid/source/DruidSource.java
@@ -128,6 +128,11 @@ public class DruidSource implements FlinkBatchSource {
                 .finish();
     }
 
+    @Override
+    public String getPluginName() {
+        return "druid";
+    }
+
     private RowTypeInfo getRowTypeInfo(String jdbcURL, String datasource, Collection<String> userColumns) {
         HashMap<String, TypeInformation> map = new LinkedHashMap<>();
 

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch/src/main/java/org/apache/seatunnel/flink/elasticsearch/sink/Elasticsearch.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch/src/main/java/org/apache/seatunnel/flink/elasticsearch/sink/Elasticsearch.java
@@ -85,6 +85,11 @@ public class Elasticsearch implements FlinkStreamSink, FlinkBatchSink {
     }
 
     @Override
+    public String getPluginName() {
+        return "elasticsearch";
+    }
+
+    @Override
     public DataStreamSink<Row> outputStream(FlinkEnvironment env, DataStream<Row> dataStream) {
 
         List<HttpHost> httpHosts = new ArrayList<>();

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch/src/main/java/org/apache/seatunnel/flink/elasticsearch/sink/Elasticsearch.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch/src/main/java/org/apache/seatunnel/flink/elasticsearch/sink/Elasticsearch.java
@@ -86,7 +86,7 @@ public class Elasticsearch implements FlinkStreamSink, FlinkBatchSink {
 
     @Override
     public String getPluginName() {
-        return "elasticsearch";
+        return "ElasticSearch";
     }
 
     @Override

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-fake/src/main/java/org/apache/seatunnel/flink/fake/source/FakeSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-fake/src/main/java/org/apache/seatunnel/flink/fake/source/FakeSource.java
@@ -53,6 +53,11 @@ public class FakeSource implements FlinkBatchSource {
     }
 
     @Override
+    public String getPluginName() {
+        return "FakeSource";
+    }
+
+    @Override
     public DataSet<Row> getData(FlinkEnvironment env) {
         Random random = new Random();
         return env.getBatchTableEnvironment().toDataSet(

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-fake/src/main/java/org/apache/seatunnel/flink/fake/source/FakeSourceStream.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-fake/src/main/java/org/apache/seatunnel/flink/fake/source/FakeSourceStream.java
@@ -61,6 +61,11 @@ public class FakeSourceStream extends RichParallelSourceFunction<Row> implements
         return config;
     }
 
+    @Override
+    public String getPluginName() {
+        return "FakeSourceStream";
+    }
+
     private static final String[] NAME_ARRAY = new String[]{"Gary", "Ricky Huo", "Kid Xiong"};
 
     @Override

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/sink/FileSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/sink/FileSink.java
@@ -157,4 +157,9 @@ public class FileSink implements FlinkStreamSink, FlinkBatchSink {
             outputFormat.close();
         }
     }
+
+    @Override
+    public String getPluginName() {
+        return "File";
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/sink/FileSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/sink/FileSink.java
@@ -160,6 +160,6 @@ public class FileSink implements FlinkStreamSink, FlinkBatchSink {
 
     @Override
     public String getPluginName() {
-        return "File";
+        return "FileSink";
     }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/source/FileSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/source/FileSource.java
@@ -121,6 +121,6 @@ public class FileSource implements FlinkBatchSource {
 
     @Override
     public String getPluginName() {
-        return "File";
+        return "FileSource";
     }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/source/FileSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-file/src/main/java/org/apache/seatunnel/flink/file/source/FileSource.java
@@ -118,4 +118,9 @@ public class FileSource implements FlinkBatchSource {
         }
 
     }
+
+    @Override
+    public String getPluginName() {
+        return "File";
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-influxdb/src/main/java/org/apache/seatunnel/flink/influxdb/sink/InfluxDbSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-influxdb/src/main/java/org/apache/seatunnel/flink/influxdb/sink/InfluxDbSink.java
@@ -86,4 +86,9 @@ public class InfluxDbSink implements FlinkBatchSink {
         this.tags = config.getStringList(TAGS);
         this.fields = config.getStringList(FIELDS);
     }
+
+    @Override
+    public String getPluginName() {
+        return "InfluxDbSink";
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-influxdb/src/main/java/org/apache/seatunnel/flink/influxdb/source/InfluxDbSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-influxdb/src/main/java/org/apache/seatunnel/flink/influxdb/source/InfluxDbSource.java
@@ -128,6 +128,11 @@ public class InfluxDbSource implements FlinkBatchSource {
                 .finish();
     }
 
+    @Override
+    public String getPluginName() {
+        return "InfluxDbSource";
+    }
+
     private RowTypeInfo getRowTypeInfo(List<String> fields, List<String> fieldTypes) {
         TypeInformation<?>[] typeInformation = new TypeInformation<?>[fieldTypes.size()];
         String[] names = new String[fieldTypes.size()];

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/sink/JdbcSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/sink/JdbcSink.java
@@ -106,6 +106,11 @@ public class JdbcSink implements FlinkStreamSink, FlinkBatchSink {
     }
 
     @Override
+    public String getPluginName() {
+        return "jdbc";
+    }
+
+    @Override
     @Nullable
     public DataStreamSink<Row> outputStream(FlinkEnvironment env, DataStream<Row> dataStream) {
         Table table = env.getStreamTableEnvironment().fromDataStream(dataStream);

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/sink/JdbcSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/sink/JdbcSink.java
@@ -107,7 +107,7 @@ public class JdbcSink implements FlinkStreamSink, FlinkBatchSink {
 
     @Override
     public String getPluginName() {
-        return "jdbc";
+        return "JdbcSink";
     }
 
     @Override

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/source/JdbcSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/source/JdbcSource.java
@@ -168,7 +168,7 @@ public class JdbcSource implements FlinkBatchSource {
 
     @Override
     public String getPluginName() {
-        return "jdbc";
+        return "JdbcSource";
     }
 
     private String extendPartitionQuerySql(String query, String column) {

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/source/JdbcSource.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/src/main/java/org/apache/seatunnel/flink/jdbc/source/JdbcSource.java
@@ -166,6 +166,11 @@ public class JdbcSource implements FlinkBatchSource {
         }
     }
 
+    @Override
+    public String getPluginName() {
+        return "jdbc";
+    }
+
     private String extendPartitionQuerySql(String query, String column) {
         Matcher matcher = COMPILE.matcher(query);
         if (matcher.find()) {

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/sink/KafkaSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/sink/KafkaSink.java
@@ -83,6 +83,11 @@ public class KafkaSink implements FlinkStreamSink {
         kafkaParams.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
     }
 
+    @Override
+    public String getPluginName() {
+        return "kafka";
+    }
+
     private FlinkKafkaProducer.Semantic getSemanticEnum(String semantic) {
         if ("exactly_once".equals(semantic)) {
             return FlinkKafkaProducer.Semantic.EXACTLY_ONCE;

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/sink/KafkaSink.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/sink/KafkaSink.java
@@ -85,7 +85,7 @@ public class KafkaSink implements FlinkStreamSink {
 
     @Override
     public String getPluginName() {
-        return "kafka";
+        return "Kafka";
     }
 
     private FlinkKafkaProducer.Semantic getSemanticEnum(String semantic) {

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/source/KafkaTableStream.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/source/KafkaTableStream.java
@@ -113,7 +113,7 @@ public class KafkaTableStream implements FlinkStreamSource {
 
     @Override
     public String getPluginName() {
-        return "kafkaStream";
+        return "KafkaTableStream";
     }
 
     @Override

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/source/KafkaTableStream.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-kafka/src/main/java/org/apache/seatunnel/flink/kafka/source/KafkaTableStream.java
@@ -112,6 +112,11 @@ public class KafkaTableStream implements FlinkStreamSource {
     }
 
     @Override
+    public String getPluginName() {
+        return "kafkaStream";
+    }
+
+    @Override
     public DataStream<Row> getData(FlinkEnvironment env) {
         StreamTableEnvironment tableEnvironment = env.getStreamTableEnvironment();
         tableEnvironment

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-socket/src/main/java/org/apache/seatunnel/flink/socket/source/SocketStream.java
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-socket/src/main/java/org/apache/seatunnel/flink/socket/source/SocketStream.java
@@ -71,4 +71,9 @@ public class SocketStream implements FlinkStreamSource {
             port = config.getInt(PORT);
         }
     }
+
+    @Override
+    public String getPluginName() {
+        return "SocketStream";
+    }
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/Clickhouse.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/Clickhouse.scala
@@ -316,6 +316,8 @@ class Clickhouse extends SparkBatchSink {
         throw e
     }
   }
+
+  override def getPluginName: String = "Clickhouse"
 }
 
 object Clickhouse {

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/ClickhouseFile.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/ClickhouseFile.scala
@@ -285,6 +285,8 @@ class ClickhouseFile extends SparkBatchSink {
 
   override def prepare(prepareEnv: SparkEnvironment): Unit = {
   }
+
+  override def getPluginName: String = "ClickhouseFile"
 }
 
 

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-console/src/main/scala/org/apache/seatunnel/spark/console/sink/Console.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-console/src/main/scala/org/apache/seatunnel/spark/console/sink/Console.scala
@@ -69,5 +69,5 @@ class Console extends SparkBatchSink {
     config = config.withFallback(defaultConfig)
   }
 
-  override def getPluginName: String = "console"
+  override def getPluginName: String = "Console"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-console/src/main/scala/org/apache/seatunnel/spark/console/sink/Console.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-console/src/main/scala/org/apache/seatunnel/spark/console/sink/Console.scala
@@ -68,4 +68,6 @@ class Console extends SparkBatchSink {
       ))
     config = config.withFallback(defaultConfig)
   }
+
+  override def getPluginName: String = "console"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-doris/src/main/scala/org/apache/seatunnel/spark/doris/sink/Doris.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-doris/src/main/scala/org/apache/seatunnel/spark/doris/sink/Doris.scala
@@ -95,4 +95,11 @@ class Doris extends SparkBatchSink with Serializable {
       batch_size = config.getInt(Config.BULK_SIZE)
     }
   }
+
+  /**
+   * Return the plugin name, this is used in seatunnel conf DSL.
+   *
+   * @return plugin name.
+   */
+  override def getPluginName: String = "Doris"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/sink/Elasticsearch.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/sink/Elasticsearch.scala
@@ -74,4 +74,10 @@ class Elasticsearch extends SparkBatchSink {
     }
   }
 
+  /**
+   * Return the plugin name, this is used in seatunnel conf DSL.
+   *
+   * @return plugin name.
+   */
+  override def getPluginName: String = "elasticsearch"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/sink/Elasticsearch.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/sink/Elasticsearch.scala
@@ -79,5 +79,5 @@ class Elasticsearch extends SparkBatchSink {
    *
    * @return plugin name.
    */
-  override def getPluginName: String = "elasticsearch"
+  override def getPluginName: String = "ElasticSearch"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/source/Elasticsearch.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/source/Elasticsearch.scala
@@ -71,5 +71,5 @@ class Elasticsearch extends SparkBatchSource {
    *
    * @return plugin name.
    */
-  override def getPluginName: String = "elasticsearch"
+  override def getPluginName: String = "ElasticSearch"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/source/Elasticsearch.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-elasticsearch/src/main/scala/org/apache/seatunnel/spark/elasticsearch/source/Elasticsearch.scala
@@ -66,4 +66,10 @@ class Elasticsearch extends SparkBatchSource {
     checkAllExists(config, HOSTS, INDEX)
   }
 
+  /**
+   * Return the plugin name, this is used in seatunnel conf DSL.
+   *
+   * @return plugin name.
+   */
+  override def getPluginName: String = "elasticsearch"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-email/src/main/scala/org/apache/seatunnel/spark/email/sink/Email.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-email/src/main/scala/org/apache/seatunnel/spark/email/sink/Email.scala
@@ -128,5 +128,5 @@ class Email extends SparkBatchSink {
    *
    * @return plugin name.
    */
-  override def getPluginName: String = "email"
+  override def getPluginName: String = "Email"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-email/src/main/scala/org/apache/seatunnel/spark/email/sink/Email.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-email/src/main/scala/org/apache/seatunnel/spark/email/sink/Email.scala
@@ -122,4 +122,11 @@ class Email extends SparkBatchSink {
     val mailer: SMTPMailer = new SMTPMailer(configuration)
     mailer
   }
+
+  /**
+   * Return the plugin name, this is used in seatunnel conf DSL.
+   *
+   * @return plugin name.
+   */
+  override def getPluginName: String = "email"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/Fake.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/Fake.scala
@@ -37,4 +37,5 @@ class Fake extends SparkBatchSource {
     env.getSparkSession.createDataset(s)(RowEncoder(schema))
   }
 
+  override def getPluginName: String = "Fake"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/FakeStream.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/FakeStream.scala
@@ -61,7 +61,7 @@ class FakeStream extends SparkStreamingSource[String] {
     }
   }
 
-  override def getPluginName: String = "FakeSourceStream"
+  override def getPluginName: String = "FakeStream"
 }
 
 private class FakeReceiver(config: Config)

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/FakeStream.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-fake/src/main/scala/org/apache/seatunnel/spark/fake/source/FakeStream.scala
@@ -60,6 +60,8 @@ class FakeStream extends SparkStreamingSource[String] {
       CheckResult.error("please make sure [content] is of type string array")
     }
   }
+
+  override def getPluginName: String = "FakeSourceStream"
 }
 
 private class FakeReceiver(config: Config)

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/sink/File.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/sink/File.scala
@@ -70,5 +70,5 @@ class File extends SparkBatchSink {
     }
   }
 
-  override def getPluginName: String = "file"
+  override def getPluginName: String = "File"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/sink/File.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/sink/File.scala
@@ -69,4 +69,6 @@ class File extends SparkBatchSink {
       case ORC => writer.orc(path)
     }
   }
+
+  override def getPluginName: String = "file"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/source/File.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/source/File.scala
@@ -63,4 +63,6 @@ class File extends SparkBatchSource {
       case _ => reader.format(format).load(path)
     }
   }
+
+  override def getPluginName: String = "file"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/source/File.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-file/src/main/scala/org/apache/seatunnel/spark/file/source/File.scala
@@ -64,5 +64,5 @@ class File extends SparkBatchSource {
     }
   }
 
-  override def getPluginName: String = "file"
+  override def getPluginName: String = "File"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/sink/Hbase.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/sink/Hbase.scala
@@ -162,4 +162,6 @@ class Hbase extends SparkBatchSink with Logging {
       admin.truncateTable(tableName, true)
     }
   }
+
+  override def getPluginName: String = "hbase"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/sink/Hbase.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/sink/Hbase.scala
@@ -163,5 +163,5 @@ class Hbase extends SparkBatchSink with Logging {
     }
   }
 
-  override def getPluginName: String = "hbase"
+  override def getPluginName: String = "Hbase"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
@@ -50,5 +50,5 @@ class Hbase extends SparkBatchSource {
     reader.load()
   }
 
-  override def getPluginName: String = "hbase"
+  override def getPluginName: String = "Hbase"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
@@ -49,4 +49,6 @@ class Hbase extends SparkBatchSource {
 
     reader.load()
   }
+
+  override def getPluginName: String = "HbaseSource"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/src/main/scala/org/apache/seatunnel/spark/hbase/source/Hbase.scala
@@ -50,5 +50,5 @@ class Hbase extends SparkBatchSource {
     reader.load()
   }
 
-  override def getPluginName: String = "HbaseSource"
+  override def getPluginName: String = "hbase"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/sink/Hive.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/sink/Hive.scala
@@ -61,4 +61,6 @@ class Hive extends SparkBatchSink with Logging {
       }
     }
   }
+
+  override def getPluginName: String = "Hive"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
@@ -32,5 +32,5 @@ class Hive extends SparkBatchSource {
     env.getSparkSession.sql(config.getString("pre_sql"))
   }
 
-  override def getPluginName: String = "hive"
+  override def getPluginName: String = "Hive"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
@@ -31,4 +31,6 @@ class Hive extends SparkBatchSource {
   override def getData(env: SparkEnvironment): Dataset[Row] = {
     env.getSparkSession.sql(config.getString("pre_sql"))
   }
+
+  override def getPluginName: String = "HiveSource"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hive/src/main/scala/org/apache/seatunnel/spark/hive/source/Hive.scala
@@ -32,5 +32,5 @@ class Hive extends SparkBatchSource {
     env.getSparkSession.sql(config.getString("pre_sql"))
   }
 
-  override def getPluginName: String = "HiveSource"
+  override def getPluginName: String = "hive"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/sink/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/sink/Hudi.scala
@@ -47,5 +47,5 @@ class Hudi extends SparkBatchSink {
       .save(config.getString("hoodie.base.path"))
   }
 
-  override def getPluginName: String = "hudi"
+  override def getPluginName: String = "Hudi"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/sink/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/sink/Hudi.scala
@@ -46,4 +46,6 @@ class Hudi extends SparkBatchSink {
     writer.mode(config.getString("save_mode"))
       .save(config.getString("hoodie.base.path"))
   }
+
+  override def getPluginName: String = "hudi"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
@@ -39,4 +39,6 @@ class Hudi extends SparkBatchSource {
 
     reader.load(config.getString("hoodie.datasource.read.paths"))
   }
+
+  override def getPluginName: String = "HudiSource"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
@@ -40,5 +40,5 @@ class Hudi extends SparkBatchSource {
     reader.load(config.getString("hoodie.datasource.read.paths"))
   }
 
-  override def getPluginName: String = "hudi"
+  override def getPluginName: String = "Hudi"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
@@ -40,5 +40,5 @@ class Hudi extends SparkBatchSource {
     reader.load(config.getString("hoodie.datasource.read.paths"))
   }
 
-  override def getPluginName: String = "HudiSource"
+  override def getPluginName: String = "hudi"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/sink/Iceberg.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/sink/Iceberg.scala
@@ -53,4 +53,6 @@ class Iceberg extends SparkBatchSink {
         "saveMode" -> "append"))
     config = config.withFallback(defaultConfig)
   }
+
+  override def getPluginName: String = "Iceberg"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
@@ -47,5 +47,5 @@ class Iceberg extends SparkBatchSource {
     checkAllExists(config, "path", "pre_sql")
   }
 
-  override def getPluginName: String = "IcebergSource"
+  override def getPluginName: String = "iceberg"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
@@ -47,5 +47,5 @@ class Iceberg extends SparkBatchSource {
     checkAllExists(config, "path", "pre_sql")
   }
 
-  override def getPluginName: String = "iceberg"
+  override def getPluginName: String = "Iceberg"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-iceberg/src/main/scala/org/apache/seatunnel/spark/iceberg/source/Iceberg.scala
@@ -47,4 +47,5 @@ class Iceberg extends SparkBatchSource {
     checkAllExists(config, "path", "pre_sql")
   }
 
+  override def getPluginName: String = "IcebergSource"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
@@ -69,4 +69,6 @@ class Jdbc extends SparkBatchSink {
         "duplicateIncs" -> ""))
     config = config.withFallback(defaultConfig)
   }
+
+  override def getPluginName: String = "jdbc"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
@@ -70,5 +70,5 @@ class Jdbc extends SparkBatchSink {
     config = config.withFallback(defaultConfig)
   }
 
-  override def getPluginName: String = "jdbc"
+  override def getPluginName: String = "Jdbc"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
@@ -60,4 +60,6 @@ class Jdbc extends SparkBatchSource {
 
     reader
   }
+
+  override def getPluginName: String = "JdbcSource"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
@@ -61,5 +61,5 @@ class Jdbc extends SparkBatchSource {
     reader
   }
 
-  override def getPluginName: String = "jdbc"
+  override def getPluginName: String = "Jdbc"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/source/Jdbc.scala
@@ -61,5 +61,5 @@ class Jdbc extends SparkBatchSource {
     reader
   }
 
-  override def getPluginName: String = "JdbcSource"
+  override def getPluginName: String = "jdbc"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/sink/Kafka.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/sink/Kafka.scala
@@ -102,4 +102,6 @@ class Kafka extends SparkBatchSink with Logging {
         }
     }
   }
+
+  override def getPluginName: String = "Kafka"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/source/KafkaStream.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/source/KafkaStream.scala
@@ -124,4 +124,6 @@ class KafkaStream extends SparkStreamingSource[(String, String)] {
       }
     }
   }
+
+  override def getPluginName: String = "kafkaStream"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/source/KafkaStream.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kafka/src/main/scala/org/apache/seatunnel/spark/kafka/source/KafkaStream.scala
@@ -125,5 +125,5 @@ class KafkaStream extends SparkStreamingSource[(String, String)] {
     }
   }
 
-  override def getPluginName: String = "kafkaStream"
+  override def getPluginName: String = "KafkaStream"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/sink/Kudu.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/sink/Kudu.scala
@@ -54,5 +54,5 @@ class Kudu extends SparkBatchSink {
     }
   }
 
-  override def getPluginName: String = "kudu"
+  override def getPluginName: String = "Kudu"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/sink/Kudu.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/sink/Kudu.scala
@@ -53,4 +53,6 @@ class Kudu extends SparkBatchSink {
       case "insertIgnore" => kuduContext.insertIgnoreRows(df, table)
     }
   }
+
+  override def getPluginName: String = "kudu"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/source/Kudu.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/source/Kudu.scala
@@ -41,4 +41,5 @@ class Kudu extends SparkBatchSource {
     ds
   }
 
+  override def getPluginName: String = "kudu"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/source/Kudu.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-kudu/src/main/scala/org/apache/seatunnel/spark/kudu/source/Kudu.scala
@@ -41,5 +41,5 @@ class Kudu extends SparkBatchSource {
     ds
   }
 
-  override def getPluginName: String = "kudu"
+  override def getPluginName: String = "Kudu"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/sink/MongoDB.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/sink/MongoDB.scala
@@ -54,4 +54,5 @@ class MongoDB extends SparkBatchSink {
     MongoSpark.save(df, writeConfig)
   }
 
+  override def getPluginName: String = "mongodb"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/sink/MongoDB.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/sink/MongoDB.scala
@@ -54,5 +54,5 @@ class MongoDB extends SparkBatchSink {
     MongoSpark.save(df, writeConfig)
   }
 
-  override def getPluginName: String = "mongodb"
+  override def getPluginName: String = "MongoDB"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/source/MongoDB.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/source/MongoDB.scala
@@ -69,5 +69,5 @@ class MongoDB extends SparkBatchSource {
     CheckConfigUtil.checkAllExists(config, "readconfig.uri", "readconfig.database", "readconfig.collection")
   }
 
-  override def getPluginName: String = "mongodb"
+  override def getPluginName: String = "MongoDB"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/source/MongoDB.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-mongodb/src/main/scala/org/apache/seatunnel/spark/mongodb/source/MongoDB.scala
@@ -69,4 +69,5 @@ class MongoDB extends SparkBatchSource {
     CheckConfigUtil.checkAllExists(config, "readconfig.uri", "readconfig.database", "readconfig.collection")
   }
 
+  override def getPluginName: String = "mongodb"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-neo4j/src/main/scala/org/apache/seatunnel/spark/neo4j/source/Neo4j.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-neo4j/src/main/scala/org/apache/seatunnel/spark/neo4j/source/Neo4j.scala
@@ -53,4 +53,6 @@ class Neo4j extends SparkBatchSource {
       neo4jConf.put(entry.getKey, config.getString(entry.getKey))
     })
   }
+
+  override def getPluginName: String = "Neo4j"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-phoenix/src/main/scala/org/apache/seatunnel/spark/phoenix/sink/Phoenix.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-phoenix/src/main/scala/org/apache/seatunnel/spark/phoenix/sink/Phoenix.scala
@@ -76,4 +76,5 @@ class Phoenix extends SparkBatchSink with Logging {
     }
   }
 
+  override def getPluginName: String = "Phoenix"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-phoenix/src/main/scala/org/apache/seatunnel/spark/phoenix/source/Phoenix.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-phoenix/src/main/scala/org/apache/seatunnel/spark/phoenix/source/Phoenix.scala
@@ -74,4 +74,5 @@ class Phoenix extends SparkBatchSource with Logging {
     }
   }
 
+  override def getPluginName: String = "Phoenix"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
@@ -109,5 +109,5 @@ class Redis extends SparkBatchSink with Logging {
     sc.toRedisHASH(value, hashName)(redisConfig = redisConfig)
   }
 
-  override def getPluginName: String = "redis"
+  override def getPluginName: String = "Redis"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
@@ -108,4 +108,6 @@ class Redis extends SparkBatchSink with Logging {
     val value = data.rdd.map(x => (x.getString(0), x.getString(1)))
     sc.toRedisHASH(value, hashName)(redisConfig = redisConfig)
   }
+
+  override def getPluginName: String = "redis"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/source/Redis.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/source/Redis.scala
@@ -123,5 +123,5 @@ class Redis extends SparkBatchSource {
     sc.fromRedisZSet(keysOrKeyPattern, partitionNum)(redisConfig = redisConfig)
   }
 
-  override def getPluginName: String = "redis"
+  override def getPluginName: String = "Redis"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/source/Redis.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/source/Redis.scala
@@ -123,4 +123,5 @@ class Redis extends SparkBatchSource {
     sc.fromRedisZSet(keysOrKeyPattern, partitionNum)(redisConfig = redisConfig)
   }
 
+  override def getPluginName: String = "redis"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-socket/src/main/scala/org/apache/seatunnel/spark/socket/source/SocketStream.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-socket/src/main/scala/org/apache/seatunnel/spark/socket/source/SocketStream.scala
@@ -49,4 +49,5 @@ class SocketStream extends SparkStreamingSource[String] {
     sparkSession.createDataFrame(rowsRDD, schema)
   }
 
+  override def getPluginName: String = "SocketStream"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/sink/Tidb.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/sink/Tidb.scala
@@ -60,5 +60,5 @@ class Tidb extends SparkBatchSink {
     checkAllExists(config, "addr", "port", "database", "table", "user", "password")
   }
 
-  override def getPluginName: String = "Tidb"
+  override def getPluginName: String = "TiDB"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/sink/Tidb.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/sink/Tidb.scala
@@ -60,4 +60,5 @@ class Tidb extends SparkBatchSink {
     checkAllExists(config, "addr", "port", "database", "table", "user", "password")
   }
 
+  override def getPluginName: String = "Tidb"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/source/Tidb.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/source/Tidb.scala
@@ -37,5 +37,5 @@ class Tidb extends SparkBatchSource {
     spark.sql(config.getString("pre_sql"))
   }
 
-  override def getPluginName: String = "Tidb"
+  override def getPluginName: String = "TiDB"
 }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/source/Tidb.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-tidb/src/main/scala/org/apache/seatunnel/spark/tidb/source/Tidb.scala
@@ -36,4 +36,6 @@ class Tidb extends SparkBatchSource {
     spark.sql("use " + config.getString("database"))
     spark.sql(config.getString("pre_sql"))
   }
+
+  override def getPluginName: String = "Tidb"
 }

--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/config/PluginFactory.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/config/PluginFactory.java
@@ -120,8 +120,7 @@ public class PluginFactory<ENVIRONMENT extends RuntimeEnv> {
         for (Iterator<Plugin<?>> it = plugins.iterator(); it.hasNext(); ) {
             try {
                 Plugin<?> plugin = it.next();
-                Class<?> serviceClass = plugin.getClass();
-                if (StringUtils.equalsIgnoreCase(serviceClass.getSimpleName(), pluginName)) {
+                if (StringUtils.equalsIgnoreCase(plugin.getPluginName(), pluginName)) {
                     return plugin;
                 }
             } catch (ServiceConfigurationError e) {

--- a/seatunnel-transforms/seatunnel-transforms-flink/seatunnel-transform-flink-split/src/main/java/org/apache/seatunnel/flink/transform/Split.java
+++ b/seatunnel-transforms/seatunnel-transforms-flink/seatunnel-transform-flink-split/src/main/java/org/apache/seatunnel/flink/transform/Split.java
@@ -101,4 +101,8 @@ public class Split implements FlinkStreamTransform, FlinkBatchTransform {
         rowTypeInfo = new RowTypeInfo(types, fields.toArray(new String[0]));
     }
 
+    @Override
+    public String getPluginName() {
+        return "split";
+    }
 }

--- a/seatunnel-transforms/seatunnel-transforms-flink/seatunnel-transform-flink-sql/src/main/java/org/apache/seatunnel/flink/transform/Sql.java
+++ b/seatunnel-transforms/seatunnel-transforms-flink/seatunnel-transform-flink-sql/src/main/java/org/apache/seatunnel/flink/transform/Sql.java
@@ -84,4 +84,9 @@ public class Sql implements FlinkStreamTransform, FlinkBatchTransform {
     public void prepare(FlinkEnvironment env) {
         sql = config.getString("sql");
     }
+
+    @Override
+    public String getPluginName() {
+        return "sql";
+    }
 }

--- a/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-json/src/main/scala/org/apache/seatunnel/spark/transform/Json.scala
+++ b/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-json/src/main/scala/org/apache/seatunnel/spark/transform/Json.scala
@@ -135,4 +135,6 @@ class Json extends BaseSparkTransform {
       this.useCustomSchema = true
     }
   }
+
+  override def getPluginName: String = "json"
 }

--- a/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-split/src/main/scala/org/apache/seatunnel/spark/transform/Split.scala
+++ b/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-split/src/main/scala/org/apache/seatunnel/spark/transform/Split.scala
@@ -85,4 +85,6 @@ class Split extends BaseSparkTransform {
     }
     filled.toSeq
   }
+
+  override def getPluginName: String = "split"
 }

--- a/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-sql/src/main/scala/org/apache/seatunnel/spark/transform/Sql.scala
+++ b/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-sql/src/main/scala/org/apache/seatunnel/spark/transform/Sql.scala
@@ -31,4 +31,6 @@ class Sql extends BaseSparkTransform {
     checkAllExists(config, "sql")
   }
 
+  override def getPluginName: String = "sql"
+
 }


### PR DESCRIPTION
## Purpose of this pull request
close #1662 
This pr add a new method in Plugin.
```java
   /**
     * Return the plugin name, this is used in seatunnel conf DSL.
     *
     * @return plugin name.
     */
    default String getPluginName() {
        return this.getClass().getSimpleName();
    }
```
And will use this method to charge whether the plugin should be used. And override this method in subclass to adapte the current plugin name.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in you PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
