### PR TITLE
[doc] property name fix

### DIFF
--- a/docs/en/connector-v2/sink/StarRocks.md
+++ b/docs/en/connector-v2/sink/StarRocks.md
@@ -16,7 +16,7 @@ The internal implementation of StarRocks sink connector is cached and imported b
 
 |            name             |  type   | required |  default value  |
 |-----------------------------|---------|----------|-----------------|
-| node_urls                   | list    | yes      | -               |
+| nodeUrls                   | list    | yes      | -               |
 | base-url                    | string  | yes      | -               |
 | username                    | string  | yes      | -               |
 | password                    | string  | yes      | -               |
@@ -33,7 +33,7 @@ The internal implementation of StarRocks sink connector is cached and imported b
 | save_mode_create_template   | string  | no       | see below       |
 | starrocks.config            | map     | no       | -               |
 
-### node_urls [list]
+### nodeUrls [list]
 
 `StarRocks` cluster address, the format is `["fe_ip:fe_http_port", ...]`
 


### PR DESCRIPTION
node_urls -> nodeUrls
node_urls doesn't work

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

This pull request fix property name of  StarRocks Source

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason: only documentation changes
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).