### PR TITLE
[Fix][Connector-V2] Fix ClickhouseFile write file failed when field value is null

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -213,14 +213,16 @@ public class ClickhouseFileSinkWriter
         String data =
                 this.readerOption.getFields().stream()
                                 .map(
-                                        field ->
-                                                row.getField(
-                                                                this.readerOption
-                                                                        .getSeaTunnelRowType()
-                                                                        .indexOf(field))
-                                                        .toString())
-                                .collect(Collectors.joining(readerOption.getFileFieldsDelimiter()))
-                        + "\n";
+                                        field -> {
+                                                      Object fieldValue = row.getField(this.readerOption.getSeaTunnelRowType().indexOf(field));
+                                                      
+                                                      if (fieldValue == null) {
+                                                          return "";
+                                                      } else {
+                                                          return fieldValue.toString();
+                                                      }
+                                                  }
+                                ).collect(Collectors.joining(readerOption.getFileFieldsDelimiter())) + "\n";
         MappedByteBuffer buffer =
                 fileChannel.map(
                         FileChannel.MapMode.READ_WRITE,

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -214,13 +214,19 @@ public class ClickhouseFileSinkWriter
                 this.readerOption.getFields().stream()
                                 .map(
                                         field -> {
-                                                Object fieldValue = row.getField(this.readerOption.getSeaTunnelRowType().indexOf(field));
-                                                if (fieldValue == null) {
-                                                        return "";
-                                                } else {
-                                                        return fieldValue.toString();
-                                                }
-                                        }).collect(Collectors.joining(readerOption.getFileFieldsDelimiter())) + "\n";
+                                            Object fieldValueObj =
+                                                    row.getField(
+                                                            this.readerOption
+                                                                    .getSeaTunnelRowType()
+                                                                    .indexOf(field));
+                                            if (fieldValueObj == null) {
+                                                return "";
+                                            } else {
+                                                return fieldValueObj.toString();
+                                            }
+                                        })
+                                .collect(Collectors.joining(readerOption.getFileFieldsDelimiter()))
+                        + "\n";
         MappedByteBuffer buffer =
                 fileChannel.map(
                         FileChannel.MapMode.READ_WRITE,

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -214,15 +214,13 @@ public class ClickhouseFileSinkWriter
                 this.readerOption.getFields().stream()
                                 .map(
                                         field -> {
-                                                      Object fieldValue = row.getField(this.readerOption.getSeaTunnelRowType().indexOf(field));
-                                                      
-                                                      if (fieldValue == null) {
-                                                          return "";
-                                                      } else {
-                                                          return fieldValue.toString();
-                                                      }
-                                                  }
-                                ).collect(Collectors.joining(readerOption.getFileFieldsDelimiter())) + "\n";
+                                                Object fieldValue = row.getField(this.readerOption.getSeaTunnelRowType().indexOf(field));
+                                                if (fieldValue == null) {
+                                                        return "";
+                                                } else {
+                                                        return fieldValue.toString();
+                                                }
+                                        }).collect(Collectors.joining(readerOption.getFileFieldsDelimiter())) + "\n";
         MappedByteBuffer buffer =
                 fileChannel.map(
                         FileChannel.MapMode.READ_WRITE,


### PR DESCRIPTION
Bug fix: When ClikchouseFileSinkerWriter writes to a temporary file, it does not check whether the field value is empty, so an exception will be thrown.

Modified to write an empty string when a null value is encountered