### PR TITLE
[Bug][Core] fix ArrayType convert for spark2.4.0 and improve the convert method name

### DIFF
--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
@@ -17,16 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.console.sink;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
 
 import org.slf4j.Logger;
@@ -36,47 +28,22 @@ import java.util.Arrays;
 
 public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleSinkWriter.class);
+
     private final SeaTunnelRowType seaTunnelRowType;
-    public static final AtomicLong cnt = new AtomicLong(0);
 
     public ConsoleSinkWriter(SeaTunnelRowType seaTunnelRowType) {
         this.seaTunnelRowType = seaTunnelRowType;
-        System.out.printf("files : %s%n", StringUtils.join(seaTunnelRowType.getFieldNames(), ", "));
-        System.out.printf("types : %s%n", StringUtils.join(seaTunnelRowType.getFieldNames(), ", "));
     }
 
     @Override
     @SuppressWarnings("checkstyle:RegexpSingleline")
     public void write(SeaTunnelRow element) {
-        String[] arr = new String[seaTunnelRowType.getTotalFields()];
-        SeaTunnelDataType<?>[] fieldTypes = seaTunnelRowType.getFieldTypes();
-        Object[] fields = element.getFields();
-        for (int i = 0; i < fieldTypes.length; i++) {
-            if (i >= element.getArity()) {
-                arr[i] = "null";
-            } else {
-                arr[i] = deepToString(fieldTypes[i], fields[i]);
-            }
-        }
-        System.out.format("row=%s : %s%n", cnt.incrementAndGet(), StringUtils.join(arr, ", "));
+        System.out.println(Arrays.toString(element.getFields()));
     }
 
     @Override
     public void close() {
         // nothing
-    }
-
-    private String deepToString(SeaTunnelDataType<?> type, Object value) {
-        switch (type.getSqlType()) {
-            case ARRAY:
-            case BYTES:
-                return Arrays.toString((Object[]) value);
-            case MAP:
-                return JsonUtils.toJsonString(value);
-            case ROW:
-                return deepToString(type, value);
-            default:
-                return String.valueOf(value);
-        }
     }
 }

--- a/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
+++ b/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
@@ -36,7 +36,7 @@ source {
     schema = {
       fields {
         c_map = "map<string, string>"
-        c_array = "array<tinyint>"
+        c_array = "array<int>"
         c_string = string
         c_boolean = boolean
         c_tinyint = tinyint
@@ -72,7 +72,7 @@ transform {
 
   # you can also use other transform plugins, such as sql
   sql {
-    sql = "select c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_null,c_bytes from fake"
+    sql = "select c_array,c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_null,c_bytes from fake"
     result_table_name = "sql"
   }
 

--- a/seatunnel-translation/seatunnel-translation-base/src/main/java/org/apache/seatunnel/translation/serialization/RowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-base/src/main/java/org/apache/seatunnel/translation/serialization/RowConverter.java
@@ -124,5 +124,5 @@ public abstract class RowConverter<T> {
      *
      * @throws IOException Thrown, if the conversion fails.
      */
-    public abstract SeaTunnelRow convert(T engineRow) throws IOException;
+    public abstract SeaTunnelRow reconvert(T engineRow) throws IOException;
 }

--- a/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/serialization/FlinkRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/serialization/FlinkRowConverter.java
@@ -86,7 +86,7 @@ public class FlinkRowConverter extends RowConverter<Row> {
     }
 
     @Override
-    public SeaTunnelRow convert(Row engineRow) throws IOException {
+    public SeaTunnelRow reconvert(Row engineRow) throws IOException {
         return (SeaTunnelRow) reconvert(engineRow, dataType);
     }
 

--- a/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
+++ b/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
@@ -48,7 +48,7 @@ public class FlinkSinkWriter<InputT, CommT, WriterStateT> implements SinkWriter<
     @Override
     public void write(InputT element, org.apache.flink.api.connector.sink.SinkWriter.Context context) throws IOException {
         if (element instanceof Row) {
-            sinkWriter.write(rowSerialization.convert((Row) element));
+            sinkWriter.write(rowSerialization.reconvert((Row) element));
         } else {
             throw new InvalidClassException("only support Flink Row at now, the element Class is " + element.getClass());
         }

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkDataWriter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkDataWriter.java
@@ -55,7 +55,7 @@ public class SparkDataWriter<CommitInfoT, StateT> implements DataWriter<Internal
 
     @Override
     public void write(InternalRow record) throws IOException {
-        sinkWriter.write(rowConverter.convert(record));
+        sinkWriter.write(rowConverter.reconvert(record));
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.translation.spark.common.serialization;
 
-import static org.apache.seatunnel.api.table.type.SqlType.INT;
-
-import com.google.gson.internal.bind.ArrayTypeAdapter;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.MapType;

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -17,6 +17,11 @@
 
 package org.apache.seatunnel.translation.spark.common.serialization;
 
+import static org.apache.seatunnel.api.table.type.SqlType.INT;
+
+import com.google.gson.internal.bind.ArrayTypeAdapter;
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.MapType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -35,6 +40,7 @@ import org.apache.spark.sql.catalyst.expressions.MutableLong;
 import org.apache.spark.sql.catalyst.expressions.MutableShort;
 import org.apache.spark.sql.catalyst.expressions.MutableValue;
 import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
@@ -84,6 +90,8 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
                 return UTF8String.fromString((String) field);
             case DECIMAL:
                 return Decimal.apply((BigDecimal) field);
+            case ARRAY:
+                return ArrayData.toArrayData(field);
             default:
                 return field;
         }
@@ -146,11 +154,11 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
     }
 
     @Override
-    public SeaTunnelRow convert(InternalRow engineRow) throws IOException {
+    public SeaTunnelRow reconvert(InternalRow engineRow) throws IOException {
         return (SeaTunnelRow) reconvert(engineRow, dataType);
     }
 
-    public static Object reconvert(Object field, SeaTunnelDataType<?> dataType) {
+    private static Object reconvert(Object field, SeaTunnelDataType<?> dataType) {
         if (field == null) {
             return null;
         }
@@ -170,12 +178,33 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
                 return field.toString();
             case DECIMAL:
                 return ((Decimal) field).toJavaBigDecimal();
+            case ARRAY:
+                ArrayData arrayData = (ArrayData) field;
+                BasicType<?> elementType = ((ArrayType<?, ?>) dataType).getElementType();
+                switch (elementType.getSqlType()) {
+                    case INT:
+                        return arrayData.toIntArray();
+                    case TINYINT:
+                        return arrayData.toByteArray();
+                    case SMALLINT:
+                        return arrayData.toShortArray();
+                    case BIGINT:
+                        return arrayData.toLongArray();
+                    case BOOLEAN:
+                        return arrayData.toBooleanArray();
+                    case FLOAT:
+                        return arrayData.toFloatArray();
+                    case DOUBLE:
+                        return arrayData.toDoubleArray();
+                    default:
+                        return arrayData.array();
+                }
             default:
                 return field;
         }
     }
 
-    public static SeaTunnelRow reconvert(InternalRow engineRow, SeaTunnelRowType rowType) {
+    private static SeaTunnelRow reconvert(InternalRow engineRow, SeaTunnelRowType rowType) {
         Object[] fields = new Object[engineRow.numFields()];
         for (int i = 0; i < engineRow.numFields(); i++) {
             fields[i] = reconvert(engineRow.get(i, TypeConverterUtils.convert(rowType.getFieldType(i))),


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

fix the ArrayType translate for spark2.4.0，the method name for spark-type to seatunnel type should be reconvert
https://github.com/apache/incubator-seatunnel/issues/2521#issue-1350203104

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
