### PR TITLE
[Improve] Speed up ck file attach (#6091)

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkAggCommitter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkAggCommitter.java
@@ -53,22 +53,8 @@ public class ClickhouseFileSinkAggCommitter
     }
 
     @Override
-    public List<CKFileAggCommitInfo> commit(List<CKFileAggCommitInfo> aggregatedCommitInfo)
-            throws IOException {
-        aggregatedCommitInfo.forEach(
-                commitInfo ->
-                        commitInfo
-                                .getDetachedFiles()
-                                .forEach(
-                                        (shard, files) -> {
-                                            try {
-                                                this.attachFileToClickhouse(shard, files);
-                                            } catch (ClickHouseException e) {
-                                                throw new SeaTunnelException(
-                                                        "failed commit file to clickhouse", e);
-                                            }
-                                        }));
-        return new ArrayList<>();
+    public List<CKFileAggCommitInfo> commit(List<CKFileAggCommitInfo> aggregatedCommitInfo) throws IOException {
+        return null;
     }
 
     @Override
@@ -110,22 +96,6 @@ public class ClickhouseFileSinkAggCommitter
     public void close() throws IOException {
         if (proxy != null) {
             proxy.close();
-        }
-    }
-
-    private void attachFileToClickhouse(Shard shard, List<String> clickhouseLocalFiles)
-            throws ClickHouseException {
-        ClickHouseRequest<?> request = getProxy().getClickhouseConnection(shard);
-        for (String clickhouseLocalFile : clickhouseLocalFiles) {
-            ClickHouseResponse response =
-                    request.query(
-                                    String.format(
-                                            "ALTER TABLE %s ATTACH PART '%s'",
-                                            clickhouseTable.getLocalTableName(),
-                                            clickhouseLocalFile.substring(
-                                                    clickhouseLocalFile.lastIndexOf("/") + 1)))
-                            .executeAndWait();
-            response.close();
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/file/ClickhouseFileSinkWriter.java
@@ -17,6 +17,9 @@
 
 package org.apache.seatunnel.connectors.seatunnel.clickhouse.sink.file;
 
+import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.ClickHouseRequest;
+import com.clickhouse.client.ClickHouseResponse;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.config.Common;
@@ -185,6 +188,8 @@ public class ClickhouseFileSinkWriter
                         // move file to server
                         moveClickhouseLocalFileToServer(shard, clickhouseLocalFiles);
                         detachedFiles.put(shard, clickhouseLocalFiles);
+                        //attach file in executor
+                        attachFileToClickhouse(shard,clickhouseLocalFiles);
                     } catch (Exception e) {
                         throw new ClickhouseConnectorException(
                                 CommonErrorCodeDeprecated.FLUSH_DATA_FAILED,
@@ -437,5 +442,21 @@ public class ClickhouseFileSinkWriter
                     createTableDDL.substring(0, p) + CLICKHOUSE_SETTINGS_KEY + filteredSetting;
         }
         return createTableDDL;
+    }
+
+    private void attachFileToClickhouse(Shard shard, List<String> clickhouseLocalFiles)
+            throws ClickHouseException {
+        ClickHouseRequest<?> request = proxy.getClickhouseConnection(shard);
+        for (String clickhouseLocalFile : clickhouseLocalFiles) {
+            ClickHouseResponse response =
+                    request.query(
+                                    String.format(
+                                            "ALTER TABLE %s ATTACH PART '%s'",
+                                            clickhouseTable.getLocalTableName(),
+                                            clickhouseLocalFile.substring(
+                                                    clickhouseLocalFile.lastIndexOf("/") + 1)))
+                            .executeAndWait();
+            response.close();
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
improve the speed of transfer data from hive to ck

### Does this PR introduce _any_ user-facing change?
no
Tips：because attach data is in executor，it means the data will keep increasing  when task is running.
if your task has failed ，you ck will also have data. so you should handle data before  run task to keep idempotent【like dataX preSql】


### How was this patch tested?
after this imporve and next ”chown improve“，300KW records from hive to ck，cost minutes reduced from 100+  to 60


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).