### PR TITLE
[Feature][Connector-V2][Assert] Support check the precision and scale of Decimal type

### DIFF
--- a/release-note.md
+++ b/release-note.md
@@ -185,6 +185,7 @@
 - [Transform-V2] Add Catalog support for FilterRowKindTransform (#4420)
 - [Transform-V2] Add support CatalogTable for FilterFieldTransform (#4422)
 - [Transform-V2] Add catalog support for SQL Transform plugin (#4819)
+- [Connector-V2] [Assert] Support check the precision and scale of Decimal type (#6110)
 
 ### Zeta(ST-Engine)
 

--- a/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/excecutor/AssertExecutor.java
+++ b/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/excecutor/AssertExecutor.java
@@ -17,9 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.assertion.excecutor;
 
+import org.apache.seatunnel.api.table.type.DecimalType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.connectors.seatunnel.assertion.exception.AssertConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.assertion.exception.AssertConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.assertion.rule.AssertFieldRule;
@@ -163,6 +165,21 @@ public class AssertExecutor {
     }
 
     private Boolean checkType(Object value, SeaTunnelDataType<?> fieldType) {
+        if (fieldType.getSqlType() == SqlType.DECIMAL) {
+            return checkDecimalType(value, fieldType);
+        }
         return value.getClass().equals(fieldType.getTypeClass());
+    }
+
+    private static Boolean checkDecimalType(Object value, SeaTunnelDataType<?> fieldType) {
+        if (!value.getClass().equals(fieldType.getTypeClass())) {
+            return false;
+        }
+        DecimalType fieldDecimalType = (DecimalType) fieldType;
+        BigDecimal valueObj = (BigDecimal) value;
+        if (valueObj.scale() != fieldDecimalType.getScale()) {
+            return false;
+        }
+        return valueObj.precision() <= fieldDecimalType.getPrecision();
     }
 }

--- a/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertExecutorTest.java
+++ b/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertExecutorTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.flink.assertion;
 
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
@@ -28,8 +29,11 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
 
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -110,5 +114,52 @@ public class AssertExecutorTest {
         valueRules.add(valueRule2);
         rule.setFieldRules(valueRules);
         return rule;
+    }
+
+    @Test
+    public void testDecimalTypeCheck() {
+        List<AssertFieldRule> rules = Lists.newArrayList();
+        AssertFieldRule rule = new AssertFieldRule();
+        rule.setFieldName("c_mock");
+        DecimalType assertFieldType = new DecimalType(10, 2);
+        rule.setFieldType(assertFieldType);
+
+        AssertFieldRule.AssertRule valueRule = new AssertFieldRule.AssertRule();
+        valueRule.setEqualTo("99999999.90");
+
+        rule.setFieldRules(Collections.singletonList(valueRule));
+        rules.add(rule);
+
+        SeaTunnelRow mockRow = new SeaTunnelRow(new Object[] {new BigDecimal("99999999.90")});
+        SeaTunnelRowType mockType =
+                new SeaTunnelRowType(
+                        new String[] {"c_mock"}, new SeaTunnelDataType[] {new DecimalType(10, 2)});
+
+        AssertFieldRule failRule = assertExecutor.fail(mockRow, mockType, rules).orElse(null);
+        assertNull(failRule);
+    }
+
+    @Test
+    public void testDecimalTypeCheckError() {
+        List<AssertFieldRule> rules = Lists.newArrayList();
+        AssertFieldRule rule = new AssertFieldRule();
+        rule.setFieldName("c_mock");
+        DecimalType assertFieldType = new DecimalType(1, 0);
+        rule.setFieldType(assertFieldType);
+
+        AssertFieldRule.AssertRule valueRule = new AssertFieldRule.AssertRule();
+        valueRule.setRuleType(AssertFieldRule.AssertRuleType.NOT_NULL);
+        rule.setFieldRules(Collections.singletonList(valueRule));
+        rules.add(rule);
+
+        SeaTunnelRow mockRow = new SeaTunnelRow(new Object[] {BigDecimal.valueOf(99999999.99)});
+        SeaTunnelRowType mockType =
+                new SeaTunnelRowType(
+                        new String[] {"c_mock"}, new SeaTunnelDataType[] {new DecimalType(10, 2)});
+
+        AssertFieldRule failRule = assertExecutor.fail(mockRow, mockType, rules).orElse(null);
+        assertNotNull(failRule);
+        assertEquals(assertFieldType, failRule.getFieldType());
+        assertEquals("c_mock", failRule.getFieldName());
     }
 }

--- a/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/rule/AssertRuleParserTest.java
+++ b/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/rule/AssertRuleParserTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
 import org.apache.seatunnel.connectors.seatunnel.assertion.rule.AssertFieldRule;
 import org.apache.seatunnel.connectors.seatunnel.assertion.rule.AssertRuleParser;
 
@@ -37,8 +38,39 @@ public class AssertRuleParserTest {
     public void testParseRules() {
         List<? extends Config> ruleConfigList = assembleConfig();
         List<AssertFieldRule> assertFieldRules = parser.parseRules(ruleConfigList);
-        assertEquals(assertFieldRules.size(), 2);
-        assertEquals(assertFieldRules.get(0).getFieldType(), BasicType.STRING_TYPE);
+        assertEquals(3, assertFieldRules.size());
+
+        AssertFieldRule nameRule = assertFieldRules.get(0);
+        List<AssertFieldRule.AssertRule> nameValueRules = nameRule.getFieldRules();
+        assertEquals(BasicType.STRING_TYPE, nameRule.getFieldType());
+        assertEquals("name", nameRule.getFieldName());
+        assertEquals(3, nameValueRules.size());
+        assertEquals(AssertFieldRule.AssertRuleType.NOT_NULL, nameValueRules.get(0).getRuleType());
+        assertEquals(
+                AssertFieldRule.AssertRuleType.MIN_LENGTH, nameValueRules.get(1).getRuleType());
+        assertEquals(3.0, nameValueRules.get(1).getRuleValue());
+        assertEquals(
+                AssertFieldRule.AssertRuleType.MAX_LENGTH, nameValueRules.get(2).getRuleType());
+        assertEquals(5.0, nameValueRules.get(2).getRuleValue());
+
+        AssertFieldRule ageRule = assertFieldRules.get(1);
+        List<AssertFieldRule.AssertRule> ageValueRules = ageRule.getFieldRules();
+        assertEquals("age", ageRule.getFieldName());
+        assertEquals(3, ageValueRules.size());
+        assertEquals(AssertFieldRule.AssertRuleType.NOT_NULL, ageValueRules.get(0).getRuleType());
+        assertEquals(AssertFieldRule.AssertRuleType.MIN, ageValueRules.get(1).getRuleType());
+        assertEquals(10.0, ageValueRules.get(1).getRuleValue());
+        assertEquals(AssertFieldRule.AssertRuleType.MAX, ageValueRules.get(2).getRuleType());
+        assertEquals(20.0, ageValueRules.get(2).getRuleValue());
+
+        AssertFieldRule decimalRule = assertFieldRules.get(2);
+        List<AssertFieldRule.AssertRule> decimalValueRules = decimalRule.getFieldRules();
+        assertEquals("c_decimal", decimalRule.getFieldName());
+        assertEquals(new DecimalType(10, 2), decimalRule.getFieldType());
+        assertEquals(2, decimalValueRules.size());
+        assertEquals(
+                AssertFieldRule.AssertRuleType.NOT_NULL, decimalValueRules.get(0).getRuleType());
+        assertEquals("12.12", decimalValueRules.get(1).getEqualTo());
     }
 
     private List<? extends Config> assembleConfig() {
@@ -74,6 +106,17 @@ public class AssertRuleParserTest {
                         + "                {\n"
                         + "                     rule_type = MAX\n"
                         + "                     rule_value = 20\n"
+                        + "                }\n"
+                        + "            ]\n"
+                        + "        },{\n"
+                        + "            field_name = c_decimal\n"
+                        + "            field_type= \" decimal( 10 , 2 ) \"\n"
+                        + "            field_value = [\n"
+                        + "                {\n"
+                        + "                    rule_type = NOT_NULL\n"
+                        + "                },\n"
+                        + "                {\n"
+                        + "                    equals_to = \"12.12\"\n"
                         + "                }\n"
                         + "            ]\n"
                         + "        }\n"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHiveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHiveIT.java
@@ -131,7 +131,7 @@ public class JdbcHiveIT extends AbstractJdbcIT {
                                 + "        TRUE,"
                                 + "        '2023-09-04',"
                                 + "        '2023-09-04 10:30:00',"
-                                + "        42.12,"
+                                + "        42.10,"
                                 + "        42.12)");
             }
         } catch (Exception exception) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/resources/jdbc_hive_source_and_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/resources/jdbc_hive_source_and_assert.conf
@@ -126,7 +126,7 @@ sink{
         {
           field_name = hive_e2e_source_table.decimal_column
           field_type = "decimal(10,2)"
-          field_value = [{equals_to = 42.12}]
+          field_value = [{equals_to = "42.10"}]
           },
         {
          field_name = hive_e2e_source_table.numeric_column

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_source_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_source_to_assert.conf
@@ -105,6 +105,15 @@ sink {
               rule_type = NOT_NULL
             }
           ]
+        },
+        {
+          field_name = c_decimal
+          field_type = "decimal(33, 18)"
+          field_value = [
+            {
+              rule_type = NOT_NULL
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
- close: #6109 
- Support more  robust field type declarations of `Decimal` type, such as ` decimal( 10 , 2 ) ` with extra spaces.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
Add new test case to cover the feature.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).