### PR TITLE
[doc] Correct v2 connector avoid duplicate slug

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -89,7 +89,8 @@ const sidebars = {
                       type: 'generated-index',
                       title: 'Source-V2 of SeaTunnel',
                       description: 'List all Sink supported Apache SeaTunnel for now.',
-                      slug: '/category/sink',
+                      // Should remove the `v2` suffix when we migrate all sink to v2 and delete the old one
+                      slug: '/category/sink-v2',
                       keywords: ['sink'],
                       image: '/img/favicon.ico',
                   },
@@ -107,7 +108,8 @@ const sidebars = {
                       type: 'generated-index',
                       title: 'Source-V2 of SeaTunnel',
                       description: 'List all source supported Apache SeaTunnel for now.',
-                      slug: '/category/source',
+                      // Should remove the `v2` suffix when we migrate all sink to v2 and delete the old one
+                      slug: '/category/source-v2',
                       keywords: ['source'],
                       image: '/img/favicon.ico',
                   },


### PR DESCRIPTION
Currently, url https://seatunnel.apache.org/docs/category/source
will expand two parent sidebar with both source and source-v2.
This is because we're using same slug in our sidebars.js.
