### PR TITLE
[Improve][CI]improve ci and remove plugin-mapping.properties check from step.filte…

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -130,7 +130,6 @@ jobs:
               - "seatunnel-e2e/seatunnel-flink-e2e/**"
               - "seatunnel-e2e/seatunnel-spark-e2e/**"
               - "seatunnel-connectors/**"
-              - "plugin-mapping.properties"
               - "pom.xml"
               - "**/workflows/**"
               - "**/tools/**"


### PR DESCRIPTION
Every new connector pr will update plugin-mapping.properties file. So if plugin-mapping.properties file add to `steps.filter.api` , every new connector pr will run all modules test. This is not what we want. So I remove this file from `steps.filter.api` .

We have a workflow named `schedule_backend`, it will run base on cron expression `0 0 03 * * ?`. This workflow will run all modules test. So I think if the `plugin-mapping.properties` have problem, we can found it in workflow `schedule_backend`.