### PR TITLE
[Bug] [zeta] fix rest api submit a job with chinese name returns an Garbled code name.

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/RestApiIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/RestApiIT.java
@@ -134,7 +134,7 @@ public class RestApiIT {
     @Test
     public void testSubmitJob() {
         Response response = submitJob("BATCH");
-        response.then().statusCode(200).body("jobName", equalTo("test"));
+        response.then().statusCode(200).body("jobName", equalTo("test测试"));
         String jobId = response.getBody().jsonPath().getString("jobId");
         SeaTunnelServer seaTunnelServer =
                 (SeaTunnelServer)
@@ -349,7 +349,7 @@ public class RestApiIT {
                         + "        }\n"
                         + "    ]\n"
                         + "}";
-        String parameters = "jobName=test";
+        String parameters = "jobName=test测试";
         if (isStartWithSavePoint) {
             parameters = parameters + "&isStartWithSavePoint=true";
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
@@ -29,6 +29,8 @@ import org.apache.seatunnel.engine.server.rest.RestConstant;
 import com.hazelcast.internal.util.StringUtil;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Map;
 
 public class RestUtil {
@@ -52,10 +54,12 @@ public class RestUtil {
         try {
             for (String s : uri.substring(indexEnd + 1).split("&")) {
                 String[] param = s.split("=");
-                requestParams.put(param[0], param[1]);
+                requestParams.put(param[0], URLDecoder.decode(param[1], "UTF-8"));
             }
         } catch (IndexOutOfBoundsException e) {
             throw new IllegalArgumentException("Invalid Params format in Params.");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("Unsupported encoding exists in the parameter.");
         }
         if (Boolean.parseBoolean(requestParams.get(RestConstant.IS_START_WITH_SAVE_POINT))
                 && requestParams.get(RestConstant.JOB_ID) == null) {


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Fixed an issue where the rest API submitted a task with garbled characters if the task name was in Chinese.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
Tested in `RestApiIT`, I modified the name of the submitted task in the test, which was originally `test`, and now it is `test测试`, adding Chinese.
