### PR TITLE
[Feature][connector] clickhousefile sink connector support non-root username for fileTransfer

### DIFF
--- a/docs/en/connector-v2/sink/ClickhouseFile.md
+++ b/docs/en/connector-v2/sink/ClickhouseFile.md
@@ -27,6 +27,7 @@ Write data to Clickhouse can also be done using JDBC
 | node_free_password     | boolean | no       | false         |
 | node_pass              | list    | no       | -             |
 | node_pass.node_address | string  | no       | -             |
+| node_pass.username     | string  | no       | "root"        |
 | node_pass.password     | string  | no       | -             |
 | common-options         | string  | no       | -             |
 
@@ -78,9 +79,13 @@ Used to save the addresses and corresponding passwords of all clickhouse servers
 
 The address corresponding to the clickhouse server
 
-### node_pass.node_password [string]
+### node_pass.username [string]
 
-The password corresponding to the clickhouse server, only support root user yet.
+The username corresponding to the clickhouse server, default root user.
+
+### node_pass.password [string]
+
+The password corresponding to the clickhouse server.
 
 ### common options [string]
 

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/Config.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/Config.java
@@ -84,7 +84,6 @@ public class Config {
     /**
      * The password of Clickhouse server node
      */
-    public static final String NODE_USER = "node_user";
     public static final String NODE_PASS = "node_pass";
 
     /**

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/Config.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/Config.java
@@ -84,6 +84,7 @@ public class Config {
     /**
      * The password of Clickhouse server node
      */
+    public static final String NODE_USER = "node_user";
     public static final String NODE_PASS = "node_pass";
 
     /**

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/FileReaderOption.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/FileReaderOption.java
@@ -32,18 +32,21 @@ public class FileReaderOption implements Serializable {
     private String clickhouseLocalPath;
     private ClickhouseFileCopyMethod copyMethod;
     private boolean nodeFreePass;
+    private Map<String, String> nodeUser;
     private Map<String, String> nodePassword;
     private SeaTunnelRowType seaTunnelRowType;
 
     public FileReaderOption(ShardMetadata shardMetadata, Map<String, String> tableSchema,
                             List<String> fields, String clickhouseLocalPath,
                             ClickhouseFileCopyMethod copyMethod,
+                            Map<String, String> nodeUser,
                             Map<String, String> nodePassword) {
         this.shardMetadata = shardMetadata;
         this.tableSchema = tableSchema;
         this.fields = fields;
         this.clickhouseLocalPath = clickhouseLocalPath;
         this.copyMethod = copyMethod;
+        this.nodeUser = nodeUser;
         this.nodePassword = nodePassword;
     }
 
@@ -77,6 +80,14 @@ public class FileReaderOption implements Serializable {
 
     public void setCopyMethod(ClickhouseFileCopyMethod copyMethod) {
         this.copyMethod = copyMethod;
+    }
+
+    public Map<String, String> getNodeUser() {
+        return nodeUser;
+    }
+
+    public void setNodeUser(Map<String, String> nodeUser) {
+        this.nodeUser = nodeUser;
     }
 
     public Map<String, String> getNodePassword() {

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
@@ -50,7 +50,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.*;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.CLICKHOUSE_LOCAL_PATH;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.COPY_METHOD;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.DATABASE;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.FIELDS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.HOST;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_ADDRESS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_PASS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.PASSWORD;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.SHARDING_KEY;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.TABLE;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.USERNAME;
 
 @AutoService(SeaTunnelSink.class)
 public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, ClickhouseSinkState, CKCommitInfo, CKAggCommitInfo> {
@@ -106,7 +116,7 @@ public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, Clickhous
         }
         Map<String, String> nodeUser = config.getObjectList(NODE_PASS).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
-                        configObject -> configObject.toConfig().hasPath(USERNAME) ? configObject.toConfig().getString(USERNAME) : "root"));
+                    configObject -> configObject.toConfig().hasPath(USERNAME) ? configObject.toConfig().getString(USERNAME) : "root"));
         Map<String, String> nodePassword = config.getObjectList(NODE_PASS).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
                     configObject -> configObject.toConfig().getString(PASSWORD)));

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
@@ -17,18 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.clickhouse.sink.file;
 
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.CLICKHOUSE_LOCAL_PATH;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.COPY_METHOD;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.DATABASE;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.FIELDS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.HOST;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_ADDRESS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_PASS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.PASSWORD;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.SHARDING_KEY;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.TABLE;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.USERNAME;
-
 import org.apache.seatunnel.api.common.PrepareFailException;
 import org.apache.seatunnel.api.common.SeaTunnelContext;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -61,6 +49,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.*;
 
 @AutoService(SeaTunnelSink.class)
 public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, ClickhouseSinkState, CKCommitInfo, CKAggCommitInfo> {
@@ -114,13 +104,16 @@ public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, Clickhous
         } else {
             fields = new ArrayList<>(tableSchema.keySet());
         }
+        Map<String, String> nodeUser = config.getObjectList(NODE_USER).stream()
+                .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
+                        configObject -> configObject.toConfig().getString(USERNAME)));
         Map<String, String> nodePassword = config.getObjectList(NODE_PASS).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
                     configObject -> configObject.toConfig().getString(PASSWORD)));
 
         proxy.close();
         this.readerOption = new FileReaderOption(shardMetadata, tableSchema, fields, config.getString(CLICKHOUSE_LOCAL_PATH),
-                ClickhouseFileCopyMethod.from(config.getString(COPY_METHOD)), nodePassword);
+                ClickhouseFileCopyMethod.from(config.getString(COPY_METHOD)), nodeUser, nodePassword);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
@@ -104,9 +104,9 @@ public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, Clickhous
         } else {
             fields = new ArrayList<>(tableSchema.keySet());
         }
-        Map<String, String> nodeUser = config.getObjectList(USERNAME).stream()
+        Map<String, String> nodeUser = config.getObjectList(NODE_PASS).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
-                        configObject -> configObject.toConfig().getString(USERNAME)));
+                        configObject -> configObject.toConfig().hasPath(USERNAME) ? configObject.toConfig().getString(USERNAME) : "root"));
         Map<String, String> nodePassword = config.getObjectList(NODE_PASS).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
                     configObject -> configObject.toConfig().getString(PASSWORD)));

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
@@ -17,6 +17,18 @@
 
 package org.apache.seatunnel.connectors.seatunnel.clickhouse.sink.file;
 
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.CLICKHOUSE_LOCAL_PATH;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.COPY_METHOD;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.DATABASE;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.FIELDS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.HOST;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_ADDRESS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_PASS;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.PASSWORD;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.SHARDING_KEY;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.TABLE;
+import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.USERNAME;
+
 import org.apache.seatunnel.api.common.PrepareFailException;
 import org.apache.seatunnel.api.common.SeaTunnelContext;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -49,18 +61,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.CLICKHOUSE_LOCAL_PATH;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.COPY_METHOD;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.DATABASE;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.FIELDS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.HOST;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_ADDRESS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.NODE_PASS;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.PASSWORD;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.SHARDING_KEY;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.TABLE;
-import static org.apache.seatunnel.connectors.seatunnel.clickhouse.config.Config.USERNAME;
 
 @AutoService(SeaTunnelSink.class)
 public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, ClickhouseSinkState, CKCommitInfo, CKAggCommitInfo> {

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSink.java
@@ -104,7 +104,7 @@ public class ClickhouseFileSink implements SeaTunnelSink<SeaTunnelRow, Clickhous
         } else {
             fields = new ArrayList<>(tableSchema.keySet());
         }
-        Map<String, String> nodeUser = config.getObjectList(NODE_USER).stream()
+        Map<String, String> nodeUser = config.getObjectList(USERNAME).stream()
                 .collect(Collectors.toMap(configObject -> configObject.toConfig().getString(NODE_ADDRESS),
                         configObject -> configObject.toConfig().getString(USERNAME)));
         Map<String, String> nodePassword = config.getObjectList(NODE_PASS).stream()

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -207,8 +207,9 @@ public class ClickhouseFileSinkWriter implements SinkWriter<SeaTunnelRow, CKComm
 
     private void attachClickhouseLocalFileToServer(Shard shard, List<String> clickhouseLocalFiles) throws ClickHouseException {
         String hostAddress = shard.getNode().getAddress().getHostName();
+        String user = readerOption.getNodeUser().getOrDefault(hostAddress, "root");
         String password = readerOption.getNodePassword().getOrDefault(hostAddress, null);
-        FileTransfer fileTransfer = FileTransferFactory.createFileTransfer(this.readerOption.getCopyMethod(), hostAddress, password);
+        FileTransfer fileTransfer = FileTransferFactory.createFileTransfer(this.readerOption.getCopyMethod(), hostAddress, user, password);
         fileTransfer.init();
         fileTransfer.transferAndChown(clickhouseLocalFiles, shardLocalDataPaths.get(shard).get(0) + "detached/");
         fileTransfer.close();

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/FileTransferFactory.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/FileTransferFactory.java
@@ -20,12 +20,12 @@ package org.apache.seatunnel.connectors.seatunnel.clickhouse.sink.file;
 import org.apache.seatunnel.connectors.seatunnel.clickhouse.config.ClickhouseFileCopyMethod;
 
 public class FileTransferFactory {
-    public static FileTransfer createFileTransfer(ClickhouseFileCopyMethod type, String host, String password) {
+    public static FileTransfer createFileTransfer(ClickhouseFileCopyMethod type, String host, String user, String password) {
         switch (type) {
             case SCP:
-                return new ScpFileTransfer(host, password);
+                return new ScpFileTransfer(host, user, password);
             case RSYNC:
-                return new RsyncFileTransfer(host, password);
+                return new RsyncFileTransfer(host, user, password);
             default:
                 throw new RuntimeException("unsupported clickhouse file copy method:" + type);
         }

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/RsyncFileTransfer.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/RsyncFileTransfer.java
@@ -37,13 +37,15 @@ public class RsyncFileTransfer implements FileTransfer {
     private static final int SSH_PORT = 22;
 
     private final String host;
+    private final String user;
     private final String password;
 
     private ClientSession clientSession;
     private SshClient sshClient;
 
-    public RsyncFileTransfer(String host, String password) {
+    public RsyncFileTransfer(String host, String user, String password) {
         this.host = host;
+        this.user = user;
         this.password = password;
     }
 
@@ -52,7 +54,7 @@ public class RsyncFileTransfer implements FileTransfer {
         try {
             sshClient = SshClient.setUpDefaultClient();
             sshClient.start();
-            clientSession = sshClient.connect("root", host, SSH_PORT).verify().getSession();
+            clientSession = sshClient.connect(user, host, SSH_PORT).verify().getSession();
             if (password != null) {
                 clientSession.addPasswordIdentity(password);
             }
@@ -61,7 +63,7 @@ public class RsyncFileTransfer implements FileTransfer {
                 throw new IOException("ssh host " + host + "authentication failed");
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to connect to host: " + host + " by user: root on port 22", e);
+            throw new RuntimeException("Failed to connect to host: " + host + " by user: " + user + " on port 22", e);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ScpFileTransfer.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ScpFileTransfer.java
@@ -36,14 +36,16 @@ public class ScpFileTransfer implements FileTransfer {
     private static final int SCP_PORT = 22;
 
     private final String host;
+    private final String user;
     private final String password;
 
     private ScpClient scpClient;
     private ClientSession clientSession;
     private SshClient sshClient;
 
-    public ScpFileTransfer(String host, String password) {
+    public ScpFileTransfer(String host, String user, String password) {
         this.host = host;
+        this.user = user;
         this.password = password;
     }
 
@@ -52,7 +54,7 @@ public class ScpFileTransfer implements FileTransfer {
         try {
             sshClient = SshClient.setUpDefaultClient();
             sshClient.start();
-            clientSession = sshClient.connect("root", host, SCP_PORT).verify().getSession();
+            clientSession = sshClient.connect(user, host, SCP_PORT).verify().getSession();
             if (password != null) {
                 clientSession.addPasswordIdentity(password);
             }
@@ -62,7 +64,7 @@ public class ScpFileTransfer implements FileTransfer {
             }
             scpClient = ScpClientCreator.instance().createScpClient(clientSession);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to connect to host: " + host + " by user: root on port 22", e);
+            throw new RuntimeException("Failed to connect to host: " + host + " by user: " + user + " on port 22", e);
         }
     }
 

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/filetransfer/RsyncFileTransfer.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/filetransfer/RsyncFileTransfer.scala
@@ -27,10 +27,12 @@ import scala.sys.process.Process
 class RsyncFileTransfer(host: String) extends FileTransfer {
 
   private val LOGGER = LoggerFactory.getLogger(classOf[RsyncFileTransfer])
+  var username: String = _
   var password: String = _
 
-  def this(host: String, password: String) {
+  def this(host: String, username: String, password: String) {
     this(host)
+    this.username = username
     this.password = password
   }
 
@@ -52,7 +54,7 @@ class RsyncFileTransfer(host: String) extends FileTransfer {
       exec.append("-e")
       exec.append(sshParameter)
       exec.append(sourcePath)
-      exec.append(s"root@$host:$targetPath")
+      exec.append(s"$username@$host:$targetPath")
       val command = Process(exec)
       LOGGER.info(command.lineStream.mkString("\n"))
       // remote exec command to change file owner. Only file owner equal with server's clickhouse user can
@@ -68,7 +70,7 @@ class RsyncFileTransfer(host: String) extends FileTransfer {
   override def init(): Unit = {
     client = SshClient.setUpDefaultClient()
     client.start()
-    session = client.connect("root", this.host, 22).verify().getSession
+    session = client.connect(this.username, this.host, 22).verify().getSession
     if (password != null) {
       session.addPasswordIdentity(this.password)
     }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/filetransfer/ScpFileTransfer.scala
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/main/scala/org/apache/seatunnel/spark/clickhouse/sink/filetransfer/ScpFileTransfer.scala
@@ -23,10 +23,12 @@ import org.apache.sshd.scp.client.{ScpClient, ScpClientCreator}
 
 class ScpFileTransfer(host: String) extends FileTransfer {
 
+  var username: String = _
   var password: String = _
 
-  def this(host: String, password: String) {
+  def this(host: String, username: String, password: String) {
     this(host)
+    this.username = username
     this.password = password
   }
 
@@ -60,7 +62,7 @@ class ScpFileTransfer(host: String) extends FileTransfer {
   override def init(): Unit = {
     client = SshClient.setUpDefaultClient()
     client.start()
-    session = client.connect("root", this.host, 22).verify().getSession
+    session = client.connect(username, this.host, 22).verify().getSession
     if (password != null) {
       session.addPasswordIdentity(this.password)
     }

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/test/resources/sea.conf
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/test/resources/sea.conf
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 env {
   execution.parallelism = 1
   spark.sql.catalogImplementation = "hive"

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/test/resources/sea.conf
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-clickhouse/src/test/resources/sea.conf
@@ -1,0 +1,44 @@
+env {
+  execution.parallelism = 1
+  spark.sql.catalogImplementation = "hive"
+}
+
+source {
+  hive {
+    pre_sql = "select * from mydb.mytb"
+  }
+}
+
+transform {
+  sql {
+    sql = "select name,age from fake"
+  }
+}
+
+sink {
+  ClickhouseFile {
+    host = "10.60.94.1:8123,10.60.94.2:8123,10.60.94.3:8123"
+    database = "mydb"
+    table = "access_msg"
+    fields = ["date", "datetime", "hostname", "http_code", "data_size", "ua", "request_time"]
+    username = "username"
+    password = "password"
+    sharding_key = "age"
+    clickhouse_local_path = "/usr/bin/clickhouse-local"
+    node_pass = [
+      {
+        node_address = "10.60.94.1"
+        username = "clickhouse"
+        password = "password"
+      }
+      {
+        node_address = "10.60.94.2"
+        password = "password"
+      }
+      {
+        node_address = "10.60.94.3"
+        password = "password"
+      }
+    ]
+}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

TO CLOSE THIS #2262 https://github.com/apache/incubator-seatunnel/issues/2262

clickhousefile sink connector support non-root username for fileTransfer

it's common using non-root user for production server for security reason

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
