### PR TITLE
[Bug][Doc] Fix postgresql jdbc download link 404 in documentation

### DIFF
--- a/docs/en/connector/flink-sql/Jdbc.md
+++ b/docs/en/connector/flink-sql/Jdbc.md
@@ -15,7 +15,7 @@ A driver dependency is also required to connect to a specified database. Here ar
 | Driver     | Group Id	         | Artifact Id	        | JAR           |
 |------------|-------------------|----------------------|---------------|
 | MySQL	     | mysql	         | mysql-connector-java | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
-| PostgreSQL | org.postgresql	 | postgresql	        | [Download](https://jdbc.postgresql.org/download.html) |
+| PostgreSQL | org.postgresql	 | postgresql	        | [Download](https://jdbc.postgresql.org/download/) |
 | Derby	     | org.apache.derby	 | derby	            | [Download](http://db.apache.org/derby/derby_downloads.html) |
 
 After downloading the driver jars, you need to place the jars into $FLINK_HOME/lib/.


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Fix postgresql jdbc download link 404 in documentation

before: https://jdbc.postgresql.org/download.html
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/37063904/188983464-cd97bf3c-dd81-4af9-ae57-f4de289e9b26.png">

after: https://jdbc.postgresql.org/download/

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/37063904/188983699-7605f077-94cd-4082-b645-ec3bfa6f94e0.png">


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
