### PR TITLE
[Bug-Fix] Fix build order issues

### DIFF
--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -41,6 +41,23 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-v2-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-spark-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-flink-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -83,6 +100,18 @@
         </profile>
         <profile>
             <id>release</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-spark-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-flink-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
When we use `./mvnw -T 1C` to build the project, sometimes `seatunnel-dist` will build before `seatunnel-connectors` . This will cause build error. If the `seatunnel-dist` module dependency on `seatunnel-connectors` module, `seatunnel-dist` will build after `seatunnel-connectors`.