### PR TITLE
[Bug]Ensure that output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations.

### DIFF
--- a/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/utils/CompressionUtils.java
+++ b/seatunnel-core/seatunnel-core-base/src/main/java/org/apache/seatunnel/core/base/utils/CompressionUtils.java
@@ -107,6 +107,9 @@ public final class CompressionUtils {
             TarArchiveEntry entry = null;
             while ((entry = (TarArchiveEntry) debInputStream.getNextEntry()) != null) {
                 final File outputFile = new File(outputDir, entry.getName()).toPath().normalize().toFile();
+                if (!outputFile.toPath().normalize().startsWith(outputDir.toPath())) {
+                    throw new IllegalStateException("Bad zip entry");
+                }
                 if (entry.isDirectory()) {
                     LOGGER.info("Attempting to write output directory {}.", outputFile.getAbsolutePath());
                     if (!outputFile.exists()) {


### PR DESCRIPTION

Extracting files from a malicious zip archive (or another archive format) without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten, due to the possible presence of directory traversal elements (..) in archive paths.
