### PR TITLE
[Hotfix][Docs] Fix error words in QuickStart Doc

### DIFF
--- a/docs/en/start/local.mdx
+++ b/docs/en/start/local.mdx
@@ -52,7 +52,7 @@ seatunnel-connector-flink-assert
 **Configure SeaTunnel**: Change the setting in `config/seatunnel-env.sh`, it is base on the path your engine install at [prepare step two](#prepare).
 Change `SPARK_HOME` if you using Spark as your engine, or change `FLINK_HOME` if you're using Flink.
 
-**Run Application with Build-in Configure**: We already providers and out-of-box configuration in directory `config` which
+**Run Application with Build-in Configure**: We already provide an out-of-box configuration in the directory `config` which
 you could find when you extract the tarball. You could start the application by the following commands
 
 <Tabs
@@ -124,7 +124,7 @@ topLevel, 20
 
 ## Explore More Build-in Examples
 
-Our local quick start is using one of the build-in example in directory `config`, and we provider more than one out-of-box
+Our local quick start is using one of the build-in example in directory `config`, and we provide more than one out-of-box
 example you could and feel free to have a try and make your hands dirty. All you have to do is change the started command
 option value in [running application](#run-seaTunnel-application) to the configuration you want to run, we use batch
 template in `config` as examples:


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

There is a syntax error and a word spelling error in the document. The configuration directory as a specific noun needs to be preceded by a definite article.

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
