### PR TITLE
[BUG][Zeta]job name Display error #6470

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
@@ -95,7 +95,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.FINISHED.equals(
-                                                    objectCompletableFuture.get())));
+                                                            objectCompletableFuture.get())));
         }
     }
 
@@ -126,7 +126,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.CANCELED.equals(
-                                                    objectCompletableFuture.get())));
+                                                            objectCompletableFuture.get())));
         }
     }
 
@@ -152,6 +152,7 @@ public class JobExecutionIT {
             Assertions.assertTrue(result.getError().startsWith("java.lang.NumberFormatException"));
         }
     }
+
     @Test
     public void testValidJobName() throws ExecutionException, InterruptedException {
         Common.setDeployMode(DeployMode.CLIENT);
@@ -250,7 +251,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.FAILED.equals(
-                                                    objectCompletableFuture.get())));
+                                                            objectCompletableFuture.get())));
         }
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
@@ -168,8 +168,8 @@ public class JobExecutionIT {
                     CompletableFuture.supplyAsync(clientJobProxy::waitForJobComplete);
             await().atMost(600000, TimeUnit.MILLISECONDS)
                     .untilAsserted(() -> Assertions.assertTrue(completableFuture.isDone()));
-            JobResult result = clientJobProxy.getJobResultCache();
-            Assertions.assertEquals("valid_job_name", jobConfig.getName());
+            String value = engineClient.getJobClient().listJobStatus(false);
+            Assertions.assertTrue(value.contains("\"jobName\":\"valid_job_name\""));
         }
     }
 

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
@@ -154,7 +154,7 @@ public class JobExecutionIT {
     }
 
     @Test
-    public void testValidJobName() throws ExecutionException, InterruptedException {
+    public void testValidJobNameInJobConfig() throws ExecutionException, InterruptedException {
         Common.setDeployMode(DeployMode.CLIENT);
         String filePath = TestUtils.getResource("valid_job_name.conf");
         JobConfig jobConfig = new JobConfig();

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/JobExecutionIT.java
@@ -95,7 +95,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.FINISHED.equals(
-                                                            objectCompletableFuture.get())));
+                                                    objectCompletableFuture.get())));
         }
     }
 
@@ -126,7 +126,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.CANCELED.equals(
-                                                            objectCompletableFuture.get())));
+                                                    objectCompletableFuture.get())));
         }
     }
 
@@ -150,6 +150,25 @@ public class JobExecutionIT {
             JobResult result = clientJobProxy.getJobResultCache();
             Assertions.assertEquals(result.getStatus(), JobStatus.FAILED);
             Assertions.assertTrue(result.getError().startsWith("java.lang.NumberFormatException"));
+        }
+    }
+    @Test
+    public void testValidJobName() throws ExecutionException, InterruptedException {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath = TestUtils.getResource("valid_job_name.conf");
+        JobConfig jobConfig = new JobConfig();
+        ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+        clientConfig.setClusterName(TestUtils.getClusterName("JobExecutionIT"));
+        try (SeaTunnelClient engineClient = new SeaTunnelClient(clientConfig)) {
+            ClientJobExecutionEnvironment jobExecutionEnv =
+                    engineClient.createExecutionContext(filePath, jobConfig, SEATUNNEL_CONFIG);
+            final ClientJobProxy clientJobProxy = jobExecutionEnv.execute();
+            CompletableFuture<JobStatus> completableFuture =
+                    CompletableFuture.supplyAsync(clientJobProxy::waitForJobComplete);
+            await().atMost(600000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> Assertions.assertTrue(completableFuture.isDone()));
+            JobResult result = clientJobProxy.getJobResultCache();
+            Assertions.assertEquals("valid_job_name", jobConfig.getName());
         }
     }
 
@@ -231,7 +250,7 @@ public class JobExecutionIT {
                                     Assertions.assertTrue(
                                             objectCompletableFuture.isDone()
                                                     && JobStatus.FAILED.equals(
-                                                            objectCompletableFuture.get())));
+                                                    objectCompletableFuture.get())));
         }
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/valid_job_name.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/valid_job_name.conf
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
+env {
+  # You can set engine configuration here
+  job.mode = "BATCH"
+  job.name = "valid_job_name"
+  #execution.checkpoint.data-uri = "hdfs://localhost:9000/checkpoint"
+}
+
+source {
+  # This is a example source plugin **only for test and demonstrate the feature source plugin**
+  FakeSource {
+    result_table_name = "fake"
+    parallelism = 4
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  console {
+    source_table_name="fake"
+  }
+}

--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/ClientJobExecutionEnvironment.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/ClientJobExecutionEnvironment.java
@@ -153,12 +153,13 @@ public class ClientJobExecutionEnvironment extends AbstractJobEnvironment {
     }
 
     public ClientJobProxy execute() throws ExecutionException, InterruptedException {
+        LogicalDag logicalDag = getLogicalDag();
         JobImmutableInformation jobImmutableInformation =
                 new JobImmutableInformation(
                         Long.parseLong(jobConfig.getJobContext().getJobId()),
                         jobConfig.getName(),
                         isStartWithSavePoint,
-                        seaTunnelHazelcastClient.getSerializationService().toData(getLogicalDag()),
+                        seaTunnelHazelcastClient.getSerializationService().toData(logicalDag),
                         jobConfig,
                         new ArrayList<>(jarUrls),
                         new ArrayList<>(connectorJarIdentifiers));

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -251,7 +251,8 @@ public class MultipleTableJobConfigParser {
     private void fillJobConfig() {
         jobConfig.getJobContext().setJobMode(envOptions.get(EnvCommonOptions.JOB_MODE));
         if (StringUtils.isEmpty(jobConfig.getName())
-                || jobConfig.getName().equals(Constants.LOGO)) {
+                || jobConfig.getName().equals(Constants.LOGO)
+                || jobConfig.getName().equals(EnvCommonOptions.JOB_NAME.defaultValue()) ) {
             jobConfig.setName(envOptions.get(EnvCommonOptions.JOB_NAME));
         }
         envOptions

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -252,7 +252,7 @@ public class MultipleTableJobConfigParser {
         jobConfig.getJobContext().setJobMode(envOptions.get(EnvCommonOptions.JOB_MODE));
         if (StringUtils.isEmpty(jobConfig.getName())
                 || jobConfig.getName().equals(Constants.LOGO)
-                || jobConfig.getName().equals(EnvCommonOptions.JOB_NAME.defaultValue()) ) {
+                || jobConfig.getName().equals(EnvCommonOptions.JOB_NAME.defaultValue())) {
             jobConfig.setName(envOptions.get(EnvCommonOptions.JOB_NAME));
         }
         envOptions


### PR DESCRIPTION
This PR is to fix seatunnel issue #6470 


Does this PR introduce any user-facing change?
No


How was this patch tested?
by bin/seatunnel.sh -c config/test.conf , submit job to server;
Then, use the command bin/seatunnel. sh - l to view the task status information, and the job name will be displayed based on the job.name in the configuration file


Check list

 