### PR TITLE
[Core][Starter] When use cluster mode, but starter app root dir also should same as client mode.

### DIFF
--- a/seatunnel-apis/seatunnel-api-flink/src/main/java/org/apache/seatunnel/flink/util/SchemaUtil.java
+++ b/seatunnel-apis/seatunnel-api-flink/src/main/java/org/apache/seatunnel/flink/util/SchemaUtil.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.flink.util;
 
-import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.flink.enums.FormatType;
 
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
@@ -200,7 +199,6 @@ public final class SchemaUtil {
         int size = json.size();
         String[] fields = new String[size];
         TypeInformation<?>[] informations = new TypeInformation[size];
-        Map<String, Object> jsonMap = JsonUtils.toMap(json);
         int i = 0;
         Iterator<Map.Entry<String, JsonNode>> nodeIterator = json.fields();
         while (nodeIterator.hasNext()) {

--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/Common.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/Common.java
@@ -35,11 +35,17 @@ public class Common {
 
     private static DeployMode MODE;
 
+    private static boolean STARTER = false;
+
     /**
      * Set mode. return false in case of failure
      */
     public static void setDeployMode(DeployMode mode) {
         MODE = mode;
+    }
+
+    public static void setStarter(boolean inStarter) {
+        STARTER = inStarter;
     }
 
     public static DeployMode getDeployMode() {
@@ -54,7 +60,7 @@ public class Common {
      * When running seatunnel in --master yarn or --master mesos, you can put plugins related files in plugins dir.
      */
     public static Path appRootDir() {
-        if (DeployMode.CLIENT == MODE) {
+        if (DeployMode.CLIENT == MODE || STARTER) {
             try {
                 String path = Common.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
                 path = new File(path).getPath();

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/FlinkSqlStarter.java
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/java/org/apache/seatunnel/core/sql/FlinkSqlStarter.java
@@ -39,6 +39,7 @@ public class FlinkSqlStarter implements Starter {
     FlinkSqlStarter(String[] args) {
         this.flinkCommandArgs = CommandLineUtils.parseCommandArgs(args, FlinkJobType.SQL);
         // set the deployment mode, used to get the job jar path.
+        Common.setStarter(true);
         Common.setDeployMode(flinkCommandArgs.getDeployMode());
         this.appJar = Common.appLibDir().resolve(APP_JAR_NAME).toString();
     }

--- a/seatunnel-core/seatunnel-core-flink/src/main/java/org/apache/seatunnel/core/flink/FlinkStarter.java
+++ b/seatunnel-core/seatunnel-core-flink/src/main/java/org/apache/seatunnel/core/flink/FlinkStarter.java
@@ -47,6 +47,7 @@ public class FlinkStarter implements Starter {
         this.flinkCommandArgs = CommandLineUtils.parseCommandArgs(args, FlinkJobType.JAR);
         // set the deployment mode, used to get the job jar path.
         Common.setDeployMode(flinkCommandArgs.getDeployMode());
+        Common.setStarter(true);
         this.appJar = Common.appLibDir().resolve(APP_JAR_NAME).toString();
     }
 

--- a/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
@@ -150,7 +150,6 @@ public class SparkStarter implements Starter {
         Common.setDeployMode(commandArgs.getDeployMode());
         Common.setStarter(true);
         this.jars.addAll(getPluginsJarDependencies());
-        this.jars.addAll(listJars(Common.appLibDir()));
         this.jars.addAll(getConnectorJarDependencies());
         this.appName = this.sparkConf.getOrDefault("spark.app.name", Constants.LOGO);
         return buildFinal();
@@ -220,18 +219,6 @@ public class SparkStarter implements Starter {
         pluginJars.addAll(sparkSourcePluginDiscovery.getPluginJarPaths(getPluginIdentifiers(config, PluginType.SOURCE)));
         pluginJars.addAll(sparkSinkPluginDiscovery.getPluginJarPaths(getPluginIdentifiers(config, PluginType.SINK)));
         return pluginJars.stream().map(url -> new File(url.getPath()).toPath()).collect(Collectors.toList());
-    }
-
-    /**
-     * list jars in given directory
-     */
-    private List<Path> listJars(Path dir) throws IOException {
-        try (Stream<Path> stream = Files.list(dir)) {
-            return stream
-                    .filter(it -> !Files.isDirectory(it))
-                    .filter(it -> it.getFileName().endsWith("jar"))
-                    .collect(Collectors.toList());
-        }
     }
 
     /**
@@ -406,10 +393,9 @@ public class SparkStarter implements Starter {
         @Override
         public List<String> buildCommands() throws IOException {
             Common.setDeployMode(commandArgs.getDeployMode());
+            Common.setStarter(true);
             Path pluginTarball = Common.pluginTarball();
-            if (Files.notExists(pluginTarball)) {
-                CompressionUtils.tarGzip(Common.pluginRootDir(), pluginTarball);
-            }
+            CompressionUtils.tarGzip(Common.pluginRootDir(), pluginTarball);
             this.files.add(pluginTarball);
             this.files.add(Paths.get(commandArgs.getConfigFile()));
             return super.buildCommands();

--- a/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-core-spark/src/main/java/org/apache/seatunnel/core/spark/SparkStarter.java
@@ -148,6 +148,7 @@ public class SparkStarter implements Starter {
     public List<String> buildCommands() throws IOException {
         setSparkConf();
         Common.setDeployMode(commandArgs.getDeployMode());
+        Common.setStarter(true);
         this.jars.addAll(getPluginsJarDependencies());
         this.jars.addAll(listJars(Common.appLibDir()));
         this.jars.addAll(getConnectorJarDependencies());

--- a/seatunnel-core/seatunnel-flink-starter/src/main/java/org/apache/seatunnel/core/starter/flink/FlinkStarter.java
+++ b/seatunnel-core/seatunnel-flink-starter/src/main/java/org/apache/seatunnel/core/starter/flink/FlinkStarter.java
@@ -47,6 +47,7 @@ public class FlinkStarter implements Starter {
         this.flinkCommandArgs = CommandLineUtils.parseCommandArgs(args, FlinkJobType.JAR);
         // set the deployment mode, used to get the job jar path.
         Common.setDeployMode(flinkCommandArgs.getDeployMode());
+        Common.setStarter(true);
         this.appJar = Common.appLibDir().resolve(APP_JAR_NAME).toString();
     }
 

--- a/seatunnel-core/seatunnel-spark-starter/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-spark-starter/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
@@ -149,8 +149,8 @@ public class SparkStarter implements Starter {
     public List<String> buildCommands() throws IOException {
         setSparkConf();
         Common.setDeployMode(commandArgs.getDeployMode());
+        Common.setStarter(true);
         this.jars.addAll(getPluginsJarDependencies());
-        this.jars.addAll(listJars(Common.appLibDir()));
         this.jars.addAll(getConnectorJarDependencies());
         this.appName = this.sparkConf.getOrDefault("spark.app.name", Constants.LOGO);
         return buildFinal();
@@ -231,18 +231,6 @@ public class SparkStarter implements Starter {
         pluginJars.addAll(sparkSourcePluginDiscovery.getPluginJarPaths(getPluginIdentifiers(config, PluginType.SOURCE)));
         pluginJars.addAll(sparkSinkPluginDiscovery.getPluginJarPaths(getPluginIdentifiers(config, PluginType.SINK)));
         return pluginJars.stream().map(url -> new File(url.getPath()).toPath()).collect(Collectors.toList());
-    }
-
-    /**
-     * list jars in given directory
-     */
-    private List<Path> listJars(Path dir) throws IOException {
-        try (Stream<Path> stream = Files.list(dir)) {
-            return stream
-                    .filter(it -> !Files.isDirectory(it))
-                    .filter(it -> it.getFileName().endsWith("jar"))
-                    .collect(Collectors.toList());
-        }
     }
 
     /**
@@ -417,10 +405,9 @@ public class SparkStarter implements Starter {
         @Override
         public List<String> buildCommands() throws IOException {
             Common.setDeployMode(commandArgs.getDeployMode());
+            Common.setStarter(true);
             Path pluginTarball = Common.pluginTarball();
-            if (Files.notExists(pluginTarball)) {
-                CompressionUtils.tarGzip(Common.pluginRootDir(), pluginTarball);
-            }
+            CompressionUtils.tarGzip(Common.pluginRootDir(), pluginTarball);
             this.files.add(pluginTarball);
             this.files.add(Paths.get(commandArgs.getConfigFile()));
             return super.buildCommands();


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
When use cluster mode, but starter app root dir also should same as client mode. If not, will 
```log
➜  target git:(dev-plugin-root-dir) ✗ ./apache-seatunnel-incubating-2.1.3-SNAPSHOT/bin/start-seatunnel-spark.sh --config ./apache-seatunnel-incubating-2.1.3-SNAPSHOT/config/spark.batch.conf.template -e cluster -m local
log4j:WARN No appenders could be found for logger (org.apache.seatunnel.core.base.utils.CompressionUtils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Exception in thread "main" java.nio.file.NoSuchFileException: plugins
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
        at java.nio.file.Files.readAttributes(Files.java:1737)
        at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219)
        at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
        at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
        at java.nio.file.Files.walkFileTree(Files.java:2662)
        at java.nio.file.Files.walkFileTree(Files.java:2742)
        at org.apache.seatunnel.core.base.utils.CompressionUtils.tarGzip(CompressionUtils.java:66)
        at org.apache.seatunnel.core.spark.SparkStarter$ClusterModeSparkStarter.buildCommands(SparkStarter.java:411)
        at org.apache.seatunnel.core.spark.SparkStarter.main(SparkStarter.java:107)

```
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
