### PR TITLE
[hotfix][transform][replace] Corrected syntax

### DIFF
--- a/docs/en/transform/replace.md
+++ b/docs/en/transform/replace.md
@@ -69,7 +69,7 @@ Use `Replace` as udf in sql.
   Replace {
     fields = "_replaced"
     pattern = "([^ ]*) ([^ ]*)"
-    replacement = "$2
+    replacement = "$2"
     isRegex = true
     replaceFirst = true
   }


### PR DESCRIPTION
## Purpose of this pull request

The example has missing quote <code>replacement = **"$2**</code>.  Update to <code>replacement = **"$2"**</code>

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
