### PR TITLE
[Improve][Connector-V2][Kafka] Recommend the prefix producer/consumer.override instead of kafka

### DIFF
--- a/docs/en/connector-v2/sink/Kafka.md
+++ b/docs/en/connector-v2/sink/Kafka.md
@@ -15,17 +15,17 @@ By default, we will use 2pc to guarantee the message is sent to kafka exactly on
 
 ## Options
 
-| name               | type                   | required | default value |
-| ------------------ | ---------------------- | -------- | ------------- |
-| topic              | string                 | yes      | -             |
-| bootstrap.servers  | string                 | yes      | -             |
-| kafka.*            | kafka producer config  | no       | -             |
-| semantic           | string                 | no       | NON           |
-| partition_key      | string                 | no       | -             |
-| partition          | int                    | no       | -             |
-| assign_partitions  | list                   | no       | -             |
-| transaction_prefix | string                 | no       | -             |
-| common-options     |                        | no       | -             |
+| name                | type                   | required | default value |
+|---------------------| ---------------------- | -------- | ------------- |
+| topic               | string                 | yes      | -             |
+| bootstrap.servers   | string                 | yes      | -             |
+| producer.override.* | kafka producer config  | no       | -             |
+| semantic            | string                 | no       | NON           |
+| partition_key       | string                 | no       | -             |
+| partition           | int                    | no       | -             |
+| assign_partitions   | list                   | no       | -             |
+| transaction_prefix  | string                 | no       | -             |
+| common-options      |                        | no       | -             |
 
 ### topic [string]
 
@@ -35,11 +35,11 @@ Kafka Topic.
 
 Kafka Brokers List.
 
-### kafka.* [kafka producer config]
+### producer.override.* [kafka producer config]
 
 In addition to the above parameters that must be specified by the `Kafka producer` client, the user can also specify multiple non-mandatory parameters for the `producer` client, covering [all the producer parameters specified in the official Kafka document](https://kafka.apache.org/documentation.html#producerconfigs).
 
-The way to specify the parameter is to add the prefix `kafka.` to the original parameter name. For example, the way to specify `request.timeout.ms` is: `kafka.request.timeout.ms = 60000` . If these non-essential parameters are not specified, they will use the default values given in the official Kafka documentation.
+The way to specify the parameter is to add the prefix `producer.override.` to the original parameter name. For example, the way to specify `request.timeout.ms` is: `producer.override.request.timeout.ms = 60000` . If these non-essential parameters are not specified, they will use the default values given in the official Kafka documentation.
 
 ### semantic [string]
 
@@ -101,7 +101,7 @@ sink {
       topic = "seatunnel"
       bootstrap.servers = "localhost:9092"
       partition = 3
-      kafka.request.timeout.ms = 60000
+      producer.override.request.timeout.ms = 60000
       semantics = EXACTLY_ONCE
   }
   

--- a/docs/en/connector-v2/source/kafka.md
+++ b/docs/en/connector-v2/source/kafka.md
@@ -24,7 +24,7 @@ Source connector for Apache Kafka.
 | pattern              | Boolean | no       | false                    |
 | consumer.group       | String  | no       | SeaTunnel-Consumer-Group |
 | commit_on_checkpoint | Boolean | no       | true                     |
-| kafka.*              | String  | no       | -                        |
+| consumer.override.*  | String  | no       | -                        |
 | common-options       |         | no       | -                        |
 | schema               |         | no       | -                        |
 | format               | String  | no       | json                     |
@@ -49,11 +49,11 @@ If `pattern` is set to `true`,the regular expression for a pattern of topic name
 
 If true the consumer's offset will be periodically committed in the background.
 
-### kafka.* [string]
+### consumer.override.* [string]
 
 In addition to the above necessary parameters that must be specified by the `Kafka consumer` client, users can also specify multiple `consumer` client non-mandatory parameters, covering [all consumer parameters specified in the official Kafka document](https://kafka.apache.org/documentation.html#consumerconfigs).
 
-The way to specify parameters is to add the prefix `kafka.` to the original parameter name. For example, the way to specify `auto.offset.reset` is: `kafka.auto.offset.reset = latest` . If these non-essential parameters are not specified, they will use the default values given in the official Kafka documentation.
+The way to specify parameters is to add the prefix `consumer.override.` to the original parameter name. For example, the way to specify `auto.offset.reset` is: `consumer.override.auto.offset.reset = latest` . If these non-essential parameters are not specified, they will use the default values given in the official Kafka documentation.
 
 ### common-options
 
@@ -85,8 +85,8 @@ source {
     field_delimiter = "#“
     topic = "topic_1,topic_2,topic_3"
     bootstrap.server = "localhost:9092"
-    kafka.max.poll.records = 500
-    kafka.client.id = client_1
+    consumer.override.max.poll.records = 500
+    consumer.override.client.id = client_1
   }
   
 }

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/config/Config.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/config/Config.java
@@ -33,7 +33,9 @@ public class Config {
      */
     public static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
 
-    public static final String KAFKA_CONFIG_PREFIX = "kafka.";
+    public static final String PRODUCER_CONFIG_PREFIX = "producer.override.";
+
+    public static final String CONSUMER_CONFIG_PREFIX = "consumer.override.";
 
     /**
      * consumer group of kafka client consume message.

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/serialize/DefaultSeaTunnelRowSerializer.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/serialize/DefaultSeaTunnelRowSerializer.java
@@ -25,7 +25,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 
 public class DefaultSeaTunnelRowSerializer implements SeaTunnelRowSerializer<byte[], byte[]> {
 
-    private int partation = -1;
+    private int partition = -1;
     private final String topic;
     private final JsonSerializationSchema jsonSerializationSchema;
 
@@ -34,15 +34,15 @@ public class DefaultSeaTunnelRowSerializer implements SeaTunnelRowSerializer<byt
         this.jsonSerializationSchema = new JsonSerializationSchema(seaTunnelRowType);
     }
 
-    public DefaultSeaTunnelRowSerializer(String topic, int partation, SeaTunnelRowType seaTunnelRowType) {
+    public DefaultSeaTunnelRowSerializer(String topic, int partition, SeaTunnelRowType seaTunnelRowType) {
         this(topic, seaTunnelRowType);
-        this.partation = partation;
+        this.partition = partition;
     }
 
     @Override
     public ProducerRecord<byte[], byte[]> serializeRow(SeaTunnelRow row) {
-        if (this.partation != -1) {
-            return new ProducerRecord<>(topic, this.partation, null, jsonSerializationSchema.serialize(row));
+        if (this.partition != -1) {
+            return new ProducerRecord<>(topic, this.partition, null, jsonSerializationSchema.serialize(row));
         }
         else {
             return new ProducerRecord<>(topic, null, jsonSerializationSchema.serialize(row));

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/KafkaSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/KafkaSinkWriter.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.kafka.sink;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.ASSIGN_PARTITIONS;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.PARTITION;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.PARTITION_KEY;
+import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.PRODUCER_CONFIG_PREFIX;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.TOPIC;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.TRANSACTION_PREFIX;
 
@@ -67,7 +68,7 @@ public class KafkaSinkWriter implements SinkWriter<SeaTunnelRow, KafkaCommitInfo
     // check config
     @Override
     public void write(SeaTunnelRow element) {
-        ProducerRecord<byte[], byte[]> producerRecord = null;
+        ProducerRecord<byte[], byte[]> producerRecord;
         //Determine the partition of the kafka send message based on the field name
         if (pluginConfig.hasPath(PARTITION_KEY)){
             String key = partitionExtractor.apply(element);
@@ -145,12 +146,9 @@ public class KafkaSinkWriter implements SinkWriter<SeaTunnelRow, KafkaCommitInfo
     }
 
     private Properties getKafkaProperties(Config pluginConfig) {
-        Config kafkaConfig = TypesafeConfigUtils.extractSubConfig(pluginConfig,
-                org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.KAFKA_CONFIG_PREFIX, false);
+        Config kafkaConfig = TypesafeConfigUtils.extractSubConfig(pluginConfig, PRODUCER_CONFIG_PREFIX, false);
         Properties kafkaProperties = new Properties();
-        kafkaConfig.entrySet().forEach(entry -> {
-            kafkaProperties.put(entry.getKey(), entry.getValue().unwrapped());
-        });
+        kafkaConfig.entrySet().forEach(entry -> kafkaProperties.put(entry.getKey(), entry.getValue().unwrapped()));
         if (pluginConfig.hasPath(ASSIGN_PARTITIONS)) {
             kafkaProperties.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, "org.apache.seatunnel.connectors.seatunnel.kafka.sink.MessageContentPartitioner");
         }

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSource.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSource.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.kafka.source;
 
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.BOOTSTRAP_SERVERS;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.COMMIT_ON_CHECKPOINT;
+import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.CONSUMER_CONFIG_PREFIX;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.CONSUMER_GROUP;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.DEFAULT_FIELD_DELIMITER;
 import static org.apache.seatunnel.connectors.seatunnel.kafka.config.Config.DEFAULT_FORMAT;
@@ -96,7 +97,7 @@ public class KafkaSource implements SeaTunnelSource<SeaTunnelRow, KafkaSourceSpl
             this.metadata.setCommitOnCheckpoint(config.getBoolean(COMMIT_ON_CHECKPOINT));
         }
 
-        TypesafeConfigUtils.extractSubConfig(config, "kafka.", false).entrySet().forEach(e -> {
+        TypesafeConfigUtils.extractSubConfig(config, CONSUMER_CONFIG_PREFIX, false).entrySet().forEach(e -> {
             this.metadata.getProperties().put(e.getKey(), String.valueOf(e.getValue().unwrapped()));
         });
 

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-kafka-flink-e2e/src/test/resources/kafka/kafkasource_json_to_console.conf
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-kafka-flink-e2e/src/test/resources/kafka/kafkasource_json_to_console.conf
@@ -30,7 +30,7 @@ source {
     bootstrap.servers = "kafkaCluster:9093"
     topic = "test_topic"
     result_table_name = "kafka_table"
-    kafka.auto.offset.reset = "earliest"
+    consumer.override.auto.offset.reset = "earliest"
     schema = {
       fields {
            id = bigint

--- a/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-kafka-flink-e2e/src/test/resources/kafka/kafkasource_text_to_console.conf
+++ b/seatunnel-e2e/seatunnel-flink-connector-v2-e2e/connector-kafka-flink-e2e/src/test/resources/kafka/kafkasource_text_to_console.conf
@@ -30,7 +30,7 @@ source {
     bootstrap.servers = "kafkaCluster:9093"
     topic = "test_topic"
     result_table_name = "kafka_table"
-    kafka.auto.offset.reset = "earliest"
+    consumer.override.auto.offset.reset = "earliest"
     schema = {
       fields {
            id = bigint

--- a/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-kafka-spark-e2e/src/test/resources/kafka/kafkasource_json_to_console.conf
+++ b/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-kafka-spark-e2e/src/test/resources/kafka/kafkasource_json_to_console.conf
@@ -31,7 +31,7 @@ source {
     bootstrap.servers = "kafkaCluster:9093"
     topic = "test_topic"
     result_table_name = "kafka_table"
-    kafka.auto.offset.reset = "earliest"
+    consumer.override.auto.offset.reset = "earliest"
     schema = {
       fields {
            id = bigint

--- a/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-kafka-spark-e2e/src/test/resources/kafka/kafkasource_text_to_console.conf
+++ b/seatunnel-e2e/seatunnel-spark-connector-v2-e2e/connector-kafka-spark-e2e/src/test/resources/kafka/kafkasource_text_to_console.conf
@@ -31,7 +31,7 @@ source {
     bootstrap.servers = "kafkaCluster:9093"
     topic = "test_topic"
     result_table_name = "kafka_table"
-    kafka.auto.offset.reset = "earliest"
+    consumer.override.auto.offset.reset = "earliest"
     schema = {
       fields {
            id = bigint


### PR DESCRIPTION
Code changes as below:
1. Fix some typo issue
2. To identify the consumer/producer configurations, change the overrided config prefix "kafka" to producer.override and  consumer.override

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
