### PR TITLE
[Doc][Connector-v2][JdbcSource] Redshift add defaultRowFetchSize

### DIFF
--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -117,7 +117,7 @@ there are some reference value for params above.
 | saphana    | com.sap.db.jdbc.Driver                              | jdbc:sap://localhost:39015                                             | https://mvnrepository.com/artifact/com.sap.cloud.db.jdbc/ngdbc                                              |
 | doris      | com.mysql.cj.jdbc.Driver                            | jdbc:mysql://localhost:3306/test                                       | https://mvnrepository.com/artifact/mysql/mysql-connector-java                                               |
 | teradata   | com.teradata.jdbc.TeraDriver                        | jdbc:teradata://localhost/DBS_PORT=1025,DATABASE=test                  | https://mvnrepository.com/artifact/com.teradata.jdbc/terajdbc                                               |
-| Redshift   | com.amazon.redshift.jdbc42.Driver                   | jdbc:redshift://localhost:5439/testdb                                  | https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42                                      |
+| Redshift   | com.amazon.redshift.jdbc42.Driver                   | jdbc:redshift://localhost:5439/testdb?defaultRowFetchSize=1000         | https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42                                      |
 | Vertica    | com.vertica.jdbc.Driver                             | jdbc:vertica://localhost:5433                                          | https://repo1.maven.org/maven2/com/vertica/jdbc/vertica-jdbc/12.0.3-0/vertica-jdbc-12.0.3-0.jar             |
 
 ## Example

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -97,7 +97,7 @@ Source plugin common parameters, please refer to [Source Common Options](common-
 If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed
 in parallel according to the concurrency of tasks.
 
-defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver. 
+defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver.
 If defaultRowFetchSize is not set , the Redshift will return all data to seatunnel source reader and the source may oom.
 
 ## appendix

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -97,6 +97,9 @@ Source plugin common parameters, please refer to [Source Common Options](common-
 If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed
 in parallel according to the concurrency of tasks.
 
+defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver. 
+If defaultRowFetchSize is not set , the Redshift will return all data to seatunnel source reader and the source may oom.
+
 ## appendix
 
 there are some reference value for params above.

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -150,26 +150,6 @@ Jdbc {
 }
 ```
 
-redshift:
-
-```
-Jdbc {
-    url = "jdbc:redshift://localhost:5439/testdb?defaultRowFetchSize=1000"
-    driver = "com.amazon.redshift.jdbc42.Driver"
-    connection_check_timeout_sec = 100
-    user = "root"
-    password = "123456"
-    query = "select * from type_bin"
-}
-```
-
-:::tip
-
-defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver.
-If defaultRowFetchSize is not set , the Redshift will return all data to seatunnel source reader and the source may oom.
-
-:::
-
 ## Changelog
 
 ### 2.2.0-beta 2022-09-26

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -97,9 +97,6 @@ Source plugin common parameters, please refer to [Source Common Options](common-
 If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed
 in parallel according to the concurrency of tasks.
 
-defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver.
-If defaultRowFetchSize is not set , the Redshift will return all data to seatunnel source reader and the source may oom.
-
 ## appendix
 
 there are some reference value for params above.
@@ -152,6 +149,26 @@ Jdbc {
     partition_num = 10
 }
 ```
+
+redshift:
+
+```
+Jdbc {
+    url = "jdbc:redshift://localhost:5439/testdb?defaultRowFetchSize=1000"
+    driver = "com.amazon.redshift.jdbc42.Driver"
+    connection_check_timeout_sec = 100
+    user = "root"
+    password = "123456"
+    query = "select * from type_bin"
+}
+```
+
+:::tip
+
+defaultRowFetchSize param is very import for JDBC Source to read data from Redshift use Redshift driver.
+If defaultRowFetchSize is not set , the Redshift will return all data to seatunnel source reader and the source may oom.
+
+:::
 
 ## Changelog
 


### PR DESCRIPTION
https://github.com/apache/incubator-seatunnel/issues/4156


## Purpose of this pull request

Add defaultRowFetchSize for Redshift source  jdbc url 
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/incubator-seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/incubator-seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/incubator-seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/incubator-seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/incubator-seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/incubator-seatunnel/blob/dev/release-note.md).