### PR TITLE
[Improve][E2E][Http] Refactor the e2e test of http, and make all the test base on the 'HttpIT'.

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpContentJsonIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpContentJsonIT.java
@@ -17,60 +17,14 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpContentJsonIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
+public class HttpContentJsonIT extends HttpIT {
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-            .withNetwork(NETWORK)
-            .withNetworkAliases("mockserver")
-            .withExposedPorts(1080)
-            .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpContentJsonIT.class.getResource(
-                    "/mockserver-contentjson-config.json").getPath()).getAbsolutePath()),
-                "/tmp/mockserver-contentjson-config.json")
-            .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-contentjson-config.json")
-            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-            .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/http_contentjson_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpContentJsonSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/http_contentjson_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-contentjson-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpGitlabIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpGitlabIT.java
@@ -17,61 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpGitlabIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Objects;
-import java.util.stream.Stream;
-
-public class HttpGitlabIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-            .withNetwork(NETWORK)
-            .withNetworkAliases("mockserver")
-            .withExposedPorts(1080)
-            .withCopyFileToContainer(MountableFile.forHostPath(new File(Objects.requireNonNull(HttpIT.class.getResource(
-                    "/mockserver-gitlab-config.json")).getPath()).getAbsolutePath()),
-                "/tmp/mockserver-gitlab-config.json")
-            .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-gitlab-config.json")
-            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-            .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/gitlab_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpGitlabSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/gitlab_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-gitlab-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
@@ -36,9 +36,13 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class HttpIT extends TestSuiteBase implements TestResource {
+
+    private static final String TMP_DIR = "/tmp";
 
     private static final String IMAGE = "mockserver/mockserver:5.14.0";
 
@@ -47,14 +51,15 @@ public class HttpIT extends TestSuiteBase implements TestResource {
     @BeforeAll
     @Override
     public void startUp() {
+        Optional<URL> resource = Optional.ofNullable(HttpIT.class.getResource(getMockServerConfig()));
         this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
             .withNetwork(NETWORK)
             .withNetworkAliases("mockserver")
             .withExposedPorts(1080)
-            .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                    "/mockserver-config.json").getPath()).getAbsolutePath()),
-                "/tmp/mockserver-config.json")
-            .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-config.json")
+            .withCopyFileToContainer(
+                    MountableFile.forHostPath(new File(resource.orElseThrow(() -> new IllegalArgumentException("Can not get config file of mockServer")).getPath()).getAbsolutePath()),
+                    TMP_DIR + getMockServerConfig())
+            .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", TMP_DIR + getMockServerConfig())
             .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
             .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
         Startables.deepStart(Stream.of(mockserverContainer)).join();
@@ -69,8 +74,16 @@ public class HttpIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
-    public void testHttpSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/http_json_to_assert.conf");
+    public void testSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
+        Container.ExecResult execResult = container.executeJob(getITTestConf());
         Assertions.assertEquals(0, execResult.getExitCode());
+    }
+
+    public String getITTestConf() {
+        return "/http_json_to_assert.conf";
+    }
+
+    public String getMockServerConfig() {
+        return "/mockserver-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpJiraIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpJiraIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpJiraIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpJiraIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpJiraIT.class.getResource(
-                                "/mockserver-jira-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-jira-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-jira-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/jira_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpJiraSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/jira_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-jira-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpJsonPathIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpJsonPathIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpJsonPathIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpJsonPathIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-            .withNetwork(NETWORK)
-            .withNetworkAliases("mockserver")
-            .withExposedPorts(1080)
-            .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpJsonPathIT.class.getResource(
-                    "/mockserver-jsonpath-config.json").getPath()).getAbsolutePath()),
-                "/tmp/mockserver-jsonpath-config.json")
-            .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-jsonpath-config.json")
-            .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-            .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/http_jsonpath_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpJsonPathSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/http_jsonpath_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-jsonpath-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpKlaviyoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpKlaviyoIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpKlaviyoIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpKlaviyoIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                                "/mockserver-klaviyo-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-klaviyo-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-klaviyo-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/klaviyo_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpKlaviyoSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/klaviyo_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-klaviyo-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpLemlistIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpLemlistIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpLemlistIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpLemlistIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                                "/mockserver-lemlist-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-lemlist-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-lemlist-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/lemlist_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpLemlistSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/lemlist_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-lemlist-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpNotionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpNotionIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpNotionIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpNotionIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                                "/mockserver-notion-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-notion-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-notion-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/notion_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpNotionSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/notion_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-notion-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpOneSignalIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpOneSignalIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpOneSignalIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpOneSignalIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                                "/mockserver-onesignal-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-onesignal-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-onesignal-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/onesignal_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpOneSignalSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/onesignal_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-onesignal-config.json";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpPersistiqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpPersistiqIT.java
@@ -17,60 +17,15 @@
 
 package org.apache.seatunnel.e2e.connector.http;
 
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.TestContainer;
+public class HttpPersistiqIT extends HttpIT {
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Stream;
-
-public class HttpPersistiqIT extends TestSuiteBase implements TestResource {
-
-    private static final String IMAGE = "mockserver/mockserver:5.14.0";
-
-    private GenericContainer<?> mockserverContainer;
-
-    @BeforeAll
     @Override
-    public void startUp() {
-        this.mockserverContainer = new GenericContainer<>(DockerImageName.parse(IMAGE))
-                .withNetwork(NETWORK)
-                .withNetworkAliases("mockserver")
-                .withExposedPorts(1080)
-                .withCopyFileToContainer(MountableFile.forHostPath(new File(HttpIT.class.getResource(
-                                "/mockserver-persistiq-config.json").getPath()).getAbsolutePath()),
-                        "/tmp/mockserver-persistiq-config.json")
-                .withEnv("MOCKSERVER_INITIALIZATION_JSON_PATH", "/tmp/mockserver-persistiq-config.json")
-                .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
-                .waitingFor(new HttpWaitStrategy().forPath("/").forStatusCode(404));
-        Startables.deepStart(Stream.of(mockserverContainer)).join();
+    public String getITTestConf() {
+        return "/persistiq_json_to_assert.conf";
     }
 
-    @AfterAll
     @Override
-    public void tearDown() {
-        if (mockserverContainer != null) {
-            mockserverContainer.stop();
-        }
-    }
-
-    @TestTemplate
-    public void testHttpPersistiqSourceToAssertSink(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult execResult = container.executeJob("/persistiq_json_to_assert.conf");
-        Assertions.assertEquals(0, execResult.getExitCode());
+    public String getMockServerConfig() {
+        return "/mockserver-persistiq-config.json";
     }
 }


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Refactor the e2e test of http, and make all the test base on the 'HttpIT'.

Make the e2e test of HTTP easier.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/incubator-seatunnel/blob/dev/release-note.md).