### PR TITLE
[Improve][shade][Config] Change HashMap to LinkedHashMap in SimpleConfigObject

### DIFF
--- a/seatunnel-config/seatunnel-config-shade/src/main/java/org/apache/seatunnel/shade/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/seatunnel-config/seatunnel-config-shade/src/main/java/org/apache/seatunnel/shade/com/typesafe/config/impl/SimpleConfigObject.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +102,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
         HashMap<String, AbstractConfigValue> smaller;
         if (next != null && v instanceof AbstractConfigObject) {
             v = ((AbstractConfigObject) v).withoutPath(next);
-            smaller = new HashMap<>(this.value);
+            smaller = new LinkedHashMap<>(this.value);
             smaller.put(key, v);
             return new SimpleConfigObject(
                     this.origin(),
@@ -109,7 +110,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
                     ResolveStatus.fromValues(smaller.values()),
                     this.ignoresFallbacks);
         } else if (next == null && v != null) {
-            smaller = new HashMap<>(this.value.size() - 1);
+            smaller = new LinkedHashMap<>(this.value.size() - 1);
 
             for (Entry<String, AbstractConfigValue> stringAbstractConfigValueEntry :
                     this.value.entrySet()) {
@@ -139,7 +140,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             if (this.value.isEmpty()) {
                 newMap = Collections.singletonMap(key, (AbstractConfigValue) v);
             } else {
-                newMap = new HashMap<>(this.value);
+                newMap = new LinkedHashMap<>(this.value);
                 newMap.put(key, v);
             }
 
@@ -197,7 +198,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
 
     public SimpleConfigObject replaceChild(
             AbstractConfigValue child, AbstractConfigValue replacement) {
-        Map<String, AbstractConfigValue> newChildren = new HashMap<>(this.value);
+        Map<String, AbstractConfigValue> newChildren = new LinkedHashMap<>(this.value);
         Iterator<Entry<String, AbstractConfigValue>> var4 = newChildren.entrySet().iterator();
 
         Entry<String, AbstractConfigValue> old;
@@ -254,7 +255,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
     }
 
     public Map<String, Object> unwrapped() {
-        Map<String, Object> m = new HashMap<>();
+        Map<String, Object> m = new LinkedHashMap<>();
 
         for (Entry<String, AbstractConfigValue> stringAbstractConfigValueEntry :
                 this.value.entrySet()) {
@@ -275,7 +276,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             SimpleConfigObject fallback = (SimpleConfigObject) abstractFallback;
             boolean changed = false;
             boolean allResolved = true;
-            Map<String, AbstractConfigValue> merged = new HashMap<>();
+            Map<String, AbstractConfigValue> merged = new LinkedHashMap<>();
             Set<String> allKeys = new HashSet<>();
             allKeys.addAll(this.keySet());
             allKeys.addAll(fallback.keySet());
@@ -337,7 +338,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             AbstractConfigValue modified = modifier.modifyChildMayThrow(k, v);
             if (modified != v) {
                 if (changes == null) {
-                    changes = new HashMap<>();
+                    changes = new LinkedHashMap<>();
                 }
 
                 changes.put(k, modified);
@@ -347,7 +348,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
         if (changes == null) {
             return this;
         } else {
-            Map<String, AbstractConfigValue> modified = new HashMap<>();
+            Map<String, AbstractConfigValue> modified = new LinkedHashMap<>();
             boolean sawUnresolved = false;
 
             for (String k : this.keySet()) {


### PR DESCRIPTION
## Purpose of this pull request

Due to the Config doesn't support set value at given order. e.g.
If we use 
```
config
.withValue("a", xx)
.withValue("b", yy)
.withValue("c", zz)
```
The out put will not in a, b, c order, since SimpleConfigObject will use HashMap to store the config.

This PR will change the HashMap to LinkedHashMap.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/incubator-seatunnel/blob/dev/release-note.md).