### PR TITLE
[Improve] Add disable 2pc in SelectDB cloud sink

### DIFF
--- a/docs/en/connector-v2/sink/SelectDB-Cloud.md
+++ b/docs/en/connector-v2/sink/SelectDB-Cloud.md
@@ -30,7 +30,7 @@ Version Supported
 
 ## Sink Options
 
-| Name               | Type   | Required | Default                | Description                                                                                                                                                                                                                                                                                                                                       |
+|        Name        |  Type  | Required |        Default         |                                                                                                                                                                    Description                                                                                                                                                                    |
 |--------------------|--------|----------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | load-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse http address, the format is `warehouse_ip:http_port`                                                                                                                                                                                                                                                                   |
 | jdbc-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse jdbc address, the format is `warehouse_ip:mysql_port`                                                                                                                                                                                                                                                                  |
@@ -170,3 +170,4 @@ sink {
   }
 }
 ```
+

--- a/docs/en/connector-v2/sink/SelectDB-Cloud.md
+++ b/docs/en/connector-v2/sink/SelectDB-Cloud.md
@@ -30,19 +30,20 @@ Version Supported
 
 ## Sink Options
 
-|        Name        |  Type  | Required |        Default         |                                                                Description                                                                |
-|--------------------|--------|----------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| load-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse http address, the format is `warehouse_ip:http_port`                                                           |
-| jdbc-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse jdbc address, the format is `warehouse_ip:mysql_port`                                                          |
-| cluster-name       | String | Yes      | -                      | `SelectDB Cloud` cluster name                                                                                                             |
-| username           | String | Yes      | -                      | `SelectDB Cloud` user username                                                                                                            |
-| password           | String | Yes      | -                      | `SelectDB Cloud` user password                                                                                                            |
-| table.identifier   | String | Yes      | -                      | The name of `SelectDB Cloud` table, the format is `database.table`                                                                        |
-| sink.enable-delete | bool   | No       | false                  | Whether to enable deletion. This option requires SelectDB Cloud table to enable batch delete function, and only supports Unique model.    |
-| sink.max-retries   | int    | No       | 3                      | the max retry times if writing records to database failed                                                                                 |
-| sink.buffer-size   | int    | No       | 10 * 1024 * 1024 (1MB) | the buffer size to cache data for stream load.                                                                                            |
-| sink.buffer-count  | int    | No       | 10000                  | the buffer count to cache data for stream load.                                                                                           |
-| selectdb.config    | map    | yes      | -                      | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql,and supported formats. |
+| Name               | Type   | Required | Default                | Description                                                                                                                                                                                                                                                                                                                                       |
+|--------------------|--------|----------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| load-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse http address, the format is `warehouse_ip:http_port`                                                                                                                                                                                                                                                                   |
+| jdbc-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse jdbc address, the format is `warehouse_ip:mysql_port`                                                                                                                                                                                                                                                                  |
+| cluster-name       | String | Yes      | -                      | `SelectDB Cloud` cluster name                                                                                                                                                                                                                                                                                                                     |
+| username           | String | Yes      | -                      | `SelectDB Cloud` user username                                                                                                                                                                                                                                                                                                                    |
+| password           | String | Yes      | -                      | `SelectDB Cloud` user password                                                                                                                                                                                                                                                                                                                    |
+| sink.enable-2pc    | bool   | No       | true                   | Whether to enable two-phase commit (2pc), the default is true, to ensure Exactly-Once semantics. SelectDB uses cache files to load data. When the amount of data is large, cached data may become invalid (the default expiration time is 1 hour). If you encounter a large amount of data write loss, please configure sink.enable-2pc to false. |
+| table.identifier   | String | Yes      | -                      | The name of `SelectDB Cloud` table, the format is `database.table`                                                                                                                                                                                                                                                                                |
+| sink.enable-delete | bool   | No       | false                  | Whether to enable deletion. This option requires SelectDB Cloud table to enable batch delete function, and only supports Unique model.                                                                                                                                                                                                            |
+| sink.max-retries   | int    | No       | 3                      | the max retry times if writing records to database failed                                                                                                                                                                                                                                                                                         |
+| sink.buffer-size   | int    | No       | 10 * 1024 * 1024 (1MB) | the buffer size to cache data for stream load.                                                                                                                                                                                                                                                                                                    |
+| sink.buffer-count  | int    | No       | 10000                  | the buffer count to cache data for stream load.                                                                                                                                                                                                                                                                                                   |
+| selectdb.config    | map    | yes      | -                      | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql,and supported formats.                                                                                                                                                                                                         |
 
 ## Data Type Mapping
 
@@ -169,11 +170,3 @@ sink {
   }
 }
 ```
-
-## Changelog
-
-### next version
-
-- [Feature] Support SelectDB Cloud Sink Connector [3958](https://github.com/apache/seatunnel/pull/3958)
-- [Improve] Refactor some SelectDB Cloud Sink code as well as support copy into batch and async flush and cdc [4312](https://github.com/apache/seatunnel/pull/4312)
-

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
@@ -71,6 +71,11 @@ public class SelectDBConfig {
                     .noDefaultValue()
                     .withDescription("the jdbc password.");
 
+    public static final Option<Boolean> SINK_ENABLE_2PC =
+            Options.key("sink.enable-2pc")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("enable 2PC while loading");
     // sink config options
     public static final Option<Integer> SINK_MAX_RETRIES =
             Options.key("sink.max-retries")
@@ -120,6 +125,7 @@ public class SelectDBConfig {
     private String tableIdentifier;
     private Boolean enableDelete;
     private String labelPrefix;
+    private boolean enable2PC;
     private Integer maxRetries;
     private Integer bufferSize;
     private Integer bufferCount;
@@ -145,6 +151,11 @@ public class SelectDBConfig {
             selectdbConfig.setMaxRetries(pluginConfig.getInt(SINK_MAX_RETRIES.key()));
         } else {
             selectdbConfig.setMaxRetries(SINK_MAX_RETRIES.defaultValue());
+        }
+        if (pluginConfig.hasPath(SINK_ENABLE_2PC.key())) {
+            selectdbConfig.setEnable2PC(pluginConfig.getBoolean(SINK_ENABLE_2PC.key()));
+        } else {
+            selectdbConfig.setEnable2PC(SINK_ENABLE_2PC.defaultValue());
         }
         if (pluginConfig.hasPath(SINK_BUFFER_SIZE.key())) {
             selectdbConfig.setBufferSize(pluginConfig.getInt(SINK_BUFFER_SIZE.key()));

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/rest/CopySQLUtil.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/rest/CopySQLUtil.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.selectdb.rest;
+
+import org.apache.seatunnel.connectors.selectdb.config.SelectDBConfig;
+import org.apache.seatunnel.connectors.selectdb.exception.SelectDBConnectorErrorCode;
+import org.apache.seatunnel.connectors.selectdb.exception.SelectDBConnectorException;
+import org.apache.seatunnel.connectors.selectdb.sink.writer.LoadStatus;
+import org.apache.seatunnel.connectors.selectdb.util.HttpPostBuilder;
+import org.apache.seatunnel.connectors.selectdb.util.HttpUtil;
+import org.apache.seatunnel.connectors.selectdb.util.ResponseUtil;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class CopySQLUtil {
+
+    private static final String COMMIT_PATTERN = "http://%s/copy/query";
+    private static final int HTTP_TEMPORARY_REDIRECT = 200;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static void copyFileToDatabase(
+            SelectDBConfig selectdbConfig, String clusterName, String copySQL, String hostPort)
+            throws IOException {
+        long start = System.currentTimeMillis();
+        CloseableHttpClient httpClient = HttpUtil.getHttpClient();
+        int statusCode = -1;
+        String reasonPhrase = null;
+        int retry = 0;
+        Map<String, String> params = new HashMap<>();
+        params.put("cluster", clusterName);
+        params.put("sql", copySQL);
+        boolean success = false;
+        CloseableHttpResponse response;
+        String loadResult = "";
+        while (retry++ <= selectdbConfig.getMaxRetries()) {
+            HttpPostBuilder postBuilder = new HttpPostBuilder();
+            postBuilder
+                    .setUrl(String.format(COMMIT_PATTERN, hostPort))
+                    .baseAuth(selectdbConfig.getUsername(), selectdbConfig.getPassword())
+                    .setEntity(new StringEntity(OBJECT_MAPPER.writeValueAsString(params)));
+            try {
+                response = httpClient.execute(postBuilder.build());
+            } catch (IOException e) {
+                log.error("commit error : ", e);
+                continue;
+            }
+            statusCode = response.getStatusLine().getStatusCode();
+            reasonPhrase = response.getStatusLine().getReasonPhrase();
+            if (statusCode != HTTP_TEMPORARY_REDIRECT) {
+                log.warn(
+                        "commit failed with status {} {}, reason {}",
+                        statusCode,
+                        hostPort,
+                        reasonPhrase);
+            } else if (response.getEntity() != null) {
+                loadResult = EntityUtils.toString(response.getEntity());
+                success = handleCommitResponse(loadResult);
+                if (success) {
+                    log.info(
+                            "commit success cost {}ms, response is {}",
+                            System.currentTimeMillis() - start,
+                            loadResult);
+                    break;
+                } else {
+                    log.warn("commit failed, retry again");
+                }
+            }
+        }
+
+        if (!success) {
+            throw new SelectDBConnectorException(
+                    SelectDBConnectorErrorCode.COMMIT_FAILED,
+                    "commit failed with SQL: "
+                            + copySQL
+                            + " Commit error with status: "
+                            + statusCode
+                            + ", Reason: "
+                            + reasonPhrase
+                            + ", Response: "
+                            + loadResult);
+        }
+    }
+
+    private static boolean handleCommitResponse(String loadResult) throws IOException {
+        BaseResponse<CopyIntoResp> baseResponse =
+                OBJECT_MAPPER.readValue(
+                        loadResult, new TypeReference<BaseResponse<CopyIntoResp>>() {});
+        if (baseResponse.getCode() == LoadStatus.SUCCESS) {
+            CopyIntoResp dataResp = baseResponse.getData();
+            if (LoadStatus.FAIL.equals(dataResp.getDataCode())) {
+                log.error("copy into execute failed, reason:{}", loadResult);
+                return false;
+            } else {
+                Map<String, String> result = dataResp.getResult();
+                if (!result.get("state").equals("FINISHED")
+                        && !ResponseUtil.isCommitted(result.get("msg"))) {
+                    log.error("copy into load failed, reason:{}", loadResult);
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        } else {
+            log.error("commit failed, reason:{}", loadResult);
+            return false;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/util/HttpUtil.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/util/HttpUtil.java
@@ -23,7 +23,7 @@ import org.apache.http.impl.client.HttpClients;
 
 /** util to build http client. */
 public class HttpUtil {
-    public HttpUtil() {}
+    private HttpUtil() {}
 
     private static final HttpClientBuilder HTTP_CLIENT_BUILDER =
             HttpClients.custom().disableRedirectHandling();


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request
This PR add config `sink.enable-2pc` to disable 2pc feature in SelectDB cloud, default value is true.
Currently, SelectDB cloud writes temporary files that rely on cache, and then submits the files to the database in the second phase. However, if the amount of data is large, the file may have expired when the second phase files are submitted. So this PR supports commit file every time when it is generated. It only takes effect when the 2pc feature is turned off.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
tested in local with selectdb cloud.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).