### PR TITLE
[Improve][File] Clean memory buffer of `JsonWriteStrategy` & `ExcelWriteStrategy`

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ExcelWriteStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ExcelWriteStrategy.java
@@ -62,6 +62,7 @@ public class ExcelWriteStrategy extends AbstractWriteStrategy {
                     }
                     needMoveFiles.put(k, getTargetLocation(k));
                 });
+        beingWrittenWriter.clear();
     }
 
     private ExcelGenerator getOrCreateExcelGenerator(@NonNull String filePath) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/JsonWriteStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/JsonWriteStrategy.java
@@ -103,6 +103,8 @@ public class JsonWriteStrategy extends AbstractWriteStrategy {
                     }
                     needMoveFiles.put(key, getTargetLocation(key));
                 });
+        beingWrittenOutputStream.clear();
+        isFirstWrite.clear();
     }
 
     private FSDataOutputStream getOrCreateOutputStream(@NonNull String filePath) {


### PR DESCRIPTION
### Purpose of this pull request

[File] Clean memory buffer of `JsonWriteStrategy` & `ExcelWriteStrategy`

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).