### PR TITLE
[SeaTunnel]Simply seatunnel e2e test.

### DIFF
--- a/seatunnel-connectors-v2/connector-fake/pom.xml
+++ b/seatunnel-connectors-v2/connector-fake/pom.xml
@@ -35,6 +35,20 @@
             <artifactId>connector-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-flink-connector-v2-e2e-local</artifactId>
+            <version>${parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-console</artifactId>
+            <version>${parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
@@ -1,0 +1,22 @@
+package org.apache.seatunnel.connectors.seatunnel.fake.source;
+
+import org.apache.seatunnel.core.starter.exception.CommandException;
+import org.apache.seatunnel.e2e.flink.local.FlinkLocalContainer;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Created 2022/8/30
+ *
+ * @author ke.hao
+ */
+public class FakeSourceITTest {
+
+    @Test
+    public void testFakeConsole() throws CommandException {
+        FlinkLocalContainer flinkLocalContainer = FlinkLocalContainer.builder()
+            .build();
+
+        flinkLocalContainer.executeSeaTunnelFlinkJob("fake/fakesource_to_console.conf");
+    }
+}

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.fake.source;
 
 import org.apache.seatunnel.core.starter.exception.CommandException;

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org.apache.seatunnel.connectors.seatunnel.fake.source/FakeSourceITTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Created 2022/8/30
- *
- * @author ke.hao
  */
 public class FakeSourceITTest {
 

--- a/seatunnel-connectors-v2/connector-fake/src/test/resources/fake/fakesource_to_console.conf
+++ b/seatunnel-connectors-v2/connector-fake/src/test/resources/fake/fakesource_to_console.conf
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
+env {
+  # You can set flink configuration here
+  execution.parallelism = 1
+  job.mode = "BATCH"
+  #execution.checkpoint.interval = 10000
+  #execution.checkpoint.data-uri = "hdfs://localhost:9000/checkpoint"
+}
+
+source {
+  # This is a example source plugin **only for test and demonstrate the feature source plugin**
+  FakeSource {
+    result_table_name = "fake"
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+  # If you would like to get more information about how to configure seatunnel and see full list of source plugins,
+  # please go to https://seatunnel.apache.org/docs/connector-v2/source/FakeSource
+}
+
+transform {
+    sql {
+      sql = "select name,age from fake"
+    }
+
+  # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
+  # please go to https://seatunnel.apache.org/docs/transform/sql
+}
+
+sink {
+  Console {}
+
+  # If you would like to get more information about how to configure seatunnel and see full list of sink plugins,
+  # please go to https://seatunnel.apache.org/docs/category/sink-v2
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -52,7 +52,52 @@
         <module>connector-neo4j</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+
+            <!--    connector-e2e-test-local    -->
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>seatunnel-flink-connector-v2-e2e-local</artifactId>
+                <version>${parent.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!--   engine test dependencies   -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/seatunnel-e2e/pom.xml
+++ b/seatunnel-e2e/pom.xml
@@ -30,6 +30,7 @@
         <module>seatunnel-flink-e2e</module>
         <module>seatunnel-spark-e2e</module>
         <module>seatunnel-flink-connector-v2-e2e</module>
+        <module>seatunnel-flink-connector-v2-e2e-local</module>
         <module>seatunnel-spark-connector-v2-e2e</module>
         <module>seatunnel-flink-sql-e2e</module>
     </modules>

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/pom.xml
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/pom.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/pom.xml
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>seatunnel-e2e</artifactId>
+        <groupId>org.apache.seatunnel</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>seatunnel-flink-connector-v2-e2e-local</artifactId>
+
+
+    <dependencies>
+
+        <!--    flink-starter    -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-flink-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
@@ -30,6 +30,7 @@ import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,7 @@ public class FlinkLocalContainer {
 
     @SneakyThrows
     private String getResource(String confFile) {
-        return FlinkLocalContainer.class.getClassLoader().getResource(confFile)
-            .toURI().getPath();
+        return Paths.get(FlinkLocalContainer.class.getClassLoader().getResource(confFile).toURI())
+            .toString();
     }
 }

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.e2e.flink.local;
 
 import org.apache.seatunnel.core.starter.Seatunnel;

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/java/org/apache/seatunnel/e2e/flink/local/FlinkLocalContainer.java
@@ -1,0 +1,46 @@
+package org.apache.seatunnel.e2e.flink.local;
+
+import org.apache.seatunnel.core.starter.Seatunnel;
+import org.apache.seatunnel.core.starter.command.Command;
+import org.apache.seatunnel.core.starter.exception.CommandException;
+import org.apache.seatunnel.core.starter.flink.args.FlinkCommandArgs;
+import org.apache.seatunnel.core.starter.flink.command.FlinkCommandBuilder;
+import org.apache.seatunnel.core.starter.flink.config.FlinkRunMode;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.SneakyThrows;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created 2022/8/30
+ */
+
+@Builder
+@AllArgsConstructor
+public class FlinkLocalContainer {
+    private static final Logger LOG = LoggerFactory.getLogger(FlinkLocalContainer.class);
+
+    private List<String> parameters = new ArrayList<>();
+
+    public void executeSeaTunnelFlinkJob(String path) throws CommandException {
+        FlinkCommandArgs flinkCommandArgs = new FlinkCommandArgs();
+        flinkCommandArgs.setRunMode(FlinkRunMode.RUN);
+        flinkCommandArgs.setConfigFile(getResource(path));
+        flinkCommandArgs.setCheckConfig(false);
+        flinkCommandArgs.setVariables(parameters);
+        Command<FlinkCommandArgs> flinkCommandArgsCommand = new FlinkCommandBuilder()
+            .buildCommand(flinkCommandArgs);
+        Seatunnel.run(flinkCommandArgsCommand);
+    }
+
+    @SneakyThrows
+    private String getResource(String confFile) {
+        return FlinkLocalContainer.class.getClassLoader().getResource(confFile)
+            .toURI().getPath();
+    }
+}

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/resources/log4j.properties
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e-local/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

Now, Seatunnel e2e test need compile and package some modules in seatunnel root project, it consume us lots of time to rebuild after e2e tests failed, so we want to improve the efficiency when we develop a new connector.

In this pull request, we use flink minicluster to support e2e test in local environment. User just need to add `seatunnel-flink-connector-v2-e2e-local` and `fakesource` or `console-sink` to the connector's pom file, then can test the connector directly.

I add an example in the module `connector-fake`.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
