### PR TITLE
Throw IllegalArgumentException when find multiple connector jar for one pluginIdentifier

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/Common.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/config/Common.java
@@ -19,6 +19,8 @@ package org.apache.seatunnel.common.config;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -67,7 +69,7 @@ public class Common {
         return MODE;
     }
 
-    private static String getSeaTunnelHome() {
+    public static String getSeaTunnelHome() {
 
         if (StringUtils.isNotEmpty(SEATUNNEL_HOME)) {
             return SEATUNNEL_HOME;
@@ -81,6 +83,11 @@ public class Common {
         }
         SEATUNNEL_HOME = seatunnelHome;
         return SEATUNNEL_HOME;
+    }
+
+    @VisibleForTesting
+    public static void setSeaTunnelHome(String seatunnelHome) {
+        SEATUNNEL_HOME = seatunnelHome;
     }
 
     /**

--- a/seatunnel-plugin-discovery/src/main/java/org/apache/seatunnel/plugin/discovery/AbstractPluginDiscovery.java
+++ b/seatunnel-plugin-discovery/src/main/java/org/apache/seatunnel/plugin/discovery/AbstractPluginDiscovery.java
@@ -47,6 +47,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public abstract class AbstractPluginDiscovery<T> implements PluginDiscovery<T> {
             };
 
     private final Path pluginDir;
-    private final Config pluginConfig;
+    private final Config pluginMappingConfig;
     private final BiConsumer<ClassLoader, URL> addURLToClassLoaderConsumer;
     protected final ConcurrentHashMap<PluginIdentifier, Optional<URL>> pluginJarPath =
             new ConcurrentHashMap<>(Common.COLLECTION_SIZE);
@@ -95,16 +96,16 @@ public abstract class AbstractPluginDiscovery<T> implements PluginDiscovery<T> {
         this(pluginDir, loadConnectorPluginConfig());
     }
 
-    public AbstractPluginDiscovery(Path pluginDir, Config pluginConfig) {
-        this(pluginDir, pluginConfig, DEFAULT_URL_TO_CLASSLOADER);
+    public AbstractPluginDiscovery(Path pluginDir, Config pluginMappingConfig) {
+        this(pluginDir, pluginMappingConfig, DEFAULT_URL_TO_CLASSLOADER);
     }
 
     public AbstractPluginDiscovery(
             Path pluginDir,
-            Config pluginConfig,
+            Config pluginMappingConfig,
             BiConsumer<ClassLoader, URL> addURLToClassLoaderConsumer) {
         this.pluginDir = pluginDir;
-        this.pluginConfig = pluginConfig;
+        this.pluginMappingConfig = pluginMappingConfig;
         this.addURLToClassLoaderConsumer = addURLToClassLoaderConsumer;
         log.info("Load {} Plugin from {}", getPluginBaseClass().getSimpleName(), pluginDir);
     }
@@ -328,16 +329,13 @@ public abstract class AbstractPluginDiscovery<T> implements PluginDiscovery<T> {
      * @return plugin jar path.
      */
     private Optional<URL> findPluginJarPath(PluginIdentifier pluginIdentifier) {
-        if (pluginConfig.isEmpty()) {
-            return Optional.empty();
-        }
         final String engineType = pluginIdentifier.getEngineType().toLowerCase();
         final String pluginType = pluginIdentifier.getPluginType().toLowerCase();
         final String pluginName = pluginIdentifier.getPluginName().toLowerCase();
-        if (!pluginConfig.hasPath(engineType)) {
+        if (!pluginMappingConfig.hasPath(engineType)) {
             return Optional.empty();
         }
-        Config engineConfig = pluginConfig.getConfig(engineType);
+        Config engineConfig = pluginMappingConfig.getConfig(engineType);
         if (!engineConfig.hasPath(pluginType)) {
             return Optional.empty();
         }
@@ -365,15 +363,24 @@ public abstract class AbstractPluginDiscovery<T> implements PluginDiscovery<T> {
         if (ArrayUtils.isEmpty(targetPluginFiles)) {
             return Optional.empty();
         }
+        if (targetPluginFiles.length > 1) {
+            throw new IllegalArgumentException(
+                    "Found multiple plugin jar: "
+                            + Arrays.stream(targetPluginFiles)
+                                    .map(File::getPath)
+                                    .collect(Collectors.joining(","))
+                            + " for pluginIdentifier: "
+                            + pluginIdentifier);
+        }
         try {
             URL pluginJarPath = targetPluginFiles[0].toURI().toURL();
-            log.info(
-                    "Discovery plugin jar: {} at: {}",
-                    pluginIdentifier.getPluginName(),
-                    pluginJarPath);
+            log.info("Discovery plugin jar for: {} at: {}", pluginIdentifier, pluginJarPath);
             return Optional.of(pluginJarPath);
         } catch (MalformedURLException e) {
-            log.warn("Cannot get plugin URL: " + targetPluginFiles[0], e);
+            log.warn(
+                    "Cannot get plugin URL: {} for pluginIdentifier: {}" + targetPluginFiles[0],
+                    pluginIdentifier,
+                    e);
             return Optional.empty();
         }
     }

--- a/seatunnel-plugin-discovery/src/test/resources/duplicate/connectors/plugin-mapping.properties
+++ b/seatunnel-plugin-discovery/src/test/resources/duplicate/connectors/plugin-mapping.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+seatunnel.source.HttpBase = connector-http
+seatunnel.sink.HttpBase = connector-http
+seatunnel.source.HttpJira = connector-http-jira
+seatunnel.sink.HttpJira = connector-http-jira


### PR DESCRIPTION
### Purpose of this pull request

Right now, we use prefix match to find the target connector, if we have two plugin jars has the same prefix, then the first one will be used, this may cause problems in some cases. So it's needed to throw an exception if we find two plugin jars for a given plugin.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add UT to test this.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).