### PR TITLE
[Bug][Core] Let the SparkCommandArgs do not split the variable value with comma

### DIFF
--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/AbstractCommandArgs.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/AbstractCommandArgs.java
@@ -29,12 +29,13 @@ import java.util.List;
 public abstract class AbstractCommandArgs implements CommandArgs {
 
     @Parameter(names = {"-c", "--config"},
-        description = "Config file",
-        required = true)
+            description = "Config file",
+            required = true)
     private String configFile;
 
     @Parameter(names = {"-i", "--variable"},
-        description = "variable substitution, such as -i city=beijing, or -i date=20190318")
+            splitter = NoopParameterSplitter.class,
+            description = "variable substitution, such as -i city=beijing, or -i date=20190318")
     private List<String> variables = Collections.emptyList();
 
     // todo: use command type enum

--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/NoopParameterSplitter.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/NoopParameterSplitter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.base.command;
+
+
+import com.beust.jcommander.converters.IParameterSplitter;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An implementation class that does nothing on the value of variable.
+ */
+public class NoopParameterSplitter implements IParameterSplitter {
+
+    @Override
+    public List<String> split(String value) {
+        return Collections.singletonList(value);
+    }
+}

--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/NoopParameterSplitter.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/command/NoopParameterSplitter.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.core.base.command;
 
-
 import com.beust.jcommander.converters.IParameterSplitter;
 
 import java.util.Collections;

--- a/seatunnel-core/seatunnel-core-spark/src/test/java/org/apache/seatunnel/core/spark/args/SparkCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-core-spark/src/test/java/org/apache/seatunnel/core/spark/args/SparkCommandArgsTest.java
@@ -29,12 +29,12 @@ public class SparkCommandArgsTest {
 
     @Test
     public void testParseSparkArgs() {
-        String[] args = {"-c", "app.conf", "-e", "client", "-m", "yarn", "-i", "city=shijiazhuang", "-i", "name=Tom"};
+        String[] args = {"-c", "app.conf", "-e", "client", "-m", "yarn", "-i", "city=shijiazhuang", "-i", "name=Tom", "-i", "hobby=basketball,football"};
         SparkCommandArgs sparkArgs = CommandLineUtils.parse(args, new SparkCommandArgs(), "seatunnel-spark", true);
         Assertions.assertEquals("app.conf", sparkArgs.getConfigFile());
         Assertions.assertEquals(DeployMode.CLIENT, sparkArgs.getDeployMode());
         Assertions.assertEquals("yarn", sparkArgs.getMaster());
-        Assertions.assertEquals(Arrays.asList("city=shijiazhuang", "name=Tom"), sparkArgs.getVariables());
+        Assertions.assertEquals(Arrays.asList("city=shijiazhuang", "name=Tom", "hobby=basketball,football"), sparkArgs.getVariables());
     }
 
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This pull request optimized the parsing rules for custom command line variables, users can pass the variable value with comma, and variable values will not be divided by comma.
#2514 

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
