### PR TITLE
[Improvement][connector] Build different version of elasticsearch connector by property

### DIFF
--- a/docs/en/connector/sink/Elasticsearch.mdx
+++ b/docs/en/connector/sink/Elasticsearch.mdx
@@ -13,7 +13,7 @@ Engine Supported and plugin name
 
 * [x] Spark: Elasticsearch(supported `ElasticSearch version is >= 2.x and <7.0.0`)
 * [x] Flink: Elasticsearch(supported `ElasticSearch version = 7.x`, if you want use Elasticsearch version is 6.x,
-please use the source code to modify the dependencies corresponding to `seatunnel/seatunnel-connectors/seatunnel-connectors-flink/pom.xml` and repackage)
+please use the source code to repackage by execute `mvn clean package -Delasticsearch=6`)
 
 :::
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,8 @@
         <play-mailer.version>7.0.2</play-mailer.version>
         <phoenix-spark.version>5.0.0-HBase-2.0</phoenix-spark.version>
         <zkclient.version>0.3</zkclient.version>
-        <elasticsearch7.version>7.5.1</elasticsearch7.version>
+        <elasticsearch6.client.version>6.3.1</elasticsearch6.client.version>
+        <elasticsearch7.client.version>7.5.1</elasticsearch7.client.version>
         <flink-shaded-hadoop-2.version>2.7.5-7.0</flink-shaded-hadoop-2.version>
         <parquet-avro.version>1.10.0</parquet-avro.version>
         <elasticsearch-spark.version>6.8.3</elasticsearch-spark.version>
@@ -158,8 +159,10 @@
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
         <maven-scm-provider-jgit.version>1.9.5</maven-scm-provider-jgit.version>
         <testcontainer.version>1.16.3</testcontainer.version>
+        <!-- Option args -->
         <skipUT>false</skipUT>
         <skipIT>true</skipIT>
+        <elasticsearch>7</elasticsearch>
     </properties>
 
     <dependencyManagement>
@@ -328,7 +331,7 @@
 
             <dependency>
                 <groupId>org.apache.flink</groupId>
-                <artifactId>flink-connector-elasticsearch7_${scala.binary.version}</artifactId>
+                <artifactId>flink-connector-elasticsearch${elasticsearch}_${scala.binary.version}</artifactId>
                 <version>${flink.version}</version>
             </dependency>
 

--- a/seatunnel-connectors/seatunnel-connectors-flink/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink/pom.xml
@@ -33,8 +33,7 @@
     <modules>
         <module>seatunnel-connector-flink-console</module>
         <module>seatunnel-connector-flink-druid</module>
-        <module>seatunnel-connector-flink-elasticsearch7</module>
-        <!--        <module>seatunnel-connector-flink-elasticsearch6</module>-->
+        <module>seatunnel-connector-flink-elasticsearch${elasticsearch}</module>
         <module>seatunnel-connector-flink-file</module>
         <module>seatunnel-connector-flink-jdbc</module>
         <module>seatunnel-connector-flink-kafka</module>

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch6/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch6/pom.xml
@@ -23,14 +23,12 @@
     <parent>
         <groupId>org.apache.seatunnel</groupId>
         <artifactId>seatunnel-connectors-flink</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>seatunnel-connector-flink-elasticsearch6</artifactId>
-    <properties>
-        <elasticsearch6.version>6.3.1</elasticsearch6.version>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
@@ -53,12 +51,12 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-elasticsearch6_${scala.binary.version}</artifactId>
+            <artifactId>flink-connector-elasticsearch${elasticsearch}_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>${elasticsearch6.version}</version>
+            <version>${elasticsearch6.client.version}</version>
         </dependency>
     </dependencies>
 

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch7/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-elasticsearch7/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>${elasticsearch7.version}</version>
+            <version>${elasticsearch7.client.version}</version>
         </dependency>
     </dependencies>
 

--- a/seatunnel-core/seatunnel-core-flink/pom.xml
+++ b/seatunnel-core/seatunnel-core-flink/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
-            <artifactId>seatunnel-connector-flink-elasticsearch7</artifactId>
+            <artifactId>seatunnel-connector-flink-elasticsearch${elasticsearch}</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Purpose of this pull request

This PR is a supplementation of #1663, make user can build with different es connector by
```shell
mvn clean package -Delasticsearch=6
```
No need to change the pom.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/development/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
