### PR TITLE
[Feature][Connector-V2] Jdbc DB2 support upsert SQL 

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/AbstractJdbcIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/AbstractJdbcIT.java
@@ -209,6 +209,17 @@ public abstract class AbstractJdbcIT extends TestSuiteBase implements TestResour
                                     jdbcCase.getSourceTable()));
             statement.execute(createSource);
 
+            if (jdbcCase.getAdditionalSqlOnSource() != null) {
+                String additionalSql =
+                        String.format(
+                                jdbcCase.getAdditionalSqlOnSource(),
+                                buildTableInfoWithSchema(
+                                        jdbcCase.getDatabase(),
+                                        jdbcCase.getSchema(),
+                                        jdbcCase.getSourceTable()));
+                statement.execute(additionalSql);
+            }
+
             if (!jdbcCase.isUseSaveModeCreateTable()) {
                 if (jdbcCase.getSinkCreateSql() != null) {
                     createTemplate = jdbcCase.getSinkCreateSql();
@@ -221,6 +232,17 @@ public abstract class AbstractJdbcIT extends TestSuiteBase implements TestResour
                                         jdbcCase.getSchema(),
                                         jdbcCase.getSinkTable()));
                 statement.execute(createSink);
+            }
+
+            if (jdbcCase.getAdditionalSqlOnSink() != null) {
+                String additionalSql =
+                        String.format(
+                                jdbcCase.getAdditionalSqlOnSink(),
+                                buildTableInfoWithSchema(
+                                        jdbcCase.getDatabase(),
+                                        jdbcCase.getSchema(),
+                                        jdbcCase.getSinkTable()));
+                statement.execute(additionalSql);
             }
 
             connection.commit();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCase.java
@@ -48,6 +48,8 @@ public class JdbcCase {
     private String jdbcUrl;
     private String createSql;
     private String sinkCreateSql;
+    private String additionalSqlOnSource;
+    private String additionalSqlOnSink;
     private String insertSql;
     private List<String> configFile;
     private Pair<String[], List<SeaTunnelRow>> testData;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2IT.java
@@ -44,9 +44,9 @@ public class JdbcDb2IT extends AbstractJdbcIT {
 
     private static final String DB2_CONTAINER_HOST = "db2-e2e";
 
-    private static final String DB2_DATABASE = "E2E";
-    private static final String DB2_SOURCE = "SOURCE";
-    private static final String DB2_SINK = "SINK";
+    protected static final String DB2_DATABASE = "E2E";
+    protected static final String DB2_SOURCE = "SOURCE";
+    protected static final String DB2_SINK = "SINK";
 
     private static final String DB2_URL = "jdbc:db2://" + HOST + ":%s/%s";
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2UpsertIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2UpsertIT.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc;
+
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JdbcDb2UpsertIT extends JdbcDb2IT {
+
+    private static final String CREATE_SQL_SINK =
+            "create table %s\n"
+                    + "(\n"
+                    + "    C_BOOLEAN          BOOLEAN,\n"
+                    + "    C_SMALLINT         SMALLINT,\n"
+                    + "    C_INT              INTEGER NOT NULL PRIMARY KEY,\n"
+                    + "    C_INTEGER          INTEGER,\n"
+                    + "    C_BIGINT           BIGINT,\n"
+                    + "    C_DECIMAL          DECIMAL(5),\n"
+                    + "    C_DEC              DECIMAL(5),\n"
+                    + "    C_NUMERIC          DECIMAL(5),\n"
+                    + "    C_NUM              DECIMAL(5),\n"
+                    + "    C_REAL             REAL,\n"
+                    + "    C_FLOAT            DOUBLE,\n"
+                    + "    C_DOUBLE           DOUBLE,\n"
+                    + "    C_DOUBLE_PRECISION DOUBLE,\n"
+                    + "    C_CHAR             CHARACTER(1),\n"
+                    + "    C_VARCHAR          VARCHAR(255),\n"
+                    + "    C_BINARY           BINARY(1),\n"
+                    + "    C_VARBINARY        VARBINARY(2048),\n"
+                    + "    C_DATE             DATE,\n"
+                    + "    C_UPDATED_AT       TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n"
+                    + ");\n";
+
+    // create a trigger to update the timestamp when the row is updated.
+    // if no changes are made to the row, the timestamp should not be updated.
+    private static final String CREATE_TRIGGER_SQL =
+            "CREATE TRIGGER c_updated_at_trigger\n"
+                    + "    BEFORE UPDATE ON %s\n"
+                    + "    REFERENCING NEW AS new_row\n"
+                    + "    FOR EACH ROW\n"
+                    + "BEGIN ATOMIC\n"
+                    + "SET new_row.c_updated_at = CURRENT_TIMESTAMP;\n"
+                    + "END;";
+
+    private static final List<String> CONFIG_FILE =
+            Lists.newArrayList("/jdbc_db2_source_and_sink_upsert.conf");
+
+    @Override
+    JdbcCase getJdbcCase() {
+        jdbcCase = super.getJdbcCase();
+        jdbcCase.setSinkCreateSql(CREATE_SQL_SINK);
+        jdbcCase.setConfigFile(CONFIG_FILE);
+        jdbcCase.setAdditionalSqlOnSink(CREATE_TRIGGER_SQL);
+        return jdbcCase;
+    }
+
+    @TestTemplate
+    public void testDb2UpsertE2e(TestContainer container)
+            throws IOException, InterruptedException, SQLException {
+        try {
+            // step 1: run the job to migrate data from source to sink.
+            Container.ExecResult execResult =
+                    container.executeJob("/jdbc_db2_source_and_sink_upsert.conf");
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+            List<List<Object>> updatedAtTimestampsBeforeUpdate =
+                    query(
+                            String.format(
+                                    "SELECT C_UPDATED_AT  FROM %s",
+                                    buildTableInfoWithSchema(DB2_DATABASE, DB2_SINK)));
+            // step 2: run the job to update the data in the sink.
+            // expected: timestamps should not be updated as the data is not changed.
+            execResult = container.executeJob("/jdbc_db2_source_and_sink_upsert.conf");
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+            List<List<Object>> updatedAtTimestampsAfterUpdate =
+                    query(
+                            String.format(
+                                    "SELECT C_UPDATED_AT  FROM %s",
+                                    buildTableInfoWithSchema(DB2_DATABASE, DB2_SINK)));
+            Assertions.assertIterableEquals(
+                    updatedAtTimestampsBeforeUpdate, updatedAtTimestampsAfterUpdate);
+        } finally {
+            clearTable(DB2_DATABASE, DB2_SINK);
+        }
+    }
+
+    private List<List<Object>> query(String sql) {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            List<List<Object>> result = new ArrayList<>();
+            int columnCount = resultSet.getMetaData().getColumnCount();
+            while (resultSet.next()) {
+                ArrayList<Object> objects = new ArrayList<>();
+                for (int i = 1; i <= columnCount; i++) {
+                    objects.add(resultSet.getString(i));
+                }
+                result.add(objects);
+                log.debug(String.format("Print query, sql: %s, data: %s", sql, objects));
+            }
+            connection.commit();
+            return result;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_db2_source_and_sink_upsert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_db2_source_and_sink_upsert.conf
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  # This is a example source plugin **only for test and demonstrate the feature source plugin**
+  Jdbc {
+    driver = com.ibm.db2.jcc.DB2Driver
+    url = "jdbc:db2://db2-e2e:50000/E2E"
+    user = "db2inst1"
+    password = "123456"
+    query = """
+    select * from "E2E".SOURCE;
+    """
+  }
+
+  # If you would like to get more information about how to configure seatunnel and see full list of source plugins,
+  # please go to https://seatunnel.apache.org/docs/connector-v2/source/Jdbc
+}
+
+sink {
+  Jdbc {
+    driver = com.ibm.db2.jcc.DB2Driver
+    url = "jdbc:db2://db2-e2e:50000/E2E"
+    user = "db2inst1"
+    password = "123456"
+    database = "E2E"
+    table = "SINK"
+    enable_upsert = true
+    # The primary keys of the table, which will be used to generate the upsert sql
+    generate_sink_sql = true
+    primary_keys = [
+      C_INT
+    ]
+  }
+
+  # If you would like to get more information about how to configure seatunnel and see full list of sink plugins,
+  # please go to https://seatunnel.apache.org/docs/connector-v2/sink/Jdbc
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
Currently Seatunnel JDBC Connector with DB2 Dialect, does not support upsert scenarios, as the implementation is unavailable. While analysing our requirements within Visa's use-cases, we have approximately 60% of jobs that heavily depend on this. 

We want to introduce the implementation for upsert support for DB2 dialect, along with the e2e Integration test case.

solves: https://github.com/apache/seatunnel/issues/4434, as Dameng DB, implementation is already present.
How do I reopen the issue? 

### Does this PR introduce _any_ user-facing change?
No, 
User does not have to provide the query parameter in sink, user has to provide database, table and generate_sink_sql, which are already available in the configurations. Please refer corresponding [Seatunnel-web] PR: https://github.com/apache/seatunnel-web/pull/233

Sample:
```
env {
  parallelism = 1
  job.mode = "BATCH"
}

source {
  # This is a example source plugin **only for test and demonstrate the feature source plugin**
  Jdbc {
    driver = com.ibm.db2.jcc.DB2Driver
    url = "jdbc:db2://db2-e2e:50000/E2E"
    user = "db2inst1"
    password = "123456"
    query = """
    select * from "E2E".SOURCE;
    """
  }
}

sink {
  Jdbc {
    driver = com.ibm.db2.jcc.DB2Driver
    url = "jdbc:db2://db2-e2e:50000/E2E"
    user = "db2inst1"
    password = "123456"
    database = "E2E"
    table = "SINK"
    # The primary keys of the table, which will be used to generate the upsert sql
    generate_sink_sql = true
    primary_keys = [
      C_INT
    ]
  }
```

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
We internally deployed, and tested the scenarios, we need to introduce a minor change in Seatunnel-web module as well, to delegate generation of sink sql to the engine, as required for the upsert use-case. 

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).