### PR TITLE
[hotfix][connector-source-fake][docs] Updated title to match the source examples

### DIFF
--- a/docs/en/connector/source/Fake.mdx
+++ b/docs/en/connector/source/Fake.mdx
@@ -109,7 +109,7 @@ The generated data is as follows, randomly extract the string from the `content`
 </TabItem>
 <TabItem value="flink">
 
-### FakeSource
+### FakeSourceStream
 
 ```bash
 source {
@@ -120,7 +120,7 @@ source {
 }
 ```
 
-### FakeSourceStream
+### FakeSource
 
 ```bash
 source {


### PR DESCRIPTION
## Purpose of this pull request

The title of `FakeSourceStream` section was labeled `FakeSource` and `FakeSource` was labeled `FakeSourceStream`.  Updated the title according to the example.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
