### PR TITLE
[2.1.4][Bug] [seatunnel-connector-spark-hbase] Exception caused by compatibility with hadoop3.x (#3262)

### DIFF
--- a/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/pom.xml
+++ b/seatunnel-connectors/seatunnel-connectors-spark/seatunnel-connector-spark-hbase/pom.xml
@@ -63,6 +63,10 @@
                     <groupId>org.codehaus.janino</groupId>
                     <artifactId>janino</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>


### PR DESCRIPTION
#3262 