### PR TITLE
[Feature] [transform] Use "skip_error_lines" transform sql key to control whether exit the job. Spark new feature

### DIFF
--- a/seatunnel-apis/seatunnel-api-spark/src/main/scala/org/apache/seatunnel/spark/stream/SparkStreamingExecution.scala
+++ b/seatunnel-apis/seatunnel-api-spark/src/main/scala/org/apache/seatunnel/spark/stream/SparkStreamingExecution.scala
@@ -55,7 +55,7 @@ class SparkStreamingExecution(sparkEnvironment: SparkEnvironment)
 
         source.beforeOutput()
 
-        if (ds.take(1).length > 0) {
+        if (ds != null && ds.take(1).length > 0) {
           sinks.foreach(sink => {
             SparkEnvironment.sinkProcess(sparkEnvironment, sink, ds)
           })

--- a/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-sql/src/main/scala/org/apache/seatunnel/spark/transform/Sql.scala
+++ b/seatunnel-transforms/seatunnel-transforms-spark/seatunnel-transform-spark-sql/src/main/scala/org/apache/seatunnel/spark/transform/Sql.scala
@@ -25,7 +25,18 @@ import org.apache.spark.sql.{Dataset, Row}
 class Sql extends BaseSparkTransform {
 
   override def process(data: Dataset[Row], env: SparkEnvironment): Dataset[Row] = {
-    env.getSparkSession.sql(config.getString("sql"))
+    try{
+      env.getSparkSession.sql(config.getString("sql"))
+    }catch {
+      case e:Exception =>
+        val skip_error_lines = config.getBoolean("skip_error_lines")
+        if(skip_error_lines){
+          e.printStackTrace()
+          null
+        }else{
+          throw e
+        }
+    }
   }
 
   override def checkConfig(): CheckResult = {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

https://github.com/apache/incubator-seatunnel/issues/1919

## Purpose of this pull request

When writing the data in kafka into clickhouse, if the format of message data is abnormal, use "skip_error_lines" transform sql key to control whether exit the job.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
