### PR TITLE
Retrieve seatunnel-config form maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,11 @@
     </mailingLists>
 
     <modules>
-        <module>seatunnel-config</module>
+        <!--
+            We retrieve the config module from maven repository. If you want to change the config module,
+            you need to open this annotation and change the dependency of config-shade to project.
+            <module>seatunnel-config</module>
+        -->
         <module>seatunnel-common</module>
         <module>seatunnel-apis</module>
         <module>seatunnel-core</module>
@@ -85,6 +89,7 @@
 
     <properties>
         <revision>2.1.1-SNAPSHOT</revision>
+        <seatunnel.config.shade.version>2.1.1</seatunnel.config.shade.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <scala.version>2.11.12</scala.version>
@@ -168,6 +173,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>seatunnel-config-shade</artifactId>
+                <version>${seatunnel.config.shade.version}</version>
+            </dependency>
             <!--spark-->
             <dependency>
                 <groupId>org.apache.spark</groupId>

--- a/seatunnel-apis/seatunnel-api-base/pom.xml
+++ b/seatunnel-apis/seatunnel-api-base/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>seatunnel-config-shade</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/seatunnel-apis/seatunnel-api-flink/pom.xml
+++ b/seatunnel-apis/seatunnel-api-flink/pom.xml
@@ -89,5 +89,4 @@
 
     </dependencies>
 
-
 </project>

--- a/seatunnel-common/pom.xml
+++ b/seatunnel-common/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>seatunnel-config-shade</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -55,6 +54,5 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/seatunnel-config/README.md
+++ b/seatunnel-config/README.md
@@ -1,0 +1,25 @@
+# Introduction
+The `seatunnel-config` is used to parse `seatunnel.conf` files. This module is based on `com.typesafe.config`, 
+We have made some enhancement and import our enhancement by using maven shade. Most of the times, you don't need to directly 
+using this module, since you can receive from maven repository.
+
+# How to modify the config module
+If you want to modify the config module, you can follow the steps below.
+1. Open the `seatunnel-config` module.
+```xml
+<!--
+    We retrieve the config module from maven repository. If you want to change the config module,
+    you need to open this annotation and change the dependency of config-shade to project.
+    <module>seatunnel-config</module>
+-->
+```
+Open the annuotaion in `pom.xml` file, to import the `seatunnel-config` module.
+2. Replace the `config-shade` dependency to project.
+```xml
+<dependency>
+    <groupId>org.apache.seatunnel</groupId>
+    <artifactId>seatunnel-config-shade</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+Add `<version>${project.version}</version>` to `seatunnel-config-shade` everywhere you use.

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -584,6 +584,8 @@ scala-xml_2.11-1.0.5.jar
 scala-xml_2.11-1.3.0.jar
 scalaj-http_2.11-2.3.0.jar
 scalap-2.11.12.jar
+seatunnel-config-base-2.1.1.jar
+seatunnel-config-shade-2.1.1.jar
 servlet-api-2.5.jar
 shims-0.9.0.jar
 shims-0.9.22.jar


### PR DESCRIPTION
## Purpose of this pull request
close #1755 
Retrieve seatunnel-config from maven, fix when import `seatunnel` into IDE, we need to install first. 

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
