### PR TITLE
[Improve] [seatunnel-examples] modify the transform URL link

### DIFF
--- a/seatunnel-examples/seatunnel-flink-connector-v2-example/src/main/resources/examples/fake_to_console.conf
+++ b/seatunnel-examples/seatunnel-flink-connector-v2-example/src/main/resources/examples/fake_to_console.conf
@@ -47,7 +47,7 @@ source {
 transform {
 
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/category/transform-v2
 }
 
 sink {

--- a/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
+++ b/seatunnel-examples/seatunnel-spark-connector-v2-example/src/main/resources/examples/spark.batch.conf
@@ -79,7 +79,7 @@ transform {
   }
 
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/category/transform-v2
 }
 
 sink {


### PR DESCRIPTION
## [Improve] modify the transform URL link

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Modify the transform URL link in the "fake_to_console.conf" file

<img width="509" alt="image" src="https://github.com/apache/seatunnel/assets/7700151/8c4487c6-7f65-492e-8d5e-949ab524f6a8">
Change  "https://seatunnel.apache.org/docs/category/transform"  to "https://seatunnel.apache.org/docs/category/transform-v2"  
<img width="1006" alt="image" src="https://github.com/apache/seatunnel/assets/7700151/dd1844a2-6913-483c-bf8d-4930481dcbf2">


