### PR TITLE
[Improve][CI] remove seatunnel-dist udpate check from ci changed files check

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -121,7 +121,6 @@ jobs:
               - "seatunnel-config/**"
               - "seatunnel-connectors/**"
               - "seatunnel-core/**"
-              - "seatunnel-dist/**"
               - "seatunnel-e2e/seatunnel-e2e-common/**"
               - "seatunnel-formats/**"
               - "seatunnel-plugin-discovery/**"


### PR DESCRIPTION
Because every new connector will update `seatunnel-dist/pom.xml`, so in order to only build the new connector modules I remove the `seatunnel-dist` module check from ci.