### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/pom.xml
+++ b/seatunnel-connectors-v2/connector-jdbc/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <mysql.version>8.0.16</mysql.version>
-        <postgresql.version>42.3.3</postgresql.version>
+        <postgresql.version>42.4.1</postgresql.version>
         <dm-jdbc.version>8.1.2.141</dm-jdbc.version>
         <sqlserver.version>9.2.1.jre8</sqlserver.version>
         <phoenix.version>5.2.5-HBase-2.x</phoenix.version>

--- a/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-flink/seatunnel-connector-flink-jdbc/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>seatunnel-connector-flink-jdbc</artifactId>
     
     <properties>
-        <pg.version>42.3.3</pg.version>
+        <pg.version>42.4.1</pg.version>
         <mysql.version>8.0.16</mysql.version>
     </properties>
 

--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-jdbc/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>seatunnel-connector-spark-jdbc</artifactId>
     
     <properties>
-        <pg.version>42.3.3</pg.version>
+        <pg.version>42.4.1</pg.version>
         <mysql.version>8.0.16</mysql.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.3.3
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.3.3 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS