### PR TITLE
[Bug][Connector]Hudi Source loads the data twice

### DIFF
--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hudi/src/main/scala/org/apache/seatunnel/spark/hudi/source/Hudi.scala
@@ -38,7 +38,7 @@ class Hudi extends SparkBatchSource {
       reader.option(e.getKey, String.valueOf(e.getValue.unwrapped()))
     }
 
-    reader.load(config.getString(HOODIE_DATASTORE_READ_PATHS))
+    reader.load()
   }
 
   override def getPluginName: String = "Hudi"


### PR DESCRIPTION
 In the option has the hudipath,and in the load method has the same path. So the spark will trigger two job, the data is double.
