### PR TITLE
[Improve] Make ClickhouseFileSinker support tables containing materialized columns

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ClickhouseProxy.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ClickhouseProxy.java
@@ -141,7 +141,7 @@ public class ClickhouseProxy {
             response.records()
                     .forEach(
                             r -> {
-                                if ("MATERIALIZED".equals(r.getValue(2).asString())) {
+                                if (!"MATERIALIZED".equals(r.getValue(2).asString())) {
                                     schema.put(r.getValue(0).asString(), r.getValue(1).asString());
                                 }
                             });

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ClickhouseProxy.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ClickhouseProxy.java
@@ -139,7 +139,12 @@ public class ClickhouseProxy {
         Map<String, String> schema = new LinkedHashMap<>();
         try (ClickHouseResponse response = request.query(sql).executeAndWait()) {
             response.records()
-                    .forEach(r -> schema.put(r.getValue(0).asString(), r.getValue(1).asString()));
+                    .forEach(
+                            r -> {
+                                if ("MATERIALIZED".equals(r.getValue(2).asString())) {
+                                    schema.put(r.getValue(0).asString(), r.getValue(1).asString());
+                                }
+                            });
         } catch (ClickHouseException e) {
             throw new ClickhouseConnectorException(
                     CommonErrorCodeDeprecated.TABLE_SCHEMA_GET_FAILED,


### PR DESCRIPTION
Make ClickhouseFileSinker supports tables containing materialized columns by ignoring the materialized columns in the CK table when extracting the temporary table schema. In this way, when generating the ck part file, the file corresponding to the materialized column will be automatically generated, otherwise an error will be reported when generating the file.


Already tested