### PR TITLE
[hotfix][connector-file][docs] Corrected description - removed reference to Doris table

### DIFF
--- a/docs/en/connector/source/File.mdx
+++ b/docs/en/connector/source/File.mdx
@@ -5,9 +5,7 @@ import TabItem from '@theme/TabItem';
 
 ## Description
 
-read data from local or hdfs file.
-
-Write Data to a Doris Table.
+Read data from local or hdfs file.
 
 :::tip
 


### PR DESCRIPTION

## Purpose of this pull request

The description for File source connector indicates `Write Data to a Doris Table`.  Removed the reference to Doris table for File connector.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
