### PR TITLE
fix seatunnel-issue-6386 and windows specific starter cmd script bug

### DIFF
--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/SystemUtil.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/SystemUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.utils;
+
+import org.apache.commons.lang3.SystemUtils;
+
+public class SystemUtil {
+
+    public static String GetOsType() {
+        String os_type = "";
+
+        if (SystemUtils.IS_OS_WINDOWS) {
+            os_type = "Windows";
+        } else if (SystemUtils.IS_OS_MAC) {
+            os_type = "Mac";
+        } else if (SystemUtils.IS_OS_LINUX) {
+            os_type = "Linux";
+        } else if (SystemUtils.IS_OS_SOLARIS) {
+            os_type = "Solaris";
+        } else {
+            os_type = "Unknown";
+        }
+
+        return os_type;
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/bin/start-seatunnel-flink-13-connector-v2.cmd
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/bin/start-seatunnel-flink-13-connector-v2.cmd
@@ -27,7 +27,11 @@ cd /d "%PRG_DIR%" || (
   exit /b 1
 )
 
-set "APP_DIR=%~dp0"
+set "currentDir=%~dp0"
+set "currentDir=%currentDir:~0,-1%"
+for %%i in ("%currentDir%") do set "APP_DIR=%%~dpi"
+set "APP_DIR=%APP_DIR:~0,-1%"
+rem set "APP_DIR=%~dp0"
 set "CONF_DIR=%APP_DIR%\config"
 set "APP_JAR=%APP_DIR%\starter\seatunnel-flink-13-starter.jar"
 set "APP_MAIN=org.apache.seatunnel.core.starter.flink.FlinkStarter"
@@ -51,20 +55,21 @@ if exist "%CONF_DIR%\log4j2.properties" (
 )
 
 set "CLASS_PATH=%APP_DIR%\starter\logging\*;%APP_JAR%"
+set "full_java_cmd=java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%"
 
-for /f "delims=" %%i in ('java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%') do (
-  set "CMD=%%i"
-  setlocal disabledelayedexpansion
+for /f "delims=" %%i in ('echo !full_java_cmd!') do (
+  rem set "CMD=%%i"
+  rem setlocal disabledelayedexpansion
   if !errorlevel! equ 234 (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b 0
   ) else if !errorlevel! equ 0 (
-    echo Execute SeaTunnel Flink Job: !CMD!
+    echo Execute SeaTunnel Flink Job: %full_java_cmd%
     endlocal
-    call !CMD!
+    call %full_java_cmd%
   ) else (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b !errorlevel!
   )

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/main/bin/start-seatunnel-flink-15-connector-v2.cmd
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/main/bin/start-seatunnel-flink-15-connector-v2.cmd
@@ -27,7 +27,11 @@ cd /d "%PRG_DIR%" || (
   exit /b 1
 )
 
-set "APP_DIR=%~dp0"
+set "currentDir=%~dp0"
+set "currentDir=%currentDir:~0,-1%"
+for %%i in ("%currentDir%") do set "APP_DIR=%%~dpi"
+set "APP_DIR=%APP_DIR:~0,-1%"
+rem set "APP_DIR=%~dp0"
 set "CONF_DIR=%APP_DIR%\config"
 set "APP_JAR=%APP_DIR%\starter\seatunnel-flink-15-starter.jar"
 set "APP_MAIN=org.apache.seatunnel.core.starter.flink.FlinkStarter"
@@ -51,20 +55,21 @@ if exist "%CONF_DIR%\log4j2.properties" (
 )
 
 set "CLASS_PATH=%APP_DIR%\starter\logging\*;%APP_JAR%"
+set "full_java_cmd=java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%"
 
-for /f "delims=" %%i in ('java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%') do (
-  set "CMD=%%i"
-  setlocal disabledelayedexpansion
+for /f "delims=" %%i in ('echo !full_java_cmd!') do (
+  rem set "CMD=%%i"
+  rem setlocal disabledelayedexpansion
   if !errorlevel! equ 234 (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b 0
   ) else if !errorlevel! equ 0 (
-    echo Execute SeaTunnel Flink Job: !CMD!
+    echo Execute SeaTunnel Flink Job: %full_java_cmd%
     endlocal
-    call !CMD!
+    call %full_java_cmd%
   ) else (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b !errorlevel!
   )

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/FlinkStarter.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/FlinkStarter.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.core.starter.Starter;
 import org.apache.seatunnel.core.starter.enums.EngineType;
 import org.apache.seatunnel.core.starter.flink.args.FlinkCommandArgs;
 import org.apache.seatunnel.core.starter.utils.CommandLineUtils;
+import org.apache.seatunnel.core.starter.utils.SystemUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +45,7 @@ public class FlinkStarter implements Starter {
         this.appJar = Common.appStarterDir().resolve(APP_JAR_NAME).toString();
     }
 
+    @SuppressWarnings("checkstyle:RegexpSingleline")
     public static void main(String[] args) {
         FlinkStarter flinkStarter = new FlinkStarter(args);
         System.out.println(String.join(" ", flinkStarter.buildCommands()));
@@ -52,8 +54,46 @@ public class FlinkStarter implements Starter {
     @Override
     public List<String> buildCommands() {
         List<String> command = new ArrayList<>();
+        String local_os_type = "";
+
+        SystemUtil my_system_util = new SystemUtil();
+        local_os_type = my_system_util.GetOsType();
+        // debug
+        // System.out.println("OS type:"+local_os_type);
+
+        String cmd_flink = "";
+
+        /* Nothe that "flink.cmd” or "flink.bat" can be retrieved from
+           lower version of flink (e.g.1.0.9),We do not check if this
+           file exists on the box, user needs to make sure this file
+           exists or not.
+        */
+        switch (local_os_type.toLowerCase()) {
+            case "windows":
+                cmd_flink = "%FLINK_HOME%/bin/flink.bat";
+                break;
+            case "linux":
+                cmd_flink = "${FLINK_HOME}/bin/flink";
+                break;
+            case "solaris":
+                cmd_flink = "${FLINK_HOME}/bin/flink";
+                break;
+            case "mac":
+                cmd_flink = "${FLINK_HOME}/bin/flink";
+                break;
+            case "unknown":
+                cmd_flink = "error";
+                break;
+        }
+
         // set start command
-        command.add("${FLINK_HOME}/bin/flink");
+        if (!(cmd_flink.equals("error"))) {
+            command.add(cmd_flink);
+        } else {
+            System.out.println("Error: Can not determine OS type, abort run !");
+            System.exit(-1);
+        }
+
         // set deploy mode, run or run-application
         command.add(flinkCommandArgs.getDeployMode().getDeployMode());
         // set submitted target master
@@ -91,6 +131,8 @@ public class FlinkStarter implements Starter {
                 .filter(Objects::nonNull)
                 .map(String::trim)
                 .forEach(variable -> command.add("-D" + variable));
+        // debug
+        // System.out.println("Whole command string:" + command.toString());
         return command;
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/TestFlinkJobCommandReturnV13.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/TestFlinkJobCommandReturnV13.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+public class TestFlinkJobCommandReturnV13 {
+    @Test
+    public void testSparkJobCommandReturnV13() throws Exception {
+        String flink_job_command = null;
+        String flink_job_command_return = null;
+        String flink_job_command_return_error = null;
+        String flink_home_dir = null;
+        String flink_submit_job_cmd = null;
+        String seatunnel_home_dir = null;
+        String seatunnel_submit_flink_job_jar_list = null;
+        String seatunnel_submit_flink_job_cmd = null;
+        String seatunnel_submit_flink_job_cmd_paras = null;
+        String seatunnel_submit_flink_job_cmd_full_path = null;
+
+        StringBuilder sb_cmd_final = new StringBuilder();
+        String seatunnel_submit_flink_job_cmd_final = null;
+
+        final String separator = "/";
+        Properties prop = new Properties();
+
+        try {
+            InputStream in =
+                    this.getClass()
+                            .getClassLoader()
+                            .getResourceAsStream("flink13-job-command.properties");
+            if (in == null) {
+                throw new FileNotFoundException(
+                        "Resource file not found. Make sure the file exists in src/test/resources.");
+            }
+            prop.load(in);
+
+            flink_home_dir = prop.getProperty("FLINK13_HOME");
+            flink_submit_job_cmd = prop.getProperty("FLINK13_SUBMIT_JOB_CMD");
+            seatunnel_home_dir = prop.getProperty("SEATUNNEL_HOME");
+            seatunnel_submit_flink_job_jar_list =
+                    prop.getProperty("SEATUNNEL_SUBMIT_FLINK13_JOB_JAR_LIST");
+            seatunnel_submit_flink_job_cmd = prop.getProperty("SEATUNNEL_SUBMIT_FLINK13_JOB_CMD");
+
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("bin");
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append(seatunnel_submit_flink_job_cmd);
+            sb_cmd_final.append(" --config ");
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("/config/v2.streaming.conf.template");
+
+            seatunnel_submit_flink_job_cmd_final = sb_cmd_final.toString();
+            // debug
+            // System.out.println("Final command:" + seatunnel_submit_flink_job_cmd_final);
+
+            Process process = Runtime.getRuntime().exec(seatunnel_submit_flink_job_cmd_final);
+            process.waitFor(); // wait for the command to finish
+
+            // Read the stdout of command
+            flink_job_command_return = readStream(process.getInputStream());
+
+            // Read the stderror of command
+            flink_job_command_return_error = readStream(process.getErrorStream());
+            Assertions.assertNotNull(flink_job_command_return);
+            Assertions.assertNull(flink_job_command_return_error);
+
+            /* if (flink_job_command_return_error == null) {
+                System.out.println("Seatunnel flink job submutted successfully.");
+            } else {
+                System.out.println("Seatunnel flink job submutted failed, error messages is:");
+                System.out.println(flink_job_command_return_error);
+            }
+            */
+
+            process.destroy();
+            // debug
+            System.out.println(
+                    "Auto closed [start-seatunnel-flink-13-connector-v2.cmd] successfully.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String readStream(InputStream inputStream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line;
+            StringBuilder sb = new StringBuilder();
+            String str_final = "";
+
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+                sb.append(line);
+            }
+            str_final = sb.toString();
+            if (!(str_final.isEmpty())) {
+                return str_final;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/TestFlinkJobCommandReturnV15.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/TestFlinkJobCommandReturnV15.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+public class TestFlinkJobCommandReturnV15 {
+    @Test
+    public void testSparkJobCommandReturnV15() throws Exception {
+        String flink_job_command = null;
+        String flink_job_command_return = null;
+        String flink_job_command_return_error = null;
+        String flink_home_dir = null;
+        String flink_submit_job_cmd = null;
+        String seatunnel_home_dir = null;
+        String seatunnel_submit_flink_job_jar_list = null;
+        String seatunnel_submit_flink_job_cmd = null;
+        String seatunnel_submit_flink_job_cmd_paras = null;
+        String seatunnel_submit_flink_job_cmd_full_path = null;
+
+        StringBuilder sb_cmd_final = new StringBuilder();
+        String seatunnel_submit_flink_job_cmd_final = null;
+
+        final String separator = "/";
+        Properties prop = new Properties();
+
+        try {
+            InputStream in =
+                    this.getClass()
+                            .getClassLoader()
+                            .getResourceAsStream("flink15-job-command.properties");
+            if (in == null) {
+                throw new FileNotFoundException(
+                        "Resource file not found. Make sure the file exists in src/test/resources.");
+            }
+            prop.load(in);
+
+            flink_home_dir = prop.getProperty("FLINK15_HOME");
+            flink_submit_job_cmd = prop.getProperty("FLINK15_SUBMIT_JOB_CMD");
+            seatunnel_home_dir = prop.getProperty("SEATUNNEL_HOME");
+            seatunnel_submit_flink_job_jar_list =
+                    prop.getProperty("SEATUNNEL_SUBMIT_FLINK15_JOB_JAR_LIST");
+            seatunnel_submit_flink_job_cmd = prop.getProperty("SEATUNNEL_SUBMIT_FLINK15_JOB_CMD");
+
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("bin");
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append(seatunnel_submit_flink_job_cmd);
+            sb_cmd_final.append(" --config ");
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("/config/v2.streaming.conf.template");
+
+            seatunnel_submit_flink_job_cmd_final = sb_cmd_final.toString();
+            // debug
+            // System.out.println("Final command:" + seatunnel_submit_flink_job_cmd_final);
+
+            Process process = Runtime.getRuntime().exec(seatunnel_submit_flink_job_cmd_final);
+            process.waitFor(); // wait for the command to finish
+
+            // Read the stdout of command
+            flink_job_command_return = readStream(process.getInputStream());
+
+            // Read the stderror of command
+            flink_job_command_return_error = readStream(process.getErrorStream());
+            Assertions.assertNotNull(flink_job_command_return);
+            Assertions.assertNull(flink_job_command_return_error);
+
+            /*
+            if (flink_job_command_return_error == null) {
+                System.out.println("Seatunnel flink job submutted successfully.");
+            } else {
+                System.out.println("Seatunnel flink job submutted failed, error messages is:");
+                System.out.println(flink_job_command_return_error);
+            }
+            */
+
+            process.destroy();
+            // debug
+            System.out.println(
+                    "Auto closed [start-seatunnel-flink-15-connector-v2.cmd] successfully.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String readStream(InputStream inputStream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line;
+            StringBuilder sb = new StringBuilder();
+            String str_final = "";
+
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+                sb.append(line);
+            }
+            str_final = sb.toString();
+            if (!(str_final.isEmpty())) {
+                return str_final;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/resources/flink13-job-command.properties
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/resources/flink13-job-command.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This property file defines all properties which is used by submitting spark3(2) job test via spark cmd script
+FLINK13_HOME=E:/Apache/flink/flink-1.13
+FLINK13_SUBMIT_JOB_CMD=flink.bat
+SEATUNNEL_HOME=E:/Apache/seatunnel/apache-seatunnel-2.3.4
+SEATUNNEL_SUBMIT_FLINK13_JOB_CMD=start-seatunnel-flink-13-connector-v2.cmd
+SEATUNNEL_SUBMIT_FLINK13_JOB_JAR_LIST=E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/seatunnel-flink-13-starter.jar;E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/logging/*
+
+

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/resources/flink15-job-command.properties
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/resources/flink15-job-command.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This property file defines all properties which is used by submitting spark3(2) job test via spark cmd script
+FLINK15_HOME=E:/Apache/flink/flink-1.18.1-build-from-src
+FLINK15_SUBMIT_JOB_CMD=flink.bat
+SEATUNNEL_HOME=E:/Apache/seatunnel/apache-seatunnel-2.3.4
+SEATUNNEL_SUBMIT_FLINK15_JOB_CMD=start-seatunnel-flink-15-connector-v2.cmd
+SEATUNNEL_SUBMIT_FLINK15_JOB_JAR_LIST=E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/seatunnel-flink-15-starter.jar;E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/logging/*
+
+

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/bin/start-seatunnel-spark-2-connector-v2.cmd
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/bin/start-seatunnel-spark-2-connector-v2.cmd
@@ -27,7 +27,11 @@ cd /d "%PRG_DIR%" || (
   exit /b 1
 )
 
-set "APP_DIR=%~dp0"
+set "currentDir=%~dp0"
+set "currentDir=%currentDir:~0,-1%"
+for %%i in ("%currentDir%") do set "APP_DIR=%%~dpi"
+set "APP_DIR=%APP_DIR:~0,-1%"
+rem set "APP_DIR=%~dp0"
 set "CONF_DIR=%APP_DIR%\config"
 set "APP_JAR=%APP_DIR%\starter\seatunnel-spark-2-starter.jar"
 set "APP_MAIN=org.apache.seatunnel.core.starter.spark.SparkStarter"
@@ -51,20 +55,21 @@ if exist "%CONF_DIR%\log4j2.properties" (
 )
 
 set "CLASS_PATH=%APP_DIR%\starter\logging\*;%APP_JAR%"
+set "full_java_cmd=java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%"
 
-for /f "delims=" %%i in ('java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%') do (
-  set "CMD=%%i"
-  setlocal disabledelayedexpansion
+for /f "delims=" %%i in ('echo !full_java_cmd!') do (
+  rem set "CMD=%%i"
+  rem setlocal disabledelayedexpansion
   if !errorlevel! equ 234 (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b 0
   ) else if !errorlevel! equ 0 (
-    echo Execute SeaTunnel Spark Job: !CMD!
+    echo Execute SeaTunnel Spark Job: %full_java_cmd%
     endlocal
-    call !CMD!
+    call %full_java_cmd%
   ) else (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b !errorlevel!
   )

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.core.starter.spark.args.SparkCommandArgs;
 import org.apache.seatunnel.core.starter.utils.CommandLineUtils;
 import org.apache.seatunnel.core.starter.utils.CompressionUtils;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
+import org.apache.seatunnel.core.starter.utils.SystemUtil;
 import org.apache.seatunnel.plugin.discovery.PluginIdentifier;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSinkPluginDiscovery;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSourcePluginDiscovery;
@@ -80,6 +81,7 @@ public class SparkStarter implements Starter {
         this.commandArgs = commandArgs;
     }
 
+    @SuppressWarnings("checkstyle:RegexpSingleline")
     public static void main(String[] args) throws IOException {
         SparkStarter starter = getInstance(args);
         List<String> command = starter.buildCommands();
@@ -95,7 +97,7 @@ public class SparkStarter implements Starter {
                 CommandLineUtils.parse(
                         args,
                         new SparkCommandArgs(),
-                        EngineType.SPARK2.getStarterShellName(),
+                        EngineType.SPARK3.getStarterShellName(),
                         true);
         DeployMode deployMode = commandArgs.getDeployMode();
         switch (deployMode) {
@@ -169,7 +171,7 @@ public class SparkStarter implements Starter {
                                 Map.Entry::getKey, e -> e.getValue().unwrapped().toString()));
     }
 
-    /** return connector's jars, which located in 'connectors/*'. */
+    /** return connector's jars, which located in 'connectors/spark/*'. */
     private List<Path> getConnectorJarDependencies() {
         Path pluginRootDir = Common.connectorDir();
         if (!Files.exists(pluginRootDir) || !Files.isDirectory(pluginRootDir)) {
@@ -195,7 +197,40 @@ public class SparkStarter implements Starter {
     /** build final spark-submit commands */
     protected List<String> buildFinal() {
         List<String> commands = new ArrayList<>();
-        commands.add("${SPARK_HOME}/bin/spark-submit");
+        String local_os_type = "";
+
+        SystemUtil my_system_util = new SystemUtil();
+        local_os_type = my_system_util.GetOsType();
+        // debug
+        // System.out.println("OS type:"+local_os_type);
+
+        String cmd_spark = "";
+
+        switch (local_os_type.toLowerCase()) {
+            case "windows":
+                cmd_spark = "%SPARK_HOME%/bin/spark-submit.cmd";
+                break;
+            case "linux":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "solaris":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "mac":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "unknown":
+                cmd_spark = "error";
+                break;
+        }
+
+        if (!(cmd_spark.equals("error"))) {
+            commands.add(cmd_spark);
+        } else {
+            System.out.println("Error: Can not determine OS type, abort run !");
+            System.exit(-1);
+        }
+
         appendOption(commands, "--class", SeaTunnelSpark.class.getName());
         appendOption(commands, "--name", this.commandArgs.getJobName());
         appendOption(commands, "--master", this.commandArgs.getMaster());
@@ -217,6 +252,9 @@ public class SparkStarter implements Starter {
         if (this.commandArgs.isCheckConfig()) {
             commands.add("--check");
         }
+
+        // debug
+        // System.out.println("Whole spark job command string:" + commands.toString());
         return commands;
     }
 
@@ -256,9 +294,10 @@ public class SparkStarter implements Starter {
     /** append appJar to StringBuilder */
     protected void appendAppJar(List<String> commands) {
         commands.add(
-                Common.appStarterDir().resolve(EngineType.SPARK2.getStarterJarName()).toString());
+                Common.appStarterDir().resolve(EngineType.SPARK3.getStarterJarName()).toString());
     }
 
+    @SuppressWarnings("checkstyle:Indentation")
     private List<PluginIdentifier> getPluginIdentifiers(Config config, PluginType... pluginTypes) {
         return Arrays.stream(pluginTypes)
                 .flatMap(

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/main/bin/start-seatunnel-spark-3-connector-v2.cmd
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/main/bin/start-seatunnel-spark-3-connector-v2.cmd
@@ -27,7 +27,11 @@ cd /d "%PRG_DIR%" || (
   exit /b 1
 )
 
-set "APP_DIR=%~dp0"
+set "currentDir=%~dp0"
+set "currentDir=%currentDir:~0,-1%"
+for %%i in ("%currentDir%") do set "APP_DIR=%%~dpi"
+set "APP_DIR=%APP_DIR:~0,-1%"
+rem set "APP_DIR=%~dp0"
 set "CONF_DIR=%APP_DIR%\config"
 set "APP_JAR=%APP_DIR%\starter\seatunnel-spark-3-starter.jar"
 set "APP_MAIN=org.apache.seatunnel.core.starter.spark.SparkStarter"
@@ -51,21 +55,23 @@ if exist "%CONF_DIR%\log4j2.properties" (
 )
 
 set "CLASS_PATH=%APP_DIR%\starter\logging\*;%APP_JAR%"
+set "full_java_cmd=java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%"
 
-for /f "delims=" %%i in ('java %JAVA_OPTS% -cp %CLASS_PATH% %APP_MAIN% %args%') do (
-  set "CMD=%%i"
-  setlocal disabledelayedexpansion
+for /f "delims=" %%i in ('echo !full_java_cmd!') do (
+  rem set "CMD=%%i"
+  rem setlocal disabledelayedexpansion
   if !errorlevel! equ 234 (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b 0
   ) else if !errorlevel! equ 0 (
-    echo Execute SeaTunnel Spark Job: !CMD!
+    echo Execute SeaTunnel Spark Job: %full_java_cmd%
     endlocal
-    call !CMD!
+    call %full_java_cmd%
   ) else (
-    echo !CMD!
+    echo %full_java_cmd%
     endlocal
     exit /b !errorlevel!
   )
 )
+

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/SparkStarter.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.core.starter.spark.args.SparkCommandArgs;
 import org.apache.seatunnel.core.starter.utils.CommandLineUtils;
 import org.apache.seatunnel.core.starter.utils.CompressionUtils;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
+import org.apache.seatunnel.core.starter.utils.SystemUtil;
 import org.apache.seatunnel.plugin.discovery.PluginIdentifier;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSinkPluginDiscovery;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSourcePluginDiscovery;
@@ -80,6 +81,7 @@ public class SparkStarter implements Starter {
         this.commandArgs = commandArgs;
     }
 
+    @SuppressWarnings("checkstyle:RegexpSingleline")
     public static void main(String[] args) throws IOException {
         SparkStarter starter = getInstance(args);
         List<String> command = starter.buildCommands();
@@ -169,7 +171,7 @@ public class SparkStarter implements Starter {
                                 Map.Entry::getKey, e -> e.getValue().unwrapped().toString()));
     }
 
-    /** return connector's jars, which located in 'connectors/*'. */
+    /** return connector's jars, which located in 'connectors/spark/*'. */
     private List<Path> getConnectorJarDependencies() {
         Path pluginRootDir = Common.connectorDir();
         if (!Files.exists(pluginRootDir) || !Files.isDirectory(pluginRootDir)) {
@@ -195,7 +197,40 @@ public class SparkStarter implements Starter {
     /** build final spark-submit commands */
     protected List<String> buildFinal() {
         List<String> commands = new ArrayList<>();
-        commands.add("${SPARK_HOME}/bin/spark-submit");
+        String local_os_type = "";
+
+        SystemUtil my_system_util = new SystemUtil();
+        local_os_type = my_system_util.GetOsType();
+        // debug
+        // System.out.println("OS type:"+local_os_type);
+
+        String cmd_spark = "";
+
+        switch (local_os_type.toLowerCase()) {
+            case "windows":
+                cmd_spark = "%SPARK_HOME%/bin/spark-submit.cmd";
+                break;
+            case "linux":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "solaris":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "mac":
+                cmd_spark = "${SPARK_HOME}/bin/spark-submit";
+                break;
+            case "unknown":
+                cmd_spark = "error";
+                break;
+        }
+
+        if (!(cmd_spark.equals("error"))) {
+            commands.add(cmd_spark);
+        } else {
+            System.out.println("Error: Can not determine OS type, abort run !");
+            System.exit(-1);
+        }
+
         appendOption(commands, "--class", SeaTunnelSpark.class.getName());
         appendOption(commands, "--name", this.commandArgs.getJobName());
         appendOption(commands, "--master", this.commandArgs.getMaster());
@@ -217,6 +252,9 @@ public class SparkStarter implements Starter {
         if (this.commandArgs.isCheckConfig()) {
             commands.add("--check");
         }
+
+        // debug
+        // System.out.println("Whole spark job command string:" + commands.toString());
         return commands;
     }
 
@@ -259,6 +297,7 @@ public class SparkStarter implements Starter {
                 Common.appStarterDir().resolve(EngineType.SPARK3.getStarterJarName()).toString());
     }
 
+    @SuppressWarnings("checkstyle:Indentation")
     private List<PluginIdentifier> getPluginIdentifiers(Config config, PluginType... pluginTypes) {
         return Arrays.stream(pluginTypes)
                 .flatMap(

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/java/org/apache/seatunnel/core/starter/spark/TestSparkJobCommandReturnV2.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/java/org/apache/seatunnel/core/starter/spark/TestSparkJobCommandReturnV2.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.spark;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+public class TestSparkJobCommandReturnV2 {
+    @Test
+    public void testSparkJobCommandReturnV2() throws Exception {
+        String spark2_job_command = null;
+        String spark2_job_command_return = null;
+        String spark2_job_command_return_error = null;
+        String spark2_home_dir = null;
+        String spark2_submit_job_cmd = null;
+        String seatunnel_home_dir = null;
+        String seatunnel_submit_spark2_job_jar_list = null;
+        String seatunnel_submit_spark2_job_cmd = null;
+        String seatunnel_submit_spark2_job_cmd_paras = null;
+        String seatunnel_submit_spark2_job_cmd_full_path = null;
+
+        StringBuilder sb_cmd_final = new StringBuilder();
+        String seatunnel_submit_spark2_job_cmd_final = null;
+
+        final String separator = "/";
+        Properties prop = new Properties();
+
+        try {
+            InputStream in =
+                    this.getClass()
+                            .getClassLoader()
+                            .getResourceAsStream("spark-2-job-command.properties");
+            if (in == null) {
+                throw new FileNotFoundException(
+                        "Resource file not found. Make sure the file exists in src/test/resources.");
+            }
+            prop.load(in);
+
+            spark2_home_dir = prop.getProperty("SPARK2_HOME");
+            spark2_submit_job_cmd = prop.getProperty("SPARK2_SUBMIT_JOB_CMD");
+            seatunnel_home_dir = prop.getProperty("SEATUNNEL_HOME");
+            seatunnel_submit_spark2_job_jar_list =
+                    prop.getProperty("SEATUNNEL_SUBMIT_SPARK2_JOB_JAR_LIST");
+            seatunnel_submit_spark2_job_cmd = prop.getProperty("SEATUNNEL_SUBMIT_SPARK2_JOB_CMD");
+
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("bin");
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append(seatunnel_submit_spark2_job_cmd);
+            sb_cmd_final.append(" --config ");
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("/config/v2.batch.config.template");
+
+            seatunnel_submit_spark2_job_cmd_final = sb_cmd_final.toString();
+            // debug
+            // System.out.println("Final command:" + seatunnel_submit_spark2_job_cmd_final);
+
+            Process process = Runtime.getRuntime().exec(seatunnel_submit_spark2_job_cmd_final);
+            process.waitFor(); // wait for the command to finish
+
+            // Read the stdout of command
+            spark2_job_command_return = readStream(process.getInputStream());
+
+            // Read the stderror of command
+            spark2_job_command_return_error = readStream(process.getErrorStream());
+            // debug
+            System.out.println("Job command returns:" + spark2_job_command_return);
+
+            Assertions.assertNotNull(spark2_job_command_return);
+            Assertions.assertNull(spark2_job_command_return_error);
+
+            /*
+            if (spark2_job_command_return_error == null) {
+                System.out.println("Seatunnel Spark2 job submutted successfully.");
+            } else {
+                System.out.println("Seatunnel Spark2 job submutted failed, error messages is:");
+                System.out.println(spark2_job_command_return_error);
+            }*/
+
+            process.destroy();
+            // debug
+            System.out.println(
+                    "Auto closed [start-seatunnel-spark-2-connector-v2.cmd] successfully.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String readStream(InputStream inputStream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line;
+            StringBuilder sb = new StringBuilder();
+            String str_final = "";
+
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+                sb.append(line);
+            }
+            str_final = sb.toString();
+            if (!(str_final.isEmpty())) {
+                return str_final;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/java/org/apache/seatunnel/core/starter/spark/TestSparkJobCommandReturnV3.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/java/org/apache/seatunnel/core/starter/spark/TestSparkJobCommandReturnV3.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.spark;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+public class TestSparkJobCommandReturnV3 {
+    @Test
+    public void testSparkJobCommandReturnV3() throws Exception {
+        String spark3_job_command = null;
+        String spark3_job_command_return = null;
+        String spark3_job_command_return_error = null;
+        String spark3_home_dir = null;
+        String spark3_submit_job_cmd = null;
+        String seatunnel_home_dir = null;
+        String seatunnel_submit_spark3_job_jar_list = null;
+        String seatunnel_submit_spark3_job_cmd = null;
+        String seatunnel_submit_spark3_job_cmd_paras = null;
+        String seatunnel_submit_spark3_job_cmd_full_path = null;
+
+        StringBuilder sb_cmd_final = new StringBuilder();
+        String seatunnel_submit_spark3_job_cmd_final = null;
+
+        final String separator = "/";
+        Properties prop = new Properties();
+
+        try {
+            InputStream in =
+                    this.getClass()
+                            .getClassLoader()
+                            .getResourceAsStream("spark-3-job-command.properties");
+            if (in == null) {
+                throw new FileNotFoundException(
+                        "Resource file not found. Make sure the file exists in src/test/resources.");
+            }
+            prop.load(in);
+
+            spark3_home_dir = prop.getProperty("SPARK3_HOME");
+            spark3_submit_job_cmd = prop.getProperty("SPARK3_SUBMIT_JOB_CMD");
+            seatunnel_home_dir = prop.getProperty("SEATUNNEL_HOME");
+            seatunnel_submit_spark3_job_jar_list =
+                    prop.getProperty("SEATUNNEL_SUBMIT_SPARK3_JOB_JAR_LIST");
+            seatunnel_submit_spark3_job_cmd = prop.getProperty("SEATUNNEL_SUBMIT_SPARK3_JOB_CMD");
+
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("bin");
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append(seatunnel_submit_spark3_job_cmd);
+            sb_cmd_final.append(" --config ");
+            sb_cmd_final.append(seatunnel_home_dir);
+            sb_cmd_final.append(separator);
+            sb_cmd_final.append("/config/v2.batch.config.template");
+
+            seatunnel_submit_spark3_job_cmd_final = sb_cmd_final.toString();
+            // debug
+            // System.out.println("Final command:" + seatunnel_submit_spark3_job_cmd_final);
+
+            Process process = Runtime.getRuntime().exec(seatunnel_submit_spark3_job_cmd_final);
+            process.waitFor(); // wait for the command to finish
+
+            // Read the stdout of command
+            spark3_job_command_return = readStream(process.getInputStream());
+
+            // Read the stderror of command
+            spark3_job_command_return_error = readStream(process.getErrorStream());
+            // debug
+            System.out.println("Job command returns:" + spark3_job_command_return);
+
+            Assertions.assertNotNull(spark3_job_command_return);
+            Assertions.assertNull(spark3_job_command_return_error);
+            /*
+            if (spark3_job_command_return_error == null) {
+                System.out.println("Seatunnel Spark3 job submutted successfully.");
+            } else {
+                System.out.println("Seatunnel Spark3 job submutted failed, error messages is:");
+                System.out.println(spark3_job_command_return_error);
+            }
+            */
+
+            process.destroy();
+            // debug
+            System.out.println(
+                    "Auto closed [start-seatunnel-spark-3-connector-v2.cmd] successfully.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String readStream(InputStream inputStream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line;
+            StringBuilder sb = new StringBuilder();
+            String str_final = "";
+
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+                sb.append(line);
+            }
+            str_final = sb.toString();
+            if (!(str_final.isEmpty())) {
+                return str_final;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/resources/spark-2-job-command.properties
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/resources/spark-2-job-command.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This property file defines all properties which is used by submitting spark3(2) job test via spark cmd script
+SPARK2_HOME=E:/Apache/spark-3.4.1-bin-hadoop3
+SPARK2_SUBMIT_JOB_CMD=spark-submit.cmd
+SEATUNNEL_HOME=E:/Apache/seatunnel/apache-seatunnel-2.3.4
+SEATUNNEL_SUBMIT_SPARK2_JOB_CMD=start-seatunnel-spark-2-connector-v2.cmd
+SEATUNNEL_SUBMIT_SPARK2_JOB_JAR_LIST=E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/seatunnel-spark-2-starter.jar;E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/logging/*
+
+

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/resources/spark-3-job-command.properties
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/test/resources/spark-3-job-command.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This property file defines all properties which is used by submitting spark3(2) job test via spark cmd script
+SPARK3_HOME=E:/Apache/spark-3.4.1-bin-hadoop3
+SPARK3_SUBMIT_JOB_CMD=spark-submit.cmd
+SEATUNNEL_HOME=E:/Apache/seatunnel/apache-seatunnel-2.3.4
+SEATUNNEL_SUBMIT_SPARK3_JOB_CMD=start-seatunnel-spark-3-connector-v2.cmd
+SEATUNNEL_SUBMIT_SPARK3_JOB_JAR_LIST=E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/seatunnel-spark-3-starter.jar;E:/Apache/seatunnel/apache-seatunnel-2.3.4/starter/logging/*
+
+


### PR DESCRIPTION
### Purpose of this pull request
fix seatunnel-issue-6386  and windows specific starter cmd script bug

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added java unit test cases.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).
* [ ] 