### PR TITLE
[Hotfix][API] Use default tablepath when can not get the tablepath from source config

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtil.java
@@ -215,7 +215,7 @@ public class CatalogTableUtil implements Serializable {
         } else {
             Optional<String> resultTableNameOptional =
                     readonlyConfig.getOptional(CommonOptions.RESULT_TABLE_NAME);
-            tablePath = resultTableNameOptional.map(TablePath::of).orElse(TablePath.EMPTY);
+            tablePath = resultTableNameOptional.map(TablePath::of).orElse(TablePath.DEFAULT);
         }
 
         return CatalogTable.of(

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/TablePath.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/TablePath.java
@@ -34,7 +34,7 @@ public final class TablePath implements Serializable {
     private final String schemaName;
     private final String tableName;
 
-    public static final TablePath EMPTY = TablePath.of(null, null, null);
+    public static final TablePath DEFAULT = TablePath.of("default", "default", "default");
 
     public static TablePath of(String fullName) {
         return of(fullName, false);

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtilTest.java
@@ -139,6 +139,21 @@ public class CatalogTableUtilTest {
     }
 
     @Test
+    public void testDefaultTablePath() throws FileNotFoundException, URISyntaxException {
+        String path = getTestConfigFile("/conf/default_tablepath.conf");
+        Config config = ConfigFactory.parseFile(new File(path));
+        Config source = config.getConfigList("source").get(0);
+        ReadonlyConfig sourceReadonlyConfig = ReadonlyConfig.fromConfig(source);
+        CatalogTable catalogTable = CatalogTableUtil.buildWithConfig(sourceReadonlyConfig);
+        Assertions.assertEquals(
+                TablePath.DEFAULT.getDatabaseName(), catalogTable.getTablePath().getDatabaseName());
+        Assertions.assertEquals(
+                TablePath.DEFAULT.getSchemaName(), catalogTable.getTablePath().getSchemaName());
+        Assertions.assertEquals(
+                TablePath.DEFAULT.getTableName(), catalogTable.getTablePath().getTableName());
+    }
+
+    @Test
     public void testGenericRowSchemaTest() throws FileNotFoundException, URISyntaxException {
         String path = getTestConfigFile("/conf/generic_row.schema.conf");
         Config config = ConfigFactory.parseFile(new File(path));

--- a/seatunnel-api/src/test/resources/conf/default_tablepath.conf
+++ b/seatunnel-api/src/test/resources/conf/default_tablepath.conf
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  job.mode = "BATCH"
+}
+
+source {
+  MongoDB-CDC {
+    hosts = "mongo0:27017"
+    database = ["inventory"]
+    collection = ["inventory.products"]
+    username = superuser
+    password = superpw
+    schema = {
+      fields {
+        "_id": string,
+        "name": string,
+        "description": string,
+        "weight": string
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  Console{}
+}

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeDataGeneratorTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeDataGeneratorTest.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.RowKind;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
@@ -84,15 +85,21 @@ public class FakeDataGeneratorTest {
     public void testRowDataParse(String conf) throws FileNotFoundException, URISyntaxException {
         SeaTunnelRow row1 = new SeaTunnelRow(new Object[] {1L, "A", 100});
         row1.setRowKind(RowKind.INSERT);
+        row1.setTableId(TablePath.DEFAULT.getFullName());
         SeaTunnelRow row2 = new SeaTunnelRow(new Object[] {2L, "B", 100});
         row2.setRowKind(RowKind.INSERT);
+        row2.setTableId(TablePath.DEFAULT.getFullName());
         SeaTunnelRow row3 = new SeaTunnelRow(new Object[] {3L, "C", 100});
         row3.setRowKind(RowKind.INSERT);
+        row3.setTableId(TablePath.DEFAULT.getFullName());
         SeaTunnelRow row1UpdateBefore = new SeaTunnelRow(new Object[] {1L, "A", 100});
+        row1UpdateBefore.setTableId(TablePath.DEFAULT.getFullName());
         row1UpdateBefore.setRowKind(RowKind.UPDATE_BEFORE);
         SeaTunnelRow row1UpdateAfter = new SeaTunnelRow(new Object[] {1L, "A_1", 100});
+        row1UpdateAfter.setTableId(TablePath.DEFAULT.getFullName());
         row1UpdateAfter.setRowKind(RowKind.UPDATE_AFTER);
         SeaTunnelRow row2Delete = new SeaTunnelRow(new Object[] {2L, "B", 100});
+        row2Delete.setTableId(TablePath.DEFAULT.getFullName());
         row2Delete.setRowKind(RowKind.DELETE);
         List<SeaTunnelRow> expected =
                 Arrays.asList(row1, row2, row3, row1UpdateBefore, row1UpdateAfter, row2Delete);


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Use default tablepath when can not get the tablepath from source config, Otherwise, downstream cannot obtain upstream table names and cannot automatically create tables.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).