### PR TITLE
[fix bug] When use TiDB, Spark JDBC update mode, Error "The isolation level ‘READ-UNCOMMITTED’ is not supported. Set tidb_skip_isolation_level_check=1 to skip this error"

### DIFF
--- a/docs/en/connector/sink/Jdbc.mdx
+++ b/docs/en/connector/sink/Jdbc.mdx
@@ -66,6 +66,10 @@ Basic mode, currently supports `overwrite` , `append` , `ignore` and `error` . F
 
 Configure when `saveMode` is specified as `update` , whether to enable ssl, the default value is `false`
 
+### isolationLevel [string]
+
+The transaction isolation level, which applies to current connection. The default value is `READ_UNCOMMITTED`
+
 ### customUpdateStmt [string]
 
 Configure when `saveMode` is specified as `update` , which is used to specify the update statement template for key conflicts

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/src/main/scala/org/apache/seatunnel/spark/jdbc/sink/Jdbc.scala
@@ -40,6 +40,7 @@ class Jdbc extends SparkBatchSink {
           "password" -> config.getString("password"),
           "dbtable" -> config.getString("dbTable"),
           "useSsl" -> config.getString("useSsl"),
+          "isolationLevel" -> config.getString("isolationLevel"),
           "customUpdateStmt" -> config.getString(
             "customUpdateStmt"
           ), // Custom mysql duplicate key update statement when saveMode is update
@@ -65,6 +66,7 @@ class Jdbc extends SparkBatchSink {
         "saveMode" -> "error",
         "useSsl" -> "false",
         "showSql" -> "true",
+        "isolationLevel" -> "READ_UNCOMMITTED",
         "customUpdateStmt" -> "",
         "duplicateIncs" -> ""))
     config = config.withFallback(defaultConfig)


### PR DESCRIPTION
…n level ‘READ-UNCOMMITTED’ is not supported. Set tidb_skip_isolation_level_check=1 to skip this erro

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
