### PR TITLE
[improve][e2e] Change the starter module from file copy to binding file path

### DIFF
--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/AbstractTestContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/AbstractTestContainer.java
@@ -72,12 +72,11 @@ public abstract class AbstractTestContainer implements TestContainer {
         //do nothing
     }
 
-    protected void copySeaTunnelStarter(GenericContainer<?> container) {
-        ContainerUtil.copySeaTunnelStarter(container,
+    protected void bindSeaTunnelStarter(GenericContainer<?> container) {
+        ContainerUtil.bindSeaTunnelStarter(container,
             this.startModuleName,
             this.startModuleFullPath,
-            SEATUNNEL_HOME,
-            getStartShellName());
+            SEATUNNEL_HOME);
     }
 
     protected Container.ExecResult executeJob(GenericContainer<?> container, String confFile) throws IOException, InterruptedException {

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
@@ -74,6 +74,7 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
             .waitingFor(new LogMessageWaitStrategy()
                 .withRegEx(".*Starting the resource manager.*")
                 .withStartupTimeout(Duration.ofMinutes(2)));
+        bindSeaTunnelStarter(jobManager);
 
         taskManager = new GenericContainer<>(dockerImage)
             .withCommand("taskmanager")
@@ -88,7 +89,6 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
 
         Startables.deepStart(Stream.of(jobManager)).join();
         Startables.deepStart(Stream.of(taskManager)).join();
-        copySeaTunnelStarter(jobManager);
         // execute extra commands
         executeExtraCommands(jobManager);
     }

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.e2e.common.container.seatunnel;
 
+import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+
 import org.apache.seatunnel.e2e.common.container.AbstractTestContainer;
 import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
 import org.apache.seatunnel.e2e.common.container.TestContainerId;
@@ -26,9 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerLoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -42,10 +44,6 @@ public class SeaTunnelContainer extends AbstractTestContainer {
 
     private static final Logger LOG = LoggerFactory.getLogger(SeaTunnelContainer.class);
     private static final String JDK_DOCKER_IMAGE = "openjdk:8";
-    protected static final Network NETWORK = Network.newNetwork();
-
-    private static final String SEATUNNEL_HOME = "/tmp/seatunnel";
-    private static final String SEATUNNEL_BIN = Paths.get(SEATUNNEL_HOME, "bin").toString();
     private static final String CLIENT_SHELL = "seatunnel.sh";
     private static final String SERVER_SHELL = "seatunnel-cluster.sh";
     private GenericContainer<?> server;
@@ -54,13 +52,15 @@ public class SeaTunnelContainer extends AbstractTestContainer {
     public void startUp() throws Exception {
         server = new GenericContainer<>(getDockerImage())
             .withNetwork(NETWORK)
-            .withCommand(Paths.get(SEATUNNEL_BIN, SERVER_SHELL).toString())
+            .withCommand(Paths.get(SEATUNNEL_HOME, "bin", SERVER_SHELL).toString())
             .withNetworkAliases("server")
             .withExposedPorts()
-            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger("seatunnel-engine:" + LOG)))
             .waitingFor(Wait.forLogMessage(".*received new worker register.*\\n", 1));
+        bindSeaTunnelStarter(server);
+        server.withFileSystemBind(PROJECT_ROOT_PATH + "/seatunnel-engine/seatunnel-engine-common/src/main/resources/",
+            Paths.get(SEATUNNEL_HOME, "config").toString());
         server.start();
-        copySeaTunnelStarter(server);
         // execute extra commands
         // TODO copy config file
         executeExtraCommands(server);

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -55,7 +55,7 @@ public class SeaTunnelContainer extends AbstractTestContainer {
             .withCommand(Paths.get(SEATUNNEL_HOME, "bin", SERVER_SHELL).toString())
             .withNetworkAliases("server")
             .withExposedPorts()
-            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger("seatunnel-engine:" + LOG)))
+            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger("seatunnel-engine:" + JDK_DOCKER_IMAGE)))
             .waitingFor(Wait.forLogMessage(".*received new worker register.*\\n", 1));
         bindSeaTunnelStarter(server);
         server.withFileSystemBind(PROJECT_ROOT_PATH + "/seatunnel-engine/seatunnel-engine-common/src/main/resources/",

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/spark/AbstractTestSparkContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/spark/AbstractTestSparkContainer.java
@@ -56,10 +56,11 @@ public abstract class AbstractTestSparkContainer extends AbstractTestContainer {
             .waitingFor(new LogMessageWaitStrategy()
                 .withRegEx(".*Master: Starting Spark master at.*")
                 .withStartupTimeout(Duration.ofMinutes(2)));
+        bindSeaTunnelStarter(master);
+
         // In most case we can just use standalone mode to execute a spark job, if we want to use cluster mode, we need to
         // start a worker.
         Startables.deepStart(Stream.of(master)).join();
-        copySeaTunnelStarter(master);
         // execute extra commands
         executeExtraCommands(master);
     }

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/util/ContainerUtil.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/util/ContainerUtil.java
@@ -74,7 +74,7 @@ public final class ContainerUtil {
         connectorFiles.forEach(jar ->
             container.copyFileToContainer(
                 MountableFile.forHostPath(jar.getAbsolutePath()),
-                Paths.get(Paths.get(seatunnelHome, "connectors").toString(), connectorType, jar.getName()).toString()));
+                Paths.get(seatunnelHome, "connectors", connectorType, jar.getName()).toString()));
     }
 
     public static String copyConfigFileToContainer(GenericContainer<?> container, String confFile) {
@@ -83,30 +83,26 @@ public final class ContainerUtil {
         return targetConfInContainer;
     }
 
-    public static void copySeaTunnelStarter(GenericContainer<?> container,
+    public static void bindSeaTunnelStarter(GenericContainer<?> container,
                                             String startModuleName,
                                             String startModulePath,
-                                            String seatunnelHomeInContainer,
-                                            String startShellName) {
+                                            String seatunnelHomeInContainer) {
         final String startJarName = startModuleName + ".jar";
-        // copy lib
+        // bind lib
         final String startJarPath = startModulePath + File.separator + "target" + File.separator + startJarName;
         checkPathExist(startJarPath);
-        container.copyFileToContainer(
-            MountableFile.forHostPath(startJarPath),
-            Paths.get(Paths.get(seatunnelHomeInContainer, "lib").toString(), startJarName).toString());
+        container.withFileSystemBind(startJarPath,
+            Paths.get(seatunnelHomeInContainer, "lib", startJarName).toString());
 
-        // copy bin
-        final String startBinPath = startModulePath + File.separator + "src/main/bin/" + startShellName;
+        // bind bin
+        final String startBinPath = startModulePath + File.separator + "src/main/bin/";
         checkPathExist(startBinPath);
-        container.copyFileToContainer(
-            MountableFile.forHostPath(startBinPath),
-            Paths.get(Paths.get(seatunnelHomeInContainer, "bin").toString(), startShellName).toString());
+        container.withFileSystemBind(startBinPath,
+            Paths.get(seatunnelHomeInContainer, "bin").toString());
 
-        // copy plugin-mapping.properties
-        container.copyFileToContainer(
-            MountableFile.forHostPath(PROJECT_ROOT_PATH + "/plugin-mapping.properties"),
-            Paths.get(Paths.get(seatunnelHomeInContainer, "connectors").toString(), PLUGIN_MAPPING_FILE).toString());
+        // bind plugin-mapping.properties
+        container.withFileSystemBind(PROJECT_ROOT_PATH + "/plugin-mapping.properties",
+            Paths.get(seatunnelHomeInContainer, "connectors", PLUGIN_MAPPING_FILE).toString());
     }
 
     public static String adaptPathForWin(String path) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
The start module file can be determined before the container is started and don‘t need to be copied.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
