### PR TITLE
[Bug] [example] IDEA cannot run the examples directly without Lombok plugin

### DIFF
--- a/docs/en/contribution/setup.md
+++ b/docs/en/contribution/setup.md
@@ -41,6 +41,11 @@ Now, you can open your JetBrains IntelliJ IDEA and explore the source code, but 
 you should also install JetBrains IntelliJ IDEA's [Scala plugin](https://plugins.jetbrains.com/plugin/1347-scala).
 See [install plugins for IDEA](https://www.jetbrains.com/help/idea/managing-plugins.html#install-plugins) if you want to.
 
+### Install JetBrains IDEA Lombok Plugin
+
+Before running the following example, you should also install JetBrains IntelliJ IDEA's [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok).
+See [install plugins for IDEA](https://www.jetbrains.com/help/idea/managing-plugins.html#install-plugins) if you want to.
+
 ## Run Simple Example
 
 After all the above things are done, you just finish the environment setup and can run an example we provide to you out


### PR DESCRIPTION
Add a step of Install JetBrains IDEA Lombok Plugin, otherwise the IDEA cannot run the example.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->
https://github.com/apache/incubator-seatunnel/issues/1840

## Purpose of this pull request
Add a step of Install JetBrains IDEA Lombok Plugin in in the document [Set Up Develop Environment](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/setup.md) to remind people to install the Lombok plugin, just as it reminds people to install Scala plugin. Otherwise, IDEA cannot run the examples successfully.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
