### PR TITLE
[Improve][Connector-V2][MongoDB] Support to convert to double from any numeric type

### DIFF
--- a/release-note.md
+++ b/release-note.md
@@ -55,7 +55,7 @@
 - [Connector-v2] [File] Fix WriteStrategy parallel writing thread unsafe issue #5546
 - [Connector-v2] [File] Inject FileSystem to OrcWriteStrategy
 - [Connector-v2] [File] Support assign encoding for file source/sink (#5973)
-- [Connector-v2] [MongoDB] Support to convert to double from numeric type that MongoDB saved it as numeric internally (#6997)
+- [Connector-v2] [Mongodb] Support to convert to double from numeric type that mongodb saved it as numeric internally (#6997)
 
 ### Zeta(ST-Engine)
 

--- a/release-note.md
+++ b/release-note.md
@@ -55,6 +55,7 @@
 - [Connector-v2] [File] Fix WriteStrategy parallel writing thread unsafe issue #5546
 - [Connector-v2] [File] Inject FileSystem to OrcWriteStrategy
 - [Connector-v2] [File] Support assign encoding for file source/sink (#5973)
+- [Connector-v2] [MongoDB] Support to convert to double from numeric type that MongoDB saved it as numeric internally (#6997)
 
 ### Zeta(ST-Engine)
 

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
@@ -353,15 +353,16 @@ public class BsonToRowDataConverters implements Serializable {
     }
 
     private static double convertToDouble(BsonValue bsonValue) {
-        if (bsonValue.isDouble()) {
+        try {
             return bsonValue.asNumber().doubleValue();
+        } catch (RuntimeException e) {
+            throw new MongodbConnectorException(
+                    UNSUPPORTED_DATA_TYPE,
+                    "Unable to convert to double from unexpected value '"
+                            + bsonValue
+                            + "' of type "
+                            + bsonValue.getBsonType());
         }
-        throw new MongodbConnectorException(
-                UNSUPPORTED_DATA_TYPE,
-                "Unable to convert to double from unexpected value '"
-                        + bsonValue
-                        + "' of type "
-                        + bsonValue.getBsonType());
     }
 
     private static int convertToInt(BsonValue bsonValue) {

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
@@ -353,16 +353,16 @@ public class BsonToRowDataConverters implements Serializable {
     }
 
     private static double convertToDouble(BsonValue bsonValue) {
-        try {
+        if (bsonValue.isNumber()) {
             return bsonValue.asNumber().doubleValue();
-        } catch (RuntimeException e) {
-            throw new MongodbConnectorException(
-                    UNSUPPORTED_DATA_TYPE,
-                    "Unable to convert to double from unexpected value '"
-                            + bsonValue
-                            + "' of type "
-                            + bsonValue.getBsonType());
         }
+
+        throw new MongodbConnectorException(
+                UNSUPPORTED_DATA_TYPE,
+                "Unable to convert to double from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
     }
 
     private static int convertToInt(BsonValue bsonValue) {

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/serde/BsonToRowDataConverters.java
@@ -356,7 +356,6 @@ public class BsonToRowDataConverters implements Serializable {
         if (bsonValue.isNumber()) {
             return bsonValue.asNumber().doubleValue();
         }
-
         throw new MongodbConnectorException(
                 UNSUPPORTED_DATA_TYPE,
                 "Unable to convert to double from unexpected value '"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
@@ -60,6 +60,8 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
 
     protected static final List<Document> TEST_NULL_DATASET = generateTestDataSetWithNull(10);
 
+    protected static final List<Document> TEST_DOUBLE_DATASET = generateTestDataSetWithTemplate(5, Arrays.asList(44.0d, 44.1d, 44.2d, 44.3d, 44.4d));
+
     protected static final String MONGODB_IMAGE = "mongo:latest";
 
     protected static final String MONGODB_CONTAINER_HOST = "e2e_mongodb";
@@ -75,6 +77,10 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
     protected static final String MONGODB_NULL_TABLE = "test_null_op_db";
 
     protected static final String MONGODB_NULL_TABLE_RESULT = "test_null_op_db_result";
+
+    protected static final String MONGODB_DOUBLE_TABLE = "test_double_op_db";
+
+    protected static final String MONGODB_DOUBLE_TABLE_RESULT = "test_double_op_db_result";
 
     protected static final String MONGODB_MATCH_RESULT_TABLE = "test_match_op_result_db";
 
@@ -119,6 +125,11 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
                 client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_NULL_TABLE);
         sourceNullTable.deleteMany(new Document());
         sourceNullTable.insertMany(TEST_NULL_DATASET);
+
+        MongoCollection<Document> sourceDoubleTable =
+                client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_DOUBLE_TABLE);
+        sourceDoubleTable.deleteMany(new Document());
+        sourceDoubleTable.insertMany(TEST_DOUBLE_DATASET);
     }
 
     protected void clearDate(String table) {
@@ -129,51 +140,7 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
         List<Document> dataSet = new ArrayList<>();
 
         for (int i = 0; i < count; i++) {
-            dataSet.add(
-                    new Document(
-                                    "c_map",
-                                    new Document("OQBqH", randomString())
-                                            .append("rkvlO", randomString())
-                                            .append("pCMEX", randomString())
-                                            .append("DAgdj", randomString())
-                                            .append("dsJag", randomString()))
-                            .append(
-                                    "c_array",
-                                    Arrays.asList(
-                                            RANDOM.nextInt(),
-                                            RANDOM.nextInt(),
-                                            RANDOM.nextInt(),
-                                            RANDOM.nextInt(),
-                                            RANDOM.nextInt()))
-                            .append("c_string", randomString())
-                            .append("c_boolean", RANDOM.nextBoolean())
-                            .append("c_int", i)
-                            .append("c_bigint", RANDOM.nextLong())
-                            .append("c_double", RANDOM.nextDouble() * Double.MAX_VALUE)
-                            .append(
-                                    "c_row",
-                                    new Document(
-                                                    "c_map",
-                                                    new Document("OQBqH", randomString())
-                                                            .append("rkvlO", randomString())
-                                                            .append("pCMEX", randomString())
-                                                            .append("DAgdj", randomString())
-                                                            .append("dsJag", randomString()))
-                                            .append(
-                                                    "c_array",
-                                                    Arrays.asList(
-                                                            RANDOM.nextInt(),
-                                                            RANDOM.nextInt(),
-                                                            RANDOM.nextInt(),
-                                                            RANDOM.nextInt(),
-                                                            RANDOM.nextInt()))
-                                            .append("c_string", randomString())
-                                            .append("c_boolean", RANDOM.nextBoolean())
-                                            .append("c_int", RANDOM.nextInt())
-                                            .append("c_bigint", RANDOM.nextLong())
-                                            .append(
-                                                    "c_double",
-                                                    RANDOM.nextDouble() * Double.MAX_VALUE)));
+            dataSet.add(generateData(i, RANDOM.nextDouble() * Double.MAX_VALUE));
         }
         return dataSet;
     }
@@ -195,6 +162,16 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
         return dataSet;
     }
 
+    public static List<Document> generateTestDataSetWithTemplate(int count, List<Double> doublePreset) {
+        List<Document> dataSet = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            dataSet.add(generateData(i, doublePreset.get(i)));
+        }
+
+        return dataSet;
+    }
+
     protected static String randomString() {
         int length = RANDOM.nextInt(10) + 1;
         StringBuilder sb = new StringBuilder(length);
@@ -203,6 +180,53 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
             sb.append(c);
         }
         return sb.toString();
+    }
+
+    private static Document generateData(int intPreset, double doublePreset) {
+        return new Document(
+                "c_map",
+                new Document("OQBqH", randomString())
+                        .append("rkvlO", randomString())
+                        .append("pCMEX", randomString())
+                        .append("DAgdj", randomString())
+                        .append("dsJag", randomString()))
+                .append(
+                        "c_array",
+                        Arrays.asList(
+                                RANDOM.nextInt(),
+                                RANDOM.nextInt(),
+                                RANDOM.nextInt(),
+                                RANDOM.nextInt(),
+                                RANDOM.nextInt()))
+                .append("c_string", randomString())
+                .append("c_boolean", RANDOM.nextBoolean())
+                .append("c_int", intPreset)
+                .append("c_bigint", RANDOM.nextLong())
+                .append("c_double", doublePreset)
+                .append(
+                        "c_row",
+                        new Document(
+                                "c_map",
+                                new Document("OQBqH", randomString())
+                                        .append("rkvlO", randomString())
+                                        .append("pCMEX", randomString())
+                                        .append("DAgdj", randomString())
+                                        .append("dsJag", randomString()))
+                                .append(
+                                        "c_array",
+                                        Arrays.asList(
+                                                RANDOM.nextInt(),
+                                                RANDOM.nextInt(),
+                                                RANDOM.nextInt(),
+                                                RANDOM.nextInt(),
+                                                RANDOM.nextInt()))
+                                .append("c_string", randomString())
+                                .append("c_boolean", RANDOM.nextBoolean())
+                                .append("c_int", RANDOM.nextInt())
+                                .append("c_bigint", RANDOM.nextLong())
+                                .append(
+                                        "c_double",
+                                        RANDOM.nextDouble() * Double.MAX_VALUE));
     }
 
     protected List<Document> readMongodbData(String collection) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.e2e.connector.v2.mongodb;
 
+import com.mongodb.client.result.InsertManyResult;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 
@@ -61,7 +62,7 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
     protected static final List<Document> TEST_NULL_DATASET = generateTestDataSetWithNull(10);
 
     protected static final List<Document> TEST_DOUBLE_DATASET =
-            generateTestDataSetWithTemplate(5, Arrays.asList(44.0d, 44.1d, 44.2d, 44.3d, 44.4d));
+            generateTestDataSetWithPresets(5, Arrays.asList(44.0d, 44.1d, 44.2d, 44.3d, 44.4d));
 
     protected static final String MONGODB_IMAGE = "mongo:latest";
 
@@ -112,25 +113,10 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
     }
 
     protected void initSourceData() {
-        MongoCollection<Document> sourceMatchTable =
-                client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_MATCH_TABLE);
-        sourceMatchTable.deleteMany(new Document());
-        sourceMatchTable.insertMany(TEST_MATCH_DATASET);
-
-        MongoCollection<Document> sourceSplitTable =
-                client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_SPLIT_TABLE);
-        sourceSplitTable.deleteMany(new Document());
-        sourceSplitTable.insertMany(TEST_SPLIT_DATASET);
-
-        MongoCollection<Document> sourceNullTable =
-                client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_NULL_TABLE);
-        sourceNullTable.deleteMany(new Document());
-        sourceNullTable.insertMany(TEST_NULL_DATASET);
-
-        MongoCollection<Document> sourceDoubleTable =
-                client.getDatabase(MONGODB_DATABASE).getCollection(MONGODB_DOUBLE_TABLE);
-        sourceDoubleTable.deleteMany(new Document());
-        sourceDoubleTable.insertMany(TEST_DOUBLE_DATASET);
+        prepareInitDataInCollection(MONGODB_MATCH_TABLE, TEST_MATCH_DATASET);
+        prepareInitDataInCollection(MONGODB_SPLIT_TABLE, TEST_SPLIT_DATASET);
+        prepareInitDataInCollection(MONGODB_NULL_TABLE, TEST_NULL_DATASET);
+        prepareInitDataInCollection(MONGODB_DOUBLE_TABLE, TEST_DOUBLE_DATASET);
     }
 
     protected void clearDate(String table) {
@@ -163,12 +149,12 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
         return dataSet;
     }
 
-    public static List<Document> generateTestDataSetWithTemplate(
-            int count, List<Double> doublePreset) {
-        List<Document> dataSet = new ArrayList<>();
+    public static List<Document> generateTestDataSetWithPresets(
+            int count, List<Double> doublePresets) {
+        List<Document> dataSet = new ArrayList<>(count);
 
         for (int i = 0; i < count; i++) {
-            dataSet.add(generateData(i, doublePreset.get(i)));
+            dataSet.add(generateData(i, doublePresets.get(i)));
         }
 
         return dataSet;
@@ -184,7 +170,7 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
         return sb.toString();
     }
 
-    private static Document generateData(int intPreset, double doublePreset) {
+    private static Document generateData(int intPreset, Double doublePreset) {
         return new Document(
                         "c_map",
                         new Document("OQBqH", randomString())
@@ -227,6 +213,18 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
                                 .append("c_int", RANDOM.nextInt())
                                 .append("c_bigint", RANDOM.nextLong())
                                 .append("c_double", RANDOM.nextDouble() * Double.MAX_VALUE));
+    }
+
+    private void prepareInitDataInCollection(String collection, List<Document> dataSet) {
+        MongoCollection<Document> source =
+                client.getDatabase(MONGODB_DATABASE).getCollection(collection);
+        source.deleteMany(new Document());
+
+        InsertManyResult result = source.insertMany(dataSet);
+
+        if (result.getInsertedIds().size() != dataSet.size()) {
+            throw new IllegalStateException("Insertion count mismatch");
+        }
     }
 
     protected List<Document> readMongodbData(String collection) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.e2e.connector.v2.mongodb;
 
-import com.mongodb.client.result.InsertManyResult;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 
@@ -37,6 +36,7 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.result.InsertManyResult;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/AbstractMongodbIT.java
@@ -60,7 +60,8 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
 
     protected static final List<Document> TEST_NULL_DATASET = generateTestDataSetWithNull(10);
 
-    protected static final List<Document> TEST_DOUBLE_DATASET = generateTestDataSetWithTemplate(5, Arrays.asList(44.0d, 44.1d, 44.2d, 44.3d, 44.4d));
+    protected static final List<Document> TEST_DOUBLE_DATASET =
+            generateTestDataSetWithTemplate(5, Arrays.asList(44.0d, 44.1d, 44.2d, 44.3d, 44.4d));
 
     protected static final String MONGODB_IMAGE = "mongo:latest";
 
@@ -162,7 +163,8 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
         return dataSet;
     }
 
-    public static List<Document> generateTestDataSetWithTemplate(int count, List<Double> doublePreset) {
+    public static List<Document> generateTestDataSetWithTemplate(
+            int count, List<Double> doublePreset) {
         List<Document> dataSet = new ArrayList<>();
 
         for (int i = 0; i < count; i++) {
@@ -184,12 +186,12 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
 
     private static Document generateData(int intPreset, double doublePreset) {
         return new Document(
-                "c_map",
-                new Document("OQBqH", randomString())
-                        .append("rkvlO", randomString())
-                        .append("pCMEX", randomString())
-                        .append("DAgdj", randomString())
-                        .append("dsJag", randomString()))
+                        "c_map",
+                        new Document("OQBqH", randomString())
+                                .append("rkvlO", randomString())
+                                .append("pCMEX", randomString())
+                                .append("DAgdj", randomString())
+                                .append("dsJag", randomString()))
                 .append(
                         "c_array",
                         Arrays.asList(
@@ -206,12 +208,12 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
                 .append(
                         "c_row",
                         new Document(
-                                "c_map",
-                                new Document("OQBqH", randomString())
-                                        .append("rkvlO", randomString())
-                                        .append("pCMEX", randomString())
-                                        .append("DAgdj", randomString())
-                                        .append("dsJag", randomString()))
+                                        "c_map",
+                                        new Document("OQBqH", randomString())
+                                                .append("rkvlO", randomString())
+                                                .append("pCMEX", randomString())
+                                                .append("DAgdj", randomString())
+                                                .append("dsJag", randomString()))
                                 .append(
                                         "c_array",
                                         Arrays.asList(
@@ -224,9 +226,7 @@ public abstract class AbstractMongodbIT extends TestSuiteBase implements TestRes
                                 .append("c_boolean", RANDOM.nextBoolean())
                                 .append("c_int", RANDOM.nextInt())
                                 .append("c_bigint", RANDOM.nextLong())
-                                .append(
-                                        "c_double",
-                                        RANDOM.nextDouble() * Double.MAX_VALUE));
+                                .append("c_double", RANDOM.nextDouble() * Double.MAX_VALUE));
     }
 
     protected List<Document> readMongodbData(String collection) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
@@ -229,7 +229,9 @@ public class MongodbIT extends AbstractMongodbIT {
         Assertions.assertEquals(0, assertResult.getExitCode(), assertResult.getStderr());
 
         Assertions.assertIterableEquals(
-                TEST_DOUBLE_DATASET.stream().peek(e -> e.remove("_id")).collect(Collectors.toList()),
+                TEST_DOUBLE_DATASET.stream()
+                        .peek(e -> e.remove("_id"))
+                        .collect(Collectors.toList()),
                 readMongodbData(MONGODB_DOUBLE_TABLE_RESULT).stream()
                         .peek(e -> e.remove("_id"))
                         .collect(Collectors.toList()));

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
@@ -225,8 +225,8 @@ public class MongodbIT extends AbstractMongodbIT {
     @TestTemplate
     public void testMongodbDoubleValue(TestContainer container)
             throws IOException, InterruptedException {
-        Container.ExecResult insertResult = container.executeJob("/mongodb_double_value.conf");
-        Assertions.assertEquals(0, insertResult.getExitCode(), insertResult.getStderr());
+        Container.ExecResult assertSinkResult = container.executeJob("/mongodb_double_value.conf");
+        Assertions.assertEquals(0, assertSinkResult.getExitCode(), assertSinkResult.getStderr());
 
         Assertions.assertIterableEquals(
                 TEST_DOUBLE_DATASET.stream()
@@ -235,7 +235,6 @@ public class MongodbIT extends AbstractMongodbIT {
                 readMongodbData(MONGODB_DOUBLE_TABLE_RESULT).stream()
                         .peek(e -> e.remove("_id"))
                         .collect(Collectors.toList()));
-        clearDate(MONGODB_DOUBLE_TABLE);
         clearDate(MONGODB_DOUBLE_TABLE_RESULT);
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
@@ -225,8 +225,8 @@ public class MongodbIT extends AbstractMongodbIT {
     @TestTemplate
     public void testMongodbDoubleValue(TestContainer container)
             throws IOException, InterruptedException {
-        Container.ExecResult assertResult = container.executeJob("/mongodb_double_value.conf");
-        Assertions.assertEquals(0, assertResult.getExitCode(), assertResult.getStderr());
+        Container.ExecResult insertResult = container.executeJob("/mongodb_double_value.conf");
+        Assertions.assertEquals(0, insertResult.getExitCode(), insertResult.getStderr());
 
         Assertions.assertIterableEquals(
                 TEST_DOUBLE_DATASET.stream()

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/mongodb/MongodbIT.java
@@ -221,4 +221,19 @@ public class MongodbIT extends AbstractMongodbIT {
         clearDate(MONGODB_TRANSACTION_SINK_TABLE);
         clearDate(MONGODB_TRANSACTION_UPSERT_TABLE);
     }
+
+    @TestTemplate
+    public void testMongodbDoubleValue(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult assertResult = container.executeJob("/mongodb_double_value.conf");
+        Assertions.assertEquals(0, assertResult.getExitCode(), assertResult.getStderr());
+
+        Assertions.assertIterableEquals(
+                TEST_DOUBLE_DATASET.stream().peek(e -> e.remove("_id")).collect(Collectors.toList()),
+                readMongodbData(MONGODB_DOUBLE_TABLE_RESULT).stream()
+                        .peek(e -> e.remove("_id"))
+                        .collect(Collectors.toList()));
+        clearDate(MONGODB_DOUBLE_TABLE);
+        clearDate(MONGODB_DOUBLE_TABLE_RESULT);
+    }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  #spark config
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 1
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  MongoDB {
+    uri = "mongodb://e2e_mongodb:27017/test_db"
+    database = "test_db"
+    collection = "test_null_op_db"
+    result_table_name = "mongodb_double_table"
+    cursor.no-timeout = true
+    fetch.size = 1000
+    max.time-min = 100
+    schema = {
+      fields {
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_row = {
+          c_map = "map<string, string>"
+          c_array = "array<int>"
+          c_string = string
+          c_boolean = boolean
+          c_int = int
+          c_bigint = bigint
+          c_double = double
+        }
+      }
+    }
+  }
+}
+
+sink {
+  MongoDB {
+    uri = "mongodb://e2e_mongodb:27017/test_db?retryWrites=true"
+    database = "test_db"
+    collection = "test_double_op_db_result"
+    source_table_name = "mongodb_double_table"
+    schema = {
+      fields {
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_row = {
+          c_map = "map<string, string>"
+          c_array = "array<int>"
+          c_string = string
+          c_boolean = boolean
+          c_int = int
+          c_bigint = bigint
+          c_double = double
+        }
+      }
+    }
+  }
+
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
@@ -18,6 +18,8 @@
 env {
   parallelism = 1
   job.mode = "BATCH"
+  # Never retries in test
+  job.retry.times = 0
   #spark config
   spark.app.name = "SeaTunnel"
   spark.executor.instances = 1
@@ -31,7 +33,7 @@ source {
     uri = "mongodb://e2e_mongodb:27017/test_db"
     database = "test_db"
     collection = "test_double_op_db"
-    result_table_name = "mongodb_double_table"
+    result_table_name = "mongodb_table"
     cursor.no-timeout = true
     fetch.size = 1000
     max.time-min = 100
@@ -63,7 +65,7 @@ sink {
     uri = "mongodb://e2e_mongodb:27017/test_db?retryWrites=true"
     database = "test_db"
     collection = "test_double_op_db_result"
-    source_table_name = "mongodb_double_table"
+    source_table_name = "mongodb_table"
     schema = {
       fields {
         c_map = "map<string, string>"
@@ -85,5 +87,4 @@ sink {
       }
     }
   }
-
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
@@ -18,8 +18,6 @@
 env {
   parallelism = 1
   job.mode = "BATCH"
-  # Never retries in test
-  job.retry.times = 0
   #spark config
   spark.app.name = "SeaTunnel"
   spark.executor.instances = 1

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-mongodb-e2e/src/test/resources/mongodb_double_value.conf
@@ -30,7 +30,7 @@ source {
   MongoDB {
     uri = "mongodb://e2e_mongodb:27017/test_db"
     database = "test_db"
-    collection = "test_null_op_db"
+    collection = "test_double_op_db"
     result_table_name = "mongodb_double_table"
     cursor.no-timeout = true
     fetch.size = 1000


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
This pull request is support to convert double from numeric type that MongoDB save `5.0` as `5` like int type. It's similar with #6726 in sink side.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
Package the connector-mongo-2.3.5-2.12.15.jar, place it in a docker image, and complete the MongoDB reading test

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).