### PR TITLE
[Fix] Fix the error msg when parse schema with unsupported type

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
@@ -94,7 +94,11 @@ public class SeaTunnelDataTypeConvertorUtil {
         if (column.startsWith(SqlType.DECIMAL.name())) {
             return parseDecimalType(column);
         }
-        return parseRowType(columnStr);
+        if (column.trim().startsWith("{")) {
+            return parseRowType(column);
+        }
+        throw new UnsupportedOperationException(
+                String.format("the type[%s] is not support", columnStr));
     }
 
     private static SeaTunnelDataType<?> parseRowType(String columnStr) {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
@@ -95,7 +95,7 @@ public class SeaTunnelDataTypeConvertorUtil {
             return parseDecimalType(column);
         }
         if (column.trim().startsWith("{")) {
-            return parseRowType(column);
+            return parseRowType(columnStr);
         }
         throw new UnsupportedOperationException(
                 String.format("the type[%s] is not support", columnStr));

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/schema/ReadonlyConfigParser.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/schema/ReadonlyConfigParser.java
@@ -81,7 +81,7 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
         return tableSchemaBuilder.build();
     }
 
-    public class FieldParser implements TableSchemaParser.FieldParser<ReadonlyConfig> {
+    private static class FieldParser implements TableSchemaParser.FieldParser<ReadonlyConfig> {
 
         @Override
         public List<Column> parse(ReadonlyConfig schemaConfig) {
@@ -102,7 +102,7 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
         }
     }
 
-    public class ColumnParser implements TableSchemaParser.ColumnParser<ReadonlyConfig> {
+    private static class ColumnParser implements TableSchemaParser.ColumnParser<ReadonlyConfig> {
 
         @Override
         public List<Column> parse(ReadonlyConfig schemaConfig) {
@@ -150,7 +150,7 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
         }
     }
 
-    public class ConstraintKeyParser
+    private static class ConstraintKeyParser
             implements TableSchemaParser.ConstraintKeyParser<ReadonlyConfig> {
 
         @Override
@@ -184,37 +184,41 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
                                                         TableSchemaOptions.ConstraintKeyOptions
                                                                 .CONSTRAINT_KEY_COLUMNS)
                                                 .map(
-                                                        constraintColumnMapList -> {
-                                                            return constraintColumnMapList.stream()
-                                                                    .map(ReadonlyConfig::fromMap)
-                                                                    .map(
-                                                                            constraintColumnConfig -> {
-                                                                                String columnName =
-                                                                                        constraintColumnConfig
-                                                                                                .getOptional(
-                                                                                                        TableSchemaOptions
-                                                                                                                .ConstraintKeyOptions
-                                                                                                                .CONSTRAINT_KEY_COLUMN_NAME)
-                                                                                                .orElseThrow(
-                                                                                                        () ->
-                                                                                                                new IllegalArgumentException(
-                                                                                                                        "schema.constraintKeys.constraintColumns.* config need option [columnName], please correct your config first"));
-                                                                                ConstraintKey
-                                                                                                .ColumnSortType
-                                                                                        columnSortType =
-                                                                                                constraintColumnConfig
-                                                                                                        .get(
-                                                                                                                TableSchemaOptions
-                                                                                                                        .ConstraintKeyOptions
-                                                                                                                        .CONSTRAINT_KEY_COLUMN_SORT_TYPE);
-                                                                                return ConstraintKey
-                                                                                        .ConstraintKeyColumn
-                                                                                        .of(
-                                                                                                columnName,
-                                                                                                columnSortType);
-                                                                            })
-                                                                    .collect(Collectors.toList());
-                                                        })
+                                                        constraintColumnMapList ->
+                                                                constraintColumnMapList.stream()
+                                                                        .map(
+                                                                                ReadonlyConfig
+                                                                                        ::fromMap)
+                                                                        .map(
+                                                                                constraintColumnConfig -> {
+                                                                                    String
+                                                                                            columnName =
+                                                                                                    constraintColumnConfig
+                                                                                                            .getOptional(
+                                                                                                                    TableSchemaOptions
+                                                                                                                            .ConstraintKeyOptions
+                                                                                                                            .CONSTRAINT_KEY_COLUMN_NAME)
+                                                                                                            .orElseThrow(
+                                                                                                                    () ->
+                                                                                                                            new IllegalArgumentException(
+                                                                                                                                    "schema.constraintKeys.constraintColumns.* config need option [columnName], please correct your config first"));
+                                                                                    ConstraintKey
+                                                                                                    .ColumnSortType
+                                                                                            columnSortType =
+                                                                                                    constraintColumnConfig
+                                                                                                            .get(
+                                                                                                                    TableSchemaOptions
+                                                                                                                            .ConstraintKeyOptions
+                                                                                                                            .CONSTRAINT_KEY_COLUMN_SORT_TYPE);
+                                                                                    return ConstraintKey
+                                                                                            .ConstraintKeyColumn
+                                                                                            .of(
+                                                                                                    columnName,
+                                                                                                    columnSortType);
+                                                                                })
+                                                                        .collect(
+                                                                                Collectors
+                                                                                        .toList()))
                                                 .orElseThrow(
                                                         () ->
                                                                 new IllegalArgumentException(
@@ -225,7 +229,8 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
         }
     }
 
-    public class PrimaryKeyParser implements TableSchemaParser.PrimaryKeyParser<ReadonlyConfig> {
+    private static class PrimaryKeyParser
+            implements TableSchemaParser.PrimaryKeyParser<ReadonlyConfig> {
 
         @Override
         public PrimaryKey parse(ReadonlyConfig schemaConfig) {
@@ -248,143 +253,5 @@ public class ReadonlyConfigParser implements TableSchemaParser<ReadonlyConfig> {
                                                     "Schema config need option [primaryKey.columnNames], please correct your config first"));
             return new PrimaryKey(primaryKeyName, columns);
         }
-    }
-
-    /**
-     * Parse columns from columns config.
-     *
-     * <pre>
-     *     columns = [
-     *      {
-     *          name = "name"
-     *          type = "string"
-     *          columnLength = 0
-     *          nullable = true
-     *          defaultValue = null
-     *          comment = "name"
-     *     },
-     *     {
-     *          name = "age"
-     *          type = "int"
-     *          columnLength = 0
-     *          nullable = true
-     *          defaultValue = null
-     *          comment = "age"
-     *     }
-     *     ]
-     * </pre>
-     *
-     * @param columnConfig columns config
-     * @return columns
-     */
-    private Column parseFromColumn(ReadonlyConfig columnConfig) {
-        String name =
-                columnConfig
-                        .getOptional(TableSchemaOptions.ColumnOptions.NAME)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "schema.columns.* config need option [name], please correct your config first"));
-        SeaTunnelDataType<?> seaTunnelDataType =
-                columnConfig
-                        .getOptional(TableSchemaOptions.ColumnOptions.TYPE)
-                        .map(SeaTunnelDataTypeConvertorUtil::deserializeSeaTunnelDataType)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "schema.columns.* config need option [type], please correct your config first"));
-
-        Integer columnLength = columnConfig.get(TableSchemaOptions.ColumnOptions.COLUMN_LENGTH);
-        Boolean nullable = columnConfig.get(TableSchemaOptions.ColumnOptions.NULLABLE);
-        Object defaultValue = columnConfig.get(TableSchemaOptions.ColumnOptions.DEFAULT_VALUE);
-        String comment = columnConfig.get(TableSchemaOptions.ColumnOptions.COMMENT);
-        return PhysicalColumn.of(
-                name, seaTunnelDataType, columnLength, nullable, defaultValue, comment);
-    }
-
-    /**
-     * Parse primary key from primary key config.
-     *
-     * <pre>
-     *     primaryKey {
-     *          name = "primary_key"
-     *          columnNames = ["name", "age"]
-     *     }
-     * </pre>
-     *
-     * @param primaryKeyConfig primary key config
-     * @return primary key
-     */
-    private PrimaryKey parsePrimaryKey(Map<String, Object> primaryKeyConfig) {
-        if (!primaryKeyConfig.containsKey(
-                        TableSchemaOptions.PrimaryKeyOptions.PRIMARY_KEY_NAME.key())
-                || !primaryKeyConfig.containsKey(
-                        TableSchemaOptions.PrimaryKeyOptions.PRIMARY_KEY_COLUMNS.key())) {
-            throw new IllegalArgumentException(
-                    "Schema config need option [primaryKey.name, primaryKey.columnNames], please correct your config first");
-        }
-
-        String primaryKeyName =
-                (String)
-                        primaryKeyConfig.get(
-                                TableSchemaOptions.PrimaryKeyOptions.PRIMARY_KEY_NAME.key());
-        List<String> columns =
-                (List<String>)
-                        primaryKeyConfig.get(
-                                TableSchemaOptions.PrimaryKeyOptions.PRIMARY_KEY_COLUMNS.key());
-        return new PrimaryKey(primaryKeyName, columns);
-    }
-
-    private ConstraintKey parseConstraintKeys(ReadonlyConfig constraintKeyConfig) {
-        String constraintName =
-                constraintKeyConfig
-                        .getOptional(TableSchemaOptions.ConstraintKeyOptions.CONSTRAINT_KEY_NAME)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "schema.constraintKeys.* config need option [constraintName], please correct your config first"));
-        ConstraintKey.ConstraintType constraintType =
-                constraintKeyConfig
-                        .getOptional(TableSchemaOptions.ConstraintKeyOptions.CONSTRAINT_KEY_TYPE)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "schema.constraintKeys.* config need option [constraintType], please correct your config first"));
-        List<ConstraintKey.ConstraintKeyColumn> columns =
-                constraintKeyConfig
-                        .getOptional(TableSchemaOptions.ConstraintKeyOptions.CONSTRAINT_KEY_COLUMNS)
-                        .map(
-                                constraintColumnMapList -> {
-                                    return constraintColumnMapList.stream()
-                                            .map(ReadonlyConfig::fromMap)
-                                            .map(
-                                                    constraintColumnConfig -> {
-                                                        String columnName =
-                                                                constraintColumnConfig
-                                                                        .getOptional(
-                                                                                TableSchemaOptions
-                                                                                        .ConstraintKeyOptions
-                                                                                        .CONSTRAINT_KEY_COLUMN_NAME)
-                                                                        .orElseThrow(
-                                                                                () ->
-                                                                                        new IllegalArgumentException(
-                                                                                                "schema.constraintKeys.constraintColumns.* config need option [columnName], please correct your config first"));
-                                                        ConstraintKey.ColumnSortType
-                                                                columnSortType =
-                                                                        constraintColumnConfig.get(
-                                                                                TableSchemaOptions
-                                                                                        .ConstraintKeyOptions
-                                                                                        .CONSTRAINT_KEY_COLUMN_SORT_TYPE);
-                                                        return ConstraintKey.ConstraintKeyColumn.of(
-                                                                columnName, columnSortType);
-                                                    })
-                                            .collect(Collectors.toList());
-                                })
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "schema.constraintKeys.* config need option [columns], please correct your config first"));
-
-        return ConstraintKey.of(constraintType, constraintName, columns);
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.table.catalog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SeaTunnelDataTypeConvertorUtilTest {
+
+    @Test
+    void testParseWithUnsupportedType() {
+
+        UnsupportedOperationException exception =
+                Assertions.assertThrows(
+                        UnsupportedOperationException.class,
+                        () -> SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("uuid"));
+        Assertions.assertEquals("the type[uuid] is not support", exception.getMessage());
+
+        RuntimeException exception2 =
+                Assertions.assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                        "{uuid}"));
+        Assertions.assertEquals(
+                "String json deserialization exception.{UUID}", exception2.getMessage());
+    }
+}

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
@@ -38,6 +38,6 @@ public class SeaTunnelDataTypeConvertorUtilTest {
                                 SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
                                         "{uuid}"));
         Assertions.assertEquals(
-                "String json deserialization exception.{UUID}", exception2.getMessage());
+                "String json deserialization exception.{uuid}", exception2.getMessage());
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request
This PR fixed when parse schema with unsupported type will return unexpected error msg.
eg:
parse schema type with `uuid`.
```log
Caused by: org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'uuid': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (byte[])"uuid"; line: 1, column: 5]
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2391)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:745)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.json.UTF8StreamJsonParser._reportInvalidToken(UTF8StreamJsonParser.java:3635)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.json.UTF8StreamJsonParser._handleUnexpectedValue(UTF8StreamJsonParser.java:2734)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.json.UTF8StreamJsonParser._nextTokenNotInObject(UTF8StreamJsonParser.java:902)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:794)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper._readTreeAndClose(ObjectMapper.java:4703)
	at org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:3090)
	at org.apache.seatunnel.common.utils.JsonUtils.parseObject(JsonUtils.java:261)
	... 79 more
```
After this PR, it will display like:
```log
java.lang.UnsupportedOperationException: the type[uuid] is not support

	at org.apache.seatunnel.api.table.catalog.SeaTunnelDataTypeConvertorUtil.parseComplexDataType(SeaTunnelDataTypeConvertorUtil.java:101)
	at org.apache.seatunnel.api.table.catalog.SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(SeaTunnelDataTypeConvertorUtil.java:49)
```


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
add new test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).