### PR TITLE
[Fix][Doc] Fix The HDFSFile Sink And LocalFile Sink Connectors Document Error.

### DIFF
--- a/docs/en/connector-v2/sink/HdfsFile.md
+++ b/docs/en/connector-v2/sink/HdfsFile.md
@@ -10,20 +10,20 @@ Output data to hdfs file. Support bounded and unbounded job.
 
 In order to use this connector, You must ensure your spark/flink cluster already integrated hadoop. The tested hadoop version is 2.x.
 
-| name                              | type   | required | default value                                                 |
-| --------------------------------- | ------ | -------- | ------------------------------------------------------------- |
-| path                              | string | yes      | -                                                             |
-| file_name_expression              | string | no       | "${transactionId}"                                            |
-| file_format                       | string | no       | "text"                                                        |
-| filename_time_format              | string | no       | "yyyy.MM.dd"                                                  |
-| field_delimiter                   | string | no       | '\001'                                                        |
-| row_delimiter                     | string | no       | "\n"                                                          |
-| partition_by                      | array  | no       | -                                                             |
-| partition_dir_expression          | string | no       | "\${k0}=\${v0}\/\${k1}=\${v1}\/...\/\${kn}=\${vn}\/"          |
-| is_partition_field_write_in_file  | boolean| no       | false                                                         |
-| sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns     |
-| is_enable_transaction             | boolean| no       | true                                                          |
-| save_mode                         | string | no       | "error"                                                       |
+| name                              | type   | required | default value                                           |
+| --------------------------------- | ------ | -------- |---------------------------------------------------------|
+| path                              | string | yes      | -                                                       |
+| file_name_expression              | string | no       | "${transactionId}"                                      |
+| file_format                       | string | no       | "text"                                                  |
+| filename_time_format              | string | no       | "yyyy.MM.dd"                                            |
+| field_delimiter                   | string | no       | '\001'                                                  |
+| row_delimiter                     | string | no       | "\n"                                                    |
+| partition_by                      | array  | no       | -                                                       |
+| partition_dir_expression          | string | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"              |
+| is_partition_field_write_in_file  | boolean| no       | false                                                   |
+| sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns |
+| is_enable_transaction             | boolean| no       | true                                                    |
+| save_mode                         | string | no       | "error"                                                 |
 
 ### path [string]
 

--- a/docs/en/connector-v2/sink/LocalFile.md
+++ b/docs/en/connector-v2/sink/LocalFile.md
@@ -8,20 +8,20 @@ Output data to local file. Support bounded and unbounded job.
 
 ## Options
 
-| name                              | type   | required | default value                                                 |
-| --------------------------------- | ------ | -------- | ------------------------------------------------------------- |
-| path                              | string | yes      | -                                                             |
-| file_name_expression              | string | no       | "${transactionId}"                                            |
-| file_format                       | string | no       | "text"                                                        |
-| filename_time_format              | string | no       | "yyyy.MM.dd"                                                  |
-| field_delimiter                   | string | no       | '\001'                                                        |
-| row_delimiter                     | string | no       | "\n"                                                          |
-| partition_by                      | array  | no       | -                                                             |
-| partition_dir_expression          | string | no       | "\${k0}=\${v0}\/\${k1}=\${v1}\/...\/\${kn}=\${vn}\/"          |
-| is_partition_field_write_in_file  | boolean| no       | false                                                         |
-| sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns     |
-| is_enable_transaction             | boolean| no       | true                                                          |
-| save_mode                         | string | no       | "error"                                                       |
+| name                              | type   | required | default value                                       |
+| --------------------------------- | ------ | -------- | --------------------------------------------------- |
+| path                              | string | yes      | -                                                   |
+| file_name_expression              | string | no       | "${transactionId}"                                  |
+| file_format                       | string | no       | "text"                                              |
+| filename_time_format              | string | no       | "yyyy.MM.dd"                                        |
+| field_delimiter                   | string | no       | '\001'                                              |
+| row_delimiter                     | string | no       | "\n"                                                |
+| partition_by                      | array  | no       | -                                                   |
+| partition_dir_expression          | string | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"          |
+| is_partition_field_write_in_file  | boolean| no       | false                                               |
+| sink_columns                      | array  | no       | When this parameter is empty, all fields are sink columns |
+| is_enable_transaction             | boolean| no       | true                                                |
+| save_mode                         | string | no       | "error"                                             |
 
 ### path [string]
 


### PR DESCRIPTION

<img width="1306" alt="image" src="https://user-images.githubusercontent.com/32193458/188114912-c2a945b5-f0c7-4b07-b26d-4be90860132e.png">


The value of `partition_dir_expression ` is `"\${k0}=\${v0}\/\${k1}=\${v1}\/...\/\${kn}=\${vn}\/"` but the expected value is `"${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/" `

The same as HDFSFile Sink.