### PR TITLE
[Bug][ConsoleSinkV2]fix fieldToString StackOverflow and add Unit-Test

### DIFF
--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
@@ -25,7 +25,9 @@ import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
@@ -60,11 +62,20 @@ public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
         switch (type.getSqlType()) {
             case ARRAY:
             case BYTES:
-                return Arrays.toString((Object[]) value);
+                List<String> arrayData = new ArrayList<>();
+                for (int i = 0; i < Array.getLength(value); i++) {
+                    arrayData.add(String.valueOf(Array.get(value, i)));
+                }
+                return arrayData.toString();
             case MAP:
                 return JsonUtils.toJsonString(value);
             case ROW:
-                return fieldToString(type, value);
+                List<String> rowData = new ArrayList<>();
+                SeaTunnelRowType rowType = (SeaTunnelRowType) type;
+                for (int i = 0; i < rowType.getTotalFields(); i++) {
+                    rowData.add(fieldToString(rowType.getFieldTypes()[i], Array.get(value, i)));
+                }
+                return rowData.toString();
             default:
                 return String.valueOf(value);
         }

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
@@ -88,7 +88,6 @@ public class ConsoleSinkWriterIT {
             map.put("key", "value");
             MapType<String, String> mapType = new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE);
             Object mapString = fieldToStringTest(mapType, map);
-            System.out.println(mapString);
             Assertions.assertNotNull(mapString);
             Assertions.assertEquals("{\"key\":\"value\"}", mapString);
         });

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
@@ -102,7 +102,6 @@ public class ConsoleSinkWriterIT {
             byte[] bytes = RandomUtils.nextBytes(10);
             Object[] rowData = {(byte) 1, bytes, bytes};
             Object rowString = fieldToStringTest(seaTunnelRowType, rowData);
-            System.out.println(rowString);
             Assertions.assertNotNull(rowString);
             Assertions.assertEquals(String.format("[1, %s, %s]", Arrays.toString(bytes), Arrays.toString(bytes)), rowString.toString());
         });

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.console.sink;
+
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.utils.ReflectionUtils;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Optional;
+
+public class ConsoleSinkWriterIT {
+
+    private ConsoleSinkWriter consoleSinkWriter;
+
+    @BeforeEach
+    void setUp() {
+        String[] fieldNames = {};
+        SeaTunnelDataType<?>[] fieldTypes = {};
+        SeaTunnelRowType seaTunnelRowType = new SeaTunnelRowType(fieldNames, fieldTypes);
+        consoleSinkWriter = new ConsoleSinkWriter(seaTunnelRowType);
+    }
+
+    private Object fieldToStringTest(SeaTunnelDataType<?> dataType, Object value) {
+        Optional<Method> fieldToString = ReflectionUtils.getDeclaredMethod(ConsoleSinkWriter.class, "fieldToString", SeaTunnelDataType.class, Object.class);
+        Method method = fieldToString.orElseThrow(() -> new RuntimeException("method fieldToString not found"));
+        try {
+            return method.invoke(consoleSinkWriter, dataType, value);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void arrayIntTest() {
+        Assertions.assertDoesNotThrow(() -> {
+            Integer[] integerArr = {1};
+            Object integerArrString = fieldToStringTest(ArrayType.INT_ARRAY_TYPE, integerArr);
+            Assertions.assertEquals(integerArrString, "[1]");
+            int[] intArr = {1, 2};
+            Object intArrString = fieldToStringTest(ArrayType.INT_ARRAY_TYPE, intArr);
+            Assertions.assertEquals(intArrString, "[1, 2]");
+        });
+    }
+
+    @Test
+    void arrayStringTest() {
+        Assertions.assertDoesNotThrow(() -> {
+            String str = RandomStringUtils.randomAlphanumeric(10);
+            Object obj = fieldToStringTest(BasicType.STRING_TYPE, str);
+            Assertions.assertTrue(obj instanceof String);
+            Assertions.assertEquals(10, ((String) obj).length());
+        });
+    }
+
+    @Test
+    void hashMapTest() {
+        Assertions.assertDoesNotThrow(() -> {
+            HashMap<Object, Object> map = new HashMap<>();
+            map.put("key", "value");
+            MapType<String, String> mapType = new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE);
+            Object mapString = fieldToStringTest(mapType, map);
+            Assertions.assertNotNull(mapString);
+        });
+    }
+
+    @Test
+    void rowTypeTest() {
+        Assertions.assertDoesNotThrow(() -> {
+            String[] fieldNames = {"c_byte", "c_array"};
+            SeaTunnelDataType<?>[] fieldTypes = {BasicType.BYTE_TYPE, ArrayType.INT_ARRAY_TYPE};
+            SeaTunnelRowType seaTunnelRowType = new SeaTunnelRowType(fieldNames, fieldTypes);
+            int[] intArr = {RandomUtils.nextInt(0, Integer.MAX_VALUE)};
+            Object[] rowData = {(byte) 1, intArr};
+            Object rowString = fieldToStringTest(seaTunnelRowType, rowData);
+            Assertions.assertNotNull(rowString);
+        });
+    }
+}

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.console.sink;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
@@ -70,7 +71,7 @@ public class ConsoleSinkWriterIT {
     }
 
     @Test
-    void arrayStringTest() {
+    void stringTest() {
         Assertions.assertDoesNotThrow(() -> {
             String str = RandomStringUtils.randomAlphanumeric(10);
             Object obj = fieldToStringTest(BasicType.STRING_TYPE, str);
@@ -93,11 +94,11 @@ public class ConsoleSinkWriterIT {
     @Test
     void rowTypeTest() {
         Assertions.assertDoesNotThrow(() -> {
-            String[] fieldNames = {"c_byte", "c_array"};
-            SeaTunnelDataType<?>[] fieldTypes = {BasicType.BYTE_TYPE, ArrayType.INT_ARRAY_TYPE};
+            String[] fieldNames = {"c_byte", "c_array", "bytes"};
+            SeaTunnelDataType<?>[] fieldTypes = {BasicType.BYTE_TYPE, ArrayType.BYTE_ARRAY_TYPE, PrimitiveByteArrayType.INSTANCE};
             SeaTunnelRowType seaTunnelRowType = new SeaTunnelRowType(fieldNames, fieldTypes);
-            int[] intArr = {RandomUtils.nextInt(0, Integer.MAX_VALUE)};
-            Object[] rowData = {(byte) 1, intArr};
+            byte[] bytes = RandomUtils.nextBytes(10);
+            Object[] rowData = {(byte) 1, bytes, bytes};
             Object rowString = fieldToStringTest(seaTunnelRowType, rowData);
             Assertions.assertNotNull(rowString);
         });

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriterIT.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -87,7 +88,9 @@ public class ConsoleSinkWriterIT {
             map.put("key", "value");
             MapType<String, String> mapType = new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE);
             Object mapString = fieldToStringTest(mapType, map);
+            System.out.println(mapString);
             Assertions.assertNotNull(mapString);
+            Assertions.assertEquals("{\"key\":\"value\"}", mapString);
         });
     }
 
@@ -100,7 +103,9 @@ public class ConsoleSinkWriterIT {
             byte[] bytes = RandomUtils.nextBytes(10);
             Object[] rowData = {(byte) 1, bytes, bytes};
             Object rowString = fieldToStringTest(seaTunnelRowType, rowData);
+            System.out.println(rowString);
             Assertions.assertNotNull(rowString);
+            Assertions.assertEquals(String.format("[1, %s, %s]", Arrays.toString(bytes), Arrays.toString(bytes)), rowString.toString());
         });
     }
 }

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeRandomData.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeRandomData.java
@@ -112,7 +112,7 @@ public class FakeRandomData {
             objectObjectHashMap.put(key, value);
             return objectObjectHashMap;
         } else if (fieldType instanceof PrimitiveByteArrayType) {
-            return RandomUtils.nextBytes(100);
+            return RandomUtils.nextBytes(3);
         } else if (VOID_TYPE.equals(fieldType) || fieldType == null) {
             return Void.TYPE;
         } else {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
when I test Map translation for Spark-Engine,I find the method named `fieldToString ` has some bug
It's my fault. 
(1) int[] -> Object[] will error
(2) for row Object will StackOverflow
I fix it and add some unit

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
