### PR TITLE
[Doc] Fix the FileSink doc content error.

### DIFF
--- a/docs/en/connector-v2/sink/File.mdx
+++ b/docs/en/connector-v2/sink/File.mdx
@@ -7,15 +7,6 @@ import TabItem from '@theme/TabItem';
 
 Output data to local or hdfs or s3 file.
 
-:::tip
-
-Used to write data to file. Supports Batch and Streaming mode.
-
-* [x] Batch
-* [x] Streaming
-
-:::
-
 ## Options
 
 <Tabs
@@ -36,7 +27,7 @@ Used to write data to file. Supports Batch and Streaming mode.
 | field_delimiter                   | string | no       | '\001'                                                        |
 | row_delimiter                     | string | no       | "\n"                                                          |
 | partition_by                      | array  | no       | -                                                             |
-| partition_dir_expression          | string | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                    |
+| partition_dir_expression          | string | no       | "\${k0}=\${v0}\/\${k1}=\${v1}\/...\/\${kn}=\${vn}\/"          |
 | is_partition_field_write_in_file  | boolean| no       | false                                                         |
 | sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns     |
 | is_enable_transaction             | boolean| no       | true                                                          |
@@ -129,7 +120,7 @@ Streaming Job not support `overwrite`.
 | field_delimiter                   | string | no       | '\001'                                                        |
 | row_delimiter                     | string | no       | "\n"                                                          |
 | partition_by                      | array  | no       | -                                                             |
-| partition_dir_expression          | string | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                    |
+| partition_dir_expression          | string | no       | "\${k0}=\${v0}\/\${k1}=\${v1}\/...\/\${kn}=\${vn}\/"          |
 | is_partition_field_write_in_file  | boolean| no       | false                                                         |
 | sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns     |
 | is_enable_transaction             | boolean| no       | true                                                          |


### PR DESCRIPTION
The expected content here should be `${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/` . But now it is not right.

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/32193458/177503193-c35eafe7-f678-44fe-8b61-183cc493aec7.png">
