### PR TITLE
[Fix][API] Fix get SeaTunnelRow size failed when array value has `null`

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
@@ -237,7 +237,9 @@ public final class SeaTunnelRow implements Serializable {
             case "String[]":
                 int s = 0;
                 for (String i : ((String[]) v)) {
-                    s += i.length();
+                    if (null != i) {
+                        s += i.length();
+                    }
                 }
                 return s;
             case "Boolean[]":

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
@@ -96,12 +96,8 @@ public final class SeaTunnelRow implements Serializable {
 
     private int getArrayNonEmptySize(Object objects) {
         int size = 0;
-        if (null == objects) {
-            return size;
-        }
-        Object object = objects;
-        if (object instanceof Object[]) {
-            Object[] nonEmptyArrays = (Object[]) object;
+        if (objects instanceof Object[]) {
+            Object[] nonEmptyArrays = (Object[]) objects;
             for (int i = 0; i < nonEmptyArrays.length; i++) {
                 if (null != nonEmptyArrays[i]) {
                     size += 1;

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
@@ -94,6 +94,23 @@ public final class SeaTunnelRow implements Serializable {
         return newRow;
     }
 
+    private int getArrayNonEmptySize(Object objects) {
+        int size = 0;
+        if (null == objects) {
+            return size;
+        }
+        Object object = objects;
+        if (object instanceof Object[]) {
+            Object[] nonEmptyArrays = (Object[]) object;
+            for (int i = 0; i < nonEmptyArrays.length; i++) {
+                if (null != nonEmptyArrays[i]) {
+                    size += 1;
+                }
+            }
+        }
+        return size;
+    }
+
     public boolean isNullAt(int pos) {
         return this.fields[pos] == null;
     }
@@ -167,27 +184,27 @@ public final class SeaTunnelRow implements Serializable {
     }
 
     private int getBytesForArray(Object v, BasicType<?> dataType) {
+        int arrayNonEmptySize = getArrayNonEmptySize(v);
         switch (dataType.getSqlType()) {
             case STRING:
                 int s = 0;
                 for (String i : ((String[]) v)) {
-                    s += i.length();
+                    if (null != i) {
+                        s += i.length();
+                    }
                 }
                 return s;
             case BOOLEAN:
-                return ((Boolean[]) v).length;
             case TINYINT:
-                return ((Byte[]) v).length;
+                return arrayNonEmptySize;
             case SMALLINT:
-                return ((Short[]) v).length * 2;
+                return arrayNonEmptySize * 2;
             case INT:
-                return ((Integer[]) v).length * 4;
             case FLOAT:
-                return ((Float[]) v).length * 4;
+                return arrayNonEmptySize * 4;
             case BIGINT:
-                return ((Long[]) v).length * 8;
             case DOUBLE:
-                return ((Double[]) v).length * 8;
+                return arrayNonEmptySize * 8;
             case NULL:
             default:
                 return 0;
@@ -210,6 +227,7 @@ public final class SeaTunnelRow implements Serializable {
             return 0;
         }
         String clazz = v.getClass().getSimpleName();
+        int arrayNonEmptySize = getArrayNonEmptySize(v);
         switch (clazz) {
             case "String":
                 return ((String) v).length();
@@ -226,8 +244,6 @@ public final class SeaTunnelRow implements Serializable {
                 return 8;
             case "BigDecimal":
                 return 36;
-            case "byte[]":
-                return ((byte[]) v).length;
             case "LocalDate":
                 return 24;
             case "LocalTime":
@@ -242,20 +258,18 @@ public final class SeaTunnelRow implements Serializable {
                     }
                 }
                 return s;
+            case "byte[]":
             case "Boolean[]":
-                return ((Boolean[]) v).length;
             case "Byte[]":
-                return ((Byte[]) v).length;
+                return arrayNonEmptySize;
             case "Short[]":
-                return ((Short[]) v).length * 2;
+                return arrayNonEmptySize * 2;
             case "Integer[]":
-                return ((Integer[]) v).length * 4;
-            case "Long[]":
-                return ((Long[]) v).length * 8;
             case "Float[]":
-                return ((Float[]) v).length * 4;
+                return arrayNonEmptySize * 4;
+            case "Long[]":
             case "Double[]":
-                return ((Double[]) v).length * 8;
+                return arrayNonEmptySize * 8;
             case "HashMap":
             case "LinkedHashMap":
                 int size = 0;

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/SeaTunnelRowTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/SeaTunnelRowTest.java
@@ -104,4 +104,23 @@ public class SeaTunnelRowTest {
         SeaTunnelRow row = new SeaTunnelRow(new Object[] {map});
         Assertions.assertEquals(8, row.getBytesSize());
     }
+
+    @Test
+    void testArrayEmptyElement() {
+        String[] stringElements = {"key", null, "value"};
+        SeaTunnelRow stringRow = new SeaTunnelRow(new Object[] {stringElements});
+        Assertions.assertEquals(8, stringRow.getBytesSize());
+
+        Double[] doubleElements = {null, 10.0, 12.0};
+        SeaTunnelRow doubleRow = new SeaTunnelRow(new Object[] {doubleElements});
+        Assertions.assertEquals(16, doubleRow.getBytesSize());
+
+        String str = "seatunnel";
+        SeaTunnelRow strRow = new SeaTunnelRow(new Object[] {str});
+        Assertions.assertEquals(9, strRow.getBytesSize());
+
+        String nonStr = null;
+        SeaTunnelRow nonStrRow = new SeaTunnelRow(new Object[] {nonStr});
+        Assertions.assertEquals(0, nonStrRow.getBytesSize());
+    }
 }


### PR DESCRIPTION


### Purpose of this pull request
when get output data byte  size info,There is null data in the collection, abnormal length obtained




<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->






