### PR TITLE
[Doc][Connector-V2][jdbc] Updated batch size description

### DIFF
--- a/docs/en/connector-v2/sink/Jdbc.md
+++ b/docs/en/connector-v2/sink/Jdbc.md
@@ -67,7 +67,7 @@ The number of retries to submit failed (executeBatch)
 
 ### batch_size[int]
 
-For batch writing, when the number of buffers reaches the number of `batch_size` or the time reaches `batch_interval_ms`
+For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `batch_interval_ms`
 , the data will be flushed into the database
 
 ### batch_interval_ms[int]


### PR DESCRIPTION

## Purpose of this pull request

Clarified the batch size description.  Updated description from <code>when the number of **buffers** reaches the number of `batch_size`</code> to <code>when the number of **buffered records** reaches the number of `batch_size`</code>

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
