### PR TITLE
[Improve][e2e] modify DM driver by downloading and add the value comparison of all columns

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/pom.xml
+++ b/seatunnel-connectors-v2/connector-jdbc/pom.xml
@@ -53,6 +53,7 @@
             <groupId>com.dameng</groupId>
             <artifactId>DmJdbcDriver18</artifactId>
             <version>${dm-jdbc.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-jdbc-flink-e2e/src/test/java/org/apache/seatunnel/e2e/flink/v2/jdbc/JdbcDmdbIT.java
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-jdbc-flink-e2e/src/test/java/org/apache/seatunnel/e2e/flink/v2/jdbc/JdbcDmdbIT.java
@@ -57,11 +57,12 @@ public class JdbcDmdbIT extends FlinkContainer {
     private static final String DATABASE = "SYSDBA";
     private static final String SOURCE_TABLE = "e2e_table_source";
     private static final String SINK_TABLE = "e2e_table_sink";
+    private static final String DM_DRIVER_JAR = "https://repo1.maven.org/maven2/com/dameng/DmJdbcDriver18/8.1.1.193/DmJdbcDriver18-8.1.1.193.jar";
     private Connection jdbcConnection;
     private GenericContainer<?> dbServer;
 
     @BeforeEach
-    public void startDmdbContainer() throws ClassNotFoundException, SQLException {
+    public void startDmdbContainer() throws ClassNotFoundException {
         dbServer = new GenericContainer<>(DOCKER_IMAGE)
             .withNetwork(NETWORK)
             .withNetworkAliases(HOST)
@@ -82,6 +83,12 @@ public class JdbcDmdbIT extends FlinkContainer {
     private void initializeJdbcConnection() throws SQLException {
         jdbcConnection = DriverManager.getConnection(String.format(
             URL, dbServer.getHost()), USERNAME, PASSWORD);
+    }
+
+    @Override
+    protected void executeExtraCommands(GenericContainer<?> container) throws IOException, InterruptedException {
+        Container.ExecResult extraCommands = container.execInContainer("bash", "-c", "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && curl -O " + DM_DRIVER_JAR);
+        Assertions.assertEquals(0, extraCommands.getExitCode());
     }
 
     /**
@@ -110,7 +117,7 @@ public class JdbcDmdbIT extends FlinkContainer {
     }
 
     private void assertHasData(String table) {
-        try (Statement statement = jdbcConnection.createStatement();) {
+        try (Statement statement = jdbcConnection.createStatement()) {
             String sql = String.format("select * from %s.%s limit 1", DATABASE, table);
             ResultSet source = statement.executeQuery(sql);
             Assertions.assertTrue(source.next());
@@ -142,6 +149,11 @@ public class JdbcDmdbIT extends FlinkContainer {
         Container.ExecResult execResult = executeSeaTunnelFlinkJob("/jdbc/jdbc_dm_source_and_sink.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
         assertHasData(SINK_TABLE);
+        JdbcE2eUtil.compare(jdbcConnection, String.format("select * from %s.%s limit 1", DATABASE, SOURCE_TABLE),
+            String.format("select * from %s.%s limit 1", DATABASE, SINK_TABLE),
+            "DM_BIT, DM_INT, DM_INTEGER, DM_PLS_INTEGER, DM_TINYINT, DM_BYTE, DM_SMALLINT, DM_BIGINT, DM_NUMERIC, DM_NUMBER, "
+                + "DM_DECIMAL, DM_DEC, DM_REAL, DM_FLOAT, DM_DOUBLE_PRECISION, DM_DOUBLE, DM_CHAR, DM_CHARACTER, DM_VARCHAR, DM_VARCHAR2,"
+                + " DM_TEXT, DM_LONG, DM_LONGVARCHAR, DM_CLOB, DM_TIMESTAMP, DM_DATETIME, DM_TIME, DM_DATE, DM_BLOB, DM_BINARY, DM_VARBINARY, DM_LONGVARBINARY");
     }
 
 }

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-jdbc-flink-e2e/src/test/java/org/apache/seatunnel/e2e/flink/v2/jdbc/JdbcE2eUtil.java
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-jdbc-flink-e2e/src/test/java/org/apache/seatunnel/e2e/flink/v2/jdbc/JdbcE2eUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.flink.v2.jdbc;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class JdbcE2eUtil {
+
+    public static void compare(Connection conn, String sourceSql, String sinkSQL, String columns) throws SQLException, IOException {
+        String[] split = StringUtils.split(columns, ",");
+        List<String> columnList = Arrays.stream(split)
+            .map(o -> StringUtils.remove(o, "\n"))
+            .map(String::trim)
+            .collect(Collectors.toList());
+        compare(conn, sourceSql, sinkSQL, columnList);
+    }
+
+    @SuppressWarnings("magicnumber")
+    public static void compare(Connection conn, String sourceSql, String sinkSQL, List<String> columns) throws SQLException, IOException {
+        Assertions.assertTrue(conn.isValid(10));
+        try (Statement sourceState = conn.createStatement();
+             Statement sinkState = conn.createStatement()
+        ) {
+            ResultSet source = sourceState.executeQuery(sourceSql);
+            ResultSet sink = sinkState.executeQuery(sinkSQL);
+            compareResultSet(source, sink, columns);
+        }
+    }
+
+    private static void compareResultSet(ResultSet source, ResultSet sink, List<String> columns) throws SQLException, IOException {
+        Assertions.assertNotNull(source, "source can't be null");
+        Assertions.assertNotNull(sink, "source can't be null");
+        ResultSetMetaData sourceMetaData = source.getMetaData();
+        ResultSetMetaData sinkMetaData = sink.getMetaData();
+        Assertions.assertEquals(sourceMetaData.getColumnCount(), sinkMetaData.getColumnCount());
+        while (source.next()) {
+            if (sink.next()) {
+                // compare by name
+                if (CollectionUtils.isNotEmpty(columns)) {
+                    for (String column : columns) {
+                        int sourceCnt = source.findColumn(column);
+                        int sinkCnt = sink.findColumn(column);
+                        Assertions.assertTrue(compareColumn(source, sink, sourceCnt, sinkCnt));
+                    }
+                } else {
+                    // compare all column
+                    for (int i = 1; i <= sourceMetaData.getColumnCount(); i++) {
+                        Assertions.assertTrue(compareColumn(source, sink, i, i));
+                    }
+                }
+                continue;
+            }
+            Assertions.fail("the row of source != sink");
+        }
+    }
+
+    private static boolean compareColumn(ResultSet source, ResultSet sink, int sourceCnt, int sinkCnt) throws SQLException, IOException {
+        Object sourceObject = source.getObject(sourceCnt);
+        Object sinkObject = sink.getObject(sinkCnt);
+        if (Objects.deepEquals(sourceObject, sinkObject)) {
+            return true;
+        }
+        InputStream sourceAsciiStream = source.getBinaryStream(sourceCnt);
+        InputStream sinkAsciiStream = sink.getBinaryStream(sinkCnt);
+        String sourceValue = IOUtils.toString(sourceAsciiStream, StandardCharsets.UTF_8);
+        String sinkValue = IOUtils.toString(sinkAsciiStream, StandardCharsets.UTF_8);
+        return StringUtils.equals(sourceValue, sinkValue);
+    }
+}

--- a/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/java/org/apache/seatunnel/e2e/spark/v2/jdbc/JdbcDmdbIT.java
+++ b/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/java/org/apache/seatunnel/e2e/spark/v2/jdbc/JdbcDmdbIT.java
@@ -52,13 +52,13 @@ public class JdbcDmdbIT extends SparkContainer {
     private static final String DM_DOCKER_IMAGE = "laglangyue/dmdb8";
     private static final String DRIVER_CLASS = "dm.jdbc.driver.DmDriver";
     private static final String HOST = "spark_e2e_dmdb";
-    private static final String LOCAL_HOST = "localhost";
     private static final String URL = "jdbc:dm://%s:5236";
     private static final String USERNAME = "SYSDBA";
     private static final String PASSWORD = "SYSDBA";
     private static final String DATABASE = "SYSDBA";
     private static final String SOURCE_TABLE = "e2e_table_source";
     private static final String SINK_TABLE = "e2e_table_sink";
+    public static final String DM_DRIVER_JAR = "https://repo1.maven.org/maven2/com/dameng/DmJdbcDriver18/8.1.1.193/DmJdbcDriver18-8.1.1.193.jar";
     private GenericContainer<?> dbServer;
     private Connection jdbcConnection;
 
@@ -94,6 +94,13 @@ public class JdbcDmdbIT extends SparkContainer {
         }
     }
 
+    @Override
+    protected void executeExtraCommands(GenericContainer<?> container) throws IOException, InterruptedException {
+        Container.ExecResult extraCommands = container.execInContainer("bash", "-c", "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib "
+            + "&& cd /tmp/seatunnel/plugins/Jdbc/lib && curl -O " + DM_DRIVER_JAR);
+        Assertions.assertEquals(0, extraCommands.getExitCode());
+    }
+
     private void initializeJdbcConnection() throws SQLException {
         jdbcConnection = DriverManager.getConnection(String.format(
             URL, dbServer.getHost()), USERNAME, PASSWORD);
@@ -125,7 +132,7 @@ public class JdbcDmdbIT extends SparkContainer {
     }
 
     private void assertHasData(String table) {
-        try (Statement statement = jdbcConnection.createStatement();) {
+        try (Statement statement = jdbcConnection.createStatement()) {
             String sql = String.format("select * from %s.%s limit 1", DATABASE, table);
             ResultSet source = statement.executeQuery(sql);
             Assertions.assertTrue(source.next());
@@ -145,7 +152,33 @@ public class JdbcDmdbIT extends SparkContainer {
     public void testDMDBSourceToJdbcSink() throws SQLException, IOException, InterruptedException {
         Container.ExecResult execResult = executeSeaTunnelSparkJob("/jdbc/jdbc_dm_source_and_sink.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
+        // assert
         assertHasData(SINK_TABLE);
+        JdbcE2eUtil.compare(jdbcConnection, String.format("select * from %s.%s limit 1", DATABASE, SOURCE_TABLE),
+            String.format("select * from %s.%s limit 1", DATABASE, SINK_TABLE),
+            Lists.newArrayList("DM_BIT",
+                "DM_INT",
+                "DM_INTEGER",
+                "DM_PLS_INTEGER",
+                "DM_TINYINT",
+                "DM_BYTE",
+                "DM_SMALLINT",
+                "DM_BIGINT",
+                "DM_NUMERIC",
+                "DM_NUMBER",
+                "DM_DECIMAL",
+                "DM_DEC",
+                "DM_REAL",
+                "DM_FLOAT",
+                "DM_DOUBLE_PRECISION",
+                "DM_DOUBLE",
+                "DM_CHAR",
+                "DM_CHARACTER",
+                "DM_VARCHAR",
+                "DM_VARCHAR2",
+                "DM_TEXT",
+                "DM_LONG",
+                "DM_LONGVARCHAR"));
     }
 
 }

--- a/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/java/org/apache/seatunnel/e2e/spark/v2/jdbc/JdbcE2eUtil.java
+++ b/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/java/org/apache/seatunnel/e2e/spark/v2/jdbc/JdbcE2eUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.spark.v2.jdbc;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class JdbcE2eUtil {
+
+    public static void compare(Connection conn, String sourceSql, String sinkSQL, String columns) throws SQLException, IOException {
+        String[] split = StringUtils.split(columns, ",");
+        List<String> columnList = Arrays.stream(split)
+            .map(o -> StringUtils.remove(o, "\n"))
+            .map(String::trim)
+            .collect(Collectors.toList());
+        compare(conn, sourceSql, sinkSQL, columnList);
+    }
+
+    @SuppressWarnings("magicnumber")
+    public static void compare(Connection conn, String sourceSql, String sinkSQL, List<String> columns) throws SQLException, IOException {
+        Assertions.assertTrue(conn.isValid(10));
+        try (Statement sourceState = conn.createStatement();
+            Statement sinkState = conn.createStatement()
+        ) {
+            ResultSet source = sourceState.executeQuery(sourceSql);
+            ResultSet sink = sinkState.executeQuery(sinkSQL);
+            compareResultSet(source, sink, columns);
+        }
+    }
+
+    private static void compareResultSet(ResultSet source, ResultSet sink, List<String> columns) throws SQLException, IOException {
+        Assertions.assertNotNull(source, "source can't be null");
+        Assertions.assertNotNull(sink, "source can't be null");
+        ResultSetMetaData sourceMetaData = source.getMetaData();
+        ResultSetMetaData sinkMetaData = sink.getMetaData();
+        Assertions.assertEquals(sourceMetaData.getColumnCount(), sinkMetaData.getColumnCount());
+        while (source.next()) {
+            if (sink.next()) {
+                // compare by name
+                if (CollectionUtils.isNotEmpty(columns)) {
+                    for (String column : columns) {
+                        int sourceCnt = source.findColumn(column);
+                        int sinkCnt = sink.findColumn(column);
+                        Assertions.assertTrue(compareColumn(source, sink, sourceCnt, sinkCnt));
+                    }
+                } else {
+                    // compare all column
+                    for (int i = 1; i <= sourceMetaData.getColumnCount(); i++) {
+                        Assertions.assertTrue(compareColumn(source, sink, i, i));
+                    }
+                }
+                continue;
+            }
+            Assertions.fail("the row of source != sink");
+        }
+    }
+
+    private static boolean compareColumn(ResultSet source, ResultSet sink, int sourceCnt, int sinkCnt) throws SQLException, IOException {
+        Object sourceObject = source.getObject(sourceCnt);
+        Object sinkObject = sink.getObject(sinkCnt);
+        if (Objects.deepEquals(sourceObject, sinkObject)) {
+            return true;
+        }
+        InputStream sourceAsciiStream = source.getBinaryStream(sourceCnt);
+        InputStream sinkAsciiStream = sink.getBinaryStream(sinkCnt);
+        String sourceValue = IOUtils.toString(sourceAsciiStream, StandardCharsets.UTF_8);
+        String sinkValue = IOUtils.toString(sinkAsciiStream, StandardCharsets.UTF_8);
+        return StringUtils.equals(sourceValue, sinkValue);
+    }
+}

--- a/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/resources/jdbc/jdbc_dm_source_and_sink.conf
+++ b/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-jdbc-spark-e2e/src/test/resources/jdbc/jdbc_dm_source_and_sink.conf
@@ -31,7 +31,32 @@ source {
     connection_check_timeout_sec = 1000
     user = "SYSDBA"
     password = "SYSDBA"
-    query = """select DM_INT,DM_VARCHAR from "SYSDBA".e2e_table_source"""
+    query = """
+    SELECT DM_BIT,
+       DM_INT,
+       DM_INTEGER,
+       DM_PLS_INTEGER,
+       DM_TINYINT,
+       DM_BYTE,
+       DM_SMALLINT,
+       DM_BIGINT,
+       DM_NUMERIC,
+       DM_NUMBER,
+       DM_DECIMAL,
+       DM_DEC,
+       DM_REAL,
+       DM_FLOAT,
+       DM_DOUBLE_PRECISION,
+       DM_DOUBLE,
+       DM_CHAR,
+       DM_CHARACTER,
+       DM_VARCHAR,
+       DM_VARCHAR2,
+       DM_TEXT,
+       DM_LONG,
+       DM_LONGVARCHAR
+FROM "SYSDBA".e2e_table_source
+"""
     partition_column = "DM_INT"
   }
 
@@ -49,8 +74,30 @@ sink {
     user = "SYSDBA"
     password = "SYSDBA"
     query = """
-          INSERT INTO "SYSDBA".e2e_table_sink(DM_INT,DM_VARCHAR)
-          values (?,?)
+INSERT INTO "SYSDBA".e2e_table_sink (DM_BIT,
+                                     DM_INT,
+                                     DM_INTEGER,
+                                     DM_PLS_INTEGER,
+                                     DM_TINYINT,
+                                     DM_BYTE,
+                                     DM_SMALLINT,
+                                     DM_BIGINT,
+                                     DM_NUMERIC,
+                                     DM_NUMBER,
+                                     DM_DECIMAL,
+                                     DM_DEC,
+                                     DM_REAL,
+                                     DM_FLOAT,
+                                     DM_DOUBLE_PRECISION,
+                                     DM_DOUBLE,
+                                     DM_CHAR,
+                                     DM_CHARACTER,
+                                     DM_VARCHAR,
+                                     DM_VARCHAR2,
+                                     DM_TEXT,
+                                     DM_LONG,
+                                     DM_LONGVARCHAR)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

1. The DM dirver is packaged with Connector-jar，I modify the scope to `provided`.
2. The dirver in e2e should be downloaded.
3. In my previous submission, I used to debug to check whether the source and destination data are the same. Now I have added a tool method to compare the consistency of the source and sink data sources through the SQL query method

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
