### PR TITLE
[Improve][Jdbc] Optimize index name conflicts when create table for postgresql

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCreateTableSqlBuilder.java
@@ -30,11 +30,14 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class PostgresCreateTableSqlBuilder {
     private List<Column> columns;
     private PrimaryKey primaryKey;
@@ -161,10 +164,7 @@ public class PostgresCreateTableSqlBuilder {
     }
 
     private String buildUniqueKeySql(ConstraintKey constraintKey) {
-        String constraintName = constraintKey.getConstraintName();
-        if (constraintName.length() > 25) {
-            constraintName = constraintName.substring(0, 25);
-        }
+        String constraintName = UUID.randomUUID().toString().replace("-", "");
         String indexColumns =
                 constraintKey.getColumnNames().stream()
                         .map(
@@ -175,16 +175,12 @@ public class PostgresCreateTableSqlBuilder {
                                                         constraintKeyColumn.getColumnName(),
                                                         fieldIde)))
                         .collect(Collectors.joining(", "));
-        return "CONSTRAINT " + constraintName + " UNIQUE (" + indexColumns + ")";
+        return "CONSTRAINT \"" + constraintName + "\" UNIQUE (" + indexColumns + ")";
     }
 
     private String buildIndexKeySql(TablePath tablePath, ConstraintKey constraintKey) {
-        // We add table name to index name to avoid name conflict in PG
-        // Since index name in PG should unique in the schema
-        String constraintName = tablePath.getTableName() + "_" + constraintKey.getConstraintName();
-        if (constraintName.length() > 25) {
-            constraintName = constraintName.substring(0, 25);
-        }
+        // If the index name is omitted, PostgreSQL will choose an appropriate name based on table
+        // name and indexed columns.
         String indexColumns =
                 constraintKey.getColumnNames().stream()
                         .map(
@@ -196,9 +192,7 @@ public class PostgresCreateTableSqlBuilder {
                                                         fieldIde)))
                         .collect(Collectors.joining(", "));
 
-        return "CREATE INDEX "
-                + constraintName
-                + " ON "
+        return "CREATE INDEX ON "
                 + tablePath.getSchemaAndTableName("\"")
                 + "("
                 + indexColumns

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCreateTableSqlBuilderTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 class PostgresCreateTableSqlBuilderTest {
 
@@ -49,17 +50,18 @@ class PostgresCreateTableSqlBuilderTest {
                             String createTableSql =
                                     postgresCreateTableSqlBuilder.build(
                                             catalogTable.getTableId().toTablePath());
-                            Assertions.assertEquals(
-                                    "CREATE TABLE \"test\" (\n"
+                            String pattern =
+                                    "CREATE TABLE \"test\" \\(\n"
                                             + "\"id\" int4 NOT NULL PRIMARY KEY,\n"
                                             + "\"name\" text NOT NULL,\n"
                                             + "\"age\" int4 NOT NULL,\n"
-                                            + "\tCONSTRAINT unique_name UNIQUE (\"name\")\n"
-                                            + ");",
-                                    createTableSql);
+                                            + "\tCONSTRAINT \"([a-zA-Z0-9]+)\" UNIQUE \\(\"name\"\\)\n"
+                                            + "\\);";
+                            Assertions.assertTrue(
+                                    Pattern.compile(pattern).matcher(createTableSql).find());
+
                             Assertions.assertEquals(
-                                    Lists.newArrayList(
-                                            "CREATE INDEX test_index_age ON \"test\"(\"age\");"),
+                                    Lists.newArrayList("CREATE INDEX ON \"test\"(\"age\");"),
                                     postgresCreateTableSqlBuilder.getCreateIndexSqls());
 
                             // skip index


### PR DESCRIPTION

### Purpose of this pull request

[Improve][Jdbc] Optimize index name conflicts when create table for postgresql

auto build index-name for pg
http://postgres.cn/docs/13/sql-createindex.html

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Already exists


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).