### PR TITLE
[Fix][Doc] Fix klaviyo doc 404 link

### DIFF
--- a/docs/en/connector-v2/source/Klaviyo.md
+++ b/docs/en/connector-v2/source/Klaviyo.md
@@ -45,7 +45,7 @@ http request url
 
 API private key for login, you can get more detail at this link:
 
-https://developers.klaviyo.com/en/docs/retrieve_api_credentials
+https://developers.klaviyo.com/en/docs
 
 ### revision [String]
 

--- a/docs/en/connector-v2/source/Klaviyo.md
+++ b/docs/en/connector-v2/source/Klaviyo.md
@@ -45,7 +45,7 @@ http request url
 
 API private key for login, you can get more detail at this link:
 
-https://developers.klaviyo.com/en/docs
+https://developers.klaviyo.com/en/docs/authenticate_#private-key-authentication
 
 ### revision [String]
 


### PR DESCRIPTION
At present, the reference link provided by Klaviyo connector is 404 inaccessible and needs to be modified, otherwise it will hinder the operation of ST project CI