### PR TITLE
[Fix][Connecotr-V2] Fix paimon dynamic bucket tale in primary key is not first

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
@@ -24,12 +24,14 @@ import org.apache.seatunnel.api.sink.DataSaveMode;
 import org.apache.seatunnel.api.sink.SchemaSaveMode;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Getter
+@Slf4j
 public class PaimonSinkConfig extends PaimonConfig {
     public static final Option<SchemaSaveMode> SCHEMA_SAVE_MODE =
             Options.key("schema_save_mode")
@@ -77,5 +79,12 @@ public class PaimonSinkConfig extends PaimonConfig {
         this.primaryKeys = stringToList(readonlyConfig.get(PRIMARY_KEYS), ",");
         this.partitionKeys = stringToList(readonlyConfig.get(PARTITION_KEYS), ",");
         this.writeProps = readonlyConfig.get(WRITE_PROPS);
+        checkConfig();
+    }
+
+    private void checkConfig() {
+        if (this.primaryKeys.isEmpty() && "-1".equals(this.writeProps.get("bucket"))) {
+            log.warn("Append only table currently do not support dynamic bucket");
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/exception/PaimonConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/exception/PaimonConnectorErrorCode.java
@@ -27,7 +27,9 @@ public enum PaimonConnectorErrorCode implements SeaTunnelErrorCode {
     GET_TABLE_FAILED("PAIMON-04", "Get table from database failed"),
     AUTHENTICATE_KERBEROS_FAILED("PAIMON-05", "Authenticate kerberos failed"),
     LOAD_CATALOG("PAIMON-06", "Load catalog failed"),
-    GET_FILED_FAILED("PAIMON-07", "Get field failed");
+    GET_FILED_FAILED("PAIMON-07", "Get field failed"),
+    UNSUPPORTED_PRIMARY_DATATYPE("PAIMON-08", "Paimon primary key datatype is unsupported"),
+    WRITE_PROPS_BUCKET_KEY_ERROR("PAIMON-09", "Cannot define 'bucket-key' in dynamic bucket mode");
 
     private final String code;
     private final String description;

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -106,6 +106,10 @@ public class PaimonSinkWriter
         BucketMode bucketMode = ((FileStoreTable) table).bucketMode();
         this.dynamicBucket =
                 BucketMode.DYNAMIC == bucketMode || BucketMode.GLOBAL_DYNAMIC == bucketMode;
+        int bucket = ((FileStoreTable) table).coreOptions().bucket();
+        if (bucket == -1 && BucketMode.UNAWARE == bucketMode) {
+            log.warn("Append only table currently do not support dynamic bucket");
+        }
         if (dynamicBucket) {
             this.bucketAssigner =
                     new PaimonBucketAssigner(

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class PaimonCatalogTest {
+
+    private PaimonCatalog paimonCatalog;
+    private TableSchema.Builder schemaBuilder;
+    private final String CATALOG_NAME = "paimon_catalog";
+    private final String DATABASE_NAME = "default";
+    private final String TABLE_NAME = "test_table";
+
+    @BeforeEach
+    public void before() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("warehouse", "/tmp/paimon");
+        properties.put("plugin_name", "Paimon");
+        properties.put("database", DATABASE_NAME);
+        properties.put("table", TABLE_NAME);
+        Map<String, String> writeProps = new HashMap<>();
+        writeProps.put("bucket", "-1");
+        writeProps.put("bucket-key", "c_string");
+        properties.put("paimon.table.write-props", writeProps);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(properties);
+        paimonCatalog = new PaimonCatalog(CATALOG_NAME, config);
+        paimonCatalog.open();
+        paimonCatalog.createDatabase(TablePath.of(DATABASE_NAME, TABLE_NAME), false);
+        this.schemaBuilder =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_map",
+                                        new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE),
+                                        (Long) null,
+                                        true,
+                                        null,
+                                        null))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_array",
+                                        ArrayType.STRING_ARRAY_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_array"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_string",
+                                        BasicType.STRING_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_string"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_boolean",
+                                        BasicType.BOOLEAN_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_boolean"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_tinyint",
+                                        BasicType.INT_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_tinyint"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_smallint",
+                                        BasicType.INT_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_smallint"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_int",
+                                        BasicType.INT_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_int"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_bigint",
+                                        BasicType.LONG_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_bigint"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_float",
+                                        BasicType.FLOAT_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_float"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_double",
+                                        BasicType.DOUBLE_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_double"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_decimal",
+                                        new DecimalType(10, 2),
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_decimal"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_bytes",
+                                        BasicType.BYTE_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_bytes"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_date",
+                                        LocalTimeType.LOCAL_DATE_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_date"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_timestamp",
+                                        LocalTimeType.LOCAL_DATE_TIME_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_timestamp"));
+    }
+
+    @Test
+    public void primaryDataTypeError() {
+        TableSchema tableSchema =
+                schemaBuilder
+                        .primaryKey(
+                                PrimaryKey.of("pk", Arrays.asList("c_map", "c_array", "c_string")))
+                        .build();
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(CATALOG_NAME, DATABASE_NAME, TABLE_NAME),
+                        tableSchema,
+                        new HashMap<>(),
+                        new ArrayList<>(),
+                        "test table");
+        Assertions.assertThrows(
+                PaimonConnectorException.class,
+                () -> {
+                    try {
+                        paimonCatalog.createTable(
+                                TablePath.of("default.default.default"), catalogTable, true);
+                    } catch (Exception e) {
+                        Assertions.assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                PaimonConnectorErrorCode
+                                                        .UNSUPPORTED_PRIMARY_DATATYPE
+                                                        .getCode()));
+                        throw e;
+                    }
+                });
+    }
+
+    @Test
+    public void bucketKeyError() {
+        TableSchema tableSchema =
+                schemaBuilder
+                        .primaryKey(PrimaryKey.of("pk", Arrays.asList("c_string", "c_bigint")))
+                        .build();
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(CATALOG_NAME, DATABASE_NAME, TABLE_NAME),
+                        tableSchema,
+                        new HashMap<>(),
+                        new ArrayList<>(),
+                        "test table");
+        Assertions.assertThrows(
+                PaimonConnectorException.class,
+                () -> {
+                    try {
+                        paimonCatalog.createTable(
+                                TablePath.of("default.default.default"), catalogTable, false);
+                    } catch (Exception e) {
+                        Assertions.assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                PaimonConnectorErrorCode
+                                                        .WRITE_PROPS_BUCKET_KEY_ERROR
+                                                        .getCode()));
+                        throw e;
+                    }
+                });
+    }
+
+    @AfterEach
+    public void after() {
+        paimonCatalog.dropDatabase(TablePath.of(DATABASE_NAME, TABLE_NAME), false);
+        paimonCatalog.close();
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_dynamic_bucket_paimon_case6.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_dynamic_bucket_paimon_case6.conf
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
+      primaryKey {
+        name = "pk"
+        columnNames = [c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_decimal,c_bytes,c_date,c_timestamp]
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [{"a": "b"}, [101], "c_string", true, 117, 15987, 563873951, 7084913402530365001, 1.21, 1.231, "2924137191386439303744.39292211", "bWlJWmo=", "2023-04-21", "2023-04-21T23:20:58"]
+      }
+      {
+        kind = INSERT
+        fields = [{"a": "c"}, [102], "c_string1", false, 118, 15988, 563873952, 7084913402530365002, 1.22, 1.232, "2924137191386439303744.39292212", "bWlJWmo=", "2023-04-22", "2023-04-22T23:20:58"]
+      }
+      {
+        kind = INSERT
+        fields = [{"a": "e"}, [103], "c_string2", true, 119, 15987, 563873953, 7084913402530365003, 1.23, 1.233, "2924137191386439303744.39292213", "bWlJWmo=", "2023-04-23", "2023-04-23T23:20:58"]
+      }
+      {
+        kind = INSERT
+        fields = [{"a": "f"}, [104], null, false, 118, 15988, 563873951, 7084913402530365004, 1.24, 1.234, "2924137191386439303744.39292214", "bWlJWmo=", "2023-04-24", "2023-04-24T23:20:58"]
+      }
+      {
+        kind = INSERT
+        fields = [{"a": "b"}, [101], "c_string1", true, 120, 15987, 563873952, 7084913402530365001, 1.21, 1.231, "2924137191386439303744.39292211", "bWlJWmo=", "2023-04-25", "2023-04-25T23:20:58"]
+      }
+      {
+        kind = UPDATE_BEFORE
+        fields = [{"a": "c"}, [102], "c_string2", false, 116, 15987, 563873953, 7084913402530365002, 1.22, 1.232, "2924137191386439303744.39292212", "bWlJWmo=", "2023-04-26", "2023-04-26T23:20:58"]
+      }
+      {
+        kind = UPDATE_AFTER
+        fields = [{"a": "e"}, [103], "c_string3", true, 116, 15989, 563873951, 7084913402530365003, 1.23, 1.233, "2924137191386439303744.39292213", "bWlJWmo=", "2023-04-27", "2023-04-27T23:20:58"]
+      }
+      {
+        kind = DELETE
+        fields = [{"a": "f"}, [104], "c_string4", true, 120, 15987, 563873952, 7084913402530365004, 1.24, 1.234, "2924137191386439303744.39292214", "bWlJWmo=", "2023-04-28", "2023-04-28T23:20:58"]
+      }
+    ]
+    result_table_name = "fake"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "file:///tmp/paimon"
+    database = "full_type"
+    table = "st_test"
+    paimon.table.write-props = {
+       bucket = -1
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_dynamic_bucket_paimon_case7.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_dynamic_bucket_paimon_case7.conf
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
+      primaryKey {
+        name = "pk"
+        columnNames = [c_string,c_boolean,c_tinyint,c_smallint,c_int,c_bigint,c_float,c_double,c_decimal,c_bytes,c_date,c_timestamp]
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [{"a": "b"}, [101], "c_string", true, 121, 15987, 563873951, 7084913402530365001, 1.21, 1.231, "2924137191386439303744.39292211", "bWlJWmo=", "2023-04-21", "2023-04-21T23:20:58"]
+      }
+      {
+        kind = INSERT
+        fields = [{"a": "b"}, [101], "c_string1", true, 122, 15987, 563873952, 7084913402530365001, 1.21, 1.231, "2924137191386439303744.39292211", "bWlJWmo=", "2023-04-25", "2023-04-25T23:20:58"]
+      }
+      {
+        kind = UPDATE_BEFORE
+        fields = [{"a": "c"}, [102], "c_string2", true, 117, 15987, 563873953, 7084913402530365002, 1.22, 1.232, "2924137191386439303744.39292212", "bWlJWmo=", "2023-04-26", "2023-04-26T23:20:58"]
+      }
+      {
+        kind = UPDATE_AFTER
+        fields = [{"a": "e"}, [103], "c_string3", false, 117, 15989, 563873951, 7084913402530365003, 1.23, 1.233, "2924137191386439303744.39292213", "bWlJWmo=", "2023-04-27", "2023-04-27T23:20:58"]
+      }
+      {
+        kind = DELETE
+        fields = [{"a": "e"}, [103], "c_string2", true, 119, 15987, 563873953, 7084913402530365003, 1.23, 1.233, "2924137191386439303744.39292213", "bWlJWmo=", "2023-04-23", "2023-04-23T23:20:58"]
+      }
+    ]
+    result_table_name = "fake"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "/tmp/paimon"
+    database = "full_type"
+    table = "st_test"
+    paimon.table.write-props = {
+      bucket = -1
+    }
+  }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
Dynamic bucket allocation did not take into account that the primary key was not in the first place, resulting in an error when executing the loadBucketIndex method in the initialization of the PaimonBucketAssigner class .  This pr fixed the problem
 
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
PaimonSinkDynamicBucketIT#primaryFullTypeAndLoadData
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).