### PR TITLE
[Bug][Avro] Fix avro miss convert short type to int

### DIFF
--- a/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroConverterTest.java
+++ b/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroConverterTest.java
@@ -66,13 +66,16 @@ class AvroConverterTest {
         subSeaTunnelRow.setField(12, bigDecimal);
         subSeaTunnelRow.setField(13, localDateTime);
 
+        Map<String, Short> mapData = new HashMap<>();
+        mapData.put("k1", Short.valueOf("1"));
+        mapData.put("k2", Short.valueOf("2"));
         SeaTunnelRow seaTunnelRow = new SeaTunnelRow(15);
-        seaTunnelRow.setField(0, map);
+        seaTunnelRow.setField(0, mapData);
         seaTunnelRow.setField(1, strArray);
         seaTunnelRow.setField(2, "strVal");
         seaTunnelRow.setField(3, true);
-        seaTunnelRow.setField(4, 1);
-        seaTunnelRow.setField(5, 2);
+        seaTunnelRow.setField(4, new Byte("1"));
+        seaTunnelRow.setField(5, Short.valueOf("2"));
         seaTunnelRow.setField(6, 3);
         seaTunnelRow.setField(7, Long.MAX_VALUE - 1);
         seaTunnelRow.setField(8, 33.333F);
@@ -138,12 +141,12 @@ class AvroConverterTest {
             "c_row"
         };
         SeaTunnelDataType<?>[] fieldTypes = {
-            new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE),
+            new MapType<>(BasicType.STRING_TYPE, BasicType.SHORT_TYPE),
             ArrayType.STRING_ARRAY_TYPE,
             BasicType.STRING_TYPE,
             BasicType.BOOLEAN_TYPE,
-            BasicType.INT_TYPE,
-            BasicType.INT_TYPE,
+            BasicType.BYTE_TYPE,
+            BasicType.SHORT_TYPE,
             BasicType.INT_TYPE,
             BasicType.LONG_TYPE,
             BasicType.FLOAT_TYPE,

--- a/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroSerializationSchemaTest.java
+++ b/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroSerializationSchemaTest.java
@@ -48,8 +48,8 @@ class AvroSerializationSchemaTest {
     private SeaTunnelRow buildSeaTunnelRow() {
         SeaTunnelRow subSeaTunnelRow = new SeaTunnelRow(14);
         Map<String, String> map = new HashMap<>();
-        map.put("k1", "v1");
-        map.put("k2", "v2");
+        map.put("k1", "1");
+        map.put("k2", "2");
         String[] strArray = new String[] {"l1", "l2"};
         byte byteVal = 100;
         subSeaTunnelRow.setField(0, map);
@@ -67,13 +67,16 @@ class AvroSerializationSchemaTest {
         subSeaTunnelRow.setField(12, bigDecimal);
         subSeaTunnelRow.setField(13, localDateTime);
 
+        Map<String, Short> mapData = new HashMap<>();
+        mapData.put("k1", Short.valueOf("1"));
+        mapData.put("k2", Short.valueOf("2"));
         SeaTunnelRow seaTunnelRow = new SeaTunnelRow(15);
-        seaTunnelRow.setField(0, map);
+        seaTunnelRow.setField(0, mapData);
         seaTunnelRow.setField(1, strArray);
         seaTunnelRow.setField(2, "strVal");
         seaTunnelRow.setField(3, true);
-        seaTunnelRow.setField(4, 1);
-        seaTunnelRow.setField(5, 2);
+        seaTunnelRow.setField(4, new Byte("1"));
+        seaTunnelRow.setField(5, Short.valueOf("2"));
         seaTunnelRow.setField(6, 3);
         seaTunnelRow.setField(7, Long.MAX_VALUE - 1);
         seaTunnelRow.setField(8, 33.333F);
@@ -138,12 +141,12 @@ class AvroSerializationSchemaTest {
             "c_row"
         };
         SeaTunnelDataType<?>[] fieldTypes = {
-            new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE),
+            new MapType<>(BasicType.STRING_TYPE, BasicType.SHORT_TYPE),
             ArrayType.STRING_ARRAY_TYPE,
             BasicType.STRING_TYPE,
             BasicType.BOOLEAN_TYPE,
-            BasicType.INT_TYPE,
-            BasicType.INT_TYPE,
+            BasicType.BYTE_TYPE,
+            BasicType.SHORT_TYPE,
             BasicType.INT_TYPE,
             BasicType.LONG_TYPE,
             BasicType.FLOAT_TYPE,


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

Fix avro miss convert short type to int. Avro doesn't support short type value.
```
2025-01-05T18:43:36.8937934Z Caused by: org.apache.avro.AvroRuntimeException: Unknown datum type java.lang.Short: 12250
2025-01-05T18:43:36.8938460Z 	at org.apache.avro.generic.GenericData.getSchemaName(GenericData.java:933)
2025-01-05T18:43:36.8938960Z 	at org.apache.avro.generic.GenericData.resolveUnion(GenericData.java:892)
2025-01-05T18:43:36.8939503Z 	at org.apache.avro.generic.GenericDatumWriter.resolveUnion(GenericDatumWriter.java:272)
2025-01-05T18:43:36.8940145Z 	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:143)
2025-01-05T18:43:36.8940748Z 	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:83)
2025-01-05T18:43:36.8941299Z 	at org.apache.avro.generic.GenericDatumWriter.writeField(GenericDatumWriter.java:221)
2025-01-05T18:43:36.8942113Z 	at org.apache.avro.generic.GenericDatumWriter.writeRecord(GenericDatumWriter.java:210)
2025-01-05T18:43:36.8942758Z 	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:131)
2025-01-05T18:43:36.8943358Z 	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:83)
2025-01-05T18:43:36.8943877Z 	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:73)
2025-01-05T18:43:36.8944506Z 	at org.apache.seatunnel.format.avro.AvroSerializationSchema.serialize(AvroSerializationSchema.java:55)
2025-01-05T18:43:36.8945466Z 	at org.apache.seatunnel.connectors.seatunnel.kafka.serialize.DefaultSeaTunnelRowSerializer.lambda$valueExtractor$9(DefaultSeaTunnelRowSerializer.java:198)
2025-01-05T18:43:36.8946607Z 	at org.apache.seatunnel.connectors.seatunnel.kafka.serialize.DefaultSeaTunnelRowSerializer.serializeRow(DefaultSeaTunnelRowSerializer.java:70)
2025-01-05T18:43:36.8947533Z 	at org.apache.seatunnel.connectors.seatunnel.kafka.sink.KafkaSinkWriter.write(KafkaSinkWriter.java:114)
2025-01-05T18:43:36.8948350Z 	at org.apache.seatunnel.connectors.seatunnel.kafka.sink.KafkaSinkWriter.write(KafkaSinkWriter.java:59)
2025-01-05T18:43:36.8949142Z 	at org.apache.seatunnel.translation.spark.sink.write.SeaTunnelSparkDataWriter.write(SeaTunnelSparkDataWriter.java:69)
2025-01-05T18:43:36.8950009Z 	at org.apache.seatunnel.translation.spark.sink.write.SeaTunnelSparkDataWriter.write(SeaTunnelSparkDataWriter.java:40)
2025-01-05T18:43:36.8950857Z 	at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.$anonfun$run$1(WriteToDataSourceV2Exec.scala:442)
2025-01-05T18:43:36.8951545Z 	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
2025-01-05T18:43:36.8952374Z 	at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:480)
2025-01-05T18:43:36.8953176Z 	at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.$anonfun$writeWithV2$2(WriteToDataSourceV2Exec.scala:381)
2025-01-05T18:43:36.8953830Z 	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
2025-01-05T18:43:36.8954246Z 	at org.apache.spark.scheduler.Task.run(Task.scala:136)
2025-01-05T18:43:36.8954681Z 	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
2025-01-05T18:43:36.8955151Z 	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
2025-01-05T18:43:36.8955663Z 	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
2025-01-05T18:43:36.8956228Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2025-01-05T18:43:36.8956781Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2025-01-05T18:43:36.8957194Z 	at java.lang.Thread.run(Thread.java:750)
```

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
modify  AvroConverterTest  and  AvroSerializationSchemaTest
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).