### PR TITLE
[Hotfix][Metrics] fix sporadic multi-metrics ci

### DIFF
--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientTest.java
@@ -662,13 +662,13 @@ public class SeaTunnelClientTest {
             Assertions.assertEquals(
                     totalCount.get(SOURCE_RECEIVED_COUNT),
                     tableCount.entrySet().stream()
-                            .filter(e -> e.getKey().startsWith(SOURCE_RECEIVED_COUNT))
+                            .filter(e -> e.getKey().startsWith(SOURCE_RECEIVED_COUNT + "#"))
                             .mapToLong(Map.Entry::getValue)
                             .sum());
             Assertions.assertEquals(
                     totalCount.get(SINK_WRITE_COUNT),
                     tableCount.entrySet().stream()
-                            .filter(e -> e.getKey().startsWith(SINK_WRITE_COUNT))
+                            .filter(e -> e.getKey().startsWith(SINK_WRITE_COUNT + "#"))
                             .mapToLong(Map.Entry::getValue)
                             .sum());
             Assertions.assertEquals(
@@ -693,7 +693,8 @@ public class SeaTunnelClientTest {
                                                             e ->
                                                                     e.getKey()
                                                                             .startsWith(
-                                                                                    SOURCE_RECEIVED_QPS))
+                                                                                    SOURCE_RECEIVED_QPS
+                                                                                            + "#"))
                                                     .mapToLong(Map.Entry::getValue)
                                                     .sum())
                             < totalCount.get(SOURCE_RECEIVED_QPS) * 0.02);
@@ -705,7 +706,8 @@ public class SeaTunnelClientTest {
                                                             e ->
                                                                     e.getKey()
                                                                             .startsWith(
-                                                                                    SINK_WRITE_QPS))
+                                                                                    SINK_WRITE_QPS
+                                                                                            + "#"))
                                                     .mapToLong(Map.Entry::getValue)
                                                     .sum())
                             < totalCount.get(SINK_WRITE_QPS) * 0.02);
@@ -717,7 +719,8 @@ public class SeaTunnelClientTest {
                                                             e ->
                                                                     e.getKey()
                                                                             .startsWith(
-                                                                                    SOURCE_RECEIVED_BYTES_PER_SECONDS))
+                                                                                    SOURCE_RECEIVED_BYTES_PER_SECONDS
+                                                                                            + "#"))
                                                     .mapToLong(Map.Entry::getValue)
                                                     .sum())
                             < totalCount.get(SOURCE_RECEIVED_BYTES_PER_SECONDS) * 0.02);
@@ -729,7 +732,8 @@ public class SeaTunnelClientTest {
                                                             e ->
                                                                     e.getKey()
                                                                             .startsWith(
-                                                                                    SINK_WRITE_BYTES_PER_SECONDS))
+                                                                                    SINK_WRITE_BYTES_PER_SECONDS
+                                                                                            + "#"))
                                                     .mapToLong(Map.Entry::getValue)
                                                     .sum())
                             < totalCount.get(SINK_WRITE_BYTES_PER_SECONDS) * 0.02);

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientTest.java
@@ -684,18 +684,55 @@ public class SeaTunnelClientTest {
                             .mapToLong(Map.Entry::getValue)
                             .sum());
             // Instantaneous rates in the same direction are directly added
-            Assertions.assertEquals(
-                    totalCount.get(SOURCE_RECEIVED_QPS),
-                    tableCount.entrySet().stream()
-                            .filter(e -> e.getKey().startsWith(SOURCE_RECEIVED_QPS + "#"))
-                            .mapToLong(Map.Entry::getValue)
-                            .sum());
-            Assertions.assertEquals(
-                    totalCount.get(SINK_WRITE_QPS),
-                    tableCount.entrySet().stream()
-                            .filter(e -> e.getKey().startsWith(SINK_WRITE_QPS + "#"))
-                            .mapToLong(Map.Entry::getValue)
-                            .sum());
+            // The size does not fluctuate more than %2 of the total value
+            Assertions.assertTrue(
+                    Math.abs(
+                                    totalCount.get(SOURCE_RECEIVED_QPS)
+                                            - tableCount.entrySet().stream()
+                                                    .filter(
+                                                            e ->
+                                                                    e.getKey()
+                                                                            .startsWith(
+                                                                                    SOURCE_RECEIVED_QPS))
+                                                    .mapToLong(Map.Entry::getValue)
+                                                    .sum())
+                            < totalCount.get(SOURCE_RECEIVED_QPS) * 0.02);
+            Assertions.assertTrue(
+                    Math.abs(
+                                    totalCount.get(SINK_WRITE_QPS)
+                                            - tableCount.entrySet().stream()
+                                                    .filter(
+                                                            e ->
+                                                                    e.getKey()
+                                                                            .startsWith(
+                                                                                    SINK_WRITE_QPS))
+                                                    .mapToLong(Map.Entry::getValue)
+                                                    .sum())
+                            < totalCount.get(SINK_WRITE_QPS) * 0.02);
+            Assertions.assertTrue(
+                    Math.abs(
+                                    totalCount.get(SOURCE_RECEIVED_BYTES_PER_SECONDS)
+                                            - tableCount.entrySet().stream()
+                                                    .filter(
+                                                            e ->
+                                                                    e.getKey()
+                                                                            .startsWith(
+                                                                                    SOURCE_RECEIVED_BYTES_PER_SECONDS))
+                                                    .mapToLong(Map.Entry::getValue)
+                                                    .sum())
+                            < totalCount.get(SOURCE_RECEIVED_BYTES_PER_SECONDS) * 0.02);
+            Assertions.assertTrue(
+                    Math.abs(
+                                    totalCount.get(SINK_WRITE_BYTES_PER_SECONDS)
+                                            - tableCount.entrySet().stream()
+                                                    .filter(
+                                                            e ->
+                                                                    e.getKey()
+                                                                            .startsWith(
+                                                                                    SINK_WRITE_BYTES_PER_SECONDS))
+                                                    .mapToLong(Map.Entry::getValue)
+                                                    .sum())
+                            < totalCount.get(SINK_WRITE_BYTES_PER_SECONDS) * 0.02);
 
         } catch (ExecutionException | InterruptedException | JsonProcessingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
### Purpose of this pull request

Avoid occasional ci errors, rate-metrics can be approximated

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).