### PR TITLE
[Bug] [SparkStarter] when spark extraJavaOptions is null, an exception parameter will be generated, resulting in submission failure

### DIFF
--- a/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
@@ -161,8 +161,8 @@ public class SparkStarter implements Starter {
                 .filter(pair -> pair.length == 2)
                 .forEach(pair -> System.setProperty(pair[0], pair[1]));
         this.sparkConf = getSparkConf(commandArgs.getConfigFile());
-        String driverJavaOpts = this.sparkConf.get("spark.driver.extraJavaOptions");
-        String executorJavaOpts = this.sparkConf.get("spark.executor.extraJavaOptions");
+        String driverJavaOpts = this.sparkConf.getOrDefault("spark.driver.extraJavaOptions", "");
+        String executorJavaOpts = this.sparkConf.getOrDefault("spark.executor.extraJavaOptions", "");
         if (!commandArgs.getVariables().isEmpty()) {
             String properties = commandArgs.getVariables()
                     .stream()
@@ -170,8 +170,8 @@ public class SparkStarter implements Starter {
                     .collect(Collectors.joining(" "));
             driverJavaOpts += " " + properties;
             executorJavaOpts += " " + properties;
-            this.sparkConf.put("spark.driver.extraJavaOptions", driverJavaOpts);
-            this.sparkConf.put("spark.executor.extraJavaOptions", executorJavaOpts);
+            this.sparkConf.put("spark.driver.extraJavaOptions", driverJavaOpts.trim());
+            this.sparkConf.put("spark.executor.extraJavaOptions", executorJavaOpts.trim());
         }
     }
 


### PR DESCRIPTION


issue_link: https://github.com/apache/incubator-seatunnel/issues/1792
close #1792 
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
Fix the bug of task submission failure when submitting tasks with --variable using start-seatunnel-spark.sh
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
