### PR TITLE
[Feature][Flink] Support Decimal Type with configurable precision and scale

### DIFF
--- a/release-note.md
+++ b/release-note.md
@@ -147,6 +147,7 @@
 - [Core] [API] Add copy method to Catalog codes (#4414)
 - [Core] [API] Add options check before create source and sink and transform in FactoryUtil (#4424)
 - [Core] [Shade] Add guava shade module (#4358)
+- [Core] [Flink] Support Decimal Type with configurable precision and scale (#5419)
 
 ### Connector-V2
 

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkRuntimeEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.core.starter.flink.execution;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.env.EnvCommonOptions;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.Constants;
 import org.apache.seatunnel.common.config.CheckResult;
 import org.apache.seatunnel.common.constants.JobMode;
@@ -51,8 +52,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -64,7 +68,8 @@ public class FlinkRuntimeEnvironment implements RuntimeEnvironment {
     private StreamExecutionEnvironment environment;
 
     private StreamTableEnvironment tableEnvironment;
-
+    private Map<String, SeaTunnelRowType> stagedTypes = new LinkedHashMap<>();
+    private Optional<SeaTunnelRowType> defaultType = Optional.empty();
     private JobMode jobMode;
 
     private String jobName = Constants.LOGO;
@@ -332,6 +337,24 @@ public class FlinkRuntimeEnvironment implements RuntimeEnvironment {
         }
         tableEnvironment.createTemporaryView(
                 name, tableEnvironment.fromChangelogStream(dataStream));
+    }
+
+    public void stageType(String tblName, SeaTunnelRowType type) {
+        stagedTypes.put(tblName, type);
+    }
+
+    public void stageDefaultType(SeaTunnelRowType type) {
+        this.defaultType = Optional.of(type);
+    }
+
+    public Optional<SeaTunnelRowType> type(String tblName) {
+        return stagedTypes.containsKey(tblName)
+                ? Optional.of(stagedTypes.get(tblName))
+                : Optional.empty();
+    }
+
+    public Optional<SeaTunnelRowType> defaultType() {
+        return this.defaultType;
     }
 
     public static FlinkRuntimeEnvironment getInstance(Config config) {

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -31,7 +31,6 @@ import org.apache.seatunnel.core.starter.exception.TaskExecuteException;
 import org.apache.seatunnel.plugin.discovery.PluginIdentifier;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSinkPluginDiscovery;
 import org.apache.seatunnel.translation.flink.sink.FlinkSink;
-import org.apache.seatunnel.translation.flink.utils.TypeConverterUtils;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -101,8 +100,8 @@ public class SinkExecuteProcessor
             SeaTunnelSink<SeaTunnelRow, Serializable, Serializable, Serializable> seaTunnelSink =
                     plugins.get(i);
             DataStream<Row> stream = fromSourceTable(sinkConfig).orElse(input);
-            seaTunnelSink.setTypeInfo(
-                    (SeaTunnelRowType) TypeConverterUtils.convert(stream.getType()));
+            SeaTunnelRowType sourceType = initSourceType(sinkConfig, stream);
+            seaTunnelSink.setTypeInfo(sourceType);
             if (SupportDataSaveMode.class.isAssignableFrom(seaTunnelSink.getClass())) {
                 SupportDataSaveMode saveModeSink = (SupportDataSaveMode) seaTunnelSink;
                 DataSaveMode dataSaveMode = saveModeSink.getUserConfigSaveMode();

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkAbstractPluginExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkAbstractPluginExecuteProcessor.java
@@ -20,9 +20,11 @@ package org.apache.seatunnel.core.starter.flink.execution;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.core.starter.execution.PluginExecuteProcessor;
 import org.apache.seatunnel.core.starter.flink.utils.TableUtil;
+import org.apache.seatunnel.translation.flink.utils.TypeConverterUtils;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
@@ -115,6 +117,36 @@ public abstract class FlinkAbstractPluginExecuteProcessor<T>
             String tableName = pluginConfig.getString(RESULT_TABLE_NAME.key());
             isAppendMap.put(tableName, false);
         }
+    }
+
+    protected void stageType(Config pluginConfig, SeaTunnelRowType type) {
+        if (!flinkRuntimeEnvironment.defaultType().isPresent()) {
+            flinkRuntimeEnvironment.stageDefaultType(type);
+        }
+
+        if (pluginConfig.hasPath("result_table_name")) {
+            String tblName = pluginConfig.getString("result_table_name");
+            flinkRuntimeEnvironment.stageType(tblName, type);
+        }
+    }
+
+    protected Optional<SeaTunnelRowType> sourceType(Config pluginConfig) {
+        if (pluginConfig.hasPath(SOURCE_TABLE_NAME)) {
+            String tblName = pluginConfig.getString(SOURCE_TABLE_NAME);
+            return flinkRuntimeEnvironment.type(tblName);
+        } else {
+            return flinkRuntimeEnvironment.defaultType();
+        }
+    }
+
+    protected SeaTunnelRowType initSourceType(Config sinkConfig, DataStream<Row> stream) {
+        SeaTunnelRowType sourceType =
+                sourceType(sinkConfig)
+                        .orElseGet(
+                                () ->
+                                        (SeaTunnelRowType)
+                                                TypeConverterUtils.convert(stream.getType()));
+        return sourceType;
     }
 
     protected abstract List<T> initializePlugins(

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkRuntimeEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.core.starter.flink.execution;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.env.EnvCommonOptions;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.Constants;
 import org.apache.seatunnel.common.config.CheckResult;
 import org.apache.seatunnel.common.constants.JobMode;
@@ -51,8 +52,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -64,6 +68,9 @@ public class FlinkRuntimeEnvironment implements RuntimeEnvironment {
     private StreamExecutionEnvironment environment;
 
     private StreamTableEnvironment tableEnvironment;
+
+    private Map<String, SeaTunnelRowType> stagedTypes = new LinkedHashMap<>();
+    private Optional<SeaTunnelRowType> defaultType = Optional.empty();
 
     private JobMode jobMode;
 
@@ -332,6 +339,24 @@ public class FlinkRuntimeEnvironment implements RuntimeEnvironment {
         }
         tableEnvironment.createTemporaryView(
                 name, tableEnvironment.fromChangelogStream(dataStream));
+    }
+
+    public void stageType(String tblName, SeaTunnelRowType type) {
+        stagedTypes.put(tblName, type);
+    }
+
+    public void stageDefaultType(SeaTunnelRowType type) {
+        this.defaultType = Optional.of(type);
+    }
+
+    public Optional<SeaTunnelRowType> type(String tblName) {
+        return stagedTypes.containsKey(tblName)
+                ? Optional.of(stagedTypes.get(tblName))
+                : Optional.empty();
+    }
+
+    public Optional<SeaTunnelRowType> defaultType() {
+        return this.defaultType;
     }
 
     public static FlinkRuntimeEnvironment getInstance(Config config) {

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -31,7 +31,6 @@ import org.apache.seatunnel.core.starter.exception.TaskExecuteException;
 import org.apache.seatunnel.plugin.discovery.PluginIdentifier;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSinkPluginDiscovery;
 import org.apache.seatunnel.translation.flink.sink.FlinkSink;
-import org.apache.seatunnel.translation.flink.utils.TypeConverterUtils;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -102,8 +101,8 @@ public class SinkExecuteProcessor
             SeaTunnelSink<SeaTunnelRow, Serializable, Serializable, Serializable> seaTunnelSink =
                     plugins.get(i);
             DataStream<Row> stream = fromSourceTable(sinkConfig).orElse(input);
-            seaTunnelSink.setTypeInfo(
-                    (SeaTunnelRowType) TypeConverterUtils.convert(stream.getType()));
+            SeaTunnelRowType sourceType = initSourceType(sinkConfig, stream);
+            seaTunnelSink.setTypeInfo(sourceType);
             if (SupportDataSaveMode.class.isAssignableFrom(seaTunnelSink.getClass())) {
                 SupportDataSaveMode saveModeSink = (SupportDataSaveMode) seaTunnelSink;
                 DataSaveMode dataSaveMode = saveModeSink.getUserConfigSaveMode();

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SourceExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SourceExecuteProcessor.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.api.common.CommonOptions;
 import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SupportCoordinate;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.core.starter.enums.PluginType;
 import org.apache.seatunnel.plugin.discovery.PluginIdentifier;
@@ -76,12 +77,15 @@ public class SourceExecuteProcessor extends FlinkAbstractPluginExecuteProcessor<
             boolean bounded =
                     internalSource.getBoundedness()
                             == org.apache.seatunnel.api.source.Boundedness.BOUNDED;
+
             DataStreamSource<Row> sourceStream =
                     addSource(
                             executionEnvironment,
                             sourceFunction,
                             "SeaTunnel " + internalSource.getClass().getSimpleName(),
                             bounded);
+            stageType(pluginConfig, (SeaTunnelRowType) internalSource.getProducedType());
+
             if (pluginConfig.hasPath(CommonOptions.PARALLELISM.key())) {
                 int parallelism = pluginConfig.getInt(CommonOptions.PARALLELISM.key());
                 sourceStream.setParallelism(parallelism);

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon.conf
@@ -27,6 +27,7 @@ env {
 
 source {
   FakeSource {
+    row.num = 100000
     schema = {
       fields {
         c_map = "map<string, string>"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_assert.conf
@@ -44,7 +44,7 @@ sink {
       row_rules = [
         {
           rule_type = MAX_ROW
-          rule_value = 5
+          rule_value = 100000
         }
       ],
       field_rules = [

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/test/java/org/apache/seatunnel/translation/flink/utils/TypeConverterUtilsTest.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/test/java/org/apache/seatunnel/translation/flink/utils/TypeConverterUtilsTest.java
@@ -83,9 +83,14 @@ public class TypeConverterUtilsTest {
 
     @Test
     public void convertBigDecimalType() {
+        /**
+         * To solve lost precision and scale of {@link
+         * org.apache.seatunnel.api.table.type.DecimalType}, use {@link
+         * org.apache.flink.api.common.typeinfo.BasicTypeInfo#STRING_TYPE_INFO} as the convert
+         * result of {@link org.apache.seatunnel.api.table.type.DecimalType} instance.
+         */
         Assertions.assertEquals(
-                BasicTypeInfo.BIG_DEC_TYPE_INFO,
-                TypeConverterUtils.convert(new DecimalType(30, 2)));
+                BasicTypeInfo.STRING_TYPE_INFO, TypeConverterUtils.convert(new DecimalType(30, 2)));
     }
 
     @Test

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/utils/TypeConverterUtils.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/utils/TypeConverterUtils.java
@@ -33,7 +33,6 @@ import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.MapTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -70,11 +69,15 @@ public class TypeConverterUtils {
                 BridgedType.of(BasicType.DOUBLE_TYPE, BasicTypeInfo.DOUBLE_TYPE_INFO));
         BRIDGED_TYPES.put(
                 Void.class, BridgedType.of(BasicType.VOID_TYPE, BasicTypeInfo.VOID_TYPE_INFO));
-        // TODO: there is a still an unresolved issue that the BigDecimal type will lose the
-        // precision and scale
+        /**
+         * To solve lost precision and scale of {@link
+         * org.apache.seatunnel.api.table.type.DecimalType}, use {@link
+         * org.apache.flink.api.common.typeinfo.BasicTypeInfo#STRING_TYPE_INFO} as the payload of
+         * {@link org.apache.seatunnel.api.table.type.DecimalType}.
+         */
         BRIDGED_TYPES.put(
                 BigDecimal.class,
-                BridgedType.of(new DecimalType(38, 18), BasicTypeInfo.BIG_DEC_TYPE_INFO));
+                BridgedType.of(new DecimalType(38, 18), BasicTypeInfo.STRING_TYPE_INFO));
 
         // data time types
         BRIDGED_TYPES.put(
@@ -134,10 +137,7 @@ public class TypeConverterUtils {
         if (bridgedType != null) {
             return bridgedType.getSeaTunnelType();
         }
-        if (dataType instanceof BigDecimalTypeInfo) {
-            BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) dataType;
-            return new DecimalType(decimalType.precision(), decimalType.scale());
-        }
+
         if (dataType instanceof MapTypeInfo) {
             MapTypeInfo<?, ?> mapTypeInfo = (MapTypeInfo<?, ?>) dataType;
             return new MapType<>(
@@ -160,10 +160,7 @@ public class TypeConverterUtils {
         if (bridgedType != null) {
             return bridgedType.getFlinkType();
         }
-        if (dataType instanceof DecimalType) {
-            DecimalType decimalType = (DecimalType) dataType;
-            return new BigDecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
-        }
+
         if (dataType instanceof MapType) {
             MapType<?, ?> mapType = (MapType<?, ?>) dataType;
             return new MapTypeInfo<>(


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request
- FIX: #5374 

#### Motivation
Flink has two type systems: TypeInformation of  DataSet/DataStream API, and LogicType of  Table & SQL API. TypeInformation has some [shortcomings](https://cwiki.apache.org/confluence/display/FLINK/FLIP-37%3A+Rework+of+the+Table+API+Type+System). For example, precision and scale can not be defined for DECIMALs. 
SeaTunnel has implemented a translation layer based on DataStream, which used TypeInformation type system. 

#### Solution
To support configurable decimal type, there are two solutions. 

##### ~~1st Solution~~
The 1st solution requires rewriting the translation layer based on Table & SQL API. **But it will consume a lot of work and cause many code changes**. 

##### 2nd Solution[Adopt]
The 2nd solution adopts the idea of type mapping and uses the String type as the carrier medium of Decimal. SeaTunnel restores the Decimal type field from String before processing the data, and converts the Decimal type field into String after completing the data processing. Because it cannot be inferred from the String type field of typeinformation whether it is a Decimal type field, this solution temporarily stores `SeaTunnelRowType` to bypass the type conversion between `TypeInformation` and `SeaTunnelDataType`. 
Because this solution does not require too much work and can guarantee the stability of the source code, I will adopt it.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).