### PR TITLE
[Improve][Jdbc] Support custom case-sensitive config for dameng

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
@@ -22,7 +22,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRow
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectTypeMapper;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,13 +30,11 @@ import java.util.stream.Collectors;
 
 public class DmdbDialect implements JdbcDialect {
 
-    public String fieldIde = FieldIdeEnum.ORIGINAL.getValue();
+    public String fieldIde;
 
     public DmdbDialect(String fieldIde) {
         this.fieldIde = fieldIde;
     }
-
-    public DmdbDialect() {}
 
     @Override
     public String dialectName() {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm;
 
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
 
 import com.google.auto.service.AutoService;
 
@@ -33,6 +34,11 @@ public class DmdbDialectFactory implements JdbcDialectFactory {
 
     @Override
     public JdbcDialect create() {
-        return new DmdbDialect();
+        return create(null, FieldIdeEnum.ORIGINAL.getValue());
+    }
+
+    @Override
+    public JdbcDialect create(String compatibleMode, String fieldIde) {
+        return new DmdbDialect(fieldIde);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DmdbDialectTest {
+    @Test
+    public void testIdentifierCaseSensitive() {
+        DmdbDialectFactory factory = new DmdbDialectFactory();
+
+        JdbcDialect dialect = factory.create();
+        Assertions.assertEquals("\"test\"", dialect.quoteIdentifier("test"));
+        Assertions.assertEquals("\"TEST\"", dialect.quoteIdentifier("TEST"));
+
+        dialect = factory.create(null, FieldIdeEnum.ORIGINAL.getValue());
+        Assertions.assertEquals("\"test\"", dialect.quoteIdentifier("test"));
+        Assertions.assertEquals("\"TEST\"", dialect.quoteIdentifier("TEST"));
+
+        dialect = factory.create(null, FieldIdeEnum.LOWERCASE.getValue());
+        Assertions.assertEquals("\"test\"", dialect.quoteIdentifier("test"));
+        Assertions.assertEquals("\"test\"", dialect.quoteIdentifier("TEST"));
+
+        dialect = factory.create(null, FieldIdeEnum.UPPERCASE.getValue());
+        Assertions.assertEquals("\"TEST\"", dialect.quoteIdentifier("test"));
+        Assertions.assertEquals("\"TEST\"", dialect.quoteIdentifier("TEST"));
+    }
+}


### PR DESCRIPTION

### Purpose of this pull request

[Jdbc] Support custom case-sensitive config for dameng

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).