### PR TITLE
[Bug] [seatunnel-core] Failed to get APP_DIR path bug fixed

### DIFF
--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
@@ -34,9 +34,9 @@ while [ -h "$PRG" ] ; do
 done
 
 PRG_DIR=`dirname "$PRG"`
-
-CONF_DIR=${PRG_DIR}/config
-APP_JAR=${PRG_DIR}/lib/seatunnel-core-flink-sql.jar
+APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
+CONF_DIR=${APP_DIR}/config
+APP_JAR=${APP_DIR}/lib/seatunnel-core-flink-sql.jar
 APP_MAIN=org.apache.seatunnel.core.sql.FlinkSqlStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
@@ -17,9 +17,27 @@
 #
 
 set -eu
-APP_DIR=$(cd $(dirname ${0})/../;pwd)
-CONF_DIR=${APP_DIR}/config
-APP_JAR=${APP_DIR}/lib/seatunnel-core-flink-sql.jar
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  # shellcheck disable=SC2006
+  ls=`ls -ld "$PRG"`
+  # shellcheck disable=SC2006
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    # shellcheck disable=SC2006
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRG_DIR=`dirname "$PRG"`
+
+CONF_DIR=${PRG_DIR}/config
+APP_JAR=${PRG_DIR}/lib/seatunnel-core-flink-sql.jar
+APP_MAIN=org.apache.seatunnel.core.sql.FlinkSqlStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
@@ -33,7 +51,7 @@ else
 fi
 
 
-CMD=$(java -cp ${APP_JAR} org.apache.seatunnel.core.sql.FlinkSqlStarter ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
+CMD=$(java -cp ${APP_JAR} ${APP_MAIN} ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 234 ]; then
     # print usage
     echo "${CMD}"

--- a/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
+++ b/seatunnel-core/seatunnel-core-flink-sql/src/main/bin/start-seatunnel-sql.sh
@@ -37,7 +37,7 @@ PRG_DIR=`dirname "$PRG"`
 APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
 CONF_DIR=${APP_DIR}/config
 APP_JAR=${APP_DIR}/lib/seatunnel-core-flink-sql.jar
-APP_MAIN=org.apache.seatunnel.core.sql.FlinkSqlStarter
+APP_MAIN="org.apache.seatunnel.core.sql.FlinkSqlStarter"
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"

--- a/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
+++ b/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
@@ -37,8 +37,8 @@ PRG_DIR=`dirname "$PRG"`
 APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
 CONF_DIR=${APP_DIR}/config
 APP_JAR=${APP_DIR}/lib/seatunnel-core-flink.jar
-ENV_PARAMETERS_MAIN=org.apache.seatunnel.core.flink.FlinkEnvParameterParser
-APP_MAIN=org.apache.seatunnel.core.flink.FlinkStarter
+ENV_PARAMETERS_MAIN="org.apache.seatunnel.core.flink.FlinkEnvParameterParser"
+APP_MAIN="org.apache.seatunnel.core.flink.FlinkStarter"
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"

--- a/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
+++ b/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
@@ -17,9 +17,27 @@
 #
 
 set -eu
-APP_DIR=$(cd $(dirname ${0})/../;pwd)
-CONF_DIR=${APP_DIR}/config
-APP_JAR=${APP_DIR}/lib/seatunnel-core-flink.jar
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  # shellcheck disable=SC2006
+  ls=`ls -ld "$PRG"`
+  # shellcheck disable=SC2006
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    # shellcheck disable=SC2006
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRG_DIR=`dirname "$PRG"`
+CONF_DIR=${PRG_DIR}/config
+APP_JAR=${PRG_DIR}/lib/seatunnel-core-flink.jar
+ENV_PARAMETERS_MAIN=org.apache.seatunnel.core.flink.FlinkEnvParameterParser
+APP_MAIN=org.apache.seatunnel.core.flink.FlinkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
@@ -32,7 +50,7 @@ else
     args=$@
 fi
 
-ENV_PARAMETERS_OR_ERROR=$(java -cp ${APP_JAR} org.apache.seatunnel.core.flink.FlinkEnvParameterParser ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
+ENV_PARAMETERS_OR_ERROR=$(java -cp ${APP_JAR} ${ENV_PARAMETERS_MAIN} ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 0 ]; then
   echo "Export JVM_ARGS: ${ENV_PARAMETERS_OR_ERROR}"
   export JVM_ARGS="${ENV_PARAMETERS_OR_ERROR}"
@@ -41,7 +59,7 @@ else
     exit ${EXIT_CODE}
 fi
 
-CMD=$(java -cp ${APP_JAR} org.apache.seatunnel.core.flink.FlinkStarter ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
+CMD=$(java -cp ${APP_JAR} ${APP_MAIN} ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 234 ]; then
     # print usage
     echo "${CMD}"

--- a/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
+++ b/seatunnel-core/seatunnel-core-flink/src/main/bin/start-seatunnel-flink.sh
@@ -34,8 +34,9 @@ while [ -h "$PRG" ] ; do
 done
 
 PRG_DIR=`dirname "$PRG"`
-CONF_DIR=${PRG_DIR}/config
-APP_JAR=${PRG_DIR}/lib/seatunnel-core-flink.jar
+APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
+CONF_DIR=${APP_DIR}/config
+APP_JAR=${APP_DIR}/lib/seatunnel-core-flink.jar
 ENV_PARAMETERS_MAIN=org.apache.seatunnel.core.flink.FlinkEnvParameterParser
 APP_MAIN=org.apache.seatunnel.core.flink.FlinkStarter
 

--- a/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
+++ b/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
@@ -16,9 +16,26 @@
 # limitations under the License.
 #
 set -eu
-APP_DIR=$(cd $(dirname ${0})/../;pwd)
-CONF_DIR=${APP_DIR}/config
-APP_JAR=${APP_DIR}/lib/seatunnel-core-spark.jar
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  # shellcheck disable=SC2006
+  ls=`ls -ld "$PRG"`
+  # shellcheck disable=SC2006
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    # shellcheck disable=SC2006
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRG_DIR=`dirname "$PRG"`
+CONF_DIR=${PRG_DIR}/config
+APP_JAR=${PRG_DIR}/lib/seatunnel-core-spark.jar
+APP_MAIN=org.apache.seatunnel.core.spark.SparkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
@@ -31,7 +48,7 @@ else
     args=$@
 fi
 
-CMD=$(java -cp ${APP_JAR} org.apache.seatunnel.core.spark.SparkStarter ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
+CMD=$(java -cp ${APP_JAR} ${APP_MAIN} ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 234 ]; then
     # print usage
     echo "${CMD}"

--- a/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
+++ b/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
@@ -33,8 +33,9 @@ while [ -h "$PRG" ] ; do
 done
 
 PRG_DIR=`dirname "$PRG"`
-CONF_DIR=${PRG_DIR}/config
-APP_JAR=${PRG_DIR}/lib/seatunnel-core-spark.jar
+APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
+CONF_DIR=${APP_DIR}/config
+APP_JAR=${APP_DIR}/lib/seatunnel-core-spark.jar
 APP_MAIN=org.apache.seatunnel.core.spark.SparkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then

--- a/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
+++ b/seatunnel-core/seatunnel-core-spark/src/main/bin/start-seatunnel-spark.sh
@@ -36,7 +36,7 @@ PRG_DIR=`dirname "$PRG"`
 APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
 CONF_DIR=${APP_DIR}/config
 APP_JAR=${APP_DIR}/lib/seatunnel-core-spark.jar
-APP_MAIN=org.apache.seatunnel.core.spark.SparkStarter
+APP_MAIN="org.apache.seatunnel.core.spark.SparkStarter"
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"

--- a/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
+++ b/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
@@ -17,9 +17,27 @@
 #
 
 set -eu
-APP_DIR=$(cd $(dirname ${0})/../;pwd)
-CONF_DIR=${APP_DIR}/config
-APP_JAR=${APP_DIR}/lib/seatunnel-flink-starter.jar
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  # shellcheck disable=SC2006
+  ls=`ls -ld "$PRG"`
+  # shellcheck disable=SC2006
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    # shellcheck disable=SC2006
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRG_DIR=`dirname "$PRG"`
+
+CONF_DIR=${PRG_DIR}/config
+APP_JAR=${PRG_DIR}/lib/seatunnel-flink-starter.jar
+APP_MAIN=org.apache.seatunnel.core.starter.flink.FlinkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
@@ -32,7 +50,7 @@ else
     args=$@
 fi
 
-CMD=$(java -cp ${APP_JAR} org.apache.seatunnel.core.starter.flink.FlinkStarter ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
+CMD=$(java -cp ${APP_JAR} ${APP_MAIN} ${args}) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 234 ]; then
     # print usage
     echo ${CMD}

--- a/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
+++ b/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
@@ -37,7 +37,7 @@ PRG_DIR=`dirname "$PRG"`
 APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
 CONF_DIR=${APP_DIR}/config
 APP_JAR=${APP_DIR}/lib/seatunnel-flink-starter.jar
-APP_MAIN=org.apache.seatunnel.core.starter.flink.FlinkStarter
+APP_MAIN="org.apache.seatunnel.core.starter.flink.FlinkStarter"
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"

--- a/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
+++ b/seatunnel-core/seatunnel-flink-starter/src/main/bin/start-seatunnel-flink-new-connector.sh
@@ -34,9 +34,9 @@ while [ -h "$PRG" ] ; do
 done
 
 PRG_DIR=`dirname "$PRG"`
-
-CONF_DIR=${PRG_DIR}/config
-APP_JAR=${PRG_DIR}/lib/seatunnel-flink-starter.jar
+APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
+CONF_DIR=${APP_DIR}/config
+APP_JAR=${APP_DIR}/lib/seatunnel-flink-starter.jar
 APP_MAIN=org.apache.seatunnel.core.starter.flink.FlinkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then

--- a/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
+++ b/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
@@ -34,8 +34,9 @@ while [ -h "$PRG" ] ; do
 done
 
 PRG_DIR=`dirname "$PRG"`
-CONF_DIR=${PRG_DIR}/config
-APP_JAR=${PRG_DIR}/lib/seatunnel-spark-starter.jar
+APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
+CONF_DIR=${APP_DIR}/config
+APP_JAR=${APP_DIR}/lib/seatunnel-spark-starter.jar
 APP_MAIN=org.apache.seatunnel.core.starter.spark.SparkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then

--- a/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
+++ b/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
@@ -16,9 +16,27 @@
 # limitations under the License.
 #
 set -eu
-APP_DIR=$(cd $(dirname ${0})/../;pwd)
-CONF_DIR=${APP_DIR}/config
-APP_JAR=${APP_DIR}/lib/seatunnel-spark-starter.jar
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  # shellcheck disable=SC2006
+  ls=`ls -ld "$PRG"`
+  # shellcheck disable=SC2006
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    # shellcheck disable=SC2006
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRG_DIR=`dirname "$PRG"`
+CONF_DIR=${PRG_DIR}/config
+APP_JAR=${PRG_DIR}/lib/seatunnel-spark-starter.jar
+APP_MAIN=org.apache.seatunnel.core.starter.spark.SparkStarter
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
@@ -31,7 +49,7 @@ else
     args=$@
 fi
 
-CMD=$(java -cp ${APP_JAR} org.apache.seatunnel.core.starter.spark.SparkStarter ${args} | tail -n 1) && EXIT_CODE=$? || EXIT_CODE=$?
+CMD=$(java -cp ${APP_JAR} ${APP_MAIN} ${args} | tail -n 1) && EXIT_CODE=$? || EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 234 ]; then
     # print usage
     echo ${CMD}

--- a/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
+++ b/seatunnel-core/seatunnel-spark-starter/src/main/bin/start-seatunnel-spark-new-connector.sh
@@ -37,7 +37,7 @@ PRG_DIR=`dirname "$PRG"`
 APP_DIR=`cd "$PRG_DIR/.." >/dev/null; pwd`
 CONF_DIR=${APP_DIR}/config
 APP_JAR=${APP_DIR}/lib/seatunnel-spark-starter.jar
-APP_MAIN=org.apache.seatunnel.core.starter.spark.SparkStarter
+APP_MAIN="org.apache.seatunnel.core.starter.spark.SparkStarter"
 
 if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"


### PR DESCRIPTION
Failed to get APP_DIR path when using Nested "$" in this shell scripts occasionally
The shell scripts are：
"start-seatunnel-flink.sh"
"start-seatunnel-flink-new-connector.sh"
"start-seatunnel-spark.sh"
"start-seatunnel-spark-new-connector.sh"
"start-seatunnel-sql.sh"

this line: "APP_DIR=(dirname ${0})/../;pwd) " causing Failed to get APP_DIR path has bug.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
