### PR TITLE
[Improve][E2E] Risk of unreproducible test cases: Some container versions do not have a fixed version number

### DIFF
--- a/release-note.md
+++ b/release-note.md
@@ -85,4 +85,5 @@
 ## Test
 ### E2E
 - [SqlServer CDC] fix SqlServerCDC IT failure #3807
+- [Container Version] Fix risk of unreproducible test cases #4591
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondynamodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/amazondynamodb/AmazondynamodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondynamodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/amazondynamodb/AmazondynamodbIT.java
@@ -81,7 +81,7 @@ import static org.awaitility.Awaitility.given;
 
 @Slf4j
 public class AmazondynamodbIT extends TestSuiteBase implements TestResource {
-    private static final String AMAZONDYNAMODB_DOCKER_IMAGE = "amazon/dynamodb-local";
+    private static final String AMAZONDYNAMODB_DOCKER_IMAGE = "amazon/dynamodb-local:1.21.0";
     private static final String AMAZONDYNAMODB_CONTAINER_HOST = "dynamodb-host";
     private static final int AMAZONDYNAMODB_CONTAINER_PORT = 8000;
     private static final String AMAZONDYNAMODB_JOB_CONFIG = "/amazondynamodbIT_source_to_sink.conf";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cassandra-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/CassandraIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cassandra-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/CassandraIT.java
@@ -86,7 +86,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 public class CassandraIT extends TestSuiteBase implements TestResource {
-    private static final String CASSANDRA_DOCKER_IMAGE = "cassandra";
+    private static final String CASSANDRA_DOCKER_IMAGE = "cassandra:4.1.1";
     private static final String HOST = "cassandra";
     private static final Integer PORT = 9042;
     private static final String INIT_CASSANDRA_PATH = "/init/cassandra_init.conf";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
@@ -76,7 +76,7 @@ import java.util.stream.Stream;
 
 public class ClickhouseIT extends TestSuiteBase implements TestResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClickhouseIT.class);
-    private static final String CLICKHOUSE_DOCKER_IMAGE = "yandex/clickhouse-server:latest";
+    private static final String CLICKHOUSE_DOCKER_IMAGE = "yandex/clickhouse-server:22.1.3.7";
     private static final String HOST = "clickhouse";
     private static final String DRIVER_CLASS = "com.clickhouse.jdbc.ClickHouseDriver";
     private static final String INIT_CLICKHOUSE_PATH = "/init/clickhouse_init.conf";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/CanalToKafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/CanalToKafkaIT.java
@@ -84,7 +84,7 @@ public class CanalToKafkaIT extends TestSuiteBase implements TestResource {
 
     // ----------------------------------------------------------------------------
     // kafka
-    private static final String KAFKA_IMAGE_NAME = "confluentinc/cp-kafka:latest";
+    private static final String KAFKA_IMAGE_NAME = "confluentinc/cp-kafka:7.0.9";
 
     private static final String KAFKA_TOPIC = "test-canal-sink";
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
@@ -67,7 +67,7 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 @Slf4j
 public class MongodbIT extends TestSuiteBase implements TestResource {
 
-    private static final String MONGODB_IMAGE = "mongo:latest";
+    private static final String MONGODB_IMAGE = "mongo:6.0.5";
     private static final String MONGODB_CONTAINER_HOST = "e2e_mongodb";
     private static final int MONGODB_PORT = 27017;
     private static final String MONGODB_DATABASE = "test_db";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-neo4j-e2e/src/test/java/org/apache/seatunnel/e2e/connector/neo4j/Neo4jIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-neo4j-e2e/src/test/java/org/apache/seatunnel/e2e/connector/neo4j/Neo4jIT.java
@@ -60,7 +60,7 @@ import static org.neo4j.driver.Values.parameters;
 @Slf4j
 public class Neo4jIT extends TestSuiteBase implements TestResource {
 
-    private static final String CONTAINER_IMAGE = "neo4j:latest";
+    private static final String CONTAINER_IMAGE = "neo4j:5.6.0";
     private static final String CONTAINER_HOST = "neo4j-host";
     private static final int HTTP_PORT = 7474;
     private static final int BOLT_PORT = 7687;


### PR DESCRIPTION
Fix in #4591 

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [X] Update the [`release-note`](https://github.com/apache/incubator-seatunnel/blob/dev/release-note.md).