### PR TITLE
[bugfix][seatunnel-core-flink]fix same source and sink registerplugin librarycache error

### DIFF
--- a/seatunnel-apis/seatunnel-api-base/src/main/java/org/apache/seatunnel/apis/base/env/RuntimeEnv.java
+++ b/seatunnel-apis/seatunnel-api-base/src/main/java/org/apache/seatunnel/apis/base/env/RuntimeEnv.java
@@ -23,7 +23,7 @@ import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import java.net.URL;
-import java.util.List;
+import java.util.Set;
 
 /**
  * engine related runtime environment
@@ -42,6 +42,6 @@ public interface RuntimeEnv {
 
     JobMode getJobMode();
 
-    void registerPlugin(List<URL> pluginPaths);
+    void registerPlugin(Set<URL> pluginPaths);
 
 }

--- a/seatunnel-apis/seatunnel-api-flink/src/main/java/org/apache/seatunnel/flink/FlinkEnvironment.java
+++ b/seatunnel-apis/seatunnel-api-flink/src/main/java/org/apache/seatunnel/flink/FlinkEnvironment.java
@@ -49,6 +49,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FlinkEnvironment implements RuntimeEnv {
@@ -120,7 +121,7 @@ public class FlinkEnvironment implements RuntimeEnv {
     }
 
     @Override
-    public void registerPlugin(List<URL> pluginPaths) {
+    public void registerPlugin(Set<URL> pluginPaths) {
         LOGGER.info("register plugins :" + pluginPaths);
         Configuration configuration;
         try {

--- a/seatunnel-apis/seatunnel-api-spark/src/main/java/org/apache/seatunnel/spark/SparkEnvironment.java
+++ b/seatunnel-apis/seatunnel-api-spark/src/main/java/org/apache/seatunnel/spark/SparkEnvironment.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-import java.util.List;
+import java.util.Set;
 
 public class SparkEnvironment implements RuntimeEnv {
 
@@ -89,7 +89,7 @@ public class SparkEnvironment implements RuntimeEnv {
     }
 
     @Override
-    public void registerPlugin(List<URL> pluginPaths) {
+    public void registerPlugin(Set<URL> pluginPaths) {
         LOGGER.info("register plugins :" + pluginPaths);
         // TODO we use --jar parameter to support submit multi-jar in spark cluster at now. Refactor it to
         //  support submit multi-jar in code or remove this logic.

--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/config/PluginFactory.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/config/PluginFactory.java
@@ -44,6 +44,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -68,7 +70,7 @@ public class PluginFactory<ENVIRONMENT extends RuntimeEnv> {
     private static final String PLUGIN_NAME_KEY = "plugin_name";
     private static final String PLUGIN_MAPPING_FILE = "plugin-mapping.properties";
 
-    private final List<URL> pluginJarPaths;
+    private final Set<URL> pluginJarPaths;
     private final ClassLoader defaultClassLoader;
 
     static {
@@ -93,17 +95,17 @@ public class PluginFactory<ENVIRONMENT extends RuntimeEnv> {
         this.defaultClassLoader = initClassLoaderWithPaths(this.pluginJarPaths);
     }
 
-    private ClassLoader initClassLoaderWithPaths(List<URL> pluginJarPaths) {
+    private ClassLoader initClassLoaderWithPaths(Set<URL> pluginJarPaths) {
         return new URLClassLoader(pluginJarPaths.toArray(new URL[0]),
                 Thread.currentThread().getContextClassLoader());
     }
 
     @Nonnull
-    private List<URL> searchPluginJar() {
+    private Set<URL> searchPluginJar() {
 
         File pluginDir = Common.connectorJarDir(this.engineType.getEngine()).toFile();
         if (!pluginDir.exists() || pluginDir.listFiles() == null) {
-            return new ArrayList<>();
+            return new HashSet<>();
         }
         Config pluginMapping = ConfigFactory
                 .parseFile(new File(getPluginMappingPath()))
@@ -140,10 +142,10 @@ public class PluginFactory<ENVIRONMENT extends RuntimeEnv> {
 
                     });
                     return pluginList.stream();
-                }).collect(Collectors.toList());
+                }).collect(Collectors.toSet());
     }
 
-    public List<URL> getPluginJarPaths() {
+    public Set<URL> getPluginJarPaths() {
         return this.pluginJarPaths;
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
when source and sink use same jar in flink job,and submit it to yarn when paralism more than 1 ,it would cause the error

java.lang.IllegalStateException: The library registration references a different set of library BLOBs than previous registrations for this job:
old:[file:/home/seatunnel-v2.1.1-release/connectors/flink/seatunnel-connector-flink-kafka-2.1.1-SNAPSHOT.jar]
new:[file:/home/seatunnel-v2.1.1-release/connectors/flink/seatunnel-connector-flink-kafka-2.1.1-SNAPSHOT.jar, file:/home/seatunnel-v2.1.1-release/connectors/flink/seatunnel-connector-flink-kafka-2.1.1-SNAPSHOT.jar]
        at org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager$ResolvedClassLoader.verifyClassLoader(BlobLibraryCacheManager.java:431) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager$ResolvedClassLoader.access$500(BlobLibraryCacheManager.java:356) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager$LibraryCacheEntry.getOrResolveClassLoader(BlobLibraryCacheManager.java:232) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager$LibraryCacheEntry.access$1100(BlobLibraryCacheManager.java:199) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager$DefaultClassLoaderLease.getOrResolveClassLoader(BlobLibraryCacheManager.java:333) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.taskmanager.Task.createUserCodeClassloader(Task.java:1024) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:628) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at org.apache.flink.runtime.taskmanager.Task.run(Task.java:566) ~[flink-dist_2.11-1.13.6.jar:1.13.6]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_282]


use set to replace list for searchplugin jars
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
