### PR TITLE
[BugFix][Connector-file-sftp] Fix SFTPInputStream.close bug

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPInputStream.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPInputStream.java
@@ -110,6 +110,7 @@ public class SFTPInputStream extends FSInputStream {
         if (closed) {
             return;
         }
+        wrappedStream.close();
         super.close();
         closed = true;
         if (!channel.isConnected()) {


### PR DESCRIPTION
### Purpose of this pull request
fix bug: SFTPInputStream.close does not correctly trigger the closing of the file stream(#6323)

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
General functionality bug fixes, no need to add testing.


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).