### PR TITLE
[improve][connector-tdengine] support read bool column from tdengine

### DIFF
--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapper.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapper.java
@@ -34,6 +34,7 @@ public class TDengineTypeMapper {
 
     private static final String TDENGINE_UNKNOWN = "UNKNOWN";
     private static final String TDENGINE_BIT = "BIT";
+    private static final String TDENGINE_BOOL = "BOOL";
 
     // -------------------------number----------------------------
     private static final String TDENGINE_TINYINT = "TINYINT";
@@ -82,6 +83,7 @@ public class TDengineTypeMapper {
 
     public static SeaTunnelDataType<?> mapping(String tdengineType) {
         switch (tdengineType) {
+            case TDENGINE_BOOL:
             case TDENGINE_BIT:
                 return BasicType.BOOLEAN_TYPE;
             case TDENGINE_TINYINT:
@@ -145,9 +147,7 @@ public class TDengineTypeMapper {
             default:
                 throw new TDengineConnectorException(
                         CommonErrorCodeDeprecated.UNSUPPORTED_DATA_TYPE,
-                        String.format(
-                                "Doesn't support TDENGINE type '%s' on column '%s'  yet.",
-                                tdengineType));
+                        String.format("Doesn't support TDENGINE type '%s' yet.", tdengineType));
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapperTest.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapperTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.tdengine.typemapper;
 
 import org.apache.seatunnel.api.table.type.BasicType;

--- a/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapperTest.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapperTest.java
@@ -1,0 +1,19 @@
+package org.apache.seatunnel.connectors.seatunnel.tdengine.typemapper;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TDengineTypeMapperTest {
+
+    @Test
+    void mapping() {
+        SeaTunnelDataType<?> type = TDengineTypeMapper.mapping("BOOL");
+        Assertions.assertEquals(BasicType.BOOLEAN_TYPE, type);
+
+        type = TDengineTypeMapper.mapping("CHAR");
+        Assertions.assertEquals(BasicType.STRING_TYPE, type);
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tdengine-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tdengine/TDengineIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tdengine-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tdengine/TDengineIT.java
@@ -109,7 +109,7 @@ public class TDengineIT extends TestSuiteBase implements TestResource {
         try (Statement stmt = connection1.createStatement()) {
             stmt.execute("CREATE DATABASE power KEEP 3650");
             stmt.execute(
-                    "CREATE STABLE power.meters (ts TIMESTAMP, current FLOAT, voltage INT, phase FLOAT) "
+                    "CREATE STABLE power.meters (ts TIMESTAMP, current FLOAT, voltage INT, phase FLOAT, off BOOL) "
                             + "TAGS (location BINARY(64), groupId INT)");
             String sql = getSQL();
             rowCount = stmt.executeUpdate(sql);
@@ -117,7 +117,7 @@ public class TDengineIT extends TestSuiteBase implements TestResource {
         try (Statement stmt = connection2.createStatement()) {
             stmt.execute("CREATE DATABASE power2 KEEP 3650");
             stmt.execute(
-                    "CREATE STABLE power2.meters2 (ts TIMESTAMP, current FLOAT, voltage INT, phase FLOAT) "
+                    "CREATE STABLE power2.meters2 (ts TIMESTAMP, current FLOAT, voltage INT, phase FLOAT, off BOOL) "
                             + "TAGS (location BINARY(64), groupId INT)");
         }
         return rowCount;
@@ -176,18 +176,18 @@ public class TDengineIT extends TestSuiteBase implements TestResource {
 
     /**
      * The generated SQL is: INSERT INTO power.d1001 USING power.meters
-     * TAGS(California.SanFrancisco, 2) VALUES('2018-10-03 14:38:05.000',10.30000,219,0.31000)
+     * TAGS(California.SanFrancisco, 2) VALUES('2018-10-03 14:38:05.000',10.30000,219,0.31000, true)
      * power.d1001 USING power.meters TAGS(California.SanFrancisco, 2) VALUES('2018-10-03
-     * 14:38:15.000',12.60000,218,0.33000) power.d1001 USING power.meters
-     * TAGS(California.SanFrancisco, 2) VALUES('2018-10-03 14:38:16.800',12.30000,221,0.31000)
+     * 14:38:15.000',12.60000,218,0.33000, false) power.d1001 USING power.meters
+     * TAGS(California.SanFrancisco, 2) VALUES('2018-10-03 14:38:16.800',12.30000,221,0.31000, true)
      * power.d1002 USING power.meters TAGS(California.SanFrancisco, 3) VALUES('2018-10-03
-     * 14:38:16.650',10.30000,218,0.25000) power.d1003 USING power.meters
-     * TAGS(California.LosAngeles, 2) VALUES('2018-10-03 14:38:05.500',11.80000,221,0.28000)
+     * 14:38:16.650',10.30000,218,0.25000, true) power.d1003 USING power.meters
+     * TAGS(California.LosAngeles, 2) VALUES('2018-10-03 14:38:05.500',11.80000,221,0.28000, true)
      * power.d1003 USING power.meters TAGS(California.LosAngeles, 2) VALUES('2018-10-03
-     * 14:38:16.600',13.40000,223,0.29000) power.d1004 USING power.meters
-     * TAGS(California.LosAngeles, 3) VALUES('2018-10-03 14:38:05.000',10.80000,223,0.29000)
+     * 14:38:16.600',13.40000,223,0.29000, true) power.d1004 USING power.meters
+     * TAGS(California.LosAngeles, 3) VALUES('2018-10-03 14:38:05.000',10.80000,223,0.29000, true)
      * power.d1004 USING power.meters TAGS(California.LosAngeles, 3) VALUES('2018-10-03
-     * 14:38:06.500',11.50000,221,0.35000)
+     * 14:38:06.500',11.50000,221,0.35000, false)
      */
     private static String getSQL() {
         StringBuilder sb = new StringBuilder("INSERT INTO ");
@@ -208,6 +208,8 @@ public class TDengineIT extends TestSuiteBase implements TestResource {
                     .append(ps[3])
                     .append(",") // voltage
                     .append(ps[4])
+                    .append(",") // off
+                    .append(ps[7])
                     .append(") "); // phase
         }
         return sb.toString();
@@ -215,13 +217,13 @@ public class TDengineIT extends TestSuiteBase implements TestResource {
 
     private static List<String> getRawData() {
         return Arrays.asList(
-                "d1001,2018-10-03 14:38:05.000,10.30000,219,0.31000,'California.SanFrancisco',2",
-                "d1001,2018-10-03 14:38:15.000,12.60000,218,0.33000,'California.SanFrancisco',2",
-                "d1001,2018-10-03 14:38:16.800,12.30000,221,0.31000,'California.SanFrancisco',2",
-                "d1002,2018-10-03 14:38:16.650,10.30000,218,0.25000,'California.SanFrancisco',3",
-                "d1003,2018-10-03 14:38:05.500,11.80000,221,0.28000,'California.LosAngeles',2",
-                "d1003,2018-10-03 14:38:16.600,13.40000,223,0.29000,'California.LosAngeles',2",
-                "d1004,2018-10-03 14:38:05.000,10.80000,223,0.29000,'California.LosAngeles',3",
-                "d1004,2018-10-03 14:38:06.500,11.50000,221,0.35000,'California.LosAngeles',3");
+                "d1001,2018-10-03 14:38:05.000,10.30000,219,0.31000,'California.SanFrancisco',2,true",
+                "d1001,2018-10-03 14:38:15.000,12.60000,218,0.33000,'California.SanFrancisco',2,false",
+                "d1001,2018-10-03 14:38:16.800,12.30000,221,0.31000,'California.SanFrancisco',2,true",
+                "d1002,2018-10-03 14:38:16.650,10.30000,218,0.25000,'California.SanFrancisco',3,true",
+                "d1003,2018-10-03 14:38:05.500,11.80000,221,0.28000,'California.LosAngeles',2,true",
+                "d1003,2018-10-03 14:38:16.600,13.40000,223,0.29000,'California.LosAngeles',2,true",
+                "d1004,2018-10-03 14:38:05.000,10.80000,223,0.29000,'California.LosAngeles',3,true",
+                "d1004,2018-10-03 14:38:06.500,11.50000,221,0.35000,'California.LosAngeles',3,false");
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

supporting read bool column from tdengine. 
close https://github.com/apache/seatunnel/issues/6008

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tested with UT. 
file path: org/apache/seatunnel/connectors/seatunnel/tdengine/typemapper/TDengineTypeMapperTest.java

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).