### PR TITLE
[doc][connector][IoTDB] Updated connection time description

### DIFF
--- a/docs/en/connector-v2/sink/IoTDB.md
+++ b/docs/en/connector-v2/sink/IoTDB.md
@@ -111,7 +111,7 @@ Enable rpc compression in `IoTDB` client
 
 ### connection_timeout_in_ms [int]
 
-The maximum time (in ms) to wait when connect `IoTDB`
+The maximum time (in ms) to wait when connecting to `IoTDB`
 
 ### common options
 


### PR DESCRIPTION
## Purpose of this pull request

Updated connection timeout description from <code>to wait when **connect** `IoTDB`</code> to <code>to wait when **connecting to** `IoTDB`</code>

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)