### PR TITLE
[Hotfix][Postgres-CDC] Fix read data missing when restore

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/DataSourceDialect.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/dialect/DataSourceDialect.java
@@ -17,9 +17,9 @@
 
 package org.apache.seatunnel.connectors.cdc.base.dialect;
 
-import org.apache.seatunnel.api.state.CheckpointListener;
 import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
 import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
 
@@ -33,8 +33,7 @@ import java.util.List;
  *
  * @param <C> The source config of data source.
  */
-public interface DataSourceDialect<C extends SourceConfig>
-        extends Serializable, CheckpointListener {
+public interface DataSourceDialect<C extends SourceConfig> extends Serializable {
 
     /** Get the name of dialect. */
     String getName();
@@ -57,9 +56,6 @@ public interface DataSourceDialect<C extends SourceConfig>
     /**
      * We have an empty default implementation here because most dialects do not have to implement
      * the method.
-     *
-     * @see CheckpointListener#notifyCheckpointComplete(long)
      */
-    @Override
-    default void notifyCheckpointComplete(long checkpointId) throws Exception {}
+    default void commitChangeLogOffset(Offset offset) throws Exception {}
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceReader.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceReader.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotPhaseEvent;
 import org.apache.seatunnel.connectors.cdc.base.source.event.CompletedSnapshotSplitsReportEvent;
 import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
@@ -72,6 +73,8 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
 
     private final DataSourceDialect<C> dataSourceDialect;
 
+    private transient volatile Offset snapshotChangeLogOffset;
+
     private final AtomicBoolean needSendSplitRequest = new AtomicBoolean(false);
 
     public IncrementalSourceReader(
@@ -113,7 +116,7 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
-        dataSourceDialect.notifyCheckpointComplete(checkpointId);
+        dataSourceDialect.commitChangeLogOffset(snapshotChangeLogOffset);
     }
 
     @Override
@@ -238,7 +241,9 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
         unfinishedSplits.addAll(finishedUnackedSplits.values());
 
         if (isIncrementalSplitPhase(unfinishedSplits)) {
-            return snapshotCheckpointDataType(unfinishedSplits);
+            IncrementalSplit incrementalSplit = unfinishedSplits.get(0).asIncrementalSplit();
+            snapshotChangeLogOffset = incrementalSplit.getStartupOffset();
+            return snapshotCheckpointDataType(incrementalSplit);
         }
 
         return unfinishedSplits;
@@ -253,12 +258,7 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
         return stateSplits.size() == 1 && stateSplits.get(0).isIncrementalSplit();
     }
 
-    private List<SourceSplitBase> snapshotCheckpointDataType(List<SourceSplitBase> stateSplits) {
-        if (!isIncrementalSplitPhase(stateSplits)) {
-            throw new IllegalStateException(
-                    "The splits should be incremental split when snapshot  checkpoint datatype");
-        }
-        IncrementalSplit incrementalSplit = stateSplits.get(0).asIncrementalSplit();
+    private List<SourceSplitBase> snapshotCheckpointDataType(IncrementalSplit incrementalSplit) {
         // Snapshot current datatype to checkpoint
         SeaTunnelDataType<T> checkpointDataType = debeziumDeserializationSchema.getProducedType();
         IncrementalSplit newIncrementalSplit =

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDialect.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/PostgresDialect.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
 import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.relational.connection.JdbcConnectionPoolFactory;
 import org.apache.seatunnel.connectors.cdc.base.source.enumerator.splitter.ChunkSplitter;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
 import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
@@ -33,6 +34,7 @@ import org.apache.seatunnel.connectors.cdc.base.utils.CatalogTableUtils;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfigFactory;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.enumerator.PostgresChunkSplitter;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.PostgresSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot.PostgresSnapshotFetchTask;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.wal.PostgresWalFetchTask;
@@ -161,9 +163,9 @@ public class PostgresDialect implements JdbcDataSourceDialect {
     }
 
     @Override
-    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+    public void commitChangeLogOffset(Offset offset) throws Exception {
         if (postgresWalFetchTask != null) {
-            postgresWalFetchTask.commitCurrentOffset();
+            postgresWalFetchTask.commitCurrentOffset((LsnOffset) offset);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.wal
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.FetchTask;
 import org.apache.seatunnel.connectors.cdc.base.source.split.IncrementalSplit;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.PostgresSourceFetchTaskContext;
 
 import io.debezium.connector.postgresql.PostgresOffsetContext;
@@ -73,12 +74,11 @@ public class PostgresWalFetchTask implements FetchTask<SourceSplitBase> {
         streamingChangeEventSource.execute(changeEventSourceContext, offsetContext);
     }
 
-    public void commitCurrentOffset() {
-        if (streamingChangeEventSource != null && offsetContext != null) {
+    public void commitCurrentOffset(LsnOffset offset) {
+        if (streamingChangeEventSource != null && offset != null) {
 
             // only extracting and storing the lsn of the last commit
-            Long commitLsn =
-                    (Long) offsetContext.getOffset().get(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+            Long commitLsn = offset.getLsn().asLong();
             if (commitLsn != null
                     && (lastCommitLsn == null
                             || Lsn.valueOf(commitLsn).compareTo(Lsn.valueOf(lastCommitLsn)) > 0)) {


### PR DESCRIPTION

### Purpose of this pull request

1. The job was not added new tables into `publication` before start to snapshot read.
2. Delete of database logs did not use checkpoint offset.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).