### PR TITLE
[Improve] Remove `Factory` option to avoid useless info

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/CommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/CommonOptions.java
@@ -23,12 +23,6 @@ import org.apache.seatunnel.api.configuration.Options;
 import java.util.List;
 
 public interface CommonOptions {
-    Option<String> FACTORY_ID =
-            Options.key("factory")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("Identifier of the SPI factory class.")
-                    .withFallbackKeys("plugin_name");
 
     Option<String> PLUGIN_NAME =
             Options.key("plugin_name")

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/ConfigParserUtil.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/ConfigParserUtil.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.seatunnel.api.common.CommonOptions.FACTORY_ID;
 import static org.apache.seatunnel.api.common.CommonOptions.PLUGIN_NAME;
 import static org.apache.seatunnel.api.common.CommonOptions.RESULT_TABLE_NAME;
 import static org.apache.seatunnel.api.common.CommonOptions.SOURCE_TABLE_NAME;
@@ -264,7 +263,7 @@ public final class ConfigParserUtil {
     }
 
     public static String getFactoryId(ReadonlyConfig readonlyConfig) {
-        return readonlyConfig.getOptional(FACTORY_ID).orElse(readonlyConfig.get(PLUGIN_NAME));
+        return readonlyConfig.get(PLUGIN_NAME);
     }
 
     public static String getFactoryId(Config config) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request
This PR remove `Factory` option. To avoid lots of info level message like `Config uses fallback configuration key 'plugin_name' instead of key 'factory'`. In fact, use `plugin_name` is our first choice for now.

Changed before:
```log
2023-10-30 19:35:20,652 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,653 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,657 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Load SeaTunnelSink Plugin from /Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors
2023-10-30 19:35:20,660 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Discovery plugin jar for: PluginIdentifier{engineType='seatunnel', pluginType='source', pluginName='FakeSource'} at: file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-fake-2.3.4-SNAPSHOT.jar
2023-10-30 19:35:20,661 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Discovery plugin jar for: PluginIdentifier{engineType='seatunnel', pluginType='sink', pluginName='Console'} at: file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-console-2.3.4-SNAPSHOT.jar
2023-10-30 19:35:20,662 INFO  [o.a.s.e.c.p.ConfigParserUtil  ] [main] - Currently, incorrect configuration of source_table_name and result_table_name options don't affect job running. In the future we will ban incorrect configurations.
2023-10-30 19:35:20,662 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,663 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,663 WARN  [o.a.s.e.c.p.ConfigParserUtil  ] [main] - This configuration is not recommended. A source/transform(FakeSource) is configured with 'result_table_name' option value of 'fake', but subsequent transform/sink(Console) is not configured with 'source_table_name' option.
2023-10-30 19:35:20,665 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all sources.
2023-10-30 19:35:20,665 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,695 INFO  [o.a.s.a.t.f.FactoryUtil       ] [main] - get the CatalogTable from source FakeSource: FakeSource.null.null
2023-10-30 19:35:20,703 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all transforms.
2023-10-30 19:35:20,703 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all sinks.
2023-10-30 19:35:20,703 INFO  [o.a.s.a.c.ReadonlyConfig      ] [main] - Config uses fallback configuration key 'plugin_name' instead of key 'factory'
2023-10-30 19:35:20,729 INFO  [o.a.s.e.c.j.ClientJobProxy    ] [main] - Start submit job, job id: 771336366817542145, with plugin jar [file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-fake-2.3.4-SNAPSHOT.jar, file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-console-2.3.4-SNAPSHOT.jar]
```

After changed:
```log
2023-10-30 19:47:26,832 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Load SeaTunnelSink Plugin from /Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors
2023-10-30 19:47:26,835 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Discovery plugin jar for: PluginIdentifier{engineType='seatunnel', pluginType='source', pluginName='FakeSource'} at: file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-fake-2.3.4-SNAPSHOT.jar
2023-10-30 19:47:26,836 INFO  [.s.p.d.AbstractPluginDiscovery] [main] - Discovery plugin jar for: PluginIdentifier{engineType='seatunnel', pluginType='sink', pluginName='Console'} at: file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-console-2.3.4-SNAPSHOT.jar
2023-10-30 19:47:26,838 INFO  [o.a.s.e.c.p.ConfigParserUtil  ] [main] - Currently, incorrect configuration of source_table_name and result_table_name options don't affect job running. In the future we will ban incorrect configurations.
2023-10-30 19:47:26,838 WARN  [o.a.s.e.c.p.ConfigParserUtil  ] [main] - This configuration is not recommended. A source/transform(FakeSource) is configured with 'result_table_name' option value of 'fake', but subsequent transform/sink(Console) is not configured with 'source_table_name' option.
2023-10-30 19:47:26,840 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all sources.
2023-10-30 19:47:26,869 INFO  [o.a.s.a.t.f.FactoryUtil       ] [main] - get the CatalogTable from source FakeSource: FakeSource.null.null
2023-10-30 19:47:26,876 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all transforms.
2023-10-30 19:47:26,876 INFO  [p.MultipleTableJobConfigParser] [main] - start generating all sinks.
2023-10-30 19:47:26,901 INFO  [o.a.s.e.c.j.ClientJobProxy    ] [main] - Start submit job, job id: 771339412628832257, with plugin jar [file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-fake-2.3.4-SNAPSHOT.jar, file:/Users/fanjia/Code/seatunnel-fork/seatunnel-dist/target/apache-seatunnel-2.3.4-SNAPSHOT/connectors/connector-console-2.3.4-SNAPSHOT.jar]
```

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
tested in local.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).