### PR TITLE
[hotfix][connector][flink-sql-elastic] Updated prepare section

### DIFF
--- a/docs/en/connector/flink-sql/ElasticSearch.md
+++ b/docs/en/connector/flink-sql/ElasticSearch.md
@@ -9,8 +9,8 @@ With elasticsearch connector, you can use the Flink SQL to write data into Elast
 ## Usage
 Let us have a brief example to show how to use the connector.
 
-### 1. kafka prepare
-Please refer to the [Eleastic Doc](https://www.elastic.co/guide/index.html) to prepare elastic environment.
+### 1. Elastic prepare
+Please refer to the [Elastic Doc](https://www.elastic.co/guide/index.html) to prepare elastic environment.
 
 ### 2. prepare seatunnel configuration
 ElasticSearch provide different connectors for different version:


### PR DESCRIPTION

## Purpose of this pull request

The flink-sql elastic doc indicates <code>1. **kafka** prepare</code> instead of <code>1. **Elastic** prepare</code> with instructions to elastic env preparation.  Also, fixed typo in http reference link.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
