### PR TITLE
[Improve][Zeta] Disable restful api v1 by default

### DIFF
--- a/config/hazelcast-master.yaml
+++ b/config/hazelcast-master.yaml
@@ -19,7 +19,7 @@ hazelcast:
   cluster-name: seatunnel
   network:
     rest-api:
-      enabled: true
+      enabled: false
       endpoint-groups:
         CLUSTER_WRITE:
           enabled: true

--- a/config/hazelcast.yaml
+++ b/config/hazelcast.yaml
@@ -19,7 +19,7 @@ hazelcast:
   cluster-name: seatunnel
   network:
     rest-api:
-      enabled: true
+      enabled: false
       endpoint-groups:
         CLUSTER_WRITE:
           enabled: true

--- a/docs/en/seatunnel-engine/rest-api-v1.md
+++ b/docs/en/seatunnel-engine/rest-api-v1.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 :::caution warn
 
-It is recommended to use the v2 version of the Rest API. The v1 version is deprecated and will be removed in the future.
+It is recommended to use the v2 version of the Rest API. The v1 version is deprecated and will be removed in the future. We already disabled the v1 version by default. If you want to use the v1 version, you need to enable it in the `hazelcast.yaml` file.
 
 :::
 
@@ -16,7 +16,8 @@ completed jobs. The monitoring API is a RESTful API that accepts HTTP requests a
 ## Overview
 
 The monitoring API is backed by a web server that runs as part of the node, each node member can provide RESTful api capability.
-By default, this server listens at port 5801, which can be configured in hazelcast.yaml like :
+By default, the server disables the RESTful API V1, and it can be enabled by setting the `rest-api.enabled` configuration in the `hazelcast.yaml` file.
+This server listens at port 5801, which can be configured in hazelcast.yaml like :
 
 ```yaml
 network:

--- a/docs/zh/seatunnel-engine/rest-api-v1.md
+++ b/docs/zh/seatunnel-engine/rest-api-v1.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 :::caution warn
 
-推荐使用v2版本的Rest API。 v1 版本已弃用，并将在将来删除。
+推荐使用v2版本的Rest API。 v1 版本已弃用，并将在将来删除。 我们已经默认关闭了v1版本的API，如果您需要使用v1版本，请在`hazelcast.yaml`文件中启用它。
 
 :::
 
@@ -15,7 +15,8 @@ SeaTunnel有一个用于监控的API，可用于查询运行作业的状态和�
 ## 概述
 
 监控API是由运行的web服务提供的，它是节点运行的一部分，每个节点成员都可以提供rest API功能。
-默认情况下，该服务监听端口为5801，该端口可以在hazelcast.yaml中配置，如下所示：
+默认情况下，服务器禁用了RESTful API V1，可以通过在`hazelcast.yaml`文件中设置`rest-api.enabled`配置来启用它。
+该服务监听端口为5801，该端口可以在hazelcast.yaml中配置，如下所示：
 
 ```yaml
 network:


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
We introduce restapi v2 in #7647 . So I think we can disable restapi v1 by default. Then user can move to v2 ASAP.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes, user need enable restapi v1 by themself.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
exist test and tested in local.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).