### PR TITLE
[Improve][api] Improve inheritance relationship of `AlterTableColumnEvent`

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/event/AlterTableChangeColumnEvent.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/event/AlterTableChangeColumnEvent.java
@@ -26,7 +26,10 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class AlterTableChangeColumnEvent extends AlterTableAddColumnEvent {
+public class AlterTableChangeColumnEvent extends AlterTableColumnEvent {
+    private final Column column;
+    private final boolean first;
+    private final String afterColumn;
     private final String oldColumn;
 
     public AlterTableChangeColumnEvent(
@@ -35,8 +38,11 @@ public class AlterTableChangeColumnEvent extends AlterTableAddColumnEvent {
             Column column,
             boolean first,
             String afterColumn) {
-        super(tableIdentifier, column, first, afterColumn);
+        super(tableIdentifier);
         this.oldColumn = oldColumn;
+        this.column = column;
+        this.first = first;
+        this.afterColumn = afterColumn;
     }
 
     public static AlterTableChangeColumnEvent changeFirst(

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/event/AlterTableModifyColumnEvent.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/event/AlterTableModifyColumnEvent.java
@@ -26,10 +26,17 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class AlterTableModifyColumnEvent extends AlterTableAddColumnEvent {
+public class AlterTableModifyColumnEvent extends AlterTableColumnEvent {
+    private final Column column;
+    private final boolean first;
+    private final String afterColumn;
+
     public AlterTableModifyColumnEvent(
             TableIdentifier tableIdentifier, Column column, boolean first, String afterColumn) {
-        super(tableIdentifier, column, first, afterColumn);
+        super(tableIdentifier);
+        this.column = column;
+        this.first = first;
+        this.afterColumn = afterColumn;
     }
 
     public static AlterTableModifyColumnEvent modifyFirst(

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/event/EventTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/event/EventTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.table.event;
+
+import org.apache.seatunnel.api.event.EventType;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.BasicType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EventTest {
+
+    @Test
+    public void testTableColumnEventInstanceOf() {
+        AlterTableModifyColumnEvent modifyColumnEvent =
+                AlterTableModifyColumnEvent.modify(
+                        TableIdentifier.of("", TablePath.DEFAULT),
+                        PhysicalColumn.builder()
+                                .name("test")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+        Assertions.assertEquals(
+                EventType.SCHEMA_CHANGE_MODIFY_COLUMN, getEventType(modifyColumnEvent));
+
+        AlterTableChangeColumnEvent changeColumnEvent =
+                AlterTableChangeColumnEvent.change(
+                        TableIdentifier.of("", TablePath.DEFAULT),
+                        "old",
+                        PhysicalColumn.builder()
+                                .name("test")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+        Assertions.assertEquals(
+                EventType.SCHEMA_CHANGE_CHANGE_COLUMN, getEventType(changeColumnEvent));
+
+        AlterTableAddColumnEvent addColumnEvent =
+                AlterTableAddColumnEvent.add(
+                        TableIdentifier.of("", TablePath.DEFAULT),
+                        PhysicalColumn.builder()
+                                .name("test")
+                                .dataType(BasicType.STRING_TYPE)
+                                .build());
+        Assertions.assertEquals(EventType.SCHEMA_CHANGE_ADD_COLUMN, getEventType(addColumnEvent));
+
+        AlterTableDropColumnEvent dropColumnEvent =
+                new AlterTableDropColumnEvent(TableIdentifier.of("", TablePath.DEFAULT), "test");
+        Assertions.assertEquals(EventType.SCHEMA_CHANGE_DROP_COLUMN, getEventType(dropColumnEvent));
+    }
+
+    private EventType getEventType(AlterTableColumnEvent event) {
+        if (event instanceof AlterTableAddColumnEvent) {
+            return EventType.SCHEMA_CHANGE_ADD_COLUMN;
+        } else if (event instanceof AlterTableDropColumnEvent) {
+            return EventType.SCHEMA_CHANGE_DROP_COLUMN;
+        } else if (event instanceof AlterTableModifyColumnEvent) {
+            return EventType.SCHEMA_CHANGE_MODIFY_COLUMN;
+        } else if (event instanceof AlterTableChangeColumnEvent) {
+            return EventType.SCHEMA_CHANGE_CHANGE_COLUMN;
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported event type: " + event.getClass().getName());
+    }
+}


### PR DESCRIPTION

### Purpose of this pull request

[Improve][api] Improve inheritance relationship of `AlterTableColumnEvent`

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Added


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).