### PR TITLE
[HotFix] Fix HiveMetaStoreProxy#enableKerberos will return true if doesn't enable kerberos

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
@@ -250,7 +250,7 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
             return;
         }
         this.fileSystem = FileSystem.get(configuration);
-        fileSystem.setWriteChecksum(false);
+        this.fileSystem.setWriteChecksum(false);
     }
 
     private Configuration createConfiguration() {
@@ -269,40 +269,41 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
     }
 
     private boolean enableKerberos() {
-        boolean kerberosPrincipalEmpty = StringUtils.isEmpty(hadoopConf.getKerberosPrincipal());
-        boolean kerberosKeytabPathEmpty = StringUtils.isEmpty(hadoopConf.getKerberosKeytabPath());
-        boolean krb5FilePathEmpty = StringUtils.isEmpty(hadoopConf.getKrb5Path());
-        if (kerberosKeytabPathEmpty && kerberosPrincipalEmpty && krb5FilePathEmpty) {
+        boolean kerberosPrincipalEmpty = StringUtils.isBlank(hadoopConf.getKerberosPrincipal());
+        boolean kerberosKeytabPathEmpty = StringUtils.isBlank(hadoopConf.getKerberosKeytabPath());
+        if (kerberosKeytabPathEmpty && kerberosPrincipalEmpty) {
             return false;
         }
-        if (!kerberosPrincipalEmpty && !kerberosKeytabPathEmpty && !krb5FilePathEmpty) {
+        if (!kerberosPrincipalEmpty && !kerberosKeytabPathEmpty) {
             return true;
         }
         if (kerberosPrincipalEmpty) {
             throw new IllegalArgumentException("Please set kerberosPrincipal");
         }
-        if (kerberosKeytabPathEmpty) {
-            throw new IllegalArgumentException("Please set kerberosKeytabPath");
-        }
-        throw new IllegalArgumentException("Please set krb5FilePath");
+        throw new IllegalArgumentException("Please set kerberosKeytabPath");
     }
 
     private void initializeWithKerberosLogin() throws IOException, InterruptedException {
-        HadoopLoginFactory.loginWithKerberos(
-                configuration,
-                hadoopConf.getKrb5Path(),
-                hadoopConf.getKerberosPrincipal(),
-                hadoopConf.getKerberosKeytabPath(),
-                (configuration, userGroupInformation) -> {
-                    this.userGroupInformation = userGroupInformation;
-                    this.fileSystem = FileSystem.get(configuration);
-                    return null;
-                });
+        Pair<UserGroupInformation, FileSystem> pair =
+                HadoopLoginFactory.loginWithKerberos(
+                        configuration,
+                        hadoopConf.getKrb5Path(),
+                        hadoopConf.getKerberosPrincipal(),
+                        hadoopConf.getKerberosKeytabPath(),
+                        (configuration, userGroupInformation) -> {
+                            this.userGroupInformation = userGroupInformation;
+                            this.fileSystem = FileSystem.get(configuration);
+                            return Pair.of(userGroupInformation, fileSystem);
+                        });
         // todo: Use a daemon thread to reloginFromTicketCache
+        this.userGroupInformation = pair.getKey();
+        this.fileSystem = pair.getValue();
+        this.fileSystem.setWriteChecksum(false);
+        log.info("Create FileSystem success with Kerberos: {}.", hadoopConf.getKerberosPrincipal());
     }
 
     private boolean enableRemoteUser() {
-        return StringUtils.isNotEmpty(hadoopConf.getRemoteUser());
+        return StringUtils.isNotBlank(hadoopConf.getRemoteUser());
     }
 
     private void initializeWithRemoteUserLogin() throws Exception {
@@ -314,7 +315,9 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
                             final FileSystem fileSystem = FileSystem.get(configuration);
                             return Pair.of(userGroupInformation, fileSystem);
                         });
+        log.info("Create FileSystem success with RemoteUser: {}.", hadoopConf.getRemoteUser());
         this.userGroupInformation = pair.getKey();
         this.fileSystem = pair.getValue();
+        this.fileSystem.setWriteChecksum(false);
     }
 }

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxy.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxy.java
@@ -56,7 +56,7 @@ public class HiveMetaStoreProxy {
                 String hiveSitePath = config.getString(HiveConfig.HIVE_SITE_PATH.key());
                 hiveConf.addResource(new File(hiveSitePath).toURI().toURL());
             }
-            if (enableKerberos(config)) {
+            if (HiveMetaStoreProxyUtils.enableKerberos(config)) {
                 this.hiveMetaStoreClient =
                         HadoopLoginFactory.loginWithKerberos(
                                 new Configuration(),
@@ -71,7 +71,7 @@ public class HiveMetaStoreProxy {
                                         new HiveMetaStoreClient(hiveConf));
                 return;
             }
-            if (enableRemoteUser(config)) {
+            if (HiveMetaStoreProxyUtils.enableRemoteUser(config)) {
                 this.hiveMetaStoreClient =
                         HadoopLoginFactory.loginWithRemoteUser(
                                 new Configuration(),
@@ -148,26 +148,5 @@ public class HiveMetaStoreProxy {
             hiveMetaStoreClient.close();
             HiveMetaStoreProxy.INSTANCE = null;
         }
-    }
-
-    private boolean enableKerberos(Config config) {
-        boolean kerberosPrincipalEmpty =
-                config.hasPath(BaseSourceConfigOptions.KERBEROS_PRINCIPAL.key());
-        boolean kerberosKeytabPathEmpty =
-                config.hasPath(BaseSourceConfigOptions.KERBEROS_KEYTAB_PATH.key());
-        if (kerberosKeytabPathEmpty && kerberosPrincipalEmpty) {
-            return false;
-        }
-        if (!kerberosPrincipalEmpty && !kerberosKeytabPathEmpty) {
-            return true;
-        }
-        if (kerberosPrincipalEmpty) {
-            throw new IllegalArgumentException("Please set kerberosPrincipal");
-        }
-        throw new IllegalArgumentException("Please set kerberosKeytabPath");
-    }
-
-    private boolean enableRemoteUser(Config config) {
-        return config.hasPath(BaseSourceConfigOptions.REMOTE_USER.key());
     }
 }

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyUtils.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hive.utils;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.connectors.seatunnel.file.config.BaseSourceConfigOptions;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class HiveMetaStoreProxyUtils {
+
+    public boolean enableKerberos(Config config) {
+        boolean kerberosPrincipalEmpty =
+                config.hasPath(BaseSourceConfigOptions.KERBEROS_PRINCIPAL.key());
+        boolean kerberosKeytabPathEmpty =
+                config.hasPath(BaseSourceConfigOptions.KERBEROS_KEYTAB_PATH.key());
+        if (kerberosKeytabPathEmpty && kerberosPrincipalEmpty) {
+            return true;
+        }
+        if (!kerberosPrincipalEmpty && !kerberosKeytabPathEmpty) {
+            return false;
+        }
+        if (kerberosPrincipalEmpty) {
+            throw new IllegalArgumentException("Please set kerberosPrincipal");
+        }
+        throw new IllegalArgumentException("Please set kerberosKeytabPath");
+    }
+
+    public boolean enableRemoteUser(Config config) {
+        return config.hasPath(BaseSourceConfigOptions.REMOTE_USER.key());
+    }
+}

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hive.utils;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.SneakyThrows;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HiveMetaStoreProxyUtilsTest {
+
+    @Test
+    void enableKerberos() {
+        Config config = parseConfig("/hive_without_kerberos.conf");
+        assertFalse(HiveMetaStoreProxyUtils.enableKerberos(config));
+        assertFalse(HiveMetaStoreProxyUtils.enableRemoteUser(config));
+
+        config = parseConfig("/hive_with_kerberos.conf");
+        assertTrue(HiveMetaStoreProxyUtils.enableKerberos(config));
+        assertFalse(HiveMetaStoreProxyUtils.enableRemoteUser(config));
+
+        config = parseConfig("/hive_with_remoteuser.conf");
+        assertTrue(HiveMetaStoreProxyUtils.enableRemoteUser(config));
+    }
+
+    @SneakyThrows
+    private Config parseConfig(String configFile) {
+        URL resource = HiveMetaStoreProxyUtilsTest.class.getResource(configFile);
+        String filePath = Paths.get(resource.toURI()).toString();
+        return ConfigFactory.parseFile(new File(filePath));
+    }
+}

--- a/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_with_kerberos.conf
+++ b/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_with_kerberos.conf
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{
+    table_name="temp.group_brand_order_list_board"
+    metastore_uri="thrift://localhost:9083"
+    hdfs_site_path = "/etc/hadoop/conf/hdfs-site.xml"
+    kerberos_principal = "hadoop"
+    kerberos_keytab_path = "/home/hadoop/hadoop.keytab"
+}

--- a/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_with_remoteuser.conf
+++ b/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_with_remoteuser.conf
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{
+    table_name="temp.group_brand_order_list_board"
+    metastore_uri="thrift://localhost:9083"
+    hdfs_site_path = "/etc/hadoop/conf/hdfs-site.xml"
+    remote_user = "hadoop"
+}

--- a/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_without_kerberos.conf
+++ b/seatunnel-connectors-v2/connector-hive/src/test/resources/hive_without_kerberos.conf
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{
+    table_name="temp.group_brand_order_list_board"
+    metastore_uri="thrift://localhost:9083"
+    hdfs_site_path = "/etc/hadoop/conf/hdfs-site.xml"
+}


### PR DESCRIPTION
### Purpose of this pull request

close #6297


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Verify by UT


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).