### PR TITLE
[Improve] Expose client cluster-connect-timeout-millis to yaml

### DIFF
--- a/config/hazelcast-client.yaml
+++ b/config/hazelcast-client.yaml
@@ -19,6 +19,9 @@ hazelcast-client:
   cluster-name: seatunnel
   properties:
     hazelcast.logging.type: log4j2
+  connection-strategy:
+    connection-retry:
+      cluster-connect-timeout-millis: 3000
   network:
     cluster-members:
       - localhost:5801

--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelHazelcastClient.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelHazelcastClient.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.client;
 import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.ClientDelegatingFuture;
 import com.hazelcast.client.impl.clientside.ClientMessageDecoder;
@@ -40,19 +41,10 @@ public class SeaTunnelHazelcastClient {
     private final HazelcastClientInstanceImpl hazelcastClient;
     private final SerializationService serializationService;
 
-    private static final int CONNECT_TIMEOUT = 3000;
-
     public SeaTunnelHazelcastClient(@NonNull ClientConfig clientConfig) {
-        Preconditions.checkNotNull(clientConfig, "config");
-        clientConfig
-                .getConnectionStrategyConfig()
-                .getConnectionRetryConfig()
-                .setClusterConnectTimeoutMillis(CONNECT_TIMEOUT);
+        Preconditions.checkNotNull(clientConfig, "hazelcast client config cannot be null");
         this.hazelcastClient =
-                ((HazelcastClientProxy)
-                                com.hazelcast.client.HazelcastClient.newHazelcastClient(
-                                        clientConfig))
-                        .client;
+                ((HazelcastClientProxy) HazelcastClient.newHazelcastClient(clientConfig)).client;
         this.serializationService = hazelcastClient.getSerializationService();
         ExceptionUtil.registerSeaTunnelExceptions(hazelcastClient.getClientExceptionFactory());
     }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/resources/hazelcast-client.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/resources/hazelcast-client.yaml
@@ -19,6 +19,9 @@ hazelcast-client:
   cluster-name: seatunnel
   properties:
       hazelcast.logging.type: log4j2
+  connection-strategy:
+    connection-retry:
+      cluster-connect-timeout-millis: 3000
   network:
     cluster-members:
       - localhost:5801

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
@@ -78,5 +78,11 @@ public class YamlSeaTunnelConfigParserTest {
         ClientConfig clientConfig = yamlClientConfigBuilder.build();
 
         Assertions.assertEquals("custmoize", clientConfig.getClusterName());
+        Assertions.assertEquals(
+                3000L,
+                clientConfig
+                        .getConnectionStrategyConfig()
+                        .getConnectionRetryConfig()
+                        .getClusterConnectTimeoutMillis());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/test/resources/custmoize-client.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/resources/custmoize-client.yaml
@@ -17,7 +17,9 @@
 
 hazelcast-client:
   cluster-name: custmoize
-
+  connection-strategy:
+    connection-retry:
+      cluster-connect-timeout-millis: 3000
   network:
     cluster-members:
       - host:5801


### PR DESCRIPTION
### Purpose of this pull request

Remove hardcoding the connect-timeout configuration.


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
tested by UT


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).