### PR TITLE
[Fix] Fix clickhouse local generate file has <0x00> (#6089)

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -174,6 +174,7 @@ public class ClickhouseFileSinkWriter
     @Override
     public Optional<CKFileCommitInfo> prepareCommit() throws IOException {
         for (FileChannel channel : rowCache.values()) {
+            channel.truncate(channel.position());
             channel.close();
         }
         Map<Shard, List<String>> detachedFiles = new HashMap<>();
@@ -249,10 +250,11 @@ public class ClickhouseFileSinkWriter
         byte[] byteData = data.getBytes(StandardCharsets.UTF_8);
         if (buffer.position() + byteData.length > buffer.capacity()) {
             buffer =
-                    fileChannel.map(FileChannel.MapMode.READ_WRITE, fileChannel.size(), bufferSize);
+                    fileChannel.map(FileChannel.MapMode.READ_WRITE, fileChannel.position(), bufferSize);
             bufferCache.put(shard, buffer);
         }
         buffer.put(byteData);
+        fileChannel.position(fileChannel.size() - bufferSize + buffer.position());
     }
 
     private List<String> generateClickhouseLocalFiles(String clickhouseLocalFileTmpFile)


### PR DESCRIPTION
### Purpose of this pull request

fix clickhouse local generate file has <0x00>,it will cause 


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
after fix，i success transfer 300KW records from hive to ck



### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).