### PR TITLE
[Improve] StarRocksSourceReader  use the existing client 

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/source/StarRocksBeReadClient.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/source/StarRocksBeReadClient.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode.CLOSE_BE_READER_FAILED;
@@ -55,21 +55,12 @@ public class StarRocksBeReadClient implements Serializable {
     private String contextId;
     private int readerOffset = 0;
     private final SourceConfig sourceConfig;
-    private final SeaTunnelRowType seaTunnelRowType;
+    private SeaTunnelRowType seaTunnelRowType;
     private StarRocksRowBatchReader rowBatch;
-
-    private final List<Long> tabletIds;
-
-    private final String queryPlan;
     protected AtomicBoolean eos = new AtomicBoolean(false);
 
-    public StarRocksBeReadClient(
-            QueryPartition queryPartition,
-            SourceConfig sourceConfig,
-            SeaTunnelRowType seaTunnelRowType) {
+    public StarRocksBeReadClient(String beNodeInfo, SourceConfig sourceConfig) {
         this.sourceConfig = sourceConfig;
-        this.seaTunnelRowType = seaTunnelRowType;
-        String beNodeInfo = queryPartition.getBeAddress();
         log.debug("Parse StarRocks BE address: '{}'.", beNodeInfo);
         String[] hostPort = beNodeInfo.split(":");
         if (hostPort.length != 2) {
@@ -79,8 +70,6 @@ public class StarRocksBeReadClient implements Serializable {
         }
         this.ip = hostPort[0].trim();
         this.port = Integer.parseInt(hostPort[1].trim());
-        this.queryPlan = queryPartition.getQueryPlan();
-        this.tabletIds = new ArrayList<>(queryPartition.getTabletIds());
         TBinaryProtocol.Factory factory = new TBinaryProtocol.Factory();
         TSocket socket =
                 new TSocket(
@@ -101,10 +90,12 @@ public class StarRocksBeReadClient implements Serializable {
         client = new TStarrocksExternalService.Client(protocol);
     }
 
-    public void openScanner() {
+    public void openScanner(QueryPartition partition, SeaTunnelRowType seaTunnelRowType) {
+        this.seaTunnelRowType = seaTunnelRowType;
+        Set<Long> tabletIds = partition.getTabletIds();
         TScanOpenParams params = new TScanOpenParams();
-        params.setTablet_ids(tabletIds);
-        params.setOpaqued_query_plan(queryPlan);
+        params.setTablet_ids(new ArrayList<>(tabletIds));
+        params.setOpaqued_query_plan(partition.getQueryPlan());
         params.setCluster(DEFAULT_CLUSTER_NAME);
         params.setDatabase(sourceConfig.getDatabase());
         params.setTable(sourceConfig.getTable());

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
@@ -37,8 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
-import static org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode.CLOSE_BE_READER_FAILED;
-
 @Slf4j
 public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRocksSourceSplit> {
 
@@ -128,8 +126,7 @@ public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRoc
                                     try {
                                         client.close();
                                     } catch (StarRocksConnectorException e) {
-                                        throw new StarRocksConnectorException(
-                                                CLOSE_BE_READER_FAILED, e);
+                                        log.error("Failed to close reader:", e);
                                     }
                                 }
                             });

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.starrocks.source;
 
-import com.starrocks.shade.org.apache.thrift.TException;
 import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
@@ -26,13 +25,17 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.client.source.StarRocksBeReadClient;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.client.source.model.QueryPartition;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SourceConfig;
-
-import lombok.extern.slf4j.Slf4j;
-import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorException;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
 import static org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode.CLOSE_BE_READER_FAILED;
 
@@ -117,15 +120,19 @@ public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRoc
     @Override
     public void close() throws IOException {
         if (!clientsPools.isEmpty()) {
-            clientsPools.values().forEach(client -> {
-                if (client != null) {
-                    try {
-                        client.close();
-                    } catch (StarRocksConnectorException e) {
-                        throw new StarRocksConnectorException(CLOSE_BE_READER_FAILED, e);
-                    }
-                }
-            });
+            clientsPools
+                    .values()
+                    .forEach(
+                            client -> {
+                                if (client != null) {
+                                    try {
+                                        client.close();
+                                    } catch (StarRocksConnectorException e) {
+                                        throw new StarRocksConnectorException(
+                                                CLOSE_BE_READER_FAILED, e);
+                                    }
+                                }
+                            });
         }
     }
 

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
@@ -23,14 +23,17 @@ import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.client.source.StarRocksBeReadClient;
+import org.apache.seatunnel.connectors.seatunnel.starrocks.client.source.model.QueryPartition;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SourceConfig;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 
 @Slf4j
@@ -40,6 +43,7 @@ public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRoc
     private final SourceReader.Context context;
     private final SourceConfig sourceConfig;
     private final SeaTunnelRowType seaTunnelRowType;
+    private Map<String, StarRocksBeReadClient> clientsPools;
     private volatile boolean noMoreSplitsAssignment;
 
     public StarRocksSourceReader(
@@ -87,26 +91,34 @@ public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRoc
     }
 
     private void read(StarRocksSourceSplit split, Collector<SeaTunnelRow> output) {
-        StarRocksBeReadClient client =
-                new StarRocksBeReadClient(split.getPartition(), sourceConfig, seaTunnelRowType);
+
+        QueryPartition partition = split.getPartition();
+        String beAddress = partition.getBeAddress();
+        StarRocksBeReadClient client = null;
+        if (clientsPools.containsKey(beAddress)) {
+            client = clientsPools.get(beAddress);
+        } else {
+            client = new StarRocksBeReadClient(beAddress, sourceConfig);
+            clientsPools.put(beAddress, client);
+        }
         // open scanner to be
-        client.openScanner();
+        client.openScanner(partition, seaTunnelRowType);
         while (client.hasNext()) {
             SeaTunnelRow seaTunnelRow = client.getNext();
             output.collect(seaTunnelRow);
         }
-        // close client to be
-        if (client != null) {
-            client.close();
-        }
     }
 
     @Override
-    public void open() throws Exception {}
+    public void open() throws Exception {
+        clientsPools = new LinkedHashMap<>(5);
+    }
 
     @Override
     public void close() throws IOException {
-        // nothing to do
+        if (!clientsPools.isEmpty()) {
+            clientsPools.values().forEach(StarRocksBeReadClient::close);
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceReader.java
@@ -126,7 +126,7 @@ public class StarRocksSourceReader implements SourceReader<SeaTunnelRow, StarRoc
                                     try {
                                         client.close();
                                     } catch (StarRocksConnectorException e) {
-                                        log.error("Failed to close reader:", e);
+                                        log.error("Failed to close reader: ", e);
                                     }
                                 }
                             });


### PR DESCRIPTION
Purpose of this pull request

StarRocksSourceReader reads partition data using the existing client instead of re-establishing a connection for each partition.

Does this PR introduce any user-facing change?
no

How was this patch tested?
exist tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).