### PR TITLE
[Bug][Translation] fix data,time,timestamp convert for spark

### DIFF
--- a/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
+++ b/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
@@ -49,7 +49,6 @@ source {
         c_null = "null"
         c_bytes = bytes
         c_date = date
-        c_time = time
         c_timestamp = timestamp
       }
     }
@@ -72,7 +71,7 @@ transform {
 
   # you can also use other transform plugins, such as sql
   sql {
-    sql = "select c_array,c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_null,c_bytes from fake"
+    sql = "select c_array,c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_null,c_bytes,c_date,c_timestamp from fake"
     result_table_name = "sql"
   }
 

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -100,7 +100,10 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
             if (TypeConverterUtils.ROW_KIND_FIELD.equals(rowType.getFieldName(i))) {
                 values[i].update(seaTunnelRow.getRowKind().toByteValue());
             } else {
-                values[i].update(convert(seaTunnelRow.getField(i), rowType.getFieldType(i)));
+                Object fieldValue = convert(seaTunnelRow.getField(i), rowType.getFieldType(i));
+                if (fieldValue != null) {
+                    values[i].update(fieldValue);
+                }
             }
         }
         return new SpecificInternalRow(values);

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.translation.serialization.RowConverter;
+import org.apache.seatunnel.translation.spark.common.utils.InstantConverterUtils;
 import org.apache.seatunnel.translation.spark.common.utils.TypeConverterUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -77,7 +78,7 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
                 // TODO: how reconvert? there are not Support for Spark Type,we must define the Type in spark
                 throw new RuntimeException("we not support for time type now");
             case TIMESTAMP:
-                return Timestamp.valueOf((LocalDateTime) field).toInstant().toEpochMilli();
+                return InstantConverterUtils.toEpochMicro(Timestamp.valueOf((LocalDateTime) field).toInstant());
             case MAP:
                 return convertMap((Map<?, ?>) field, (MapType<?, ?>) dataType, InternalRowConverter::convert);
             case STRING:
@@ -166,9 +167,9 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
                 return LocalDate.ofEpochDay((int) field);
             case TIME:
                 // todo: support this Type
-                throw new RuntimeException("not support now but will");
+                throw new RuntimeException("time type not support now but will");
             case TIMESTAMP:
-                return Timestamp.from(Instant.ofEpochMilli((long) field)).toLocalDateTime();
+                return Timestamp.from(InstantConverterUtils.ofEpochMicro((long) field)).toLocalDateTime();
             case MAP:
                 return convertMap((Map<?, ?>) field, (MapType<?, ?>) dataType, InternalRowConverter::reconvert);
             case STRING:

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -75,8 +75,8 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
             case DATE:
                 return (int) ((LocalDate) field).toEpochDay();
             case TIME:
-                // TODO: how reconvert? there are not Support for Spark Type,we must define the Type in spark
-                throw new RuntimeException("we not support for time type now");
+                // TODO: Support TIME Type
+                throw new RuntimeException("time type is not supported now, but will be supported in the future.");
             case TIMESTAMP:
                 return InstantConverterUtils.toEpochMicro(Timestamp.valueOf((LocalDateTime) field).toInstant());
             case MAP:

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/serialization/InternalRowConverter.java
@@ -169,8 +169,8 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
             case DATE:
                 return LocalDate.ofEpochDay((int) field);
             case TIME:
-                // todo: support this Type
-                throw new RuntimeException("time type not support now but will");
+                // TODO: Support TIME Type
+                throw new RuntimeException("time type is not supported now, but will be supported in the future.");
             case TIMESTAMP:
                 return Timestamp.from(InstantConverterUtils.ofEpochMicro((long) field)).toLocalDateTime();
             case MAP:

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/utils/InstantConverterUtils.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/utils/InstantConverterUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.translation.spark.common.utils;
+
+import java.time.Instant;
+
+public class InstantConverterUtils {
+
+    private static final int MICRO_OF_SECOND = 1000_000;
+    private static final int MICRO_OF_NANOS = 1000;
+
+    /**
+     * @see Instant#toEpochMilli()
+     */
+    public static Long toEpochMicro(Instant instant) {
+        long seconds = instant.getEpochSecond();
+        int nanos = instant.getNano();
+        if (seconds < 0 && nanos > 0) {
+            long micro = Math.multiplyExact(seconds + 1, MICRO_OF_SECOND);
+            long adjustment = nanos / MICRO_OF_NANOS - MICRO_OF_SECOND;
+            return Math.addExact(micro, adjustment);
+        } else {
+            long millis = Math.multiplyExact(seconds, MICRO_OF_SECOND);
+            return Math.addExact(millis, nanos / MICRO_OF_NANOS);
+        }
+    }
+
+    /**
+     * @see Instant#ofEpochMilli(long)
+     */
+    public static Instant ofEpochMicro(long epochMicro) {
+        long secs = Math.floorDiv(epochMicro, MICRO_OF_SECOND);
+        int mos = (int) Math.floorMod(epochMicro, MICRO_OF_SECOND);
+        return Instant.ofEpochSecond(secs, Math.multiplyExact(mos, MICRO_OF_NANOS));
+    }
+}

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/utils/TypeConverterUtils.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/common/utils/TypeConverterUtils.java
@@ -85,8 +85,8 @@ public class TypeConverterUtils {
                 return DataTypes.BinaryType;
             case DATE:
                 return DataTypes.DateType;
-            case TIME:
-                // TODO: how reconvert?
+            // case TIME:
+                // TODO: not support now, how reconvert?
             case TIMESTAMP:
                 return DataTypes.TimestampType;
             case ARRAY:


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
fix data,time,timestamp convert for spark

![image](https://user-images.githubusercontent.com/35491928/188301176-e0520c28-3fcd-4427-8e9c-e6bfeafc5983.png)


I chose the UTC zone for timestamp，
time can be epochDay +time =timestamp,value is long
date is epochDay , value is int
time is timestamp , value is long




## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
