### PR TITLE
[Improve][format] Using number format for Decimal type in `seatunnel-format-compatible-debezium-json`

### DIFF
--- a/seatunnel-formats/seatunnel-format-compatible-debezium-json/src/main/java/org/apache/seatunnel/format/compatible/debezium/json/DebeziumJsonConverter.java
+++ b/seatunnel-formats/seatunnel-format-compatible-debezium-json/src/main/java/org/apache/seatunnel/format/compatible/debezium/json/DebeziumJsonConverter.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.format.compatible.debezium.json;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.json.DecimalFormat;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -30,7 +31,8 @@ import lombok.RequiredArgsConstructor;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class DebeziumJsonConverter implements Serializable {
@@ -68,10 +70,12 @@ public class DebeziumJsonConverter implements Serializable {
             synchronized (this) {
                 if (keyConverter == null) {
                     keyConverter = new JsonConverter();
-                    keyConverter.configure(
-                            Collections.singletonMap(
-                                    JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, keySchemaEnable),
-                            true);
+                    Map<String, Object> configs = new HashMap<>();
+                    configs.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, keySchemaEnable);
+                    configs.put(
+                            JsonConverterConfig.DECIMAL_FORMAT_CONFIG,
+                            DecimalFormat.NUMERIC.name());
+                    keyConverter.configure(configs, true);
                     keyConverterMethod =
                             ReflectionUtils.getDeclaredMethod(
                                             JsonConverter.class,
@@ -88,10 +92,12 @@ public class DebeziumJsonConverter implements Serializable {
             synchronized (this) {
                 if (valueConverter == null) {
                     valueConverter = new JsonConverter();
-                    valueConverter.configure(
-                            Collections.singletonMap(
-                                    JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, valueSchemaEnable),
-                            false);
+                    Map<String, Object> configs = new HashMap<>();
+                    configs.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, valueSchemaEnable);
+                    configs.put(
+                            JsonConverterConfig.DECIMAL_FORMAT_CONFIG,
+                            DecimalFormat.NUMERIC.name());
+                    valueConverter.configure(configs, false);
                     valueConverterMethod =
                             ReflectionUtils.getDeclaredMethod(
                                             JsonConverter.class,

--- a/seatunnel-formats/seatunnel-format-compatible-debezium-json/src/test/java/org/apache/seatunnel/format/compatible/debezium/json/TestDebeziumJsonConverter.java
+++ b/seatunnel-formats/seatunnel-format-compatible-debezium-json/src/test/java/org/apache/seatunnel/format/compatible/debezium/json/TestDebeziumJsonConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.format.compatible.debezium.json;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.util.Collections;
+
+public class TestDebeziumJsonConverter {
+
+    @Test
+    public void testSerializeDecimalToNumber()
+            throws InvocationTargetException, IllegalAccessException, JsonProcessingException {
+        String key = "k";
+        String value = "v";
+        Struct keyStruct =
+                new Struct(SchemaBuilder.struct().field(key, Decimal.builder(2).build()).build());
+        keyStruct.put(key, BigDecimal.valueOf(1101, 2));
+        Struct valueStruct =
+                new Struct(SchemaBuilder.struct().field(value, Decimal.builder(2).build()).build());
+        valueStruct.put(value, BigDecimal.valueOf(1101, 2));
+
+        SourceRecord sourceRecord =
+                new SourceRecord(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        null,
+                        keyStruct.schema(),
+                        keyStruct,
+                        valueStruct.schema(),
+                        valueStruct);
+
+        DebeziumJsonConverter converter = new DebeziumJsonConverter(false, false);
+        Assertions.assertEquals("{\"k\":11.01}", converter.serializeKey(sourceRecord));
+        Assertions.assertEquals("{\"v\":11.01}", converter.serializeValue(sourceRecord));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Using number format for Decimal type in `seatunnel-format-compatible-debezium-json`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testcase


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).