### PR TITLE
[Hotfix][MySQL-CDC] Fix ArrayIndexOutOfBoundsException in mysql binlog read

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/com/github/shyiko/mysql/binlog/io/BufferedSocketInputStream.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/com/github/shyiko/mysql/binlog/io/BufferedSocketInputStream.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.shyiko.mysql.binlog.io;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Copied from https://github.com/osheroff/mysql-binlog-connector-java project to fix
+ * https://github.com/apache/seatunnel/issues/7380
+ *
+ * <p>reference: - https://github.com/osheroff/mysql-binlog-connector-java/issues/66 -
+ * https://github.com/apache/flink-cdc/issues/460
+ */
+public class BufferedSocketInputStream extends FilterInputStream {
+
+    private byte[] buffer;
+    private int offset;
+    private int limit;
+
+    public BufferedSocketInputStream(InputStream in) {
+        this(in, 512 * 1024);
+    }
+
+    public BufferedSocketInputStream(InputStream in, int bufferSize) {
+        super(in);
+        this.buffer = new byte[bufferSize];
+    }
+
+    @Override
+    public int available() throws IOException {
+        return limit == -1 ? in.available() : limit - offset + in.available();
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (offset < limit) {
+            return buffer[offset++] & 0xff;
+        }
+        offset = 0;
+        limit = in.read(buffer, 0, buffer.length);
+        return limit != -1 ? buffer[offset++] & 0xff : -1;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (offset >= limit) {
+            if (len >= buffer.length) {
+                return in.read(b, off, len);
+            }
+            offset = 0;
+            limit = in.read(buffer, 0, buffer.length);
+            if (limit == -1) {
+                return limit;
+            }
+        }
+        int bytesRemainingInBuffer = Math.min(len, limit - offset);
+        System.arraycopy(buffer, offset, b, off, bytesRemainingInBuffer);
+        offset += bytesRemainingInBuffer;
+        return bytesRemainingInBuffer;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/com/github/shyiko/mysql/binlog/io/BufferedSocketInputStreamTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/com/github/shyiko/mysql/binlog/io/BufferedSocketInputStreamTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.shyiko.mysql.binlog.io;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BufferedSocketInputStreamTest {
+
+    @Test
+    public void testReadFromBufferedSocketInputStream() throws Exception {
+        BufferedSocketInputStream in =
+                new BufferedSocketInputStream(
+                        new ByteArrayInputStream(
+                                new byte[] {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'}));
+        byte[] buf = new byte[3];
+        assertEquals(3, in.read(buf, 0, buf.length));
+        Arrays.equals(new byte[] {'A', 'B', 'C'}, buf);
+        assertEquals(5, in.available());
+
+        assertEquals(3, in.read(buf, 0, buf.length));
+        Arrays.equals(new byte[] {'D', 'E', 'F'}, buf);
+        assertEquals(2, in.available());
+
+        assertEquals(2, in.read(buf, 0, buf.length));
+        Arrays.equals(new byte[] {'G', 'H'}, buf);
+        assertEquals(0, in.available());
+
+        // reach the end of stream normally
+        assertEquals(-1, in.read(buf, 0, buf.length));
+        assertEquals(0, in.available());
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

### Purpose of this pull request

[MySQL-CDC] Fix ArrayIndexOutOfBoundsException in mysql binlog read
reference:
- https://github.com/osheroff/mysql-binlog-connector-java/issues/66
- https://github.com/apache/flink-cdc/issues/460

close #7380

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).