### PR TITLE
[Bug][CDC] Fix state recovery error when switching a single table to multiple tables

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtil.java
@@ -151,13 +151,17 @@ public class CatalogTableUtil implements Serializable {
         if (catalogTables.size() == 1) {
             return catalogTables.get(0).getTableSchema().toPhysicalRowDataType();
         } else {
-            Map<String, SeaTunnelRowType> rowTypeMap = new HashMap<>();
-            for (CatalogTable catalogTable : catalogTables) {
-                String tableId = catalogTable.getTableId().toTablePath().toString();
-                rowTypeMap.put(tableId, catalogTable.getTableSchema().toPhysicalRowDataType());
-            }
-            return new MultipleRowType(rowTypeMap);
+            return convertToMultipleRowType(catalogTables);
         }
+    }
+
+    public static MultipleRowType convertToMultipleRowType(List<CatalogTable> catalogTables) {
+        Map<String, SeaTunnelRowType> rowTypeMap = new HashMap<>();
+        for (CatalogTable catalogTable : catalogTables) {
+            String tableId = catalogTable.getTableId().toTablePath().toString();
+            rowTypeMap.put(tableId, catalogTable.getTableSchema().toPhysicalRowDataType());
+        }
+        return new MultipleRowType(rowTypeMap);
     }
 
     // We need to use buildWithConfig(String catalogName, ReadonlyConfig readonlyConfig);

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/MongodbIncrementalSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/MongodbIncrementalSourceFactory.java
@@ -77,7 +77,7 @@ public class MongodbIncrementalSourceFactory implements TableSourceFactory {
                     CatalogTableUtil.getCatalogTables(
                             context.getOptions(), context.getClassLoader());
             SeaTunnelDataType<SeaTunnelRow> dataType =
-                    CatalogTableUtil.convertToDataType(catalogTables);
+                    CatalogTableUtil.convertToMultipleRowType(catalogTables);
             return (SeaTunnelSource<T, SplitT, StateT>)
                     new MongodbIncrementalSource<>(context.getOptions(), dataType, catalogTables);
         };

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/sender/MongoDBConnectorDeserializationSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/sender/MongoDBConnectorDeserializationSchema.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.DecimalType;
 import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.MultipleRowType;
 import org.apache.seatunnel.api.table.type.RowKind;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -41,6 +42,7 @@ import org.bson.json.JsonWriterSettings;
 import org.bson.types.Decimal128;
 
 import com.mongodb.client.model.changestream.OperationType;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 
@@ -67,17 +69,17 @@ import static org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.config.Mongo
 import static org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.utils.MongodbRecordUtils.extractBsonDocument;
 import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
 
+@Slf4j
 public class MongoDBConnectorDeserializationSchema
         implements DebeziumDeserializationSchema<SeaTunnelRow> {
-
     private final SeaTunnelDataType<SeaTunnelRow> resultTypeInfo;
 
-    private final DeserializationRuntimeConverter physicalConverter;
+    private final Map<String, DeserializationRuntimeConverter> tableRowConverters;
 
     public MongoDBConnectorDeserializationSchema(
             SeaTunnelDataType<SeaTunnelRow> physicalDataType,
             SeaTunnelDataType<SeaTunnelRow> resultTypeInfo) {
-        this.physicalConverter = createConverter(physicalDataType);
+        this.tableRowConverters = createConverter(physicalDataType);
         this.resultTypeInfo = resultTypeInfo;
     }
 
@@ -92,29 +94,44 @@ public class MongoDBConnectorDeserializationSchema
                         Objects.requireNonNull(
                                 extractBsonDocument(value, valueSchema, DOCUMENT_KEY)));
         BsonDocument fullDocument = extractBsonDocument(value, valueSchema, FULL_DOCUMENT);
+        String tableId = extractTableId(record);
+        DeserializationRuntimeConverter tableRowConverter;
+        if (tableId == null && tableRowConverters.size() == 1) {
+            tableRowConverter = tableRowConverters.values().iterator().next();
+        } else {
+            tableRowConverter = tableRowConverters.get(tableId);
+        }
+        if (tableRowConverter == null) {
+            log.debug("Ignore newly added table {}", tableId);
+            return;
+        }
 
         switch (op) {
             case INSERT:
-                SeaTunnelRow insert = extractRowData(fullDocument);
+                SeaTunnelRow insert = extractRowData(tableRowConverter, fullDocument);
                 insert.setRowKind(RowKind.INSERT);
+                insert.setTableId(tableId);
                 emit(record, insert, out);
                 break;
             case DELETE:
-                SeaTunnelRow delete = extractRowData(documentKey);
+                SeaTunnelRow delete = extractRowData(tableRowConverter, documentKey);
                 delete.setRowKind(RowKind.DELETE);
+                delete.setTableId(tableId);
                 emit(record, delete, out);
                 break;
             case UPDATE:
                 if (fullDocument == null) {
                     break;
                 }
-                SeaTunnelRow updateAfter = extractRowData(fullDocument);
+                SeaTunnelRow updateAfter = extractRowData(tableRowConverter, fullDocument);
                 updateAfter.setRowKind(RowKind.UPDATE_AFTER);
+                updateAfter.setTableId(tableId);
                 emit(record, updateAfter, out);
                 break;
             case REPLACE:
-                SeaTunnelRow replaceAfter = extractRowData(fullDocument);
+                SeaTunnelRow replaceAfter = extractRowData(tableRowConverter, fullDocument);
                 replaceAfter.setRowKind(RowKind.UPDATE_AFTER);
+                replaceAfter.setTableId(tableId);
                 emit(record, replaceAfter, out);
                 break;
             case INVALIDATE:
@@ -145,9 +162,15 @@ public class MongoDBConnectorDeserializationSchema
         collector.collect(physicalRow);
     }
 
-    private SeaTunnelRow extractRowData(BsonDocument document) {
+    private SeaTunnelRow extractRowData(
+            DeserializationRuntimeConverter tableRowConverter, BsonDocument document) {
         checkNotNull(document);
-        return (SeaTunnelRow) physicalConverter.convert(document);
+        return (SeaTunnelRow) tableRowConverter.convert(document);
+    }
+
+    private String extractTableId(SourceRecord record) {
+        // TODO extract table id from record
+        return null;
     }
 
     // -------------------------------------------------------------------------------------
@@ -159,17 +182,24 @@ public class MongoDBConnectorDeserializationSchema
         Object convert(BsonValue bsonValue);
     }
 
-    public DeserializationRuntimeConverter createConverter(SeaTunnelDataType<?> type) {
-        SerializableFunction<BsonValue, Object> internalRowConverter =
-                createNullSafeInternalConverter(type);
-        return new DeserializationRuntimeConverter() {
-            private static final long serialVersionUID = 1L;
+    public Map<String, DeserializationRuntimeConverter> createConverter(
+            SeaTunnelDataType<?> inputDataType) {
+        Map<String, DeserializationRuntimeConverter> tableRowConverters = new HashMap<>();
+        for (Map.Entry<String, SeaTunnelRowType> item : (MultipleRowType) inputDataType) {
+            SerializableFunction<BsonValue, Object> internalRowConverter =
+                    createNullSafeInternalConverter(item.getValue());
+            DeserializationRuntimeConverter itemRowConverter =
+                    new DeserializationRuntimeConverter() {
+                        private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object convert(BsonValue bsonValue) {
-                return internalRowConverter.apply(bsonValue);
-            }
-        };
+                        @Override
+                        public Object convert(BsonValue bsonValue) {
+                            return internalRowConverter.apply(bsonValue);
+                        }
+                    };
+            tableRowConverters.put(item.getKey(), itemRowConverter);
+        }
+        return tableRowConverters;
     }
 
     private static SerializableFunction<BsonValue, Object> createNullSafeInternalConverter(

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/MySqlIncrementalSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/MySqlIncrementalSourceFactory.java
@@ -97,7 +97,7 @@ public class MySqlIncrementalSourceFactory implements TableSourceFactory {
                     CatalogTableUtil.getCatalogTables(
                             context.getOptions(), context.getClassLoader());
             SeaTunnelDataType<SeaTunnelRow> dataType =
-                    CatalogTableUtil.convertToDataType(catalogTables);
+                    CatalogTableUtil.convertToMultipleRowType(catalogTables);
             return (SeaTunnelSource<T, SplitT, StateT>)
                     new MySqlIncrementalSource<>(context.getOptions(), dataType, catalogTables);
         };

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/source/SqlServerIncrementalSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/source/SqlServerIncrementalSourceFactory.java
@@ -102,7 +102,7 @@ public class SqlServerIncrementalSourceFactory implements TableSourceFactory {
                     CatalogTableUtil.getCatalogTables(
                             context.getOptions(), context.getClassLoader());
             SeaTunnelDataType<SeaTunnelRow> dataType =
-                    CatalogTableUtil.convertToDataType(catalogTables);
+                    CatalogTableUtil.convertToMultipleRowType(catalogTables);
             return new SqlServerIncrementalSource(context.getOptions(), dataType, catalogTables);
         };
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/MysqlCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/MysqlCDCIT.java
@@ -324,6 +324,12 @@ public class MysqlCDCIT extends TestSuiteBase implements TestResource {
                                                                 getSourceQuerySQL(
                                                                         MYSQL_DATABASE2,
                                                                         SOURCE_TABLE_2)))));
+
+        log.info("****************** container logs start ******************");
+        String containerLogs = container.getServerLogs();
+        log.info(containerLogs);
+        Assertions.assertFalse(containerLogs.contains("ERROR"));
+        log.info("****************** container logs end ******************");
     }
 
     private Connection getJdbcConnection() throws SQLException {


### PR DESCRIPTION
### Purpose of this pull request

[CDC] Fix state recovery error when switching a single table to multiple tables


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/MysqlCDCIT.java#L290


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).