### PR TITLE
[Core]ConnectorV2 no longer provides binary packages

### DIFF
--- a/seatunnel-connectors-v2-dist/pom.xml
+++ b/seatunnel-connectors-v2-dist/pom.xml
@@ -119,5 +119,16 @@
                 </executions>
             </plugin>
         </plugins>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
     </build>
 </project>

--- a/seatunnel-connectors-v2-dist/pom.xml
+++ b/seatunnel-connectors-v2-dist/pom.xml
@@ -118,17 +118,14 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
     </build>
 </project>

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -56,5 +56,15 @@
             <artifactId>junit-jupiter-params</artifactId>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -149,6 +149,7 @@
             </excludes>
             <outputDirectory>/connectors/spark</outputDirectory>
         </fileSet>
+        <!--todo remove it, because not publish it to binary package-->
         <fileSet>
             <directory>../seatunnel-connectors-v2-dist/target/lib</directory>
             <includes>

--- a/seatunnel-dist/src/main/assembly/assembly-bin.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin.xml
@@ -149,18 +149,6 @@
             </excludes>
             <outputDirectory>/connectors/spark</outputDirectory>
         </fileSet>
-        <!--todo remove it, because not publish it to binary package-->
-        <fileSet>
-            <directory>../seatunnel-connectors-v2-dist/target/lib</directory>
-            <includes>
-                <include>connector-*.jar</include>
-            </includes>
-            <excludes>
-                <exclude>%regex[.*((javadoc)|(sources))\.jar]</exclude>
-                <exclude>connector-common*.jar</exclude>
-            </excludes>
-            <outputDirectory>/connectors/seatunnel</outputDirectory>
-        </fileSet>
         <fileSet>
             <directory>../</directory>
             <includes>

--- a/seatunnel-e2e/pom.xml
+++ b/seatunnel-e2e/pom.xml
@@ -52,4 +52,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/tools/dependencies/checkLicense.sh
+++ b/tools/dependencies/checkLicense.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-./mvnw --batch-mode --no-snapshot-updates dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=/tmp/seatunnel-dependencies
+./mvnw --batch-mode -pl '!seatunnel-examples,!seatunnel-e2e,!seatunnel-connectors-v2,!seatunnel-connectors-v2-dist,' --no-snapshot-updates dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=/tmp/seatunnel-dependencies
 
 # List all modules(jars) that belong to the SeaTunnel itself, these will be ignored when checking the dependency
 ls /tmp/seatunnel-dependencies | sort > all-dependencies.txt


### PR DESCRIPTION
We will not release the binary package of the connector, and may help users to download it in the form of a script later.