### PR TITLE
[Engine][Task] Fix multi SourceReader use same TaskGroupID

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlanGenerator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlanGenerator.java
@@ -224,8 +224,9 @@ public class PhysicalPlanGenerator {
             .flatMap(flow -> {
                 List<PhysicalVertex> t = new ArrayList<>();
                 long taskIDPrefix = idGenerator.getNextId();
+                long taskGroupIDPrefix = idGenerator.getNextId();
                 for (int i = 0; i < flow.getAction().getParallelism(); i++) {
-                    long taskGroupID = idGenerator.getNextId();
+                    long taskGroupID = mixIDPrefixAndIndex(taskGroupIDPrefix, i);
                     setFlowConfig(flow, i);
                     SeaTunnelTask seaTunnelTask = new TransformSeaTunnelTask(jobImmutableInformation.getJobId(),
                         new TaskLocation(taskGroupID, mixIDPrefixAndIndex(taskIDPrefix, i)), i, flow);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
@@ -45,7 +45,6 @@ import org.apache.seatunnel.engine.server.task.group.TaskGroupWithIntermediateQu
 
 import lombok.NonNull;
 
-import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -150,12 +149,6 @@ public abstract class SeaTunnelTask extends AbstractTask {
         if (flowFutures.stream().allMatch(CompletableFuture::isDone)) {
             progress.done();
         }
-    }
-
-    @Override
-    public void close() throws IOException {
-        startFlowLifeCycle.close();
-        progress.done();
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import lombok.NonNull;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -64,8 +65,13 @@ public class SourceSeaTunnelTask<T, SplitT extends SourceSplit> extends SeaTunne
     @SuppressWarnings("unchecked")
     public ProgressState call() throws Exception {
         ((SourceFlowLifeCycle<T, SplitT>) startFlowLifeCycle).collect();
-        checkDone();
         return progress.toState();
+    }
+
+    @Override
+    public void close() throws IOException {
+        startFlowLifeCycle.close();
+        progress.done();
     }
 
     public void receivedSourceSplit(List<SplitT> splits) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSplitEnumeratorTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSplitEnumeratorTask.java
@@ -135,7 +135,7 @@ public class SourceSplitEnumeratorTask<SplitT extends SourceSplit> extends Coord
     private void stateProcess() throws Exception {
         switch (currState) {
             case INIT:
-                if (readerFinishFuture.isDone()) {
+                if (readerRegisterFuture.isDone()) {
                     readerRegisterFuture.get();
                     currState = EnumeratorState.READER_REGISTER_COMPLETE;
                 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java
@@ -80,8 +80,9 @@ public class SourceFlowLifeCycle<T, SplitT extends SourceSplit> extends Abstract
 
     @Override
     public void close() throws IOException {
-        super.close();
+        collector.close();
         reader.close();
+        super.close();
     }
 
     public void collect() throws Exception {
@@ -91,10 +92,9 @@ public class SourceFlowLifeCycle<T, SplitT extends SourceSplit> extends Abstract
     }
 
     public void signalNoMoreElement() {
-        // Close this reader
+        // ready close this reader
         try {
             this.closed = true;
-            collector.close();
             runningTask.getExecutionContext().sendToMaster(new SourceNoMoreElementOperation(currentTaskID,
                     enumeratorTaskID)).get();
         } catch (Exception e) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
Fix multi SourceReader use same TaskGroupID
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
