### PR TITLE
[Bugfix][TDengine] Fix the issue of losing the driver due to multiple calls to the submit task API. #6581

### DIFF
--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
@@ -56,6 +56,7 @@ import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengine
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.URL;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.USERNAME;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.buildSourceConfig;
+import static org.apache.seatunnel.connectors.seatunnel.tdengine.utils.TDengineUtil.checkDriverExist;
 
 /**
  * TDengine source each split corresponds one subtable
@@ -135,6 +136,8 @@ public class TDengineSource
                         config.getUsername(),
                         "&password=",
                         config.getPassword());
+        // check td driver whether exist and if not, try to register
+        checkDriverExist(jdbcUrl);
         try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
             try (Statement statement = conn.createStatement()) {
                 ResultSet metaResultSet =

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSourceReader.java
@@ -44,6 +44,8 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.seatunnel.connectors.seatunnel.tdengine.utils.TDengineUtil.checkDriverExist;
+
 @Slf4j
 public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengineSourceSplit> {
 
@@ -108,6 +110,8 @@ public class TDengineSourceReader implements SourceReader<SeaTunnelRow, TDengine
         // @bobo (tdengine)
         connProps.setProperty(TSDBDriver.PROPERTY_KEY_BATCH_LOAD, "false");
         try {
+            // check td driver whether exist and if not, try to register
+            checkDriverExist(jdbcUrl);
             conn = DriverManager.getConnection(jdbcUrl, connProps);
         } catch (SQLException e) {
             throw new TDengineConnectorException(


### PR DESCRIPTION
### Purpose of this pull request
[Bugfix][TDengine] Fix the issue of losing the driver due to multiple calls to the submit task API. #6581

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).