### PR TITLE
[Hotfix][Core] Fix the NullPointException for the json config of the job without pluginname

### DIFF
--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/java/org/apache/seatunnel/core/starter/flink/FlinkCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/java/org/apache/seatunnel/core/starter/flink/FlinkCommandArgsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigException;
+
+import org.apache.seatunnel.core.starter.SeaTunnel;
+import org.apache.seatunnel.core.starter.flink.args.FlinkCommandArgs;
+import org.apache.seatunnel.core.starter.flink.multitable.MultiTableSinkTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+
+import static org.apache.seatunnel.api.common.CommonOptions.PLUGIN_NAME;
+
+public class FlinkCommandArgsTest {
+    @Test
+    public void testExecuteClientCommandArgsWithPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        FlinkCommandArgs flinkCommandArgs = buildFlinkCommandArgs(configFile);
+        Assertions.assertDoesNotThrow(() -> SeaTunnel.run(flinkCommandArgs.buildCommand()));
+    }
+
+    @Test
+    public void testExecuteClientCommandArgsWithoutPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory_without_pluginname.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        FlinkCommandArgs flinkCommandArgs = buildFlinkCommandArgs(configFile);
+        ConfigException configException =
+                Assertions.assertThrows(
+                        ConfigException.class,
+                        () -> SeaTunnel.run(flinkCommandArgs.buildCommand()));
+        Assertions.assertEquals(
+                String.format("No configuration setting found for key '%s'", PLUGIN_NAME.key()),
+                configException.getMessage());
+    }
+
+    private static FlinkCommandArgs buildFlinkCommandArgs(String configFile) {
+        FlinkCommandArgs flinkCommandArgs = new FlinkCommandArgs();
+        flinkCommandArgs.setConfigFile(configFile);
+        flinkCommandArgs.setCheckConfig(false);
+        flinkCommandArgs.setVariables(null);
+        return flinkCommandArgs;
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/java/org/apache/seatunnel/core/starter/flink/multitable/MultiTableSinkTest.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/java/org/apache/seatunnel/core/starter/flink/multitable/MultiTableSinkTest.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.e2e.sink.inmemory.InMemoryAggregatedCommitter;
 import org.apache.seatunnel.e2e.sink.inmemory.InMemorySinkWriter;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@Order(1)
 public class MultiTableSinkTest {
 
     @Test

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/resources/config/fake_to_inmemory.json
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/resources/config/fake_to_inmemory.json
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH"
+  },
+  "source": [
+    {
+      "plugin_name": "FakeSource",
+      "result_table_name": "fake_to_inmemory_wtih_flink",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "plugin_name": "InMemory",
+      "source_table_name": "fake_to_inmemory_wtih_flink"
+    }
+  ]
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-15-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH"
+  },
+  "source": [
+    {
+      "result_table_name": "fake_to_inmemory_wtih_flink",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "source_table_name": "fake_to_inmemory_wtih_flink"
+    }
+  ]
+}

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/SparkCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/SparkCommandArgsTest.java
@@ -25,12 +25,19 @@ import org.apache.seatunnel.core.starter.spark.multitable.MultiTableSinkTest;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 
 import static org.apache.seatunnel.api.common.CommonOptions.PLUGIN_NAME;
 
+@DisabledOnJre(
+        value = JRE.JAVA_11,
+        disabledReason =
+                "We should update apache common lang3 version to 3.8 to avoid NPE, "
+                        + "see https://github.com/apache/commons-lang/commit/50ce8c44e1601acffa39f5568f0fc140aade0564")
 public class SparkCommandArgsTest {
     @Test
     public void testExecuteClientCommandArgsWithPluginName()
@@ -63,6 +70,7 @@ public class SparkCommandArgsTest {
         sparkCommandArgs.setConfigFile(configFile);
         sparkCommandArgs.setCheckConfig(false);
         sparkCommandArgs.setVariables(null);
+        sparkCommandArgs.setDeployMode(DeployMode.CLIENT);
         return sparkCommandArgs;
     }
 }

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/SparkCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/SparkCommandArgsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.spark;
+
+import org.apache.seatunnel.common.config.DeployMode;
+import org.apache.seatunnel.core.starter.SeaTunnel;
+import org.apache.seatunnel.core.starter.exception.CommandExecuteException;
+import org.apache.seatunnel.core.starter.spark.args.SparkCommandArgs;
+import org.apache.seatunnel.core.starter.spark.multitable.MultiTableSinkTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+
+import static org.apache.seatunnel.api.common.CommonOptions.PLUGIN_NAME;
+
+public class SparkCommandArgsTest {
+    @Test
+    public void testExecuteClientCommandArgsWithPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        SparkCommandArgs sparkCommandArgs = buildSparkCommands(configFile);
+        sparkCommandArgs.setDeployMode(DeployMode.CLIENT);
+        Assertions.assertDoesNotThrow(() -> SeaTunnel.run(sparkCommandArgs.buildCommand()));
+    }
+
+    @Test
+    public void testExecuteClientCommandArgsWithoutPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory_without_pluginname.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        SparkCommandArgs sparkCommandArgs = buildSparkCommands(configFile);
+        sparkCommandArgs.setDeployMode(DeployMode.CLIENT);
+        CommandExecuteException commandExecuteException =
+                Assertions.assertThrows(
+                        CommandExecuteException.class,
+                        () -> SeaTunnel.run(sparkCommandArgs.buildCommand()));
+        Assertions.assertEquals(
+                String.format("No configuration setting found for key '%s'", PLUGIN_NAME.key()),
+                commandExecuteException.getCause().getMessage());
+    }
+
+    private static SparkCommandArgs buildSparkCommands(String configFile) {
+        SparkCommandArgs sparkCommandArgs = new SparkCommandArgs();
+        sparkCommandArgs.setConfigFile(configFile);
+        sparkCommandArgs.setCheckConfig(false);
+        sparkCommandArgs.setVariables(null);
+        return sparkCommandArgs;
+    }
+}

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/multitable/MultiTableSinkTest.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/java/org/apache/seatunnel/core/starter/spark/multitable/MultiTableSinkTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.e2e.sink.inmemory.InMemoryAggregatedCommitter;
 import org.apache.seatunnel.e2e.sink.inmemory.InMemorySinkWriter;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Slf4j
+@Order(1)
 public class MultiTableSinkTest {
 
     @Test

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/resources/config/fake_to_inmemory.json
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/resources/config/fake_to_inmemory.json
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH",
+    "spark.executor.instances": 1,
+    "spark.executor.cores": 1,
+    "spark.executor.memory": "1g",
+    "spark.master": "local"
+  },
+  "source": [
+    {
+      "plugin_name": "FakeSource",
+      "result_table_name": "fake_to_inmemory_wtih_spark",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "plugin_name": "InMemory",
+      "source_table_name": "fake_to_inmemory_wtih_spark"
+    }
+  ]
+}

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-3-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
@@ -1,0 +1,30 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH",
+    "spark.executor.instances": 1,
+    "spark.executor.cores": 1,
+    "spark.executor.memory": "1g",
+    "spark.master": "local"
+  },
+  "source": [
+    {
+      "result_table_name": "fake_to_inmemory_wtih_spark",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "source_table_name": "fake_to_inmemory_wtih_spark"
+    }
+  ]
+}

--- a/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.seatunnel.args;
+
+import org.apache.seatunnel.core.starter.SeaTunnel;
+import org.apache.seatunnel.core.starter.enums.MasterType;
+import org.apache.seatunnel.core.starter.exception.CommandExecuteException;
+import org.apache.seatunnel.core.starter.seatunnel.multitable.MultiTableSinkTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+
+import static org.apache.seatunnel.api.common.CommonOptions.PLUGIN_NAME;
+
+public class ClientCommandArgsTest {
+    @Test
+    public void testExecuteClientCommandArgsWithPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        ClientCommandArgs clientCommandArgs = buildClientCommandArgs(configFile);
+        Assertions.assertDoesNotThrow(() -> SeaTunnel.run(clientCommandArgs.buildCommand()));
+    }
+
+    @Test
+    public void testExecuteClientCommandArgsWithoutPluginName()
+            throws FileNotFoundException, URISyntaxException {
+        String configurePath = "/config/fake_to_inmemory_without_pluginname.json";
+        String configFile = MultiTableSinkTest.getTestConfigFile(configurePath);
+        ClientCommandArgs clientCommandArgs = buildClientCommandArgs(configFile);
+        CommandExecuteException commandExecuteException =
+                Assertions.assertThrows(
+                        CommandExecuteException.class,
+                        () -> SeaTunnel.run(clientCommandArgs.buildCommand()));
+        Assertions.assertEquals(
+                String.format(
+                        "The '%s' option is not configured, please configure it.",
+                        PLUGIN_NAME.key()),
+                commandExecuteException.getCause().getMessage());
+    }
+
+    private static ClientCommandArgs buildClientCommandArgs(String configFile) {
+        ClientCommandArgs clientCommandArgs = new ClientCommandArgs();
+        clientCommandArgs.setVariables(new ArrayList<>());
+        clientCommandArgs.setConfigFile(configFile);
+        clientCommandArgs.setMasterType(MasterType.LOCAL);
+        clientCommandArgs.setCheckConfig(false);
+        return clientCommandArgs;
+    }
+}

--- a/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/multitable/MultiTableSinkTest.java
+++ b/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/multitable/MultiTableSinkTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.e2e.sink.inmemory.InMemoryAggregatedCommitter;
 import org.apache.seatunnel.e2e.sink.inmemory.InMemorySinkWriter;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@Order(1)
 public class MultiTableSinkTest {
 
     @Test

--- a/seatunnel-core/seatunnel-starter/src/test/resources/config/fake_to_inmemory.json
+++ b/seatunnel-core/seatunnel-starter/src/test/resources/config/fake_to_inmemory.json
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH"
+  },
+  "source": [
+    {
+      "plugin_name": "FakeSource",
+      "result_table_name": "fake_to_inmemory_wtih_zeta",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "plugin_name": "InMemory",
+      "source_table_name": "fake_to_inmemory_wtih_zeta"
+    }
+  ]
+}

--- a/seatunnel-core/seatunnel-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
+++ b/seatunnel-core/seatunnel-starter/src/test/resources/config/fake_to_inmemory_without_pluginname.json
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "parallelism": 4,
+    "job.mode": "BATCH"
+  },
+  "source": [
+    {
+      "result_table_name": "fake_to_inmemory_wtih_zeta",
+      "row.num": 10,
+      "schema": {
+        "fields": {
+          "name": "string",
+          "age": "int",
+          "card": "int"
+        }
+      }
+    }
+  ],
+  "transform": [
+  ],
+  "sink": [
+    {
+      "source_table_name": "fake_to_inmemory_wtih_zeta"
+    }
+  ]
+}

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/resources/junit-platform.properties
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/resources/junit-platform.properties
@@ -1,0 +1,20 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# We can use the following to order the test classes
+junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/ConfigParserUtil.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/ConfigParserUtil.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.factory.FactoryUtil;
 import org.apache.seatunnel.engine.common.exception.JobDefineCheckException;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import scala.Tuple2;
@@ -263,7 +264,14 @@ public final class ConfigParserUtil {
     }
 
     public static String getFactoryId(ReadonlyConfig readonlyConfig) {
-        return readonlyConfig.get(PLUGIN_NAME);
+        String pluginName = readonlyConfig.get(PLUGIN_NAME);
+        if (StringUtils.isBlank(pluginName)) {
+            throw new JobDefineCheckException(
+                    String.format(
+                            "The '%s' option is not configured, please configure it.",
+                            PLUGIN_NAME.key()));
+        }
+        return pluginName;
     }
 
     public static String getFactoryId(Config config) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request
When we use the json config of the job define that without pluginname, this case will throw NullPointerException.
![截屏2024-05-09 08 17 40](https://github.com/apache/seatunnel/assets/18141150/0b528a2f-2226-4160-974e-5899aa48a8fb)

Like this:
`{
  "env": {
    "parallelism": 4,
    "job.mode": "BATCH"
  },
  "source": [
    {
      "result_table_name": "fake",
      "row.num": 100,
      "schema": {
        "fields": {
          "name": "string",
          "age": "int",
          "card": "int"
        }
      }
    }
  ],
  "transform": [
  ],
  "sink": [
    {
      "source_table_name": "fake1"
    }
  ]
}
`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).