### PR TITLE
[Bug][Connector-V2] kafka can be configured without partition_key

### DIFF
--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/KafkaSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/KafkaSinkWriter.java
@@ -190,6 +190,9 @@ public class KafkaSinkWriter implements SinkWriter<SeaTunnelRow, KafkaCommitInfo
 
     private Function<SeaTunnelRow, String> createPartitionExtractor(Config pluginConfig,
                                                                     SeaTunnelRowType seaTunnelRowType) {
+        if (!pluginConfig.hasPath(PARTITION_KEY)){
+            return row -> null;
+        }
         String partitionKey = pluginConfig.getString(PARTITION_KEY);
         List<String> fieldNames = Arrays.asList(seaTunnelRowType.getFieldNames());
         if (!fieldNames.contains(partitionKey)) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

KafkaSinkWriter needs to load createPartitionExtractor, if not judged, run to pluginConfig.getString(PARTITION_KEY) will report an error.

![1](https://user-images.githubusercontent.com/45089228/196864913-d65f422f-1d38-4ecd-89e9-c49ea477b2dd.png)
![2](https://user-images.githubusercontent.com/45089228/196864923-555f1467-8fbd-436d-8b04-8ca06c0c5b3f.png)


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
