### PR TITLE
[Bug][connector-jdbc] JDBC get primitive type null value bug (#6567)

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
@@ -111,6 +111,9 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                             CommonErrorCodeDeprecated.UNSUPPORTED_DATA_TYPE,
                             "Unexpected value: " + seaTunnelDataType);
             }
+            if (rs.wasNull()) {
+                fields[fieldIndex] = null;
+            }
         }
         return new SeaTunnelRow(fields);
     }


### PR DESCRIPTION
### Purpose of this pull request
According to the JDK JDBC interface, when converting to a primitive type, if the column value was `null`, the returned values would be the default value of the corresponding primitive type. For example if the value of an type int in MySQL database is `null`, but in Hive it will be `0`. This is a bug.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
yes

### Check list
No