### PR TITLE
[Improve] Test Improvement - Assertions in the org.apache.seatunnel.api.configuration.util.OptionUtilTest

### DIFF
--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionUtilTest.java
@@ -30,38 +30,38 @@ public class OptionUtilTest {
     @Test
     public void test() throws InstantiationException, IllegalAccessException {
         List<Option<?>> options = OptionUtil.getOptions(TestOptionConfig.class);
-        Assertions.assertEquals(options.get(0).key(), "short-value");
-        Assertions.assertEquals(options.get(0).getDescription(), "shortValue");
-        Assertions.assertEquals(options.get(0).typeReference().getType(), Short.class);
+        Assertions.assertEquals("short-value", options.get(0).key());
+        Assertions.assertEquals("shortValue",options.get(0).getDescription());
+        Assertions.assertEquals(Short.class, options.get(0).typeReference().getType());
 
-        Assertions.assertEquals(options.get(1).typeReference().getType(), Integer.class);
-        Assertions.assertEquals(options.get(1).key(), "int_value");
-        Assertions.assertEquals(options.get(1).getDescription(), "");
+        Assertions.assertEquals(Integer.class, options.get(1).typeReference().getType());
+        Assertions.assertEquals("int_value", options.get(1).key());
+        Assertions.assertEquals("", options.get(1).getDescription());
         Assertions.assertNull(options.get(1).defaultValue());
 
-        Assertions.assertEquals(options.get(2).typeReference().getType(), Long.class);
+        Assertions.assertEquals(Long.class, options.get(2).typeReference().getType());
 
-        Assertions.assertEquals(options.get(3).typeReference().getType(), Float.class);
+        Assertions.assertEquals(Float.class, options.get(3).typeReference().getType());
 
-        Assertions.assertEquals(options.get(4).typeReference().getType(), Double.class);
+        Assertions.assertEquals(Double.class, options.get(4).typeReference().getType());
 
-        Assertions.assertEquals(options.get(5).typeReference().getType(), String.class);
-        Assertions.assertEquals(options.get(5).defaultValue(), "default string");
+        Assertions.assertEquals(String.class, options.get(5).typeReference().getType());
+        Assertions.assertEquals("default string", options.get(5).defaultValue());
 
-        Assertions.assertEquals(options.get(6).typeReference().getType(), Boolean.class);
-        Assertions.assertEquals(options.get(6).defaultValue(), true);
+        Assertions.assertEquals(Boolean.class, options.get(6).typeReference().getType());
+        Assertions.assertEquals(true, options.get(6).defaultValue());
 
-        Assertions.assertEquals(options.get(7).typeReference().getType(), Byte.class);
+        Assertions.assertEquals(Byte.class, options.get(7).typeReference().getType());
 
-        Assertions.assertEquals(options.get(8).typeReference().getType(), Character.class);
-        Assertions.assertEquals(options.get(9).typeReference().getType(), TestOptionConfigEnum.class);
-        Assertions.assertEquals(options.get(9).defaultValue(), TestOptionConfigEnum.KEY2);
+        Assertions.assertEquals(Character.class, options.get(8).typeReference().getType());
+        Assertions.assertEquals(TestOptionConfigEnum.class, options.get(9).typeReference().getType());
+        Assertions.assertEquals(TestOptionConfigEnum.KEY2, options.get(9).defaultValue());
 
-        Assertions.assertEquals(options.get(10).typeReference().getType(), TestOptionConfig.class);
+        Assertions.assertEquals(TestOptionConfig.class, options.get(10).typeReference().getType());
 
-        Assertions.assertEquals(options.get(11).typeReference().getType(), List.class);
+        Assertions.assertEquals(List.class, options.get(11).typeReference().getType());
 
-        Assertions.assertEquals(options.get(12).typeReference().getType(), Map.class);
+        Assertions.assertEquals(Map.class, options.get(12).typeReference().getType());
 
     }
 

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionUtilTest.java
@@ -31,7 +31,7 @@ public class OptionUtilTest {
     public void test() throws InstantiationException, IllegalAccessException {
         List<Option<?>> options = OptionUtil.getOptions(TestOptionConfig.class);
         Assertions.assertEquals("short-value", options.get(0).key());
-        Assertions.assertEquals("shortValue",options.get(0).getDescription());
+        Assertions.assertEquals("shortValue", options.get(0).getDescription());
         Assertions.assertEquals(Short.class, options.get(0).typeReference().getType());
 
         Assertions.assertEquals(Integer.class, options.get(1).typeReference().getType());


### PR DESCRIPTION
## Contribution Checklist
Corresponds to the issue [#3668]

## Purpose of this pull request

According to the documentation of [Assertions.assertEquals](https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertEquals-java.lang.Object-java.lang.Object-), the first parameter is the expected value and the second parameter is the actual value. In the test org.apache.seatunnel.api.configuration.util.OptionUtilTest, this order has been reversed and can mislead the results. The order has been corrected in this pull request.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)