### PR TITLE
[Improve][Zeta] Remove `result_table_name` from action name(checkpoint state key)

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/factory/FactoryUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/factory/FactoryUtil.java
@@ -43,7 +43,6 @@ import scala.Tuple2;
 
 import java.io.Serializable;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -64,17 +63,12 @@ public final class FactoryUtil {
     public static final String DEFAULT_ID = "default-identifier";
 
     public static <T, SplitT extends SourceSplit, StateT extends Serializable>
-            List<Tuple2<SeaTunnelSource<T, SplitT, StateT>, List<CatalogTable>>>
-                    createAndPrepareSource(
-                            ReadonlyConfig options,
-                            ClassLoader classLoader,
-                            String factoryIdentifier) {
+            Tuple2<SeaTunnelSource<T, SplitT, StateT>, List<CatalogTable>> createAndPrepareSource(
+                    ReadonlyConfig options, ClassLoader classLoader, String factoryIdentifier) {
 
         try {
             final TableSourceFactory factory =
                     discoverFactory(classLoader, TableSourceFactory.class, factoryIdentifier);
-            List<Tuple2<SeaTunnelSource<T, SplitT, StateT>, List<CatalogTable>>> sources =
-                    new ArrayList<>();
             SeaTunnelSource<T, SplitT, StateT> source =
                     createAndPrepareSource(factory, options, classLoader);
             List<CatalogTable> catalogTables;
@@ -100,8 +94,7 @@ public final class FactoryUtil {
                 catalogTables.clear();
                 catalogTables.add(catalogTable);
             }
-            sources.add(new Tuple2<>(source, catalogTables));
-            return sources;
+            return new Tuple2<>(source, catalogTables);
         } catch (Throwable t) {
             throw new FactoryException(
                     String.format(

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/LogicalDagGeneratorTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/LogicalDagGeneratorTest.java
@@ -56,7 +56,7 @@ public class LogicalDagGeneratorTest {
         LogicalDag logicalDag = logicalDagGenerator.generate();
         JsonObject logicalDagJson = logicalDag.getLogicalDagAsJson();
         String result =
-                "{\"vertices\":[{\"id\":1,\"name\":\"Source[0]-FakeSource-fake(id=1)\",\"parallelism\":3},{\"id\":2,\"name\":\"Source[0]-FakeSource-fake2(id=2)\",\"parallelism\":3},{\"id\":3,\"name\":\"Sink[0]-LocalFile-default-identifier(id=3)\",\"parallelism\":3}],\"edges\":[{\"inputVertex\":\"Source[0]-FakeSource-fake\",\"targetVertex\":\"Sink[0]-LocalFile-default-identifier\"},{\"inputVertex\":\"Source[0]-FakeSource-fake2\",\"targetVertex\":\"Sink[0]-LocalFile-default-identifier\"}]}";
+                "{\"vertices\":[{\"id\":1,\"name\":\"Source[0]-FakeSource(id=1)\",\"parallelism\":3},{\"id\":2,\"name\":\"Source[1]-FakeSource(id=2)\",\"parallelism\":3},{\"id\":3,\"name\":\"Sink[0]-LocalFile(id=3)\",\"parallelism\":3}],\"edges\":[{\"inputVertex\":\"Source[0]-FakeSource\",\"targetVertex\":\"Sink[0]-LocalFile\"},{\"inputVertex\":\"Source[1]-FakeSource\",\"targetVertex\":\"Sink[0]-LocalFile\"}]}";
         Assertions.assertEquals(result, logicalDagJson.toString());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/MultipleTableJobConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/MultipleTableJobConfigParserTest.java
@@ -54,10 +54,10 @@ public class MultipleTableJobConfigParserTest {
         ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse();
         List<Action> actions = parse.getLeft();
         Assertions.assertEquals(1, actions.size());
-        Assertions.assertEquals("Sink[0]-LocalFile-default-identifier", actions.get(0).getName());
+        Assertions.assertEquals("Sink[0]-LocalFile", actions.get(0).getName());
         Assertions.assertEquals(1, actions.get(0).getUpstream().size());
         Assertions.assertEquals(
-                "Source[0]-FakeSource-fake", actions.get(0).getUpstream().get(0).getName());
+                "Source[0]-FakeSource", actions.get(0).getUpstream().get(0).getName());
 
         Assertions.assertEquals(3, actions.get(0).getUpstream().get(0).getParallelism());
         Assertions.assertEquals(3, actions.get(0).getParallelism());
@@ -75,10 +75,10 @@ public class MultipleTableJobConfigParserTest {
         List<Action> actions = parse.getLeft();
         Assertions.assertEquals(1, actions.size());
 
-        Assertions.assertEquals("Sink[0]-LocalFile-default-identifier", actions.get(0).getName());
+        Assertions.assertEquals("Sink[0]-LocalFile", actions.get(0).getName());
         Assertions.assertEquals(2, actions.get(0).getUpstream().size());
 
-        String[] expected = {"Source[0]-FakeSource-fake", "Source[0]-FakeSource-fake2"};
+        String[] expected = {"Source[0]-FakeSource", "Source[1]-FakeSource"};
         String[] actual = {
             actions.get(0).getUpstream().get(0).getName(),
             actions.get(0).getUpstream().get(1).getName()
@@ -106,8 +106,8 @@ public class MultipleTableJobConfigParserTest {
         List<Action> actions = parse.getLeft();
         Assertions.assertEquals(2, actions.size());
 
-        Assertions.assertEquals("Sink[0]-LocalFile-default-identifier", actions.get(0).getName());
-        Assertions.assertEquals("Sink[1]-LocalFile-default-identifier", actions.get(1).getName());
+        Assertions.assertEquals("Sink[0]-LocalFile", actions.get(0).getName());
+        Assertions.assertEquals("Sink[1]-LocalFile", actions.get(1).getName());
     }
 
     @Test
@@ -122,7 +122,7 @@ public class MultipleTableJobConfigParserTest {
         ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse();
         List<Action> actions = parse.getLeft();
         Assertions.assertEquals(1, actions.size());
-        Assertions.assertEquals("MultiTableSink-Console", actions.get(0).getName());
+        Assertions.assertEquals("Sink[0]-console-MultiTableSink", actions.get(0).getName());
         Assertions.assertFalse(
                 ((SinkAction) actions.get(0)).getSink().createCommitter().isPresent());
         Assertions.assertFalse(

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/JobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/JobConfigParser.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.engine.core.parse;
 
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
-import org.apache.seatunnel.api.common.CommonOptions;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -56,7 +55,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.api.table.factory.FactoryUtil.DEFAULT_ID;
 import static org.apache.seatunnel.engine.core.parse.MultipleTableJobConfigParser.checkProducedTypeEquals;
 import static org.apache.seatunnel.engine.core.parse.MultipleTableJobConfigParser.handleSaveMode;
 
@@ -87,8 +85,7 @@ public class JobConfigParser {
         source.setJobContext(jobConfig.getJobContext());
         PluginUtil.ensureJobModeMatch(jobConfig.getJobContext(), source);
         String actionName =
-                createSourceActionName(
-                        0, config.getString(CollectionConstants.PLUGIN_NAME), getTableName(config));
+                createSourceActionName(0, config.getString(CollectionConstants.PLUGIN_NAME));
         SourceAction action =
                 new SourceAction(
                         idGenerator.getNextId(),
@@ -118,8 +115,7 @@ public class JobConfigParser {
         transform.prepare(config);
         transform.setJobContext(jobConfig.getJobContext());
         transform.setTypeInfo((SeaTunnelDataType) rowType);
-        final String actionName =
-                createTransformActionName(0, tuple.getLeft().getPluginName(), getTableName(config));
+        final String actionName = createTransformActionName(0, tuple.getLeft().getPluginName());
         final TransformAction action =
                 new TransformAction(
                         idGenerator.getNextId(),
@@ -208,8 +204,7 @@ public class JobConfigParser {
             handleSaveMode(sink);
         }
         final String actionName =
-                createSinkActionName(
-                        configIndex, tuple.getLeft().getPluginName(), getTableName(config));
+                createSinkActionName(configIndex, tuple.getLeft().getPluginName());
         final SinkAction action =
                 new SinkAction<>(
                         idGenerator.getNextId(),
@@ -222,30 +217,19 @@ public class JobConfigParser {
         return action;
     }
 
-    static String createSourceActionName(int configIndex, String pluginName, String tableName) {
-        return String.format("Source[%s]-%s-%s", configIndex, pluginName, tableName);
+    static String createSourceActionName(int configIndex, String pluginName) {
+        return String.format("Source[%s]-%s", configIndex, pluginName);
     }
 
-    static String createSinkActionName(int configIndex, String pluginName, String tableName) {
-        return String.format("Sink[%s]-%s-%s", configIndex, pluginName, tableName);
+    static String createSinkActionName(int configIndex, String pluginName) {
+        return String.format("Sink[%s]-%s", configIndex, pluginName);
     }
 
-    static String createTransformActionName(int configIndex, String pluginName, String tableName) {
-        return String.format("Transform[%s]-%s-%s", configIndex, pluginName, tableName);
+    static String createSinkActionName(int configIndex, String pluginName, String table) {
+        return String.format("Sink[%s]-%s-%s", configIndex, pluginName, table);
     }
 
-    static String getTableName(Config config) {
-        return getTableName(config, DEFAULT_ID);
-    }
-
-    static String getTableName(Config config, String defaultValue) {
-        String resultTableName = null;
-        if (config.hasPath(CommonOptions.RESULT_TABLE_NAME.key())) {
-            resultTableName = config.getString(CommonOptions.RESULT_TABLE_NAME.key());
-        }
-        if (resultTableName == null) {
-            return defaultValue;
-        }
-        return resultTableName;
+    static String createTransformActionName(int configIndex, String pluginName) {
+        return String.format("Transform[%s]-%s", configIndex, pluginName);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/ActionState.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/ActionState.java
@@ -17,10 +17,13 @@
 
 package org.apache.seatunnel.engine.server.checkpoint;
 
+import lombok.ToString;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
+@ToString
 public class ActionState implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/ActionSubtaskState.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/ActionSubtaskState.java
@@ -18,11 +18,13 @@
 package org.apache.seatunnel.engine.server.checkpoint;
 
 import lombok.Data;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.List;
 
 @Data
+@ToString(exclude = "state")
 public class ActionSubtaskState implements Serializable {
     private static final long serialVersionUID = 1L;
     private final ActionStateKey stateKey;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -185,10 +185,22 @@ public class CheckpointCoordinator {
         this.pipelineTaskStatus = new ConcurrentHashMap<>();
         this.checkpointIdCounter = checkpointIdCounter;
         this.readyToCloseStartingTask = new CopyOnWriteArraySet<>();
+
+        LOG.info(
+                "Create CheckpointCoordinator for job({}@{}) with plan({})",
+                pipelineId,
+                jobId,
+                plan);
         if (pipelineState != null) {
             this.latestCompletedCheckpoint =
                     serializer.deserialize(pipelineState.getStates(), CompletedCheckpoint.class);
             this.latestCompletedCheckpoint.setRestored(true);
+            LOG.info(
+                    "Restore job({}@{}) with checkpoint({}), data: {}",
+                    pipelineId,
+                    jobId,
+                    latestCompletedCheckpoint.getCheckpointId(),
+                    latestCompletedCheckpoint);
         }
         this.checkpointCoordinatorFuture = new CompletableFuture();
 
@@ -280,6 +292,10 @@ public class CheckpointCoordinator {
                                 ActionState actionState =
                                         latestCompletedCheckpoint.getTaskStates().get(tuple.f0());
                                 if (actionState == null) {
+                                    LOG.info(
+                                            "Not found task({}) state for key({})",
+                                            taskLocation,
+                                            tuple.f0());
                                     return;
                                 }
                                 if (COORDINATOR_INDEX.equals(tuple.f1())) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointPlan.java
@@ -24,6 +24,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /** checkpoint plan info */
+@ToString
 @Getter
 @Builder(builderClassName = "Builder")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CompletedCheckpoint.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CompletedCheckpoint.java
@@ -22,10 +22,12 @@ import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.Map;
 
+@ToString
 public class CompletedCheckpoint implements Checkpoint, Serializable {
     private static final long serialVersionUID = 1L;
     private final long jobId;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/SubtaskStatistics.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/SubtaskStatistics.java
@@ -19,9 +19,11 @@ package org.apache.seatunnel.engine.server.checkpoint;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
+@ToString
 @Getter
 @AllArgsConstructor
 public class SubtaskStatistics implements Serializable {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/TaskStatistics.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/TaskStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.engine.server.checkpoint;
 
+import lombok.ToString;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.List;
 import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
 
+@ToString
 public class TaskStatistics implements Serializable {
     /** ID of the task the statistics belong to. */
     private final Long jobVertexId;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/execution/TaskLocation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/execution/TaskLocation.java
@@ -25,10 +25,12 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import lombok.ToString;
 
 import java.io.IOException;
 import java.io.Serializable;
 
+@ToString
 public class TaskLocation implements IdentifiedDataSerializable, Serializable {
 
     private TaskGroupLocation taskGroupLocation;


### PR DESCRIPTION
### Purpose of this pull request

[Improve][Zeta] Remove `result_table_name` from action name(checkpoint state key)

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?

updated testcase


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).