### PR TITLE
Revert "[fix][hive-source][bug] fix An error occurred reading an empty directory"

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
@@ -24,6 +24,8 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.file.config.BaseSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
+import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.file.sink.util.FileSystemUtils;
 
 import org.apache.hadoop.conf.Configuration;
@@ -151,9 +153,15 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
                 }
             }
         }
-        if (this.fileNames.isEmpty()) {
-            log.error("The current directory is empty " + path);
+
+        if (fileNames.isEmpty()) {
+            throw new FileConnectorException(
+                    FileConnectorErrorCode.FILE_LIST_EMPTY,
+                    "The target file list is empty,"
+                            + "SeaTunnel will not be able to sync empty table, "
+                            + "please check the configuration parameters such as: [file_filter_pattern]");
         }
+
         return fileNames;
     }
 
@@ -188,12 +196,10 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
 
     protected Map<String, String> parsePartitionsByPath(String path) {
         LinkedHashMap<String, String> partitions = new LinkedHashMap<>();
-        if (path != null && !path.isEmpty()) {
-            Arrays.stream(path.split("/", -1))
-                    .filter(split -> split.contains("="))
-                    .map(split -> split.split("=", -1))
-                    .forEach(kv -> partitions.put(kv[0], kv[1]));
-        }
+        Arrays.stream(path.split("/", -1))
+                .filter(split -> split.contains("="))
+                .map(split -> split.split("=", -1))
+                .forEach(kv -> partitions.put(kv[0], kv[1]));
         return partitions;
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ExcelReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ExcelReadStrategy.java
@@ -136,8 +136,7 @@ public class ExcelReadStrategy extends AbstractReadStrategy {
                     "Schmea information is not set or incorrect schmea settings");
         }
         SeaTunnelRowType userDefinedRowTypeWithPartition =
-                mergePartitionTypes(
-                        fileNames.size() > 0 ? fileNames.get(0) : null, seaTunnelRowType);
+                mergePartitionTypes(fileNames.get(0), seaTunnelRowType);
         // column projection
         if (pluginConfig.hasPath(BaseSourceConfig.READ_COLUMNS.key())) {
             // get the read column index from user-defined row type

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/TextReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/TextReadStrategy.java
@@ -138,8 +138,7 @@ public class TextReadStrategy extends AbstractReadStrategy {
     @Override
     public void setSeaTunnelRowTypeInfo(SeaTunnelRowType seaTunnelRowType) {
         SeaTunnelRowType userDefinedRowTypeWithPartition =
-                mergePartitionTypes(
-                        fileNames.size() > 0 ? fileNames.get(0) : null, seaTunnelRowType);
+                mergePartitionTypes(fileNames.get(0), seaTunnelRowType);
         if (pluginConfig.hasPath(BaseSourceConfig.DELIMITER.key())) {
             fieldDelimiter = pluginConfig.getString(BaseSourceConfig.DELIMITER.key());
         } else {


### PR DESCRIPTION
Sorry, This PR will cause Hive to be unable to read the schema due to the lack of files when reading, so we believe that if the directory is empty, the synchronization job should not run normally.

Revert PR https://github.com/apache/seatunnel/pull/5427