### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/seatunnel-examples/seatunnel-spark-connector-v2-example/pom.xml
+++ b/seatunnel-examples/seatunnel-spark-connector-v2-example/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <spark.scope>compile</spark.scope>
-        <spark.2.4.0.jackson.version>2.6.7</spark.2.4.0.jackson.version>
+        <spark.2.4.0.jackson.version>2.12.6.1</spark.2.4.0.jackson.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
### What happened？
There are 65 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.6.7
- [CVE-2019-14540](https://www.oscs1024.com/hd/CVE-2019-14540)
- [CVE-2019-16335](https://www.oscs1024.com/hd/CVE-2019-16335)
- [CVE-2019-16942](https://www.oscs1024.com/hd/CVE-2019-16942)
- [CVE-2019-16943](https://www.oscs1024.com/hd/CVE-2019-16943)
- [CVE-2019-17267](https://www.oscs1024.com/hd/CVE-2019-17267)
- [CVE-2019-17531](https://www.oscs1024.com/hd/CVE-2019-17531)
- [CVE-2019-12086](https://www.oscs1024.com/hd/CVE-2019-12086)
- [CVE-2019-12814](https://www.oscs1024.com/hd/CVE-2019-12814)
- [CVE-2019-12384](https://www.oscs1024.com/hd/CVE-2019-12384)
- [CVE-2019-14379](https://www.oscs1024.com/hd/CVE-2019-14379)
- [CVE-2019-14439](https://www.oscs1024.com/hd/CVE-2019-14439)
- [CVE-2019-20330](https://www.oscs1024.com/hd/CVE-2019-20330)
- [CVE-2020-24616](https://www.oscs1024.com/hd/CVE-2020-24616)
- [CVE-2020-24750](https://www.oscs1024.com/hd/CVE-2020-24750)
- [CVE-2020-35490](https://www.oscs1024.com/hd/CVE-2020-35490)
- [CVE-2020-35491](https://www.oscs1024.com/hd/CVE-2020-35491)
- [CVE-2020-35728](https://www.oscs1024.com/hd/CVE-2020-35728)
- [CVE-2020-8840](https://www.oscs1024.com/hd/CVE-2020-8840)
- [CVE-2020-10650](https://www.oscs1024.com/hd/CVE-2020-10650)
- [CVE-2020-9546](https://www.oscs1024.com/hd/CVE-2020-9546)
- [CVE-2020-9548](https://www.oscs1024.com/hd/CVE-2020-9548)
- [CVE-2019-14892](https://www.oscs1024.com/hd/CVE-2019-14892)
- [CVE-2019-14893](https://www.oscs1024.com/hd/CVE-2019-14893)
- [CVE-2020-10672](https://www.oscs1024.com/hd/CVE-2020-10672)
- [CVE-2020-10673](https://www.oscs1024.com/hd/CVE-2020-10673)
- [CVE-2020-10968](https://www.oscs1024.com/hd/CVE-2020-10968)
- [CVE-2020-10969](https://www.oscs1024.com/hd/CVE-2020-10969)
- [CVE-2020-11111](https://www.oscs1024.com/hd/CVE-2020-11111)
- [CVE-2020-11112](https://www.oscs1024.com/hd/CVE-2020-11112)
- [CVE-2020-11113](https://www.oscs1024.com/hd/CVE-2020-11113)
- [CVE-2020-11619](https://www.oscs1024.com/hd/CVE-2020-11619)
- [CVE-2020-11620](https://www.oscs1024.com/hd/CVE-2020-11620)
- [CVE-2020-14061](https://www.oscs1024.com/hd/CVE-2020-14061)
- [CVE-2020-14062](https://www.oscs1024.com/hd/CVE-2020-14062)
- [CVE-2020-14060](https://www.oscs1024.com/hd/CVE-2020-14060)
- [CVE-2020-14195](https://www.oscs1024.com/hd/CVE-2020-14195)
- [CVE-2020-36179](https://www.oscs1024.com/hd/CVE-2020-36179)
- [CVE-2020-36180](https://www.oscs1024.com/hd/CVE-2020-36180)
- [CVE-2020-36182](https://www.oscs1024.com/hd/CVE-2020-36182)
- [CVE-2020-36183](https://www.oscs1024.com/hd/CVE-2020-36183)
- [CVE-2020-36184](https://www.oscs1024.com/hd/CVE-2020-36184)
- [CVE-2020-36185](https://www.oscs1024.com/hd/CVE-2020-36185)
- [CVE-2020-36186](https://www.oscs1024.com/hd/CVE-2020-36186)
- [CVE-2020-36187](https://www.oscs1024.com/hd/CVE-2020-36187)
- [CVE-2020-36188](https://www.oscs1024.com/hd/CVE-2020-36188)
- [CVE-2020-36189](https://www.oscs1024.com/hd/CVE-2020-36189)
- [CVE-2021-20190](https://www.oscs1024.com/hd/CVE-2021-20190)
- [MPS-2022-12433](https://www.oscs1024.com/hd/MPS-2022-12433)
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)
- [CVE-2017-17485](https://www.oscs1024.com/hd/CVE-2017-17485)
- [CVE-2018-5968](https://www.oscs1024.com/hd/CVE-2018-5968)
- [CVE-2017-15095](https://www.oscs1024.com/hd/CVE-2017-15095)
- [CVE-2017-7525](https://www.oscs1024.com/hd/CVE-2017-7525)
- [CVE-2018-7489](https://www.oscs1024.com/hd/CVE-2018-7489)
- [CVE-2018-14718](https://www.oscs1024.com/hd/CVE-2018-14718)
- [CVE-2018-14719](https://www.oscs1024.com/hd/CVE-2018-14719)
- [CVE-2018-14720](https://www.oscs1024.com/hd/CVE-2018-14720)
- [CVE-2018-14721](https://www.oscs1024.com/hd/CVE-2018-14721)
- [CVE-2018-19360](https://www.oscs1024.com/hd/CVE-2018-19360)
- [CVE-2018-19361](https://www.oscs1024.com/hd/CVE-2018-19361)
- [CVE-2018-19362](https://www.oscs1024.com/hd/CVE-2018-19362)
- [CVE-2018-12022](https://www.oscs1024.com/hd/CVE-2018-12022)
- [CVE-2018-12023](https://www.oscs1024.com/hd/CVE-2018-12023)
- [CVE-2018-11307](https://www.oscs1024.com/hd/CVE-2018-11307)
- [CVE-2020-36181](https://www.oscs1024.com/hd/CVE-2020-36181)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.6.7 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS