### PR TITLE
[Improvement][connector-tdengine] support read column data from tdengine table or write column data to tdengine table

### DIFF
--- a/docs/en/connector-v2/sink/TDengine.md
+++ b/docs/en/connector-v2/sink/TDengine.md
@@ -6,6 +6,10 @@
 
 Used to write data to TDengine. You need to create stable before running seatunnel task
 
+***attention please***
++ you don't need to config sub-table name, first column read is used as sub-table name
++ we will use last n columns as table tags, n is count of tags
+
 ## Key features
 
 - [x] [exactly-once](../../concept/connector-v2-features.md)
@@ -13,13 +17,14 @@ Used to write data to TDengine. You need to create stable before running seatunn
 
 ## Options
 
-|   name   |  type  | required | default value |
+| name     | type   | required | default value |
 |----------|--------|----------|---------------|
 | url      | string | yes      | -             |
 | username | string | yes      | -             |
 | password | string | yes      | -             |
 | database | string | yes      |               |
 | stable   | string | yes      | -             |
+| fields   | list   | no       | -             |
 | timezone | string | no       | UTC           |
 
 ### url [string]
@@ -54,18 +59,51 @@ the timeznoe of the TDengine sever, it's important to the ts field
 
 ## Example
 
-### sink
+### write 3 columns into table power.meter 
+
+power.meter schema information:
+
+```sql
+CREATE STABLE `meter` (`ts` TIMESTAMP, `latitude` DOUBLE, `longtitude` DOUBLE) TAGS (`tenant_id` INT)
+```
+seatunnel config file
 
 ```hocon
+source {
+  # This is a example input plugin **only for test and demonstrate the feature input plugin**
+  FakeSource {
+    row.num = 1
+    schema = {
+      fields {
+        table_name = int
+        ts = timestamp
+        latitude = double
+        tenant_id = int
+      }
+    }
+    result_table_name = "fake"
+  }
+}
+
 sink {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power2"
-          stable : "meters2"
-          timezone: UTC
-        }
+    TDengine {
+        source_table_name='fake'
+        url : "jdbc:TAOS-RS://localhost:6041/"
+        username : "root"
+        password : "taosdata"
+        database : "test"
+        fields: ['ts','latitude']
+        stable : "meter"
+        timezone: UTC
+    }
 }
 ```
+execute query and print table data
+```sql
+taos> select * from meter;
+           ts            |         latitude          |        longtitude         |  tenant_id  |
+================================================================================================
+ 2024-03-08 03:47:54.000 |    9.594743198982019e+306 |                      NULL |  1215981593 |
+ 2024-08-18 07:34:56.000 |    1.712320739538011e+308 |                      NULL |  1965348204 |
+ 2024-07-05 21:59:04.000 |    4.499682197436227e+307 |                      NULL |   203469706 |
 

--- a/docs/en/connector-v2/source/TDengine.md
+++ b/docs/en/connector-v2/source/TDengine.md
@@ -20,13 +20,14 @@ supports query SQL and can achieve projection effect.
 
 ## Options
 
-|    name     |  type  | required | default value |
+| name        | type   | required | default value |
 |-------------|--------|----------|---------------|
 | url         | string | yes      | -             |
 | username    | string | yes      | -             |
 | password    | string | yes      | -             |
 | database    | string | yes      |               |
 | stable      | string | yes      | -             |
+| fields      | list   | no       | -             |
 | lower_bound | long   | yes      | -             |
 | upper_bound | long   | yes      | -             |
 
@@ -56,6 +57,10 @@ the database of the TDengine when you select
 
 the stable of the TDengine when you select
 
+### fields [list]
+
+table columns selected from source table, such as: [ts,longtitude]
+
 ### lower_bound [long]
 
 the lower_bound of the migration period
@@ -76,6 +81,7 @@ source {
           password : "taosdata"
           database : "power"
           stable : "meters"
+          fields : [ts,longtitude]
           lower_bound : "2018-10-03 14:38:05.000"
           upper_bound : "2018-10-03 14:38:16.800"
           result_table_name = "tdengine_result"

--- a/docs/zh/connector-v2/sink/TDengine.md
+++ b/docs/zh/connector-v2/sink/TDengine.md
@@ -1,0 +1,82 @@
+# TDengine
+
+> TDengine(Taos)数据接收器
+
+## Description
+
+连接TDengine(Taos)数据库并将数据写入数据库
+
+***需要注意的点***
+
++ 写入tdengine时无需指定子表名称，会将reader中读取出来的第一个字段当作子表名称，假如数据源是一个jdbc任务，query语句是select device_id,ts,power,tenant_id from xxx，那么写入的子表名称将会是device_id的值。
++ 同理，写入时会将读出来的最后几列当作tag，假设写入的超级表指定了tag是tenant_id，那么在写入时会将tenant_id的值当作tag
+
+## Key features
+
+- [x] [批处理](../../concept/connector-v2-features.md)
+- [ ] [流处理](../../concept/connector-v2-features.md)
+- [x] [精确一次](../../concept/connector-v2-features.md)
+- [x] [并行度](../../concept/connector-v2-features.md)
+
+## 源选项
+
+| 名称       | 类型     | 是否必须	 | 默认值 | 描述                                                 |
+|----------|--------|-------|---------------|----------------------------------------------------|
+| url      | string | 是     | -             | 连接数据库使用的jdbc url，比如: jdbc:TAOS-RS://localhost:6041 |
+| username | string | 是     | -             | 连接数据库使用的用户名                                        |
+| password | string | 是     | -             | 连接数据库使用的密码                                         |
+| database | string | 是     |               | 数据写入的数据库名称                                         |
+| stable   | string | 是     | -             | 数据写入的数据表名称                                         |
+| fields   | list   | 否     | -             | 写入的数据表字段                                           |
+| timezone | string | 否     | -             | 客户端时区                                              | 
+
+## 任务示例
+
+### 往power.meters表中写入ts和longtitude两个字段的数据
+
+power.meters表结构:
+
+```sql
+CREATE STABLE `meter` (`ts` TIMESTAMP, `latitude` DOUBLE, `longtitude` DOUBLE) TAGS (`tenant_id` INT)
+```
+seatunnel 配置信息
+```hocon
+source {
+  # This is a example input plugin **only for test and demonstrate the feature input plugin**
+  FakeSource {
+    row.num = 1
+    schema = {
+      fields {
+        table_name = int
+        ts = timestamp
+        latitude = double
+        tenant_id = int
+      }
+    }
+    result_table_name = "fake"
+  }
+}
+
+sink {
+    TDengine {
+        source_table_name='fake'
+        url : "jdbc:TAOS-RS://localhost:6041/"
+        username : "root"
+        password : "taosdata"
+        database : "test"
+        fields: ['ts','latitude']
+        stable : "meter"
+        timezone: UTC
+    }
+}
+```
+查询tdengine数据库查看最新数据
+
+```sql
+taos> select * from meter;
+           ts            |         latitude          |        longtitude         |  tenant_id  |
+================================================================================================
+ 2024-03-08 03:47:54.000 |    9.594743198982019e+306 |                      NULL |  1215981593 |
+ 2024-08-18 07:34:56.000 |    1.712320739538011e+308 |                      NULL |  1965348204 |
+ 2024-07-05 21:59:04.000 |    4.499682197436227e+307 |                      NULL |   203469706 |
+```

--- a/docs/zh/connector-v2/source/TDengine.md
+++ b/docs/zh/connector-v2/source/TDengine.md
@@ -1,0 +1,48 @@
+# TDengine
+
+> TDengine(Taos)数据源连接器
+
+## Description
+
+从TDengine(Taos)数据源读取数据，支持全表读取、指定列读取。
+
+## Key features
+
+- [x] [批处理](../../concept/connector-v2-features.md)
+- [ ] [流处理](../../concept/connector-v2-features.md)
+- [x] [精确一次](../../concept/connector-v2-features.md)
+- [x] [并行度](../../concept/connector-v2-features.md)
+
+## 源选项
+
+| 名称        | 类型   | 是否必须	 | 默认值 | 描述                                                                     |
+|-------------|--------|-------|---------------|------------------------------------------------------------------------|
+| url         | string | 是     | -             | 连接数据库使用的jdbc url，比如: jdbc:TAOS-RS://localhost:6041 |
+| username    | string | 是     | -             | 连接数据库使用的用户名                                                            |
+| password    | string | 是     | -             | 连接数据库使用的密码                                                             |
+| database    | string | 是     |               | 数据源表所在的数据库名称                                                           |
+| stable      | string | 是     | -             | 数据源表的名称                                                                |
+| fields      | list   | 否     | -             | 需要从数据源表中读取的字段                                                          |
+| lower_bound | long   | 是    | -             | 过滤条件。从数据源中读取数据时，数据的最早时间                                                |
+| upper_bound | long   | 是    | -             | 过滤条件。从数据源中读取数据时，数据的最晚时间                                                |
+
+## 任务示例
+
+### 从power.meters表中读取ts和longtitude两个字段的数据，指定的数据时间范围是[2018-10-03 14:38:05.000,2018-10-03 14:38:16.800) 
+
+```hocon
+source {
+        TDengine {
+          url : "jdbc:TAOS-RS://localhost:6041/"
+          username : "root"
+          password : "taosdata"
+          database : "power"
+          stable : "meters"
+          fields : [ts,longtitude]
+          lower_bound : "2018-10-03 14:38:05.000"
+          upper_bound : "2018-10-03 14:38:16.800"
+          result_table_name = "tdengine_result"
+        }
+}
+```
+

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
@@ -32,7 +32,6 @@ import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengine
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.STABLE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.TIMEZONE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.UPPER_BOUND;
-import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.URL;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.USERNAME;
 
 @Data

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
@@ -26,13 +26,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.DATABASE;
+import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.FIELDS;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.LOWER_BOUND;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.PASSWORD;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.STABLE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.TIMEZONE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.UPPER_BOUND;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.URL;
-import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.FIELDS;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.USERNAME;
 
 @Data

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.DATABASE;
@@ -30,6 +31,8 @@ import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengine
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.STABLE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.TIMEZONE;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.UPPER_BOUND;
+import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.URL;
+import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.FIELDS;
 import static org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig.ConfigNames.USERNAME;
 
 @Data
@@ -71,6 +74,10 @@ public class TDengineSourceConfig implements Serializable {
                 pluginConfig.hasPath(LOWER_BOUND) ? pluginConfig.getString(LOWER_BOUND) : null);
         tdengineSourceConfig.setTimezone(
                 pluginConfig.hasPath(TIMEZONE) ? pluginConfig.getString(TIMEZONE) : "UTC");
+        tdengineSourceConfig.setFields(
+                pluginConfig.hasPath(FIELDS)
+                        ? pluginConfig.getStringList(FIELDS)
+                        : new ArrayList<>());
 
         return tdengineSourceConfig;
     }
@@ -85,5 +92,6 @@ public class TDengineSourceConfig implements Serializable {
         public static String TIMEZONE = "timezone";
         public static String LOWER_BOUND = "lower_bound";
         public static String UPPER_BOUND = "upper_bound";
+        public static String FIELDS = "fields";
     }
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/exception/TDengineConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/exception/TDengineConnectorErrorCode.java
@@ -20,7 +20,8 @@ package org.apache.seatunnel.connectors.seatunnel.tdengine.exception;
 import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
 
 public enum TDengineConnectorErrorCode implements SeaTunnelErrorCode {
-    LOAD_DRIVER_FAILED("TDengine-01", "Fail to create driver of class");
+    LOAD_DRIVER_FAILED("TDengine-01", "Fail to create driver of class"),
+    FIELD_NOT_EXIST("TDengine-02", "Selected fields does not exist!");
 
     private final String code;
     private final String description;

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
@@ -100,11 +100,13 @@ public class TDengineSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
                 conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
             String sql =
                     String.format(
-                            "INSERT INTO %s using %s tags ( %s ) VALUES ( %s );",
+                            "INSERT INTO %s using %s tags ( %s ) (%s) VALUES ( %s );",
                             element.getField(0),
                             config.getStable(),
                             tagValues,
+                            String.join(",", config.getFields()),
                             StringUtils.join(convertDataType(metrics), ","));
+            log.debug("sql content: {}", sql);
             final int rowCount = statement.executeUpdate(sql);
             if (rowCount == 0) {
                 Throwables.propagateIfPossible(

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -100,12 +101,21 @@ public class TDengineSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
                 conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
             String sql =
                     String.format(
-                            "INSERT INTO %s using %s tags ( %s ) (%s) VALUES ( %s );",
+                            "INSERT INTO %s using %s tags ( %s ) VALUES ( %s );",
                             element.getField(0),
                             config.getStable(),
                             tagValues,
-                            String.join(",", config.getFields()),
                             StringUtils.join(convertDataType(metrics), ","));
+            if (CollectionUtils.isNotEmpty(config.getFields())) {
+                sql =
+                        String.format(
+                                "INSERT INTO %s using %s tags ( %s ) (%s) VALUES ( %s );",
+                                element.getField(0),
+                                config.getStable(),
+                                tagValues,
+                                String.join(",", config.getFields()),
+                                StringUtils.join(convertDataType(metrics), ","));
+            }
             log.debug("sql content: {}", sql);
             final int rowCount = statement.executeUpdate(sql);
             if (rowCount == 0) {

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorErrorCode;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.common.PrepareFailException;
@@ -49,6 +51,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
@@ -128,6 +131,7 @@ public class TDengineSource
         List<String> subTableNames = new ArrayList<>();
         List<String> fieldNames = new ArrayList<>();
         List<SeaTunnelDataType<?>> fieldTypes = new ArrayList<>();
+        List<String> fields = config.getFields();
 
         String jdbcUrl = String.join("", config.getUrl(), config.getDatabase());
 
@@ -152,8 +156,16 @@ public class TDengineSource
                 if (timestampFieldName == null) {
                     timestampFieldName = metaResultSet.getString(1);
                 }
-                fieldNames.add(metaResultSet.getString(1));
-                fieldTypes.add(TDengineTypeMapper.mapping(metaResultSet.getString(2)));
+                String fieldName = metaResultSet.getString(1);
+                if (CollectionUtils.isNotEmpty(fields)) {
+                    if (fields.contains(fieldName)) {
+                        fieldNames.add(fieldName);
+                        fieldTypes.add(TDengineTypeMapper.mapping(metaResultSet.getString(2)));
+                    }
+                } else {
+                    fieldNames.add(fieldName);
+                    fieldTypes.add(TDengineTypeMapper.mapping(metaResultSet.getString(2)));
+                }
             }
 
             while (subTableNameResultSet.next()) {

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.tdengine.source;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorErrorCode;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.common.PrepareFailException;
@@ -35,10 +33,12 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.config.CheckConfigUtil;
 import org.apache.seatunnel.common.config.CheckResult;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.state.TDengineSourceState;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.typemapper.TDengineTypeMapper;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.google.auto.service.AutoService;

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
@@ -33,7 +33,6 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.config.CheckConfigUtil;
 import org.apache.seatunnel.common.config.CheckResult;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.config.TDengineSourceConfig;
-import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.exception.TDengineConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.state.TDengineSourceState;
 import org.apache.seatunnel.connectors.seatunnel.tdengine.typemapper.TDengineTypeMapper;
@@ -51,7 +50,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

close https://github.com/apache/seatunnel/issues/7886

### Does this PR introduce _any_ user-facing change?

no 

### How was this patch tested?

case 1: column count(reader) < column count(writer)

result: operation failed. according to config, seatunnel try write 2 columns into table but only 1 column provided(except table_name and tags)

st config:

```
env {
  execution.parallelism = 1
  job.mode = "BATCH"
}

source {
  # This is a example input plugin **only for test and demonstrate the feature input plugin**
  FakeSource {
    row.num = 1
    schema = {
      fields {
        table_name = int
        ts = timestamp
        tenant_id = int
      }
    }
    result_table_name = "fake"
  }
}

sink {
        TDengine {
source_table_name='fake'
          url : "jdbc:TAOS-RS://localhost:6041/"
          username : "root"
          password : "taosdata"
          database : "test"
fields: ['ts','latitude']
          stable : "meter"
          timezone: UTC
        }
}
```

test log: 

```
Exception in thread "main" org.apache.seatunnel.core.starter.exception.CommandExecuteException: SeaTunnel job executed failed
        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:213)
        at org.apache.seatunnel.core.starter.SeaTunnel.run(SeaTunnel.java:40)
        at org.apache.seatunnel.core.starter.seatunnel.SeaTunnelClient.main(SeaTunnelClient.java:34)
Caused by: org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException: java.lang.RuntimeException: java.sql.SQLException: TDengine ERROR (216): sql: INSERT INTO 534905432 using meter tags ( 1.9691318559072168E307 ) ('ts','latitude') VALUES ( '2024-09-24 02:27:45.000' );, desc: syntax error near '1.9691318559072168e307 ) ('ts','latitude') values ( '2024-09-24' (invalid int data)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:253)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:66)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTransformCollector.collect(SeaTunnelTransformCollector.java:39)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTransformCollector.collect(SeaTunnelTransformCollector.java:27)
        at org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue.handleRecord(IntermediateBlockingQueue.java:75)
        at org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue.collect(IntermediateBlockingQueue.java:50)
        at org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle.collect(IntermediateQueueFlowLifeCycle.java:51)
        at org.apache.seatunnel.engine.server.task.TransformSeaTunnelTask.collect(TransformSeaTunnelTask.java:73)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTask.stateProcess(SeaTunnelTask.java:168)
        at org.apache.seatunnel.engine.server.task.TransformSeaTunnelTask.call(TransformSeaTunnelTask.java:78)
        at org.apache.seatunnel.engine.server.TaskExecutionService$BlockingWorker.run(TaskExecutionService.java:693)
        at org.apache.seatunnel.engine.server.TaskExecutionService$NamedTaskWrapper.run(TaskExecutionService.java:1018)
        at org.apache.seatunnel.api.tracing.MDCRunnable.run(MDCRunnable.java:39)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.sql.SQLException: TDengine ERROR (216): sql: INSERT INTO 534905432 using meter tags ( 1.9691318559072168E307 ) ('ts','latitude') VALUES ( '2024-09-24 02:27:45.000' );, desc: syntax error near '1.9691318559072168e307 ) ('ts','latitude') values ( '2024-09-24' (invalid int data)
        at com.taosdata.jdbc.TSDBError.createSQLException(TSDBError.java:76)
        at com.taosdata.jdbc.rs.RestfulStatement.execute(RestfulStatement.java:77)
        at com.taosdata.jdbc.rs.RestfulStatement.executeUpdate(RestfulStatement.java:46)
        at org.apache.seatunnel.connectors.seatunnel.tdengine.sink.TDengineSinkWriter.write(TDengineSinkWriter.java:109)
        at org.apache.seatunnel.connectors.seatunnel.tdengine.sink.TDengineSinkWriter.write(TDengineSinkWriter.java:51)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:249)
        ... 17 more

        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:205)
```

case 2: column count(reader) == column count(writer)

result: succeed write data into database

st config:

```
env {
  execution.parallelism = 1
  job.mode = "BATCH"
}

source {
  # This is a example input plugin **only for test and demonstrate the feature input plugin**
  FakeSource {
    row.num = 1
    schema = {
      fields {
        table_name = int
        ts = timestamp
        lat = double
        tenant_id = int
      }
    }
    result_table_name = "fake"
  }
}

sink {
        TDengine {
source_table_name='fake'
          url : "jdbc:TAOS-RS://localhost:6041/"
          username : "root"
          password : "taosdata"
          database : "test"
fields: ['ts','latitude']
          stable : "meter"
          timezone: UTC
        }
}
```

test log:

```
2024-10-23 20:07:54,149 DEBUG [o.a.s.c.s.f.s.FakeSourceReader] [hz.main.generic-operation.thread-20] - reader 0 add splits [FakeSourceSplit(tableId=fake, splitId=0, rowNum=1)]
2024-10-23 20:07:54,464 DEBUG [c.h.s.i.o.i.InvocationMonitor ] [hz.main.InvocationMonitorThread] - [localhost]:5801 [seatunnel-868391] [5.1] Invocations:1 timeouts:0 backup-timeouts:0
2024-10-23 20:07:55,098 INFO  [o.a.s.c.s.f.s.FakeSourceReader] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - 1 rows of data have been generated in split(fake_0) for table fake. Generation time: 1729685275089
2024-10-23 20:07:55,098 INFO  [o.a.s.c.s.f.s.FakeSourceReader] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - Closed the bounded fake source
2024-10-23 20:07:55,107 DEBUG [a.s.c.s.t.s.TDengineSinkWriter] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - sql content: INSERT INTO 1173840892 using meter tags ( 1730702775 ) ('ts','latitude') VALUES ( '2024-08-04 16:11:32.000',6.408192514684265E307 );
2024-10-23 20:07:55,109 DEBUG [o.a.h.c.p.RequestAddCookies   ] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - CookieSpec selected: default
2024-10-23 20:07:55,109 DEBUG [o.a.h.c.p.RequestAuthCache    ] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - Auth cache not set in the context
2024-10-23 20:07:55,109 DEBUG [ingHttpClientConnectionManager] [BlockingWorker-TaskGroupLocation{jobId=901441798688210945, pipelineId=1, taskGroupId=30000}] - Connection request: [route: {}->http://10.5.2.26:6041][total available: 1; route allocated: 1 of 20; total allocated: 1 of 200]
```

case 3: column count(reader) > column count(writer)

result: operation failed. according to config, seatunnel shuld write 2 columns into table but 3 column provided(except table_name and tags), currently seatunnel does not support find column value by column name, so a wrong sql is generated.

st config:

```
env {
  execution.parallelism = 1
  job.mode = "BATCH"
}

source {
  # This is a example input plugin **only for test and demonstrate the feature input plugin**
  FakeSource {
    row.num = 1
    schema = {
      fields {
        table_name = int
        ts = timestamp
        test_field = string
        lat = double
        tenant_id = int
      }
    }
    result_table_name = "fake"
  }
}

sink {
        TDengine {
source_table_name='fake'
          url : "jdbc:TAOS-RS://localhost:6041/"
          username : "root"
          password : "taosdata"
          database : "test"
fields: ['ts','latitude']
          stable : "meter"
          timezone: UTC
        }
}
```

test log:

```
Exception in thread "main" org.apache.seatunnel.core.starter.exception.CommandExecuteException: SeaTunnel job executed failed
        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:213)
        at org.apache.seatunnel.core.starter.SeaTunnel.run(SeaTunnel.java:40)
        at org.apache.seatunnel.core.starter.seatunnel.SeaTunnelClient.main(SeaTunnelClient.java:34)
Caused by: org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException: java.lang.RuntimeException: java.sql.SQLException: TDengine ERROR (216): sql: INSERT INTO 1574017200 using meter tags ( 18329617 ) ('ts','latitude') VALUES ( '2024-07-13 19:04:23.000','douag',1.6443365459008203E308 );, desc: syntax error near 'douag' (illegal double data)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:253)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:66)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTransformCollector.collect(SeaTunnelTransformCollector.java:39)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTransformCollector.collect(SeaTunnelTransformCollector.java:27)
        at org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue.handleRecord(IntermediateBlockingQueue.java:75)
        at org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue.collect(IntermediateBlockingQueue.java:50)
        at org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle.collect(IntermediateQueueFlowLifeCycle.java:51)
        at org.apache.seatunnel.engine.server.task.TransformSeaTunnelTask.collect(TransformSeaTunnelTask.java:73)
        at org.apache.seatunnel.engine.server.task.SeaTunnelTask.stateProcess(SeaTunnelTask.java:168)
        at org.apache.seatunnel.engine.server.task.TransformSeaTunnelTask.call(TransformSeaTunnelTask.java:78)
        at org.apache.seatunnel.engine.server.TaskExecutionService$BlockingWorker.run(TaskExecutionService.java:693)
        at org.apache.seatunnel.engine.server.TaskExecutionService$NamedTaskWrapper.run(TaskExecutionService.java:1018)
        at org.apache.seatunnel.api.tracing.MDCRunnable.run(MDCRunnable.java:39)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.sql.SQLException: TDengine ERROR (216): sql: INSERT INTO 1574017200 using meter tags ( 18329617 ) ('ts','latitude') VALUES ( '2024-07-13 19:04:23.000','douag',1.6443365459008203E308 );, desc: syntax error near 'douag' (illegal double data)
        at com.taosdata.jdbc.TSDBError.createSQLException(TSDBError.java:76)
        at com.taosdata.jdbc.rs.RestfulStatement.execute(RestfulStatement.java:77)
        at com.taosdata.jdbc.rs.RestfulStatement.executeUpdate(RestfulStatement.java:46)
        at org.apache.seatunnel.connectors.seatunnel.tdengine.sink.TDengineSinkWriter.write(TDengineSinkWriter.java:109)
        at org.apache.seatunnel.connectors.seatunnel.tdengine.sink.TDengineSinkWriter.write(TDengineSinkWriter.java:51)
        at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.received(SinkFlowLifeCycle.java:249)
        ... 17 more

        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:205)
        ... 2 more
```

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).