### PR TITLE
[Bug][seatunnel-connectors]Fix clickhouse array inject funtion

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/inject/ArrayInjectFunction.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/inject/ArrayInjectFunction.java
@@ -27,7 +27,7 @@ public class ArrayInjectFunction implements ClickhouseFieldInjectFunction {
 
     @Override
     public void injectFields(PreparedStatement statement, int index, Object value) throws SQLException {
-        statement.setArray(index, statement.getConnection().createArrayOf("varchar", new Object[]{value}));
+        statement.setArray(index, statement.getConnection().createArrayOf("text", new Object[]{value}));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/inject/ArrayInjectFunction.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/inject/ArrayInjectFunction.java
@@ -27,7 +27,7 @@ public class ArrayInjectFunction implements ClickhouseFieldInjectFunction {
 
     @Override
     public void injectFields(PreparedStatement statement, int index, Object value) throws SQLException {
-        statement.setArray(index, (java.sql.Array) value);
+        statement.setArray(index, statement.getConnection().createArrayOf("varchar", new Object[]{value}));
     }
 
     @Override


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->
https://github.com/apache/incubator-seatunnel/issues/2987
## Purpose of this pull request
Fixed a bug in clickhouse ArrayInjectFunction that cause a ClassCastException. The actual type of the object value cannot be converted to java.sql.array,use createArrayOf method to convert it.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
