### PR TITLE
[Improvement][connector-spark-redis] Host and port are optional so removed existence check

### DIFF
--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-redis/src/main/scala/org/apache/seatunnel/spark/redis/sink/Redis.scala
@@ -18,7 +18,7 @@
 package org.apache.seatunnel.spark.redis.sink
 
 import com.redislabs.provider.redis.{RedisConfig, RedisEndpoint, toRedisContext}
-import org.apache.seatunnel.common.config.{CheckConfigUtil, CheckResult}
+import org.apache.seatunnel.common.config.CheckResult
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory
 import org.apache.seatunnel.spark.SparkEnvironment
 import org.apache.seatunnel.spark.batch.SparkBatchSink
@@ -56,7 +56,6 @@ class Redis extends SparkBatchSink with Logging {
   }
 
   override def checkConfig(): CheckResult = {
-    CheckConfigUtil.checkAllExists(config, HOST, PORT)
     if (config.hasPath(DATA_TYPE)) {
       val dataType = config.getString(DATA_TYPE)
       val dataTypeList = List("KV", "HASH", "SET", "ZSET", "LIST")


### PR DESCRIPTION

## Purpose of this pull request

[Host and port config parameters are optional](https://seatunnel.apache.org/docs/2.1.1/connector/sink/Redis#options) have default values so removed existence check.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
