### PR TITLE
[Fix][CI] Add remove jar from  /tmp/seatunnel-dependencies before run

### DIFF
--- a/tools/dependencies/checkLicense.sh
+++ b/tools/dependencies/checkLicense.sh
@@ -19,6 +19,10 @@
 
 set -e
 
+if [ -d "/tmp/seatunnel-dependencies" ]; then
+  rm -rf /tmp/seatunnel-dependencies/*
+fi
+
 ./mvnw --batch-mode --no-snapshot-updates dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=/tmp/seatunnel-dependencies -P release
 
 # List all modules(jars) that belong to the SeaTunnel itself, these will be ignored when checking the dependency


### PR DESCRIPTION
If this directory is not cleared , the inspection results will be inaccurate when run checkLicense.sh in local.