### PR TITLE
[Fix][Oracle-CDC] Fix invalid split key when no primary key

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/source/eumerator/OracleChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/source/eumerator/OracleChunkSplitter.java
@@ -33,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 import oracle.sql.ROWID;
 
 import java.sql.SQLException;
-import java.sql.Types;
 
 /**
  * The {@code ChunkSplitter} used to split Oracle table into a set of chunks for JDBC data source.
@@ -103,22 +102,5 @@ public class OracleChunkSplitter extends AbstractJdbcSourceChunkSplitter {
         } else {
             return ObjectUtils.compare(obj1, obj2);
         }
-    }
-
-    @Override
-    protected Column getSplitColumn(
-            JdbcConnection jdbc, JdbcDataSourceDialect dialect, TableId tableId)
-            throws SQLException {
-        try {
-            Column splitColumn = super.getSplitColumn(jdbc, dialect, tableId);
-            if (splitColumn != null) {
-                return splitColumn;
-            }
-        } catch (SQLException e) {
-            log.info(
-                    "Failed to obtain the split key policy, the split key is changed to the default one",
-                    e);
-        }
-        return Column.editor().jdbcType(Types.VARCHAR).name(ROWID.class.getSimpleName()).create();
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
@@ -272,7 +272,7 @@ public class OracleCDCIT extends TestSuiteBase implements TestResource {
             value = {},
             type = {EngineType.SPARK, EngineType.FLINK},
             disabledReason = "Currently SPARK and FLINK do not support multi table")
-    public void testMysqlCdcMultiTableE2e(TestContainer container)
+    public void testOracleCdcMultiTableE2e(TestContainer container)
             throws IOException, InterruptedException {
 
         clearTable(DATABASE, SOURCE_TABLE1);


### PR DESCRIPTION

### Purpose of this pull request

[Oracle-CDC] Fix invalid split key when no primary key

supported no primary-key & custom primary-key
https://github.com/apache/seatunnel/pull/6209
https://github.com/apache/seatunnel/pull/6216

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
https://github.com/apache/seatunnel/pull/6209/files#diff-2ce020b038574b0a89a2903359d5806b57f2f672a144ad7dfdac74d231ac2ee8


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).