### PR TITLE
[Improve][Connector] CDC same code extraction, ConfigurationOption formatting

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceConfigFactory.java
@@ -23,11 +23,11 @@ import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
 import org.apache.seatunnel.connectors.cdc.base.utils.ObjectUtils;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /** A {@link SourceConfig.Factory} to provide {@link SourceConfig} of JDBC data source. */
@@ -189,7 +189,6 @@ public abstract class JdbcSourceConfigFactory implements SourceConfig.Factory<Jd
         return this;
     }
 
-
     /**
      * Returns an immutable map
      */
@@ -207,7 +206,6 @@ public abstract class JdbcSourceConfigFactory implements SourceConfig.Factory<Jd
                     ObjectUtils.getValueByFieldName(field.getName(), this));
         }
     }
-
 
     public JdbcSourceConfigFactory fromReadonlyConfig(ReadonlyConfig config) {
         this.port = config.get(JdbcSourceOptions.PORT);

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/JdbcSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/JdbcSourceOptions.java
@@ -34,7 +34,7 @@ public class JdbcSourceOptions extends SourceOptions {
     public static final Option<Integer> PORT =
             Options.key("port")
                     .intType()
-                    .defaultValue(3306)
+                    .noDefaultValue()
                     .withDescription("Integer port number of the database server.");
 
     public static final Option<String> USERNAME =

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/SourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/option/SourceOptions.java
@@ -29,7 +29,8 @@ public class SourceOptions {
     public static final Option<Integer> SNAPSHOT_SPLIT_SIZE = Options.key("snapshot.split.size")
         .intType()
         .defaultValue(8096)
-        .withDescription("The split size (number of rows) of table snapshot, captured tables are split into multiple splits when read the snapshot of table.");
+        .withDescription("The split size (number of rows) of table snapshot, " +
+                "captured tables are split into multiple splits when read the snapshot of table.");
 
     public static final Option<Integer> SNAPSHOT_FETCH_SIZE = Options.key("snapshot.fetch.size")
         .intType()

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
@@ -17,8 +17,12 @@
 
 package org.apache.seatunnel.connectors.cdc.base.utils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Utilities for operation on {@link Object}. */
 public class ObjectUtils {
@@ -98,4 +102,22 @@ public class ObjectUtils {
         BigDecimal bigDecimal2 = BigDecimal.valueOf(arg2);
         return bigDecimal1.compareTo(bigDecimal2);
     }
+    /**
+     * Get the value of this attribute according to the attribute name
+     * @param fieldName
+     * @param object
+     * @return
+     */
+    public static Object getValueByFieldName(String fieldName,Object object){
+        String firstLetter=fieldName.substring(0,1).toUpperCase();
+        String getter = "get"+firstLetter+fieldName.substring(1);
+        try {
+            Method method = object.getClass().getMethod(getter, new Class[]{});
+            Object value = method.invoke(object, new Object[] {});
+            return value;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/ObjectUtils.java
@@ -17,12 +17,9 @@
 
 package org.apache.seatunnel.connectors.cdc.base.utils;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
 
 /** Utilities for operation on {@link Object}. */
 public class ObjectUtils {
@@ -102,15 +99,14 @@ public class ObjectUtils {
         BigDecimal bigDecimal2 = BigDecimal.valueOf(arg2);
         return bigDecimal1.compareTo(bigDecimal2);
     }
+
     /**
      * Get the value of this attribute according to the attribute name
-     * @param fieldName
-     * @param object
-     * @return
      */
-    public static Object getValueByFieldName(String fieldName,Object object){
-        String firstLetter=fieldName.substring(0,1).toUpperCase();
-        String getter = "get"+firstLetter+fieldName.substring(1);
+    public static Object getValueByFieldName(String fieldName, Object object){
+        String firstLetter = fieldName.substring(0, 1).toUpperCase();
+        String getter = "get" + firstLetter + fieldName.substring(1);
+
         try {
             Method method = object.getClass().getMethod(getter, new Class[]{});
             Object value = method.invoke(object, new Object[] {});

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourcePropertiesUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourcePropertiesUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * When a subclass inherits the {@link JdbcSourceConfigFactory} class to implement the create method,
+ *   * First obtain the public Properties configuration through this class
+ */
+public class SourcePropertiesUtils {
+
+    public static Properties getProperties(JdbcSourceConfigFactory sourceConfigFactory,Integer subtaskId){
+        Map<String, Object> sourceConfig = sourceConfigFactory.getSourceConfig();
+        Properties props = new Properties();
+
+        // database Basic information
+        props.setProperty("database.hostname", checkNotNull(String.valueOf(sourceConfig.get("hostname"))));
+        props.setProperty("database.user", checkNotNull(String.valueOf(sourceConfig.get("username"))));
+        props.setProperty("database.password", checkNotNull(String.valueOf(sourceConfig.get("password"))));
+        props.setProperty("database.port", checkNotNull(String.valueOf(sourceConfig.get("port"))));
+
+        // database history
+        props.setProperty("database.history", EmbeddedDatabaseHistory.class.getCanonicalName());
+        props.setProperty("database.history.instance.name", UUID.randomUUID() + "_" + subtaskId);
+        props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
+        props.setProperty("database.history.refer.ddl", String.valueOf(true));
+
+        // TODO Not yet supported
+        props.setProperty("include.schema.changes", String.valueOf(false));
+
+        if (sourceConfig.get("databaseList") != null){
+            props.setProperty("database.include.list",
+                    String.join(",",(List<String>) sourceConfig.get("databaseList")));
+        }
+
+        return props;
+    }
+
+
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourcePropertiesUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/utils/SourcePropertiesUtils.java
@@ -14,14 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.seatunnel.connectors.cdc.base.utils;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
 import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
 
-import java.util.*;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 
 /**
  * When a subclass inherits the {@link JdbcSourceConfigFactory} class to implement the create method,
@@ -29,7 +33,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class SourcePropertiesUtils {
 
-    public static Properties getProperties(JdbcSourceConfigFactory sourceConfigFactory,Integer subtaskId){
+    /**
+     * Extract public properties here
+     */
+    public static Properties getProperties(JdbcSourceConfigFactory sourceConfigFactory, Integer subtaskId) {
         Map<String, Object> sourceConfig = sourceConfigFactory.getSourceConfig();
         Properties props = new Properties();
 
@@ -50,11 +57,10 @@ public class SourcePropertiesUtils {
 
         if (sourceConfig.get("databaseList") != null){
             props.setProperty("database.include.list",
-                    String.join(",",(List<String>) sourceConfig.get("databaseList")));
+                    String.join(",", (List<String>) sourceConfig.get("databaseList")));
         }
 
         return props;
     }
-
 
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
@@ -17,10 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config;
 
-import io.debezium.config.Configuration;
-import io.debezium.connector.mysql.MySqlConnectorConfig;
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
 import org.apache.seatunnel.connectors.cdc.base.utils.SourcePropertiesUtils;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 
 import java.util.Properties;
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/config/SqlServerSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/config/SqlServerSourceConfigFactory.java
@@ -17,14 +17,15 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.source.config;
 
-import io.debezium.connector.sqlserver.SqlServerConnector;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
 import org.apache.seatunnel.connectors.cdc.base.utils.SourcePropertiesUtils;
 
+import io.debezium.connector.sqlserver.SqlServerConnector;
+
 import java.util.Properties;
 import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /** Factory for creating {@link SqlServerSourceConfig}. */
 public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/config/SqlServerSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/config/SqlServerSourceConfigFactory.java
@@ -17,16 +17,14 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.source.config;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
-import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
-
 import io.debezium.connector.sqlserver.SqlServerConnector;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
+import org.apache.seatunnel.connectors.cdc.base.utils.SourcePropertiesUtils;
 
 import java.util.Properties;
-import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /** Factory for creating {@link SqlServerSourceConfig}. */
 public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
@@ -36,8 +34,7 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
 
     @Override
     public SqlServerSourceConfig create(int subtask) {
-        Properties props = new Properties();
-        props.setProperty("connector.class", SqlServerConnector.class.getCanonicalName());
+        Properties props = SourcePropertiesUtils.getProperties(this, subtask);
 
         // hard code server name, because we don't need to distinguish it, docs:
         // Logical name that identifies and provides a namespace for the SQL Server database
@@ -45,21 +42,11 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
         // all other connectors, since it is used as a prefix for all Kafka topic names
         // emanating from this connector. Only alphanumeric characters and underscores should be
         // used.
+
         props.setProperty("database.server.name", DATABASE_SERVER_NAME);
-        props.setProperty("database.hostname", checkNotNull(hostname));
-        props.setProperty("database.user", checkNotNull(username));
-        props.setProperty("database.password", checkNotNull(password));
-        props.setProperty("database.port", String.valueOf(port));
+        props.setProperty("connector.class", SqlServerConnector.class.getCanonicalName());
         props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
         props.setProperty("database.dbname", checkNotNull(databaseList.get(0)));
-
-        props.setProperty("database.history", EmbeddedDatabaseHistory.class.getCanonicalName());
-        props.setProperty("database.history.instance.name", UUID.randomUUID() + "_" + subtask);
-        props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
-        props.setProperty("database.history.refer.ddl", String.valueOf(true));
-
-        //TODO Not yet supported
-        props.setProperty("include.schema.changes", String.valueOf(false));
 
         if (databaseList != null) {
             props.setProperty("database.include.list", String.join(",", databaseList));

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcConfig.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcConfig.java
@@ -31,49 +31,140 @@ public class JdbcConfig implements Serializable {
     private static final int DEFAULT_CONNECTION_CHECK_TIMEOUT_SEC = 30;
     private static final boolean DEFAULT_AUTO_COMMIT = true;
 
-    public static final Option<String> URL = Options.key("url").stringType().noDefaultValue().withDescription("url");
+    public static final Option<String> URL =
+            Options.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("url");
 
-    public static final Option<String> DRIVER =  Options.key("driver").stringType().noDefaultValue().withDescription("driver");
+    public static final Option<String> DRIVER =
+            Options.key("driver")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("driver");
 
-    public static final Option<Integer> CONNECTION_CHECK_TIMEOUT_SEC = Options.key("connection_check_timeout_sec").intType().defaultValue(DEFAULT_CONNECTION_CHECK_TIMEOUT_SEC).withDescription("connection check time second");
+    public static final Option<Integer> CONNECTION_CHECK_TIMEOUT_SEC =
+            Options.key("connection_check_timeout_sec")
+                    .intType()
+                    .defaultValue(DEFAULT_CONNECTION_CHECK_TIMEOUT_SEC)
+                    .withDescription("connection check time second");
 
-    public static final Option<Integer> MAX_RETRIES = Options.key("max_retries").intType().defaultValue(0).withDescription("max_retired");
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription("max_retired");
 
-    public static final Option<String> USER = Options.key("user").stringType().noDefaultValue().withDescription("user");
+    public static final Option<String> USER =
+            Options.key("user")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("user");
 
-    public static final Option<String> PASSWORD = Options.key("password").stringType().noDefaultValue().withDescription("password");
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("password");
 
-    public static final Option<String> QUERY = Options.key("query").stringType().noDefaultValue().withDescription("query");
+    public static final Option<String> QUERY =
+            Options.key("query")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("query");
 
-    public static final Option<Boolean> AUTO_COMMIT = Options.key("auto_commit").booleanType().defaultValue(DEFAULT_AUTO_COMMIT).withDescription("auto commit");
+    public static final Option<Boolean> AUTO_COMMIT =
+            Options.key("auto_commit")
+                    .booleanType()
+                    .defaultValue(DEFAULT_AUTO_COMMIT)
+                    .withDescription("auto commit");
 
-    public static final Option<Integer> BATCH_SIZE = Options.key("batch_size").intType().defaultValue(1000).withDescription("batch size");
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("batch size");
 
-    public static final Option<Integer> FETCH_SIZE = Options.key("fetch_size").intType().defaultValue(0).withDescription("For queries that return a large number of objects, " +
-        "you can configure the row fetch size used in the query to improve performance by reducing the number database hits required to satisfy the selection criteria. Zero means use jdbc default value.");
+    public static final Option<Integer> FETCH_SIZE =
+            Options.key("fetch_size")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription("For queries that return a large number of objects, you can configure " +
+                            "the row fetch size used in the query to improve performance by reducing the number " +
+                            "database hits required to satisfy the selection criteria. Zero means use jdbc default value.");
 
-    public static final Option<Integer> BATCH_INTERVAL_MS = Options.key("batch_interval_ms").intType().defaultValue(1000).withDescription("batch interval milliSecond");
+    public static final Option<Integer> BATCH_INTERVAL_MS =
+            Options.key("batch_interval_ms")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("batch interval milliSecond");
 
-    public static final Option<Boolean> IS_EXACTLY_ONCE = Options.key("is_exactly_once").booleanType().defaultValue(true).withDescription("exactly once");
+    public static final Option<Boolean> IS_EXACTLY_ONCE =
+            Options.key("is_exactly_once")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("exactly once");
 
-    public static final Option<String> XA_DATA_SOURCE_CLASS_NAME = Options.key("xa_data_source_class_name").stringType().noDefaultValue().withDescription("data source class name");
+    public static final Option<String> XA_DATA_SOURCE_CLASS_NAME =
+            Options.key("xa_data_source_class_name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("data source class name");
 
-    public static final Option<Integer> MAX_COMMIT_ATTEMPTS = Options.key("max_commit_attempts").intType().defaultValue(3).withDescription("max commit attempts");
+    public static final Option<Integer> MAX_COMMIT_ATTEMPTS =
+            Options.key("max_commit_attempts")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("max commit attempts");
 
-    public static final Option<Integer> TRANSACTION_TIMEOUT_SEC = Options.key("transaction_timeout_sec").intType().defaultValue(-1).withDescription("transaction timeout (second)");
+    public static final Option<Integer> TRANSACTION_TIMEOUT_SEC =
+            Options.key("transaction_timeout_sec")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription("transaction timeout (second)");
 
-    public static final Option<String> TABLE = Options.key("table").stringType().noDefaultValue().withDescription("table");
+    public static final Option<String> TABLE =
+            Options.key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("table");
 
-    public static final Option<List<String>> PRIMARY_KEYS = Options.key("primary_keys").listType().noDefaultValue().withDescription("primary keys");
+    public static final Option<List<String>> PRIMARY_KEYS =
+            Options.key("primary_keys")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("primary keys");
 
-    public static final Option<Boolean> SUPPORT_UPSERT_BY_QUERY_PRIMARY_KEY_EXIST = Options.key("support_upsert_by_query_primary_key_exist")
-        .booleanType().defaultValue(false).withDescription("support upsert by query primary_key exist");
+    public static final Option<Boolean> SUPPORT_UPSERT_BY_QUERY_PRIMARY_KEY_EXIST =
+            Options.key("support_upsert_by_query_primary_key_exist")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("support upsert by query primary_key exist");
 
     //source config
-    public static final Option<String> PARTITION_COLUMN = Options.key("partition_column").stringType().noDefaultValue().withDescription("partition column");
-    public static final Option<String> PARTITION_UPPER_BOUND = Options.key("partition_upper_bound").stringType().noDefaultValue().withDescription("partition upper bound");
-    public static final Option<String> PARTITION_LOWER_BOUND = Options.key("partition_lower_bound").stringType().noDefaultValue().withDescription("partition lower bound");
-    public static final Option<String> PARTITION_NUM = Options.key("partition_num").stringType().noDefaultValue().withDescription("partition num");
+    public static final Option<String> PARTITION_COLUMN =
+            Options.key("partition_column")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("partition column");
+
+    public static final Option<String> PARTITION_UPPER_BOUND =
+            Options.key("partition_upper_bound")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("partition upper bound");
+
+    public static final Option<String> PARTITION_LOWER_BOUND =
+            Options.key("partition_lower_bound")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("partition lower bound");
+
+    public static final Option<String> PARTITION_NUM =
+            Options.key("partition_num")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("partition num");
 
     public static JdbcConnectionOptions buildJdbcConnectionOptions(Config config) {
 


### PR DESCRIPTION
## Purpose of this pull request
- When constructing MySql, SqlServer, and SourceConfig, some repeated string keys appear directly in the code
- The JdbcSourceOptions class in the connector-cdc-base module is a public options class, and the PORT field attribute defaults to 3306. This port is only used by mysql, and other databases may have some hidden dangers when using this key.
- I found that there may be inelegant writing in the code of some options

#### issue: [here](https://github.com/apache/incubator-seatunnel/issues/3971)

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/incubator-seatunnel/blob/dev/release-note.md).