### PR TITLE
[Feature][Seatunnel-core-flink/spark] format usage help message

### DIFF
--- a/seatunnel-core/seatunnel-core-flink/src/main/java/org/apache/seatunnel/core/flink/utils/CommandLineUtils.java
+++ b/seatunnel-core/seatunnel-core-flink/src/main/java/org/apache/seatunnel/core/flink/utils/CommandLineUtils.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.core.flink.args.FlinkCommandArgs;
 import org.apache.seatunnel.core.flink.config.FlinkJobType;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.UnixStyleUsageFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,7 @@ public class CommandLineUtils {
         // The args is not belongs to seatunnel, add into flink params
         flinkCommandArgs.setFlinkParams(jCommander.getUnknownOptions());
         if (flinkCommandArgs.isHelp()) {
+            jCommander.setUsageFormatter(new UnixStyleUsageFormatter(jCommander));
             jCommander.usage();
             System.exit(USAGE_EXIT_CODE);
         }

--- a/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
@@ -35,6 +35,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigResolveOptions;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.UnixStyleUsageFormatter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
@@ -133,6 +134,7 @@ public class SparkStarter implements Starter {
                 .args(args)
                 .build();
         if (commandArgs.isHelp()) {
+            commander.setUsageFormatter(new UnixStyleUsageFormatter(commander));
             commander.usage();
             System.exit(USAGE_EXIT_CODE);
         }


### PR DESCRIPTION
## Purpose of this pull request

related issue: https://github.com/apache/incubator-seatunnel/issues/1787

With this PR, we can get a better output of usage help message

Before
```shell
./start-seatunnel-flink.sh -h
Usage: start-seatunnel-flink.sh [options] Options: -t, --check check config Default: false start-seatunnel-flink.sh start-seatunnel-spark.sh start-seatunnel-sql.sh -c, --config Config file -h, --help Show the usage message -r, --run-mode job run mode, run or run-application Default: RUN Possible Values: [RUN, APPLICATION_RUN] -i, --variable variable substitution, such as -i city=beijing, or -i date=20190318 Default: []
```

After
```shell
Usage: start-seatunnel-sql.sh [options]
  Options:
    -t, --check    check config (default: false)
  * -c, --config   Config file
    -h, --help     Show the usage message
    -r, --run-mode job run mode, run or run-application (default: RUN) 
                   (values: [RUN, APPLICATION_RUN])
    -i, --variable variable substitution, such as -i city=beijing, or -i 
                   date=20190318 (default: [])
```

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
