### PR TITLE
Decide table format using outputFormat in HiveSinkConfig

### DIFF
--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkConfig.java
@@ -92,13 +92,13 @@ public class HiveSinkConfig implements Serializable {
 
         try {
             table = hiveMetaStoreClient.getTable(dbName, tableName);
-            String inputFormat = table.getSd().getInputFormat();
+            String outputFormat = table.getSd().getOutputFormat();
             Map<String, String> parameters = table.getSd().getSerdeInfo().getParameters();
-            if ("org.apache.hadoop.mapred.TextInputFormat".equals(inputFormat)) {
+            if ("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat".equals(outputFormat)) {
                 config = config.withValue(FILE_FORMAT, ConfigValueFactory.fromAnyRef(FileFormat.TEXT.toString()))
                         .withValue(FIELD_DELIMITER, ConfigValueFactory.fromAnyRef(parameters.get("field.delim")))
                         .withValue(ROW_DELIMITER, ConfigValueFactory.fromAnyRef(parameters.get("line.delim")));
-            } else if ("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat".equals(inputFormat)) {
+            } else if ("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat".equals(outputFormat)) {
                 config = config.withValue(FILE_FORMAT, ConfigValueFactory.fromAnyRef(FileFormat.PARQUET.toString()));
             } else {
                 throw new RuntimeException("Only support text or parquet file now");


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

When writing hive table, it use outputFormat to handle data. So, we can using outputFormat property to decide the file format of hive table.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
