### PR TITLE
[hotfix][flink-1.13] fix flink example NPE & NoSuchMethodError

### DIFF
--- a/seatunnel-examples/seatunnel-flink-connector-v2-example/pom.xml
+++ b/seatunnel-examples/seatunnel-flink-connector-v2-example/pom.xml
@@ -76,11 +76,6 @@
             <artifactId>connector-dingtalk</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.seatunnel</groupId>
-            <artifactId>connector-datahub</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <!--   seatunnel connectors   -->
 
         <!--flink-->

--- a/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/source/BaseSeaTunnelSourceFunction.java
+++ b/seatunnel-translation/seatunnel-translation-flink/src/main/java/org/apache/seatunnel/translation/flink/source/BaseSeaTunnelSourceFunction.java
@@ -102,8 +102,10 @@ public abstract class BaseSeaTunnelSourceFunction extends RichSourceFunction<Row
     public void cancel() {
         running = false;
         try {
-            LOG.debug("Cancel the SeaTunnelSourceFunction of Flink.");
-            internalSource.close();
+            if (internalSource != null) {
+                LOG.debug("Cancel the SeaTunnelSourceFunction of Flink.");
+                internalSource.close();
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
1. Datahub don't add example to the `seatunnel-flink-connector-v2-example` module.
2. `connector-datahub` depends on the lower version of `common-io`, causing dependency conflicts.
3. NoSuchMethodError exception caused by dependency conflict.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
