### PR TITLE
[Feature][Flink-SQL] Support connector dynamic loading for FlinkSQL job and add Flink SQL jdbc connector

### DIFF
--- a/docs/en/connector/flink-sql/Jdbc.md
+++ b/docs/en/connector/flink-sql/Jdbc.md
@@ -1,0 +1,65 @@
+# Flink SQL JDBC Connector
+
+## Description
+
+We can use the Flink SQL JDBC Connector to connect to a JDBC database. Refer to the [Flink SQL JDBC Connector](https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/table/jdbc/index.html) for more information.
+
+
+## Usage
+
+### 1. download driver
+A driver dependency is also required to connect to a specified database. Here are drivers currently supported:
+
+| Driver     | Group Id	         | Artifact Id	        | JAR           |
+|------------|-------------------|----------------------|---------------|
+| MySQL	     | mysql	         | mysql-connector-java | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
+| PostgreSQL | org.postgresql	 | postgresql	        | [Download](https://jdbc.postgresql.org/download.html) |
+| Derby	     | org.apache.derby	 | derby	            | [Download](http://db.apache.org/derby/derby_downloads.html) |
+
+After downloading the driver jars, you need to place the jars into $FLINK_HOME/lib/.
+
+### 2. prepare data
+Start mysql server locally, and create a database named "test" and a table named "test_table" in the database.
+
+The table "test_table" could be created by the following SQL:
+```bash
+CREATE TABLE IF NOT EXISTS `test_table`(
+   `id` INT UNSIGNED AUTO_INCREMENT,
+   `name` VARCHAR(100) NOT NULL,
+   PRIMARY KEY ( `id` )
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
+
+Insert some data into the table "test_table".
+
+### 3. seatunnel config 
+Prepare a seatunnel config file with the following content:
+```text
+SET table.dml-sync = true;
+
+CREATE TABLE test (
+  id BIGINT,
+  name STRING
+) WITH (
+'connector'='jdbc',
+  'url' = 'jdbc:mysql://localhost:3306/test',
+  'table-name' = 'test_table',
+  'username' = '<replace with your username>',
+  'password' = '<replace with your password>'
+);
+
+CREATE TABLE print_table (
+  id BIGINT,
+  name STRING
+) WITH (
+  'connector' = 'print',
+  'sink.parallelism' = '1'
+);
+
+INSERT INTO print_table SELECT * FROM test;
+```
+
+### 4. run job
+```bash
+./bin/start-seatunnel-sql.sh --config <path/to/your/config>
+```

--- a/docs/en/connector/flink-sql/Jdbc.md
+++ b/docs/en/connector/flink-sql/Jdbc.md
@@ -34,7 +34,7 @@ Insert some data into the table "test_table".
 
 ### 3. seatunnel config 
 Prepare a seatunnel config file with the following content:
-```text
+```sql
 SET table.dml-sync = true;
 
 CREATE TABLE test (

--- a/docs/en/connector/flink-sql/Jdbc.md
+++ b/docs/en/connector/flink-sql/Jdbc.md
@@ -22,7 +22,7 @@ After downloading the driver jars, you need to place the jars into $FLINK_HOME/l
 Start mysql server locally, and create a database named "test" and a table named "test_table" in the database.
 
 The table "test_table" could be created by the following SQL:
-```bash
+```sql
 CREATE TABLE IF NOT EXISTS `test_table`(
    `id` INT UNSIGNED AUTO_INCREMENT,
    `name` VARCHAR(100) NOT NULL,

--- a/seatunnel-connectors/seatunnel-connectors-flink-sql-dist/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink-sql-dist/pom.xml
@@ -28,7 +28,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.seatunnel</groupId>
-<!--      <artifactId>seatunnel-connector-flink-console</artifactId>-->
       <artifactId>flink-sql-connector-jdbc</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/seatunnel-connectors/seatunnel-connectors-flink-sql-dist/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink-sql-dist/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>seatunnel-connectors</artifactId>
+    <groupId>org.apache.seatunnel</groupId>
+    <version>${revision}</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>seatunnel-connectors-flink-sql-dist</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.seatunnel</groupId>
+<!--      <artifactId>seatunnel-connector-flink-console</artifactId>-->
+      <artifactId>flink-sql-connector-jdbc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-connector</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <type>jar</type>
+              <includeTypes>jar</includeTypes>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/seatunnel-connectors/seatunnel-connectors-flink-sql/flink-sql-connector-jdbc/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink-sql/flink-sql-connector-jdbc/pom.xml
@@ -1,42 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
     this work for additional information regarding copyright ownership.
     The ASF licenses this file to You under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License.  You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.apache.seatunnel</groupId>
-        <artifactId>seatunnel</artifactId>
-        <version>${revision}</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>seatunnel-connectors-flink-sql</artifactId>
+    <groupId>org.apache.seatunnel</groupId>
+    <version>${revision}</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>seatunnel-connectors</artifactId>
-    <packaging>pom</packaging>
+  <artifactId>flink-sql-connector-jdbc</artifactId>
 
-    <modules>
-        <module>seatunnel-connectors-flink</module>
-        <module>seatunnel-connectors-flink-dist</module>
-        <module>seatunnel-connectors-spark</module>
-        <module>seatunnel-connectors-spark-dist</module>
-        <module>seatunnel-connectors-flink-sql</module>
-        <module>seatunnel-connectors-flink-sql-dist</module>
-    </modules>
-
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-connector-jdbc_2.11</artifactId>
+      <version>1.13.6</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/seatunnel-connectors/seatunnel-connectors-flink-sql/flink-sql-connector-jdbc/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink-sql/flink-sql-connector-jdbc/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-jdbc_2.11</artifactId>
-      <version>1.13.6</version>
+      <version>${flink.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/seatunnel-connectors/seatunnel-connectors-flink-sql/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink-sql/pom.xml
@@ -1,42 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
     this work for additional information regarding copyright ownership.
     The ASF licenses this file to You under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License.  You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.apache.seatunnel</groupId>
-        <artifactId>seatunnel</artifactId>
-        <version>${revision}</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-
+  <parent>
     <artifactId>seatunnel-connectors</artifactId>
-    <packaging>pom</packaging>
+    <groupId>org.apache.seatunnel</groupId>
+    <version>${revision}</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <modules>
-        <module>seatunnel-connectors-flink</module>
-        <module>seatunnel-connectors-flink-dist</module>
-        <module>seatunnel-connectors-spark</module>
-        <module>seatunnel-connectors-spark-dist</module>
-        <module>seatunnel-connectors-flink-sql</module>
-        <module>seatunnel-connectors-flink-sql-dist</module>
-    </modules>
+  <artifactId>seatunnel-connectors-flink-sql</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>flink-sql-connector-jdbc</module>
+  </modules>
+
 
 </project>

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
@@ -34,6 +34,13 @@ public class CustomClassLoader extends URLClassLoader {
         super(new URL[0]);
     }
 
+    /*
+     * If the table declared in 'create table' with connector 'xxx' and the table is not referenced in the job, namely,
+     * used in the 'insert into' statement, the connector 'xxx' will not be needed by Flink.
+     * So it might be ok fail to load it. If it's needed, we can see the error in Flink logs.
+     *
+     * Refer https://github.com/apache/incubator-seatunnel/pull/1850
+     */
     public void addJar(Path jarPath) {
         try {
             this.addURL(jarPath.toUri().toURL());

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
+// TODO: maybe a unified plugin-style discovery mechanism is better.
 public class CustomClassLoader extends URLClassLoader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomClassLoader.class);

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.sql.classloader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+public class CustomClassLoader extends URLClassLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomClassLoader.class);
+
+    public CustomClassLoader() {
+        super(new URL[0]);
+    }
+
+    public void addJar(Path jarPath) {
+        try {
+            this.addURL(jarPath.toUri().toURL());
+        } catch (MalformedURLException e) {
+            LOGGER.error("Failed to add jar to classloader. Jar: {}", jarPath, e);
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-core-flink-sql/src/test/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoaderTest.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/test/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoaderTest.java
@@ -1,0 +1,18 @@
+package org.apache.seatunnel.core.sql.classloader;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class CustomClassLoaderTest {
+
+    @Test
+    public void testAddJar() {
+        CustomClassLoader classLoader = new CustomClassLoader();
+
+        File file = new File(ClassLoader.getSystemResource("flink.sql.conf.template").getPath());
+        classLoader.addJar(file.toPath());
+        Assert.assertEquals(classLoader.getURLs()[0].toString(), file.toURI().toString());
+    }
+}

--- a/seatunnel-core/seatunnel-core-flink-sql/src/test/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoaderTest.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/test/java/org/apache/seatunnel/core/sql/classloader/CustomClassLoaderTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.core.sql.classloader;
 
 import org.junit.Assert;

--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -99,6 +99,16 @@
             <outputDirectory>/connectors/flink</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>../seatunnel-connectors/seatunnel-connectors-flink-sql-dist/target/lib</directory>
+            <includes>
+                <include>flink-sql-connector*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>%regex[.*((javadoc)|(sources))\.jar]</exclude>
+            </excludes>
+            <outputDirectory>/connectors/flink-sql</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>../seatunnel-connectors/seatunnel-connectors-spark-dist/target/lib</directory>
             <includes>
                 <include>seatunnel-connector-spark*.jar</include>


### PR DESCRIPTION
## Purpose of this pull request
issue ref: https://github.com/apache/incubator-seatunnel/issues/1849

works in this PR:
1. add flink sql build module and dist module
2. add flink sql jdbc connector
3. loading on-demand connectors for flink sql job, by parsing sql

Follow-ups:
I have add ut for this PR as much as I can, but that's not enough. We still need some follow-ups:
1. IT cases for job with specified sql connectors  
2. more detailed docs, maybe located in `docs/en/flink-sql-connector`?

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
