### PR TITLE
[Bug] [website] Checkpoint-Storage description is incorrect.

### DIFF
--- a/docs/en/seatunnel-engine/checkpoint-storage.md
+++ b/docs/en/seatunnel-engine/checkpoint-storage.md
@@ -162,7 +162,7 @@ seatunnel:
           seatunnel.hadoop.dfs.ha.namenodes.usdp-bing: nn1,nn2
           seatunnel.hadoop.dfs.namenode.rpc-address.usdp-bing.nn1: usdp-bing-nn1:8020
           seatunnel.hadoop.dfs.namenode.rpc-address.usdp-bing.nn2: usdp-bing-nn2:8020
-          seatunnel.hadoop.dfs.client.failover.proxy.provider.usdp-bing: org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
+          seatunnel.hadoop.dfs.client.failover.proxy.provider.usdp-bing: org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider
 
 ```
 

--- a/release-note.md
+++ b/release-note.md
@@ -207,3 +207,4 @@
 - [Docs] Add Value types in Java to Schema features (#5087)
 - [Docs] Replace username by user in the options of FtpFile (#5421)
 - [Docs] Add how to configure logging related parameters of SeaTunnel-E2E Test (#5589)
+- [Docs] Remove redundant double quotation mark from an example code (#5845)


### PR DESCRIPTION
### Purpose of this pull request

Resolves https://github.com/apache/seatunnel/issues/5848 → 
```
https://seatunnel.incubator.apache.org/docs/2.3.3/seatunnel-engine/checkpoint-storage
Among the HDFS section, the kerberosKeytab configuration item is incorrect.
Among them, the seatunnel.hadoop.dfs.client.failover.proxy.provider.usdp-bing configuration item has an extra double quotation mark at the end.
```

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
before:
![image](https://github.com/apache/seatunnel/assets/39671742/fbb67ad2-a07a-4ec2-87e7-59788e56cf22)

after:
![image](https://github.com/apache/seatunnel/assets/39671742/8f65dbaa-ea82-42e7-b630-1f2a6ab2ec45)


### Check list

~* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)~
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
~* [ ] If you are contributing the connector code, please check that the following files are updated:~
~1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)~
~2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it~
~3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)~
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).