### PR TITLE
[Improve][Api] Supports simultaneous config of conditions and optional options

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
@@ -245,15 +245,24 @@ public class OptionRule {
             verifyRequiredOptionDuplicate(requiredOption, false);
         }
 
+        /**
+         * Verifies if there are duplicate options within the required options.
+         *
+         * @param requiredOption The required option to be verified
+         * @param ignoreVerifyDuplicateOptions Whether to ignore duplicate option verification If
+         *     the value is true, the existing items in OptionOptions are ignored Currently, it
+         *     applies only to conditional
+         * @throws OptionValidationException If duplicate options are found
+         */
         private void verifyRequiredOptionDuplicate(
                 @NonNull RequiredOption requiredOption,
-                @NonNull Boolean ignoreVerifyDuplicateWithOptionOptions) {
+                @NonNull Boolean ignoreVerifyDuplicateOptions) {
             requiredOption
                     .getOptions()
                     .forEach(
                             option -> {
-                                // Check if the option is duplicate with other required options
-                                if (!ignoreVerifyDuplicateWithOptionOptions) {
+                                if (!ignoreVerifyDuplicateOptions) {
+                                    // Check if required option that duplicate with option options
                                     verifyDuplicateWithOptionOptions(
                                             option, requiredOption.getClass().getSimpleName());
                                 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
@@ -165,7 +165,7 @@ public class OptionRule {
                 @NonNull Option<?>... requiredOptions) {
             verifyConditionalExists(conditionalOption);
 
-            if (expectValues.size() == 0) {
+            if (expectValues.isEmpty()) {
                 throw new OptionValidationException(
                         String.format(
                                 "conditional option '%s' must have expect values .",
@@ -187,7 +187,7 @@ public class OptionRule {
             RequiredOption.ConditionalRequiredOptions option =
                     RequiredOption.ConditionalRequiredOptions.of(
                             expression, new ArrayList<>(Arrays.asList(requiredOptions)));
-            verifyRequiredOptionDuplicate(option);
+            verifyRequiredOptionDuplicate(option, true);
             this.requiredOptions.add(option);
             return this;
         }
@@ -204,7 +204,7 @@ public class OptionRule {
                     RequiredOption.ConditionalRequiredOptions.of(
                             expression, new ArrayList<>(Arrays.asList(requiredOptions)));
 
-            verifyRequiredOptionDuplicate(conditionalRequiredOption);
+            verifyRequiredOptionDuplicate(conditionalRequiredOption, true);
             this.requiredOptions.add(conditionalRequiredOption);
             return this;
         }
@@ -242,12 +242,21 @@ public class OptionRule {
         }
 
         private void verifyRequiredOptionDuplicate(@NonNull RequiredOption requiredOption) {
+            verifyRequiredOptionDuplicate(requiredOption, false);
+        }
+
+        private void verifyRequiredOptionDuplicate(
+                @NonNull RequiredOption requiredOption,
+                @NonNull Boolean ignoreVerifyDuplicateWithOptionOptions) {
             requiredOption
                     .getOptions()
                     .forEach(
                             option -> {
-                                verifyDuplicateWithOptionOptions(
-                                        option, requiredOption.getClass().getSimpleName());
+                                // Check if the option is duplicate with other required options
+                                if (!ignoreVerifyDuplicateWithOptionOptions) {
+                                    verifyDuplicateWithOptionOptions(
+                                            option, requiredOption.getClass().getSimpleName());
+                                }
                                 requiredOptions.forEach(
                                         ro -> {
                                             if (ro


### PR DESCRIPTION
### Purpose of this pull request

conditional does not conflict with optional options

ex: api-path
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/8b295d1b-85cf-4f46-96ff-ce8d2d2c65ad">


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).