### PR TITLE
[Fix][connector-v2]Fix Paimon table connector  Error log information.

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -193,7 +193,7 @@ public class PaimonSinkWriter
         } catch (Exception e) {
             throw new PaimonConnectorException(
                     PaimonConnectorErrorCode.TABLE_PRE_COMMIT_FAILED,
-                    "Flink table store failed to prepare commit",
+                    "Paimon pre-commit failed.",
                     e);
         }
     }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
@@ -103,7 +103,7 @@ public class PaimonAggregatedCommitter
         } catch (Exception e) {
             throw new PaimonConnectorException(
                     PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED,
-                    "Flink table store commit operation failed",
+                    "Paimon table storage write-commit Failed.",
                     e);
         }
         return Collections.emptyList();


### PR DESCRIPTION
This commit fixes: the paimon table write commit, pre-commit failure error log, written to Flink table failure information.