### PR TITLE
[ST-Engine][CI] Add engine_backend CI 

### DIFF
--- a/.github/workflows/engine_backend.yml
+++ b/.github/workflows/engine_backend.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Backend
+name: Engine_Backend
 on:
   push:
   pull_request:

--- a/.github/workflows/engine_backend.yml
+++ b/.github/workflows/engine_backend.yml
@@ -19,10 +19,7 @@ name: Backend
 on:
   push:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - 'seatunnel-ui/**'
+    paths:
       - 'seatunnel-engine/**'
 
 concurrency:
@@ -155,7 +152,7 @@ jobs:
           cache: 'maven'
       - name: Run Unit tests
         run: |
-          ./mvnw -B -T 1C clean verify -D"maven.test.skip"=false -D"checkstyle.skip"=true -D"scalastyle.skip"=true -D"license.skipAddThirdParty"=true --no-snapshot-updates
+          ./mvnw -B -T 1C clean verify -D"maven.test.skip"=false -D"checkstyle.skip"=true -D"scalastyle.skip"=true -D"license.skipAddThirdParty"=true --no-snapshot-updates -P engine_all
         env:
           MAVEN_OPTS: -Xmx2048m
 
@@ -178,6 +175,6 @@ jobs:
           cache: 'maven'
       - name: Run Integration tests
         run: |
-          ./mvnw -T 1C -B verify -DskipUT=true -DskipIT=false -D"checkstyle.skip"=true -D"scalastyle.skip"=true -D"license.skipAddThirdParty"=true --no-snapshot-updates
+          ./mvnw -T 1C -B verify -DskipUT=true -DskipIT=false -D"checkstyle.skip"=true -D"scalastyle.skip"=true -D"license.skipAddThirdParty"=true --no-snapshot-updates -P engine_all
         env:
           MAVEN_OPTS: -Xmx2048m

--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,7 @@
         <module>seatunnel-common</module>
         <module>seatunnel-apis</module>
         <module>seatunnel-core</module>
-        <module>seatunnel-transforms</module>
-        <module>seatunnel-connectors</module>
         <module>seatunnel-api</module>
-        <module>seatunnel-translation</module>
         <module>seatunnel-plugin-discovery</module>
         <module>seatunnel-formats</module>
         <module>seatunnel-dist</module>
@@ -92,11 +89,32 @@
     </modules>
 
     <profiles>
+        <!-- Use in CI, UT and integration test -->
         <profile>
             <id>all</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <modules>
+                <module>seatunnel-transforms</module>
+                <module>seatunnel-translation</module>
+                <module>seatunnel-connectors</module>
+                <module>seatunnel-connectors-v2</module>
+                <module>seatunnel-connectors-v2-dist</module>
+                <module>seatunnel-examples</module>
+                <module>seatunnel-e2e</module>
+            </modules>
+        </profile>
+        <!--
+            profile engine-all is used to build the package that not contains spark and flink things. For example
+            spark and flink connectors
+            spark and flink e2e and examples
+            spark and flink starters
+            spark and flink transforms
+            spark and flink translation
+        -->
+        <profile>
+            <id>engine-all</id>
             <modules>
                 <module>seatunnel-connectors-v2</module>
                 <module>seatunnel-connectors-v2-dist</module>
@@ -106,6 +124,11 @@
         </profile>
         <profile>
             <id>release</id>
+            <modules>
+                <module>seatunnel-transforms</module>
+                <module>seatunnel-translation</module>
+                <module>seatunnel-connectors</module>
+            </modules>
         </profile>
     </profiles>
 

--- a/seatunnel-core/pom.xml
+++ b/seatunnel-core/pom.xml
@@ -30,14 +30,43 @@
     <artifactId>seatunnel-core</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>seatunnel-core-base</module>
-        <module>seatunnel-core-flink</module>
-        <module>seatunnel-core-spark</module>
-        <module>seatunnel-core-flink-sql</module>
-        <module>seatunnel-core-starter</module>
-        <module>seatunnel-flink-starter</module>
-        <module>seatunnel-spark-starter</module>
-        <module>seatunnel-seatunnel-starter</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>seatunnel-core-base</module>
+                <module>seatunnel-core-flink</module>
+                <module>seatunnel-core-spark</module>
+                <module>seatunnel-core-flink-sql</module>
+                <module>seatunnel-core-starter</module>
+                <module>seatunnel-flink-starter</module>
+                <module>seatunnel-spark-starter</module>
+                <module>seatunnel-seatunnel-starter</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>engine-all</id>
+            <modules>
+                <module>seatunnel-core-base</module>
+                <module>seatunnel-core-starter</module>
+                <module>seatunnel-seatunnel-starter</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>seatunnel-core-base</module>
+                <module>seatunnel-core-flink</module>
+                <module>seatunnel-core-spark</module>
+                <module>seatunnel-core-flink-sql</module>
+                <module>seatunnel-core-starter</module>
+                <module>seatunnel-flink-starter</module>
+                <module>seatunnel-spark-starter</module>
+                <module>seatunnel-seatunnel-starter</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -99,6 +99,58 @@
             </build>
         </profile>
         <profile>
+            <id>engine-all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>seatunnel-connectors-v2-dist</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>bin</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/assembly-bin-ci.xml</descriptor>
+                                    </descriptors>
+                                    <appendAssemblyId>true</appendAssemblyId>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>src</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/assembly-src.xml</descriptor>
+                                    </descriptors>
+                                    <appendAssemblyId>true</appendAssemblyId>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+                <finalName>apache-seatunnel-incubating-${project.version}</finalName>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
If only `seatunnel-engine` module be changed, we should only build the necessary module.