### PR TITLE
[Feature] make data block balance before importing data #5026

### DIFF
--- a/docs/en/connector-v2/sink/common-options.md
+++ b/docs/en/connector-v2/sink/common-options.md
@@ -6,6 +6,8 @@
 |-------------------|--------|----------|---------------|
 | source_table_name | string | no       | -             |
 | parallelism       | int    | no       | -             |
+| partition_balance | boolean| no       | false         |
+
 
 ### source_table_name [string]
 
@@ -18,6 +20,16 @@ When `source_table_name` is specified, the current plug-in is processing the dat
 When `parallelism` is not specified, the `parallelism` in env is used by default.
 
 When parallelism is specified, it will override the parallelism in env.
+
+### partition_balance [boolean]
+When `partition_balance` is set to true, in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time. 
+
+The default value is false, support Spark and Flink engine
+
+When `partition_balance` is not specified, the `partition_balance` in env is used by default.
+
+When `partition_balance` is specified, it will override the `partition_balance` in env.
+
 
 ## Examples
 

--- a/docs/en/connector-v2/sink/common-options.md
+++ b/docs/en/connector-v2/sink/common-options.md
@@ -2,12 +2,11 @@
 
 > Common parameters of sink connectors
 
-|       name        |  type  | required | default value |
-|-------------------|--------|----------|---------------|
-| source_table_name | string | no       | -             |
-| parallelism       | int    | no       | -             |
-| partition_balance | boolean| no       | false         |
-
+|       name        |  type   | required | default value |
+|-------------------|---------|----------|---------------|
+| source_table_name | string  | no       | -             |
+| parallelism       | int     | no       | -             |
+| partition_balance | boolean | no       | false         |
 
 ### source_table_name [string]
 
@@ -22,14 +21,14 @@ When `parallelism` is not specified, the `parallelism` in env is used by default
 When parallelism is specified, it will override the parallelism in env.
 
 ### partition_balance [boolean]
-When `partition_balance` is set to true, in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time. 
+
+When `partition_balance` is set to true, in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time.
 
 The default value is false, support Spark and Flink engine
 
 When `partition_balance` is not specified, the `partition_balance` in env is used by default.
 
 When `partition_balance` is specified, it will override the `partition_balance` in env.
-
 
 ## Examples
 

--- a/docs/en/connector-v2/sink/common-options.md
+++ b/docs/en/connector-v2/sink/common-options.md
@@ -24,7 +24,7 @@ When parallelism is specified, it will override the parallelism in env.
 
 When `partition_balance` is set to true, in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time.
 
-The default value is false, support Spark and Flink engine
+The default value is false, only supported by Spark and Flink engine
 
 When `partition_balance` is not specified, the `partition_balance` in env is used by default.
 

--- a/docs/en/connector-v2/sink/common-options.md
+++ b/docs/en/connector-v2/sink/common-options.md
@@ -24,7 +24,7 @@ When parallelism is specified, it will override the parallelism in env.
 
 When `partition_balance` is set to true, in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time.
 
-The default value is false, only supported by Spark and Flink engine
+The default value is false, support Spark and Flink engine
 
 When `partition_balance` is not specified, the `partition_balance` in env is used by default.
 

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/CommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/CommonOptions.java
@@ -66,4 +66,13 @@ public interface CommonOptions {
                     .withDescription(
                             "When parallelism is not specified, the parallelism in env is used by default. "
                                     + "When parallelism is specified, it will override the parallelism in env.");
+
+    Option<Boolean> PARTITION_BALANCE =
+            Options.key("partition_balance")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When partition_balance is set to true, "
+                                    + "in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, "
+                                    + "which can avoid problems caused by data skew, but it will consume some extra time. The default value is false");
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -115,6 +115,17 @@ public class SinkExecuteProcessor
                 DataSaveMode dataSaveMode = saveModeSink.getDataSaveMode();
                 saveModeSink.handleSaveMode(dataSaveMode);
             }
+            Boolean needBalanceInEnv =
+                    flinkRuntimeEnvironment
+                            .getConfig()
+                            .getBoolean(CommonOptions.PARTITION_BALANCE.key());
+            boolean needBalance =
+                    needBalanceInEnv != null
+                            ? needBalanceInEnv
+                            : CommonOptions.PARTITION_BALANCE.defaultValue();
+            if (needBalance) {
+                stream = stream.shuffle();
+            }
             DataStreamSink<Row> dataStreamSink =
                     stream.sinkTo(SinkV1Adapter.wrap(new FlinkSink<>(seaTunnelSink)))
                             .name(seaTunnelSink.getPluginName());

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -115,16 +115,11 @@ public class SinkExecuteProcessor
                 DataSaveMode dataSaveMode = saveModeSink.getDataSaveMode();
                 saveModeSink.handleSaveMode(dataSaveMode);
             }
-            Boolean needBalanceInEnv =
-                    flinkRuntimeEnvironment
-                            .getConfig()
-                            .getBoolean(CommonOptions.PARTITION_BALANCE.key());
-            boolean needBalance =
-                    needBalanceInEnv != null
-                            ? needBalanceInEnv
-                            : CommonOptions.PARTITION_BALANCE.defaultValue();
-            if (needBalance) {
-                stream = stream.shuffle();
+            if (sinkConfig.hasPath(CommonOptions.PARTITION_BALANCE.key())) {
+                Boolean needBalance = sinkConfig.getBoolean(CommonOptions.PARTITION_BALANCE.key());
+                if (needBalance) {
+                    stream = stream.shuffle();
+                }
             }
             DataStreamSink<Row> dataStreamSink =
                     stream.sinkTo(SinkV1Adapter.wrap(new FlinkSink<>(seaTunnelSink)))

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -110,6 +110,18 @@ public class SinkExecuteProcessor
                                         CommonOptions.PARALLELISM.key(),
                                         CommonOptions.PARALLELISM.defaultValue());
             }
+            Boolean needBalanceInEnv =
+                    sparkRuntimeEnvironment
+                            .getConfig()
+                            .getBoolean(CommonOptions.PARTITION_BALANCE.key());
+            boolean needBalance =
+                    needBalanceInEnv != null
+                            ? needBalanceInEnv
+                            : CommonOptions.PARTITION_BALANCE.defaultValue();
+
+            if (needBalance) {
+                dataset = dataset.repartition(parallelism);
+            }
             dataset.sparkSession().read().option(CommonOptions.PARALLELISM.key(), parallelism);
             // TODO modify checkpoint location
             seaTunnelSink.setTypeInfo(

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -110,17 +110,11 @@ public class SinkExecuteProcessor
                                         CommonOptions.PARALLELISM.key(),
                                         CommonOptions.PARALLELISM.defaultValue());
             }
-            Boolean needBalanceInEnv =
-                    sparkRuntimeEnvironment
-                            .getConfig()
-                            .getBoolean(CommonOptions.PARTITION_BALANCE.key());
-            boolean needBalance =
-                    needBalanceInEnv != null
-                            ? needBalanceInEnv
-                            : CommonOptions.PARTITION_BALANCE.defaultValue();
-
-            if (needBalance) {
-                dataset = dataset.repartition(parallelism);
+            if (sinkConfig.hashPath(CommonOptions.PARTITION_BALANCE.key())) {
+                boolean needBalance = sinkConfig.getBoolean();
+                if (needBalance) {
+                    dataset = dataset.repartition(parallelism);
+                }
             }
             dataset.sparkSession().read().option(CommonOptions.PARALLELISM.key(), parallelism);
             // TODO modify checkpoint location

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -110,7 +110,7 @@ public class SinkExecuteProcessor
                                         CommonOptions.PARALLELISM.key(),
                                         CommonOptions.PARALLELISM.defaultValue());
             }
-            if (sinkConfig.hashPath(CommonOptions.PARTITION_BALANCE.key())) {
+            if (sinkConfig.hasPath(CommonOptions.PARTITION_BALANCE.key())) {
                 boolean needBalance = sinkConfig.getBoolean(CommonOptions.PARTITION_BALANCE.key());
                 if (needBalance) {
                     dataset = dataset.repartition(parallelism);

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -111,7 +111,7 @@ public class SinkExecuteProcessor
                                         CommonOptions.PARALLELISM.defaultValue());
             }
             if (sinkConfig.hashPath(CommonOptions.PARTITION_BALANCE.key())) {
-                boolean needBalance = sinkConfig.getBoolean();
+                boolean needBalance = sinkConfig.getBoolean(CommonOptions.PARTITION_BALANCE.key());
                 if (needBalance) {
                     dataset = dataset.repartition(parallelism);
                 }


### PR DESCRIPTION
make data block balance before importing data #5026

When partition_balance is set to true in the env,in the sink process, a repartition will be performed first to ensure that the size of each partition is roughly the same, which can avoid problems caused by data skew, but it will consume some extra time. The default value is false. 

support spark and flink engine
