### PR TITLE
[fix] [connector-tdengine] fix sql exception and concurrentmodifyexception when connect to taos and read data

### DIFF
--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
@@ -30,7 +30,6 @@ import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengine
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.STABLE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.TIMEZONE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.UPPER_BOUND;
-import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.URL;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.USERNAME;
 
 @Data
@@ -54,7 +53,10 @@ public class TDengineSourceConfig implements Serializable {
 
     public static TDengineSourceConfig buildSourceConfig(Config pluginConfig) {
         TDengineSourceConfig tdengineSourceConfig = new TDengineSourceConfig();
-        tdengineSourceConfig.setUrl(pluginConfig.hasPath(URL) ? pluginConfig.getString(URL) : null);
+        tdengineSourceConfig.setUrl(
+                pluginConfig.hasPath(ConfigNames.URL)
+                        ? pluginConfig.getString(ConfigNames.URL)
+                        : null);
         tdengineSourceConfig.setDatabase(
                 pluginConfig.hasPath(DATABASE) ? pluginConfig.getString(DATABASE) : null);
         tdengineSourceConfig.setStable(
@@ -69,6 +71,7 @@ public class TDengineSourceConfig implements Serializable {
                 pluginConfig.hasPath(LOWER_BOUND) ? pluginConfig.getString(LOWER_BOUND) : null);
         tdengineSourceConfig.setTimezone(
                 pluginConfig.hasPath(TIMEZONE) ? pluginConfig.getString(TIMEZONE) : "UTC");
+
         return tdengineSourceConfig;
     }
 

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -81,7 +81,7 @@ public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengine
                 }
             } else if (noMoreSplit && sourceSplits.isEmpty()) {
                 // signal to the source that we have reached the end of the data.
-                log.info("Closed the bounded jdbc source");
+                log.info("Closed the bounded TDengine source");
                 context.signalNoMoreElement();
             } else {
                 Thread.sleep(1000L);

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
 
-import com.taosdata.jdbc.TSDBDriver;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -25,8 +24,7 @@ import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.taosdata.jdbc.TSDBDriver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -123,8 +123,8 @@ public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengine
     }
 
     private void read(TDengineSourceSplit split, Collector<SeaTunnelRow> output) throws Exception {
-        try (Statement statement = conn.createStatement()) {
-            final ResultSet resultSet = statement.executeQuery(split.getQuery());
+        try (Statement statement = conn.createStatement();
+                ResultSet resultSet = statement.executeQuery(split.getQuery())) {
             ResultSetMetaData meta = resultSet.getMetaData();
 
             while (resultSet.next()) {

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -114,7 +114,8 @@ public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengine
         } catch (SQLException e) {
             throw new TDengineConnectorException(
                     CommonErrorCodeDeprecated.READER_OPERATION_FAILED,
-                    "get TDengine connection failed:" + jdbcUrl, e);
+                    "get TDengine connection failed:" + jdbcUrl,
+                    e);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
 
+import com.taosdata.jdbc.TSDBDriver;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -26,7 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConn
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.taosdata.jdbc.TSDBDriver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
@@ -93,24 +93,15 @@ public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengine
 
     @Override
     public void open() {
-        String jdbcUrl =
-                StringUtils.join(
-                        config.getUrl(),
-                        config.getDatabase(),
-                        "?user=",
-                        config.getUsername(),
-                        "&password=",
-                        config.getPassword());
-        Properties connProps = new Properties();
-        // todo: when TSDBDriver.PROPERTY_KEY_BATCH_LOAD set to "true",
-        // there is a exception : Caused by: java.sql.SQLException: can't create connection with
-        // server
-        // under docker network env
-        // @bobo (tdengine)
-        connProps.setProperty(TSDBDriver.PROPERTY_KEY_BATCH_LOAD, "true");
+        String jdbcUrl = config.getUrl();
+
+        Properties properties = new Properties();
+        properties.put(TSDBDriver.PROPERTY_KEY_USER, config.getUsername());
+        properties.put(TSDBDriver.PROPERTY_KEY_PASSWORD, config.getPassword());
+
         try {
             checkDriverExist(jdbcUrl);
-            conn = DriverManager.getConnection(jdbcUrl, connProps);
+            conn = DriverManager.getConnection(jdbcUrl, properties);
         } catch (SQLException e) {
             throw new TDengineConnectorException(
                     CommonErrorCodeDeprecated.READER_OPERATION_FAILED,

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
@@ -142,7 +142,7 @@ public class TDengineSourceSplitEnumerator
 
     @Override
     public void addSplitsBack(List<TDengineSourceSplit> splits, int subtaskId) {
-        log.info("Add back splits {} to JdbcSourceSplitEnumerator.", splits);
+        log.info("Add back splits {} to TDengineSourceSplitEnumerator.", splits);
         if (!splits.isEmpty()) {
             addPendingSplit(splits);
             assignSplit(Collections.singletonList(subtaskId));

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
@@ -17,28 +17,34 @@
 
 package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
 
-import org.apache.seatunnel.api.source.SourceEvent;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.state.TDengineSourceState;
 
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class TDengineSourceSplitEnumerator
         implements SourceSplitEnumerator<TDengineSourceSplit, TDengineSourceState> {
 
     private final SourceSplitEnumerator.Context<TDengineSourceSplit> context;
     private final TDengineSourceConfig config;
     private final StableMetadata stableMetadata;
-    private Set<TDengineSourceSplit> pendingSplit = new HashSet<>();
-    private Set<TDengineSourceSplit> assignedSplit = new HashSet<>();
+    private volatile boolean shouldEnumerate;
+    private final Object stateLock = new Object();
+    private final Map<Integer, List<TDengineSourceSplit>> pendingSplits = new ConcurrentHashMap<>();
 
     public TDengineSourceSplitEnumerator(
             StableMetadata stableMetadata,
@@ -55,8 +61,10 @@ public class TDengineSourceSplitEnumerator
         this.config = config;
         this.context = context;
         this.stableMetadata = stableMetadata;
+        this.shouldEnumerate = sourceState == null;
         if (sourceState != null) {
-            this.assignedSplit = sourceState.getAssignedSplit();
+            this.shouldEnumerate = sourceState.isShouldEnumerate();
+            this.pendingSplits.putAll(sourceState.getPendingSplits());
         }
     }
 
@@ -69,16 +77,33 @@ public class TDengineSourceSplitEnumerator
 
     @Override
     public void run() {
-        pendingSplit = getAllSplits();
-        assignSplit(context.registeredReaders());
+        Set<Integer> readers = context.registeredReaders();
+        if (shouldEnumerate) {
+            List<TDengineSourceSplit> newSplits = discoverySplits();
+
+            synchronized (stateLock) {
+                addPendingSplit(newSplits);
+                shouldEnumerate = false;
+            }
+
+            assignSplit(readers);
+        }
+
+        log.info("No more splits to assign." + " Sending NoMoreSplitsEvent to reader {}.", readers);
+        readers.forEach(context::signalNoMoreSplits);
     }
 
-    /*
-     * each split has one sub table
-     */
-    private Set<TDengineSourceSplit> getAllSplits() {
+    private void addPendingSplit(List<TDengineSourceSplit> newSplits) {
+        int readerCount = context.currentParallelism();
+        for (TDengineSourceSplit split : newSplits) {
+            int ownerReader = getSplitOwner(split.splitId(), readerCount);
+            pendingSplits.computeIfAbsent(ownerReader, r -> new ArrayList<>()).add(split);
+        }
+    }
+
+    private List<TDengineSourceSplit> discoverySplits() {
         final String timestampFieldName = stableMetadata.getTimestampFieldName();
-        final Set<TDengineSourceSplit> splits = new HashSet<>();
+        final List<TDengineSourceSplit> splits = new ArrayList<>();
         for (String subTableName : stableMetadata.getSubTableNames()) {
             TDengineSourceSplit splitBySubTable =
                     createSplitBySubTable(subTableName, timestampFieldName);
@@ -92,6 +117,7 @@ public class TDengineSourceSplitEnumerator
         String selectFields =
                 Arrays.stream(stableMetadata.getRowType().getFieldNames())
                         .skip(1)
+                        .map(name -> String.format("`%s`", name))
                         .collect(Collectors.joining(","));
         String subTableSQL =
                 "select " + selectFields + " from " + config.getDatabase() + "." + subTableName;
@@ -116,69 +142,64 @@ public class TDengineSourceSplitEnumerator
 
     @Override
     public void addSplitsBack(List<TDengineSourceSplit> splits, int subtaskId) {
+        log.info("Add back splits {} to JdbcSourceSplitEnumerator.", splits);
         if (!splits.isEmpty()) {
-            pendingSplit.addAll(splits);
+            addPendingSplit(splits);
             assignSplit(Collections.singletonList(subtaskId));
         }
     }
 
     @Override
     public int currentUnassignedSplitSize() {
-        return pendingSplit.size();
+        return pendingSplits.size();
     }
 
     @Override
     public void registerReader(int subtaskId) {
-        if (!pendingSplit.isEmpty()) {
+        log.info("Register reader {} to TDengineSourceSplitEnumerator.", subtaskId);
+        if (!pendingSplits.isEmpty()) {
             assignSplit(Collections.singletonList(subtaskId));
         }
     }
 
-    private void assignSplit(Collection<Integer> taskIDList) {
-        assignedSplit =
-                pendingSplit.stream()
-                        .map(
-                                split -> {
-                                    int splitOwner =
-                                            getSplitOwner(
-                                                    split.splitId(), context.currentParallelism());
-                                    if (taskIDList.contains(splitOwner)) {
-                                        context.assignSplit(splitOwner, split);
-                                        return split;
-                                    } else {
-                                        return null;
-                                    }
-                                })
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toSet());
-        pendingSplit.clear();
+    private void assignSplit(Collection<Integer> readers) {
+        log.info("Assign pendingSplits to readers {}", readers);
+
+        for (int reader : readers) {
+            List<TDengineSourceSplit> assignmentForReader = pendingSplits.remove(reader);
+            if (assignmentForReader != null && !assignmentForReader.isEmpty()) {
+                log.info("Assign splits {} to reader {}", assignmentForReader, reader);
+                try {
+                    context.assignSplit(reader, assignmentForReader);
+                } catch (Exception e) {
+                    log.error(
+                            "Failed to assign splits {} to reader {}",
+                            assignmentForReader,
+                            reader,
+                            e);
+                    pendingSplits.put(reader, assignmentForReader);
+                }
+            }
+        }
     }
 
     @Override
     public TDengineSourceState snapshotState(long checkpointId) {
-        return new TDengineSourceState(assignedSplit);
+        synchronized (stateLock) {
+            return new TDengineSourceState(shouldEnumerate, pendingSplits);
+        }
     }
 
     @Override
-    public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
-        SourceSplitEnumerator.super.handleSourceEvent(subtaskId, sourceEvent);
-    }
-
-    @Override
-    public void notifyCheckpointComplete(long checkpointId) {
-        // nothing to do
-    }
-
-    @Override
-    public void notifyCheckpointAborted(long checkpointId) throws Exception {
-        SourceSplitEnumerator.super.notifyCheckpointAborted(checkpointId);
-    }
+    public void notifyCheckpointComplete(long checkpointId) {}
 
     @Override
     public void close() {}
 
     @Override
     public void handleSplitRequest(int subtaskId) {
-        // nothing to do
+        throw new TDengineConnectorException(
+                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                String.format("Unsupported handleSplitRequest: %d", subtaskId));
     }
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceSplitEnumerator.java
@@ -120,7 +120,8 @@ public class TDengineSourceSplitEnumerator
                         .map(name -> String.format("`%s`", name))
                         .collect(Collectors.joining(","));
         String subTableSQL =
-                "select " + selectFields + " from " + config.getDatabase() + "." + subTableName;
+                String.format(
+                        "select %s from %s.`%s`", selectFields, config.getDatabase(), subTableName);
         String start = config.getLowerBound();
         String end = config.getUpperBound();
         if (start != null || end != null) {

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/state/TDengineSourceState.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/state/TDengineSourceState.java
@@ -19,18 +19,16 @@ package org.apache.seatunnel.connectors.seatunnel.tdengine.state;
 
 import org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplit;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.io.Serializable;
-import java.util.Set;
+import java.util.List;
+import java.util.Map;
 
+@AllArgsConstructor
+@Getter
 public class TDengineSourceState implements Serializable {
-
-    private final Set<TDengineSourceSplit> assignedSplit;
-
-    public TDengineSourceState(Set<TDengineSourceSplit> assignedSplit) {
-        this.assignedSplit = assignedSplit;
-    }
-
-    public Set<TDengineSourceSplit> getAssignedSplit() {
-        return assignedSplit;
-    }
+    private boolean shouldEnumerate;
+    private final Map<Integer, List<TDengineSourceSplit>> pendingSplits;
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/test/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReaderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+class TDengineSourceReaderTest {
+    Logger logger;
+    TDengineSourceReader tDengineSourceReader;
+
+    @BeforeEach
+    void setup() {
+        tDengineSourceReader = new TDengineSourceReader(null, null);
+
+        List<TDengineSourceSplit> sourceSplits = new ArrayList<>();
+        int splitCnt = 100;
+        for (int i = 0; i < splitCnt; i++) {
+            sourceSplits.add(new TDengineSourceSplit(Integer.toString(i), "select sever_status()"));
+        }
+
+        tDengineSourceReader.addSplits(sourceSplits);
+
+        logger = Logger.getLogger("TDengineSourceReaderTest");
+    }
+
+    @Test
+    void testPoll() throws InterruptedException {
+        TestCollector testCollector = new TestCollector();
+
+        int totalSplitCnt = 150;
+        ThreadPoolExecutor pool =
+                new ThreadPoolExecutor(8, 8, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+        pool.execute(
+                () -> {
+                    for (int i = 0; i < totalSplitCnt; i++) {
+                        try {
+                            tDengineSourceReader.pollNext(testCollector);
+                            Thread.sleep(new Random().nextInt(5));
+                        } catch (TDengineConnectorException e) {
+                            logger.info("skip create connection!");
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+
+        int newSplitCnt = 50;
+        int threadCnt = 3;
+        for (int i = 0; i < threadCnt; i++) {
+            pool.execute(
+                    () -> {
+                        for (int idx = 0; idx < newSplitCnt; idx++) {
+                            logger.info(
+                                    String.format(
+                                            "%s receive new split",
+                                            Thread.currentThread().getName()));
+                            tDengineSourceReader.addSplits(
+                                    Collections.singletonList(
+                                            new TDengineSourceSplit(
+                                                    String.format(
+                                                            "new_%s",
+                                                            Thread.currentThread().getName() + idx),
+                                                    "select server_status()")));
+                            try {
+                                Thread.sleep(new Random().nextInt(5));
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    });
+        }
+
+        pool.awaitTermination(3, TimeUnit.SECONDS);
+    }
+
+    private static class TestCollector implements Collector<SeaTunnelRow> {
+
+        private final List<SeaTunnelRow> rows = new ArrayList<>();
+
+        public List<SeaTunnelRow> getRows() {
+            return rows;
+        }
+
+        @Override
+        public void collect(SeaTunnelRow record) {
+            rows.add(record);
+        }
+
+        @Override
+        public Object getCheckpointLock() {
+            return new Object();
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

close https://github.com/apache/seatunnel/issues/6032
close https://github.com/apache/seatunnel/issues/5998

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

test with seatunnel-engine-example, belowing is application log:
```
2023-12-26 16:12:21,967 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - checkpoint is disabled, because in batch mode and 'checkpoint.interval' of env is missing.
2023-12-26 16:12:22,001 INFO  org.apache.seatunnel.engine.server.task.SourceSplitEnumeratorTask - received enough reader, starting enumerator...
2023-12-26 16:12:22,011 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplitEnumerator - Assign pendingSplits to readers [0]
2023-12-26 16:12:22,012 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplitEnumerator - Assign splits [org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplit@6ace399c, org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplit@432a36dc, org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplit@7669b2b7, org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplit@7599e205] to reader 0
2023-12-26 16:12:22,020 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceSplitEnumerator - No more splits to assign. Sending NoMoreSplitsEvent to reader [0].
2023-12-26 16:12:22,021 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - no more split accepted!
2023-12-26 16:12:22,061 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - polling new split from queue!
2023-12-26 16:12:22,062 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - starting run new split d_1, query sql: select `ts`,`s_1`,`s_2`,`city_code` from test.d_1!
2023-12-26 16:12:22,169 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - polling new split from queue!
2023-12-26 16:12:22,169 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - starting run new split d_2, query sql: select `ts`,`s_1`,`s_2`,`city_code` from test.d_2!
2023-12-26 16:12:22,171 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=1:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_1, 2023-12-26T13:43:54.609, 1.0, 2.0, HF
2023-12-26 16:12:22,171 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=2:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_1, 2023-12-26T13:44:05.303, 1.1, 2.0, HF
2023-12-26 16:12:22,171 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=3:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_1, 2023-12-26T13:44:09.812, 1.2, 2.1, HF
2023-12-26 16:12:22,181 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=4:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_2, 2023-12-26T13:44:24.184, 1.1, 2.2, HF
2023-12-26 16:12:22,181 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=5:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_2, 2023-12-26T13:44:27.687, 1.2, 2.2, HF
2023-12-26 16:12:22,181 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=6:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_2, 2023-12-26T13:44:32.231, 1.3, 2.3, HF
2023-12-26 16:12:22,184 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - polling new split from queue!
2023-12-26 16:12:22,184 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - starting run new split d_4, query sql: select `ts`,`s_1`,`s_2`,`city_code` from test.d_4!
2023-12-26 16:12:22,193 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=7:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_4, 2023-12-26T13:45:21.366, 1.1, 2.1, HF
2023-12-26 16:12:22,193 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=8:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_4, 2023-12-26T13:45:24.381, 1.2, 2.1, HF
2023-12-26 16:12:22,193 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=9:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_4, 2023-12-26T13:45:26.941, 1.3, 2.1, HF
2023-12-26 16:12:22,193 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=10:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_4, 2023-12-26T13:45:30.452, 1.4, 2.2, HF
2023-12-26 16:12:22,197 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - polling new split from queue!
2023-12-26 16:12:22,197 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - starting run new split d_3, query sql: select `ts`,`s_1`,`s_2`,`city_code` from test.d_3!
2023-12-26 16:12:22,222 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=11:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_3, 2023-12-26T13:44:43.803, 1.0, 2.0, HF
2023-12-26 16:12:22,223 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=12:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_3, 2023-12-26T13:44:49.397, 1.1, 2.0, HF
2023-12-26 16:12:22,223 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=13:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : d_3, 2023-12-26T13:44:52.932, 1.2, 2.1, HF
2023-12-26 16:12:22,237 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - polling new split from queue!
2023-12-26 16:12:22,237 INFO  org.apache.seatunnel.connectors.seatunnel.tdengine.source.TDengineSourceReader - Closed the bounded jdbc source
2023-12-26 16:12:22,361 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - wait checkpoint completed: 9223372036854775807
2023-12-26 16:12:23,021 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - pending checkpoint(9223372036854775807/1@791940519440678913) notify finished!
2023-12-26 16:12:23,021 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - start notify checkpoint completed, job id: 791940519440678913, pipeline id: 1, checkpoint id:9223372036854775807
2023-12-26 16:12:23,043 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - start clean pending checkpoint cause CheckpointCoordinator completed.
2023-12-26 16:12:23,054 INFO  org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator - Turn checkpoint_state_791940519440678913_1 state from null to FINISHED
2023-12-26 16:12:23,126 INFO  org.apache.seatunnel.engine.server.TaskExecutionService - [localhost]:5801 [seatunnel-670882] [5.1] taskDone, taskId = 50000, taskGroup = TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}
2023-12-26 16:12:23,149 INFO  org.apache.seatunnel.engine.server.TaskExecutionService - [localhost]:5801 [seatunnel-670882] [5.1] taskDone, taskId = 20000, taskGroup = TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1}
2023-12-26 16:12:23,150 INFO  org.apache.seatunnel.engine.server.TaskExecutionService - [localhost]:5801 [seatunnel-670882] [5.1] Task TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1} complete with state FINISHED
2023-12-26 16:12:23,150 INFO  org.apache.seatunnel.engine.server.CoordinatorService - [localhost]:5801 [seatunnel-670882] [5.1] Received task end from execution TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1}, state FINISHED
2023-12-26 16:12:23,155 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SplitEnumerator (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1}] turned from state RUNNING to FINISHED.
2023-12-26 16:12:23,156 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SplitEnumerator (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1}] state process is stopped
2023-12-26 16:12:23,157 INFO  org.apache.seatunnel.engine.server.dag.physical.SubPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SplitEnumerator (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=1}] future complete with state FINISHED
2023-12-26 16:12:23,157 INFO  org.apache.seatunnel.engine.server.TaskExecutionService - [localhost]:5801 [seatunnel-670882] [5.1] taskDone, taskId = 40000, taskGroup = TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}
2023-12-26 16:12:23,158 INFO  org.apache.seatunnel.engine.server.TaskExecutionService - [localhost]:5801 [seatunnel-670882] [5.1] Task TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000} complete with state FINISHED
2023-12-26 16:12:23,158 INFO  org.apache.seatunnel.engine.server.CoordinatorService - [localhost]:5801 [seatunnel-670882] [5.1] Received task end from execution TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}, state FINISHED
2023-12-26 16:12:23,162 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SourceTask (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}] turned from state RUNNING to FINISHED.
2023-12-26 16:12:23,163 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SourceTask (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}] state process is stopped
2023-12-26 16:12:23,163 INFO  org.apache.seatunnel.engine.server.dag.physical.SubPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)], task: [pipeline-1 [Source[0]-TDengine]-SourceTask (1/1)], taskGroupLocation: [TaskGroupLocation{jobId=791940519440678913, pipelineId=1, taskGroupId=30000}] future complete with state FINISHED
2023-12-26 16:12:23,163 INFO  org.apache.seatunnel.engine.server.dag.physical.SubPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)] will end with state FINISHED
2023-12-26 16:12:23,163 INFO  org.apache.seatunnel.engine.server.dag.physical.SubPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)] turned from state RUNNING to FINISHED.
2023-12-26 16:12:23,207 INFO  org.apache.seatunnel.engine.server.master.JobMaster - release the pipeline Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)] resource
2023-12-26 16:12:23,215 INFO  org.apache.seatunnel.engine.server.service.slot.DefaultSlotService - received slot release request, jobID: 791940519440678913, slot: SlotProfile{worker=[localhost]:5801, slotID=2, ownerJobID=791940519440678913, assigned=true, resourceProfile=ResourceProfile{cpu=CPU{core=0}, heapMemory=Memory{bytes=0}}, sequence='19c5a1c0-2b4e-4dea-968a-cc15ff536616'}
2023-12-26 16:12:23,215 INFO  org.apache.seatunnel.engine.server.service.slot.DefaultSlotService - received slot release request, jobID: 791940519440678913, slot: SlotProfile{worker=[localhost]:5801, slotID=1, ownerJobID=791940519440678913, assigned=true, resourceProfile=ResourceProfile{cpu=CPU{core=0}, heapMemory=Memory{bytes=0}}, sequence='19c5a1c0-2b4e-4dea-968a-cc15ff536616'}
2023-12-26 16:12:23,215 INFO  org.apache.seatunnel.engine.server.dag.physical.SubPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)] state process is stop
2023-12-26 16:12:23,216 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan - Job fake_to_console.conf (791940519440678913), Pipeline: [(1/1)] future complete with state FINISHED
2023-12-26 16:12:23,216 DEBUG org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan - Try to update the Job fake_to_console.conf (791940519440678913) state from RUNNING to FINISHED
2023-12-26 16:12:23,216 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan - Job fake_to_console.conf (791940519440678913) turned from state RUNNING to FINISHED.
2023-12-26 16:12:23,217 INFO  org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan - Job fake_to_console.conf (791940519440678913) state process is stop
2023-12-26 16:12:23,251 INFO  org.apache.seatunnel.engine.client.job.ClientJobProxy - Job (791940519440678913) end with state FINISHED
2023-12-26 16:12:23,401 INFO  org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand - 
***********************************************
           Job Statistic Information
***********************************************
Start Time                : 2023-12-26 16:08:53
End Time                  : 2023-12-26 16:12:23
Total Time(s)             :                 209
Total Read Count          :                  13
Total Write Count         :                  13
Total Failed Count        :                   0
***********************************************
```

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).