### PR TITLE
[Hotfix][Zeta] Fix savepoint result when job failed

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -516,7 +516,12 @@ public class CoordinatorService {
                             CompletableFuture.supplyAsync(
                                     () -> {
                                         JobMaster runningJobMaster = runningJobMasterMap.get(jobId);
-                                        runningJobMaster.savePoint().join();
+                                        if (!runningJobMaster.savePoint().join()) {
+                                            throw new SavePointFailedException(
+                                                    "The job with id '"
+                                                            + jobId
+                                                            + "' save point failed");
+                                        }
                                         return null;
                                     },
                                     executorService));

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -77,7 +77,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                                 .getJobStatus(jobId)
                                                 .equals(JobStatus.RUNNING)));
         Thread.sleep(1000);
-        CompletableFuture<Void> future1 =
+        CompletableFuture<Boolean> future1 =
                 server.getCoordinatorService().getJobMaster(jobId).savePoint();
         future1.join();
         await().atMost(120000, TimeUnit.MILLISECONDS)

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/SavePointTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/SavePointTest.java
@@ -82,8 +82,7 @@ public class SavePointTest extends AbstractSeaTunnelServerTest<SavePointTest> {
         } catch (Exception e) {
             errorCount++;
         }
-        // we should make sure only one savepoint success in the same time
-        Assertions.assertEquals(2, errorCount);
+        Assertions.assertEquals(3, errorCount);
         await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->


### PR DESCRIPTION
### Purpose of this pull request

[Hotfix][Zeta] Fix savepoint result when job failed


fix testcase

<img width="1201" alt="image" src="https://github.com/apache/seatunnel/assets/14371345/99d3f0ee-1a36-45f3-8761-ed4c597a95d5">



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
updated


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).