### PR TITLE
[Fix][Connector-JDBC] Fix JDBC driver selection for data source connections

### DIFF
--- a/docs/en/connector-v2/changelog/connector-jdbc.md
+++ b/docs/en/connector-v2/changelog/connector-jdbc.md
@@ -2,6 +2,7 @@
 
 | Change | Commit | Version |
 | --- | --- | --- |
+|[Fix][Connector-JDBC] Fix JDBC driver selection for data source connections(#8986) | https://github.com/apache/seatunnel/pull/8986 | dev |
 |[Fix][Connector-V2] Fix parse SqlServer JDBC Url error (#8784)|https://github.com/apache/seatunnel/commit/373d2162d3| dev |
 |[Improve][Jdbc] Support upsert for opengauss (#8627)|https://github.com/apache/seatunnel/commit/56110bf392| dev |
 |[Improve][Jdbc] Remove useless utils. (#8793)|https://github.com/apache/seatunnel/commit/36a7533e85| dev |

--- a/docs/en/connector-v2/sink/Jdbc.md
+++ b/docs/en/connector-v2/sink/Jdbc.md
@@ -1,3 +1,5 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
 # JDBC
 
 > JDBC sink connector
@@ -434,28 +436,5 @@ sink {
 
 ## Changelog
 
-### 2.2.0-beta 2022-09-26
+<ChangeLog />
 
-- Add Console Sink Connector
-
-### 2.3.0-beta 2022-10-20
-
-- [BugFix] Fix JDBC split exception ([2904](https://github.com/apache/seatunnel/pull/2904))
-- [Feature] Support Phoenix JDBC Sink ([2499](https://github.com/apache/seatunnel/pull/2499))
-- [Feature] Support SQL Server JDBC Sink ([2646](https://github.com/apache/seatunnel/pull/2646))
-- [Feature] Support Oracle JDBC Sink ([2550](https://github.com/apache/seatunnel/pull/2550))
-- [Feature] Support StarRocks JDBC Sink ([3060](https://github.com/apache/seatunnel/pull/3060))
-- [Feature] Support DB2 JDBC Sink ([2410](https://github.com/apache/seatunnel/pull/2410))
-
-### next version
-
-- [Feature] Support CDC write DELETE/UPDATE/INSERT events ([3378](https://github.com/apache/seatunnel/issues/3378))
-- [Feature] Support Teradata JDBC　Sink ([3362](https://github.com/apache/seatunnel/pull/3362))
-- [Feature] Support Sqlite JDBC Sink ([3089](https://github.com/apache/seatunnel/pull/3089))
-- [Feature] Support CDC write DELETE/UPDATE/INSERT events ([3378](https://github.com/apache/seatunnel/issues/3378))
-- [Feature] Support Doris JDBC Sink
-- [Feature] Support Redshift JDBC Sink([#3615](https://github.com/apache/seatunnel/pull/3615))
-- [Improve] Add config item enable upsert by query([#3708](https://github.com/apache/seatunnel/pull/3708))
-- [Improve] Add database field to sink config([#4199](https://github.com/apache/seatunnel/pull/4199))
-- [Improve] Add Vertica connector([#4303](https://github.com/apache/seatunnel/pull/4303))
-- [Fix] Fix JDBC driver selection for data source connections([#8986](https://github.com/apache/seatunnel/pull/8986))

--- a/docs/en/connector-v2/sink/Jdbc.md
+++ b/docs/en/connector-v2/sink/Jdbc.md
@@ -1,5 +1,3 @@
-import ChangeLog from '../changelog/connector-jdbc.md';
-
 # JDBC
 
 > JDBC sink connector
@@ -436,5 +434,28 @@ sink {
 
 ## Changelog
 
-<ChangeLog />
+### 2.2.0-beta 2022-09-26
 
+- Add Console Sink Connector
+
+### 2.3.0-beta 2022-10-20
+
+- [BugFix] Fix JDBC split exception ([2904](https://github.com/apache/seatunnel/pull/2904))
+- [Feature] Support Phoenix JDBC Sink ([2499](https://github.com/apache/seatunnel/pull/2499))
+- [Feature] Support SQL Server JDBC Sink ([2646](https://github.com/apache/seatunnel/pull/2646))
+- [Feature] Support Oracle JDBC Sink ([2550](https://github.com/apache/seatunnel/pull/2550))
+- [Feature] Support StarRocks JDBC Sink ([3060](https://github.com/apache/seatunnel/pull/3060))
+- [Feature] Support DB2 JDBC Sink ([2410](https://github.com/apache/seatunnel/pull/2410))
+
+### next version
+
+- [Feature] Support CDC write DELETE/UPDATE/INSERT events ([3378](https://github.com/apache/seatunnel/issues/3378))
+- [Feature] Support Teradata JDBC　Sink ([3362](https://github.com/apache/seatunnel/pull/3362))
+- [Feature] Support Sqlite JDBC Sink ([3089](https://github.com/apache/seatunnel/pull/3089))
+- [Feature] Support CDC write DELETE/UPDATE/INSERT events ([3378](https://github.com/apache/seatunnel/issues/3378))
+- [Feature] Support Doris JDBC Sink
+- [Feature] Support Redshift JDBC Sink([#3615](https://github.com/apache/seatunnel/pull/3615))
+- [Improve] Add config item enable upsert by query([#3708](https://github.com/apache/seatunnel/pull/3708))
+- [Improve] Add database field to sink config([#4199](https://github.com/apache/seatunnel/pull/4199))
+- [Improve] Add Vertica connector([#4303](https://github.com/apache/seatunnel/pull/4303))
+- [Fix] Fix JDBC driver selection for data source connections([#8986](https://github.com/apache/seatunnel/pull/8986))

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -1,5 +1,3 @@
-import ChangeLog from '../changelog/connector-jdbc.md';
-
 # JDBC
 
 > JDBC source connector
@@ -304,4 +302,29 @@ Jdbc {
 
 ## Changelog
 
-<ChangeLog />
+### 2.2.0-beta 2022-09-26
+
+- Add ClickHouse Source Connector
+
+### 2.3.0-beta 2022-10-20
+
+- [Feature] Support Phoenix JDBC Source ([2499](https://github.com/apache/seatunnel/pull/2499))
+- [Feature] Support SQL Server JDBC Source ([2646](https://github.com/apache/seatunnel/pull/2646))
+- [Feature] Support Oracle JDBC Source ([2550](https://github.com/apache/seatunnel/pull/2550))
+- [Feature] Support StarRocks JDBC Source ([3060](https://github.com/apache/seatunnel/pull/3060))
+- [Feature] Support GBase8a JDBC Source ([3026](https://github.com/apache/seatunnel/pull/3026))
+- [Feature] Support DB2 JDBC Source ([2410](https://github.com/apache/seatunnel/pull/2410))
+
+### next version
+
+- [BugFix] Fix jdbc split bug ([3220](https://github.com/apache/seatunnel/pull/3220))
+- [Feature] Support Sqlite JDBC Source ([3089](https://github.com/apache/seatunnel/pull/3089))
+- [Feature] Support Tablestore Source ([3309](https://github.com/apache/seatunnel/pull/3309))
+- [Feature] Support Teradata JDBC　Source ([3362](https://github.com/apache/seatunnel/pull/3362))
+- [Feature] Support JDBC Fetch Size Config ([3478](https://github.com/apache/seatunnel/pull/3478))
+- [Feature] Support Doris JDBC Source ([3586](https://github.com/apache/seatunnel/pull/3586))
+- [Feature] Support Redshift JDBC Sink([#3615](https://github.com/apache/seatunnel/pull/3615))
+- [BugFix] Fix jdbc connection reset bug ([3670](https://github.com/apache/seatunnel/pull/3670))
+- [Improve] Add Vertica connector([#4303](https://github.com/apache/seatunnel/pull/4303))
+- [Fix] Fix JDBC driver selection for data source connections([#8986](https://github.com/apache/seatunnel/pull/8986))
+

--- a/docs/en/connector-v2/source/Jdbc.md
+++ b/docs/en/connector-v2/source/Jdbc.md
@@ -1,3 +1,5 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
 # JDBC
 
 > JDBC source connector
@@ -302,29 +304,4 @@ Jdbc {
 
 ## Changelog
 
-### 2.2.0-beta 2022-09-26
-
-- Add ClickHouse Source Connector
-
-### 2.3.0-beta 2022-10-20
-
-- [Feature] Support Phoenix JDBC Source ([2499](https://github.com/apache/seatunnel/pull/2499))
-- [Feature] Support SQL Server JDBC Source ([2646](https://github.com/apache/seatunnel/pull/2646))
-- [Feature] Support Oracle JDBC Source ([2550](https://github.com/apache/seatunnel/pull/2550))
-- [Feature] Support StarRocks JDBC Source ([3060](https://github.com/apache/seatunnel/pull/3060))
-- [Feature] Support GBase8a JDBC Source ([3026](https://github.com/apache/seatunnel/pull/3026))
-- [Feature] Support DB2 JDBC Source ([2410](https://github.com/apache/seatunnel/pull/2410))
-
-### next version
-
-- [BugFix] Fix jdbc split bug ([3220](https://github.com/apache/seatunnel/pull/3220))
-- [Feature] Support Sqlite JDBC Source ([3089](https://github.com/apache/seatunnel/pull/3089))
-- [Feature] Support Tablestore Source ([3309](https://github.com/apache/seatunnel/pull/3309))
-- [Feature] Support Teradata JDBC　Source ([3362](https://github.com/apache/seatunnel/pull/3362))
-- [Feature] Support JDBC Fetch Size Config ([3478](https://github.com/apache/seatunnel/pull/3478))
-- [Feature] Support Doris JDBC Source ([3586](https://github.com/apache/seatunnel/pull/3586))
-- [Feature] Support Redshift JDBC Sink([#3615](https://github.com/apache/seatunnel/pull/3615))
-- [BugFix] Fix jdbc connection reset bug ([3670](https://github.com/apache/seatunnel/pull/3670))
-- [Improve] Add Vertica connector([#4303](https://github.com/apache/seatunnel/pull/4303))
-- [Fix] Fix JDBC driver selection for data source connections([#8986](https://github.com/apache/seatunnel/pull/8986))
-
+<ChangeLog />

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
@@ -49,12 +49,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -82,12 +84,15 @@ public abstract class AbstractJdbcCatalog implements Catalog {
 
     protected final Map<String, Connection> connectionMap;
 
+    private final String driverClass;
+
     public AbstractJdbcCatalog(
             String catalogName,
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
+            String defaultSchema,
+            String driverClass) {
 
         checkArgument(StringUtils.isNotBlank(username));
         checkArgument(StringUtils.isNotBlank(urlInfo.getUrlWithoutDatabase()));
@@ -100,6 +105,7 @@ public abstract class AbstractJdbcCatalog implements Catalog {
         this.suffix = urlInfo.getSuffix();
         this.defaultSchema = Optional.ofNullable(defaultSchema);
         this.connectionMap = new ConcurrentHashMap<>();
+        this.driverClass = driverClass;
     }
 
     @Override
@@ -115,6 +121,33 @@ public abstract class AbstractJdbcCatalog implements Catalog {
     protected Connection getConnection(String url) {
         if (connectionMap.containsKey(url)) {
             return connectionMap.get(url);
+        }
+        if (driverClass != null) {
+            log.info("try to find driver {}", driverClass);
+            java.util.Properties info = new java.util.Properties();
+            if (username != null) {
+                info.put("user", username);
+            }
+            if (pwd != null) {
+                info.put("password", pwd);
+            }
+            Enumeration<Driver> drivers = DriverManager.getDrivers();
+            try {
+                // Driver Manager may load the wrong driver, prioritize finding the driver by class
+                // name
+                while (drivers.hasMoreElements()) {
+                    Driver driver = drivers.nextElement();
+                    if (StringUtils.equals(driver.getClass().getName(), driverClass)) {
+                        try {
+                            return driver.connect(url, info);
+                        } catch (Exception e) {
+                            log.info("try connector failed", e);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.info("find driver error, back to DriverManager.getConnection", e);
+            }
         }
         try {
             Connection connection = DriverManager.getConnection(url, username, pwd);

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
@@ -139,7 +139,9 @@ public abstract class AbstractJdbcCatalog implements Catalog {
                     Driver driver = drivers.nextElement();
                     if (StringUtils.equals(driver.getClass().getName(), driverClass)) {
                         try {
-                            return driver.connect(url, info);
+                            Connection connection = driver.connect(url, info);
+                            connectionMap.put(url, connection);
+                            return connection;
                         } catch (Exception e) {
                             log.info("try connector failed", e);
                         }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogOptions.java
@@ -84,4 +84,6 @@ public interface JdbcCatalogOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription("Create index or not when auto create table");
+
+    Option<String> DRIVER = Options.key("driver").stringType().noDefaultValue();
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalog.java
@@ -64,8 +64,9 @@ public class DamengCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
@@ -52,7 +52,8 @@ public class DamengCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalog.java
@@ -26,7 +26,8 @@ public class HighGoCatalog extends PostgresCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
@@ -42,7 +42,8 @@ public class HighGoCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     public String factoryIdentifier() {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalog.java
@@ -61,8 +61,12 @@ public class IrisCatalog extends AbstractJdbcCatalog {
             "SELECT TABLE_SCHEMA,TABLE_NAME FROM INFORMATION_SCHEMA.Tables WHERE TABLE_SCHEMA='%s' and TABLE_TYPE != 'SYSTEM TABLE' and TABLE_TYPE != 'SYSTEM VIEW'";
 
     public IrisCatalog(
-            String catalogName, String username, String password, JdbcUrlUtil.UrlInfo urlInfo) {
-        super(catalogName, username, password, urlInfo, null);
+            String catalogName,
+            String username,
+            String password,
+            JdbcUrlUtil.UrlInfo urlInfo,
+            String driverClass) {
+        super(catalogName, username, password, urlInfo, null, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
@@ -51,7 +51,8 @@ public class IrisCatalogFactory implements CatalogFactory {
                 catalogName,
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
-                urlInfo);
+                urlInfo,
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalog.java
@@ -62,8 +62,12 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
     private MySqlTypeConverter typeConverter;
 
     public MySqlCatalog(
-            String catalogName, String username, String pwd, JdbcUrlUtil.UrlInfo urlInfo) {
-        super(catalogName, username, pwd, urlInfo, null);
+            String catalogName,
+            String username,
+            String pwd,
+            JdbcUrlUtil.UrlInfo urlInfo,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, null, driverClass);
         this.version = resolveVersion();
         this.typeConverter = new MySqlTypeConverter(version);
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
@@ -51,7 +51,8 @@ public class MySqlCatalogFactory implements CatalogFactory {
                 catalogName,
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
-                urlInfo);
+                urlInfo,
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
@@ -71,13 +71,15 @@ public class OceanBaseCatalogFactory implements CatalogFactory {
                     options.get(JdbcCatalogOptions.USERNAME),
                     options.get(JdbcCatalogOptions.PASSWORD),
                     urlInfo,
-                    options.get(JdbcCatalogOptions.SCHEMA));
+                    options.get(JdbcCatalogOptions.SCHEMA),
+                    options.get(JdbcCatalogOptions.DRIVER));
         }
         return new OceanBaseMySqlCatalog(
                 catalogName,
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
-                urlInfo);
+                urlInfo,
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseMySqlCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseMySqlCatalog.java
@@ -66,8 +66,12 @@ public class OceanBaseMySqlCatalog extends AbstractJdbcCatalog {
     private OceanBaseMySqlTypeConverter typeConverter;
 
     public OceanBaseMySqlCatalog(
-            String catalogName, String username, String pwd, JdbcUrlUtil.UrlInfo urlInfo) {
-        super(catalogName, username, pwd, urlInfo, null);
+            String catalogName,
+            String username,
+            String pwd,
+            JdbcUrlUtil.UrlInfo urlInfo,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, null, driverClass);
         this.typeConverter = new OceanBaseMySqlTypeConverter();
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseOracleCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseOracleCatalog.java
@@ -38,8 +38,9 @@ public class OceanBaseOracleCatalog extends OracleCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalog.java
@@ -34,8 +34,9 @@ public class OpenGaussCatalog extends PostgresCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @VisibleForTesting

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
@@ -52,7 +52,8 @@ public class OpenGaussCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalog.java
@@ -81,14 +81,16 @@ public class OracleCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
+            String defaultSchema,
+            String driverClass) {
         this(
                 catalogName,
                 username,
                 pwd,
                 urlInfo,
                 defaultSchema,
-                JdbcOptions.DECIMAL_TYPE_NARROWING.defaultValue());
+                JdbcOptions.DECIMAL_TYPE_NARROWING.defaultValue(),
+                driverClass);
     }
 
     public OracleCatalog(
@@ -97,8 +99,9 @@ public class OracleCatalog extends AbstractJdbcCatalog {
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
             String defaultSchema,
-            boolean decimalTypeNarrowing) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            boolean decimalTypeNarrowing,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
         this.decimalTypeNarrowing = decimalTypeNarrowing;
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
@@ -54,7 +54,8 @@ public class OracleCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
                 options.get(JdbcCatalogOptions.SCHEMA),
-                options.get(JdbcOptions.DECIMAL_TYPE_NARROWING));
+                options.get(JdbcOptions.DECIMAL_TYPE_NARROWING),
+                options.get(JdbcOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalog.java
@@ -86,8 +86,9 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
@@ -52,7 +52,8 @@ public class PostgresCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalog.java
@@ -45,8 +45,9 @@ public class RedshiftCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String schema) {
-        super(catalogName, username, pwd, urlInfo, schema);
+            String schema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, schema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
@@ -59,7 +59,8 @@ public class RedshiftCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalog.java
@@ -85,8 +85,9 @@ public class SapHanaCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
@@ -52,7 +52,8 @@ public class SapHanaCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalog.java
@@ -64,8 +64,9 @@ public class SqlServerCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
@@ -45,7 +45,8 @@ public class SqlServerCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalog.java
@@ -23,7 +23,11 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalog
 public class TiDBCatalog extends MySqlCatalog {
 
     public TiDBCatalog(
-            String catalogName, String username, String pwd, JdbcUrlUtil.UrlInfo urlInfo) {
-        super(catalogName, username, pwd, urlInfo);
+            String catalogName,
+            String username,
+            String pwd,
+            JdbcUrlUtil.UrlInfo urlInfo,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, driverClass);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
@@ -51,7 +51,8 @@ public class TiDBCatalogFactory implements CatalogFactory {
                 catalogName,
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
-                urlInfo);
+                urlInfo,
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalog.java
@@ -115,8 +115,9 @@ public class XuguCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             JdbcUrlUtil.UrlInfo urlInfo,
-            String defaultSchema) {
-        super(catalogName, username, pwd, urlInfo, defaultSchema);
+            String defaultSchema,
+            String driverClass) {
+        super(catalogName, username, pwd, urlInfo, defaultSchema, driverClass);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
@@ -53,7 +53,8 @@ public class XuguCatalogFactory implements CatalogFactory {
                 options.get(JdbcCatalogOptions.USERNAME),
                 options.get(JdbcCatalogOptions.PASSWORD),
                 urlInfo,
-                options.get(JdbcCatalogOptions.SCHEMA));
+                options.get(JdbcCatalogOptions.SCHEMA),
+                options.get(JdbcCatalogOptions.DRIVER));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtils.java
@@ -403,6 +403,7 @@ public class JdbcCatalogUtils {
                 .ifPresent(val -> catalogConfig.put(JdbcCatalogOptions.COMPATIBLE_MODE.key(), val));
         catalogConfig.put(
                 JdbcOptions.DECIMAL_TYPE_NARROWING.key(), config.isDecimalTypeNarrowing());
+        catalogConfig.put(JdbcCatalogOptions.DRIVER.key(), config.getDriverName());
         return ReadonlyConfig.fromMap(catalogConfig);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengJdbcTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengJdbcTest.java
@@ -52,7 +52,13 @@ public class DamengJdbcTest {
     @BeforeAll
     static void before() {
         DAMENG_CATALOG =
-                new DamengCatalog("DAMENG_CATALOG", "DM_USER01", "Te$Dt_1234", DM_URL_INFO, null);
+                new DamengCatalog(
+                        "DAMENG_CATALOG",
+                        "DM_USER01",
+                        "Te$Dt_1234",
+                        DM_URL_INFO,
+                        null,
+                        "dm.jdbc.driver.DmDriver");
         DAMENG_CATALOG.open();
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/DriverSelectionTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/DriverSelectionTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
 
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/DriverSelectionTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/DriverSelectionTest.java
@@ -1,0 +1,93 @@
+package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
+
+import org.apache.seatunnel.common.utils.JdbcUrlUtil;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+public class DriverSelectionTest {
+
+    @Test
+    void assertDriver() {
+        String url = "jdbc:mock://127.0.0.1:3306/test?useSSL=false";
+        String driverName = OtherDriver.class.getName();
+        String expectedDriverName = ExpectedDriver.class.getName();
+        JdbcUrlUtil.UrlInfo MysqlUrlInfo = JdbcUrlUtil.getUrlInfo(url);
+        MySqlCatalog mySqlCatalog =
+                new MySqlCatalog("mock", "root", "123456", MysqlUrlInfo, expectedDriverName);
+        try {
+            Class.forName(driverName);
+            Class.forName(expectedDriverName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        List<String> driverNames = new ArrayList<>();
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            driverNames.add(drivers.nextElement().getClass().getName());
+        }
+        int expectedDriverIndex = driverNames.indexOf(expectedDriverName);
+        int otherDriverIndex = driverNames.indexOf(driverName);
+        assert expectedDriverIndex != -1 : "ExpectedDriver not registered in DriverManager";
+        assert otherDriverIndex != -1 : "OtherDriver not registered in DriverManager";
+        System.out.println(
+                "expectedDriverIndex is "
+                        + expectedDriverIndex
+                        + " otherDriverIndex is "
+                        + otherDriverIndex);
+        assert expectedDriverIndex > otherDriverIndex
+                : "ExpectedDriver should be registered after OtherDriver, but found ExpectedDriver at index "
+                        + expectedDriverIndex
+                        + " and OtherDriver at index "
+                        + otherDriverIndex;
+        /*
+         * This test verifies that even when the driver is registered later in the DriverManager's list,
+         * the system can still load the correct jar/driver based on the specified driverName parameter.
+         * This ensures that our connection mechanism correctly prioritizes explicitly specified drivers
+         * over the default driver discovery order in DriverManager.
+         */
+        Method getConnectionMethod = findGetConnectionMethod(mySqlCatalog.getClass());
+        if (getConnectionMethod != null) {
+            getConnectionMethod.setAccessible(true);
+            Connection connection;
+            try {
+                connection = (Connection) getConnectionMethod.invoke(mySqlCatalog, url);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+            System.out.println(
+                    "Connection class: "
+                            + connection
+                                    .getClass()
+                                    .getName()
+                                    .startsWith(ExpectedDriver.class.getName()));
+            assert connection.getClass().getName().startsWith(ExpectedDriver.class.getName())
+                    : "Connection should be created by "
+                            + expectedDriverName
+                            + " but was created by a class named "
+                            + connection.getClass().getName();
+        } else {
+            assert false : "Could not find getConnection method";
+        }
+    }
+
+    private Method findGetConnectionMethod(Class<?> clazz) {
+        if (clazz == null) {
+            return null;
+        }
+        try {
+            return clazz.getDeclaredMethod("getConnection", String.class);
+        } catch (NoSuchMethodException e) {
+            return findGetConnectionMethod(clazz.getSuperclass());
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/ExpectedDriver.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/ExpectedDriver.java
@@ -1,0 +1,326 @@
+package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+public class ExpectedDriver implements Driver {
+
+    static {
+        try {
+            DriverManager.registerDriver(new ExpectedDriver());
+        } catch (SQLException e) {
+            throw new RuntimeException("register expected driver error", e);
+        }
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        return new Connection() {
+            @Override
+            public Statement createStatement() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(String sql) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public CallableStatement prepareCall(String sql) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public String nativeSQL(String sql) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setAutoCommit(boolean autoCommit) throws SQLException {}
+
+            @Override
+            public boolean getAutoCommit() throws SQLException {
+                return false;
+            }
+
+            @Override
+            public void commit() throws SQLException {}
+
+            @Override
+            public void rollback() throws SQLException {}
+
+            @Override
+            public void close() throws SQLException {}
+
+            @Override
+            public boolean isClosed() throws SQLException {
+                return false;
+            }
+
+            @Override
+            public DatabaseMetaData getMetaData() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setReadOnly(boolean readOnly) throws SQLException {}
+
+            @Override
+            public boolean isReadOnly() throws SQLException {
+                return false;
+            }
+
+            @Override
+            public void setCatalog(String catalog) throws SQLException {}
+
+            @Override
+            public String getCatalog() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setTransactionIsolation(int level) throws SQLException {}
+
+            @Override
+            public int getTransactionIsolation() throws SQLException {
+                return 0;
+            }
+
+            @Override
+            public SQLWarning getWarnings() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void clearWarnings() throws SQLException {}
+
+            @Override
+            public Statement createStatement(int resultSetType, int resultSetConcurrency)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(
+                    String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public CallableStatement prepareCall(
+                    String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Map<String, Class<?>> getTypeMap() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setTypeMap(Map<String, Class<?>> map) throws SQLException {}
+
+            @Override
+            public void setHoldability(int holdability) throws SQLException {}
+
+            @Override
+            public int getHoldability() throws SQLException {
+                return 0;
+            }
+
+            @Override
+            public Savepoint setSavepoint() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Savepoint setSavepoint(String name) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void rollback(Savepoint savepoint) throws SQLException {}
+
+            @Override
+            public void releaseSavepoint(Savepoint savepoint) throws SQLException {}
+
+            @Override
+            public Statement createStatement(
+                    int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(
+                    String sql,
+                    int resultSetType,
+                    int resultSetConcurrency,
+                    int resultSetHoldability)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public CallableStatement prepareCall(
+                    String sql,
+                    int resultSetType,
+                    int resultSetConcurrency,
+                    int resultSetHoldability)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PreparedStatement prepareStatement(String sql, String[] columnNames)
+                    throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Clob createClob() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Blob createBlob() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public NClob createNClob() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public SQLXML createSQLXML() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public boolean isValid(int timeout) throws SQLException {
+                return false;
+            }
+
+            @Override
+            public void setClientInfo(String name, String value) throws SQLClientInfoException {}
+
+            @Override
+            public void setClientInfo(Properties properties) throws SQLClientInfoException {}
+
+            @Override
+            public String getClientInfo(String name) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Properties getClientInfo() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setSchema(String schema) throws SQLException {}
+
+            @Override
+            public String getSchema() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void abort(Executor executor) throws SQLException {}
+
+            @Override
+            public void setNetworkTimeout(Executor executor, int milliseconds)
+                    throws SQLException {}
+
+            @Override
+            public int getNetworkTimeout() throws SQLException {
+                return 0;
+            }
+
+            @Override
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public boolean isWrapperFor(Class<?> iface) throws SQLException {
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url != null && url.startsWith("jdbc:mock");
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/ExpectedDriver.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/ExpectedDriver.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
 
 import java.sql.Array;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/OtherDriver.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/OtherDriver.java
@@ -1,0 +1,56 @@
+package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class OtherDriver implements Driver {
+
+    static {
+        try {
+            DriverManager.registerDriver(new OtherDriver());
+        } catch (SQLException e) {
+            throw new RuntimeException("register other driver error", e);
+        }
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url != null && url.startsWith("jdbc:mock");
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/OtherDriver.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/driver/OtherDriver.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.driver;
 
 import java.sql.Connection;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogTest.java
@@ -75,9 +75,10 @@ class MySqlCatalogTest {
         tablePathMySql = TablePath.of(databaseName, "mysql_to_mysql");
         tablePathPG = TablePath.of(databaseName, "pg_to_mysql");
         tablePathOracle = TablePath.of(databaseName, "oracle_to_mysql");
-        sqlServerCatalog = new SqlServerCatalog("sqlserver", "sa", "root@123", sqlParse, null);
-        mySqlCatalog = new MySqlCatalog("mysql", "root", "123456", MysqlUrlInfo);
-        postgresCatalog = new PostgresCatalog("postgres", "postgres", "postgres", pg, null);
+        sqlServerCatalog =
+                new SqlServerCatalog("sqlserver", "sa", "root@123", sqlParse, null, null);
+        mySqlCatalog = new MySqlCatalog("mysql", "root", "123456", MysqlUrlInfo, null);
+        postgresCatalog = new PostgresCatalog("postgres", "postgres", "postgres", pg, null, null);
         mySqlCatalog.open();
         sqlServerCatalog.open();
         postgresCatalog.open();

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogTest.java
@@ -40,6 +40,7 @@ class OracleCatalogTest {
                         "test",
                         "oracle",
                         OracleURLParser.parse("jdbc:oracle:thin:@127.0.0.1:1521:xe"),
+                        null,
                         null);
 
         catalog.open();

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogTest.java
@@ -43,6 +43,7 @@ class PostgresCatalogTest {
                         "pg",
                         "pg#2024",
                         JdbcUrlUtil.getUrlInfo("jdbc:postgresql://127.0.0.1:5432/postgres"),
+                        null,
                         null);
 
         catalog.open();
@@ -55,7 +56,8 @@ class PostgresCatalogTest {
                         "mysql",
                         "root",
                         "root@123",
-                        JdbcUrlUtil.getUrlInfo("jdbc:mysql://127.0.0.1:33062/mingdongtest"));
+                        JdbcUrlUtil.getUrlInfo("jdbc:mysql://127.0.0.1:33062/mingdongtest"),
+                        null);
 
         mySqlCatalog.open();
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogTest.java
@@ -66,9 +66,10 @@ class SqlServerCatalogTest {
         tablePathMySql = TablePath.of(databaseName, schemaName, "mysql_to_sqlserver");
         tablePathPG = TablePath.of(databaseName, schemaName, "pg_to_sqlserver");
         tablePathOracle = TablePath.of(databaseName, schemaName, "oracle_to_sqlserver");
-        sqlServerCatalog = new SqlServerCatalog("sqlserver", "sa", "root@123", sqlParse, null);
-        mySqlCatalog = new MySqlCatalog("mysql", "root", "root@123", MysqlUrlInfo);
-        postgresCatalog = new PostgresCatalog("postgres", "postgres", "postgres", pg, null);
+        sqlServerCatalog =
+                new SqlServerCatalog("sqlserver", "sa", "root@123", sqlParse, null, null);
+        mySqlCatalog = new MySqlCatalog("mysql", "root", "root@123", MysqlUrlInfo, null);
+        postgresCatalog = new PostgresCatalog("postgres", "postgres", "postgres", pg, null, null);
         mySqlCatalog.open();
         sqlServerCatalog.open();
         postgresCatalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCWithSchemaChangeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCWithSchemaChangeIT.java
@@ -415,13 +415,15 @@ public class OracleCDCWithSchemaChangeIT extends AbstractOracleCDCIT implements 
                                 "mysql",
                                 MYSQL_CONNECTOR_NAME,
                                 MYSQL_CONNECTOR_PASSWORD,
-                                JdbcUrlUtil.getUrlInfo(MYSQL_CONTAINER.getJdbcUrl()));
+                                JdbcUrlUtil.getUrlInfo(MYSQL_CONTAINER.getJdbcUrl()),
+                                null);
                 OracleCatalog oracleCatalog =
                         new OracleCatalog(
                                 "oracle",
                                 CONNECTOR_USER,
                                 CONNECTOR_PWD,
                                 OracleURLParser.parse(ORACLE_CONTAINER.getJdbcUrl()),
+                                null,
                                 null)) {
             mySqlCatalog.open();
             oracleCatalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlIT.java
@@ -446,7 +446,8 @@ public class JdbcMysqlIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         JdbcUrlUtil.getUrlInfo(
-                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())));
+                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
+                        null);
         catalog.open();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleIT.java
@@ -308,7 +308,8 @@ public class JdbcOracleIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         OracleURLParser.parse(jdbcUrl),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         catalog.open();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOceanBaseMysqlIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOceanBaseMysqlIT.java
@@ -315,7 +315,8 @@ public class JdbcOceanBaseMysqlIT extends JdbcOceanBaseITBase {
                         USERNAME,
                         PASSWORD,
                         JdbcUrlUtil.getUrlInfo(
-                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())));
+                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
+                        null);
         catalog.open();
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOceanBaseOracleIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOceanBaseOracleIT.java
@@ -213,7 +213,8 @@ public class JdbcOceanBaseOracleIT extends JdbcOceanBaseITBase {
                         USERNAME,
                         PASSWORD,
                         JdbcUrlUtil.getUrlInfo(jdbcCase.getJdbcUrl().replace(HOST, HOSTNAME)),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         catalog.open();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPostgresIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPostgresIT.java
@@ -278,7 +278,8 @@ public class JdbcPostgresIT extends TestSuiteBase implements TestResource {
                         POSTGRESQL_CONTAINER.getUsername(),
                         POSTGRESQL_CONTAINER.getPassword(),
                         JdbcUrlUtil.getUrlInfo(POSTGRESQL_CONTAINER.getJdbcUrl()),
-                        schema);
+                        schema,
+                        null);
         postgresCatalog.open();
 
         CatalogTable catalogTable = postgresCatalog.getTable(sourceTablePath);
@@ -361,7 +362,8 @@ public class JdbcPostgresIT extends TestSuiteBase implements TestResource {
                         POSTGRESQL_CONTAINER.getUsername(),
                         POSTGRESQL_CONTAINER.getPassword(),
                         JdbcUrlUtil.getUrlInfo(POSTGRESQL_CONTAINER.getJdbcUrl()),
-                        schema);
+                        schema,
+                        null);
         catalog.open();
 
         TablePath tablePath = new TablePath(databaseName, schema, tableName);
@@ -544,7 +546,8 @@ public class JdbcPostgresIT extends TestSuiteBase implements TestResource {
                         POSTGRESQL_CONTAINER.getUsername(),
                         POSTGRESQL_CONTAINER.getPassword(),
                         JdbcUrlUtil.getUrlInfo(POSTGRESQL_CONTAINER.getJdbcUrl()),
-                        schema);
+                        schema,
+                        null);
         postgresCatalog.open();
         CatalogTable catalogTable = postgresCatalog.getTable(tablePathPG);
         // sink tableExists ?

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSqlServerIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSqlServerIT.java
@@ -340,7 +340,8 @@ public class JdbcSqlServerIT extends AbstractJdbcIT {
                         jdbcCase.getPassword(),
                         SqlServerURLParser.parse(
                                 jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
-                        SQLSERVER_SCHEMA);
+                        SQLSERVER_SCHEMA,
+                        null);
         catalog.open();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-4/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlCreateTableIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-4/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlCreateTableIT.java
@@ -270,10 +270,10 @@ public class JdbcMySqlCreateTableIT extends TestSuiteBase implements TestResourc
         TablePath tablePathPG = TablePath.of("pg", "public", "mysql_auto_create_pg");
 
         SqlServerCatalog sqlServerCatalog =
-                new SqlServerCatalog("sqlserver", "sa", PASSWORD, sqlParse, "dbo");
-        MySqlCatalog mySqlCatalog = new MySqlCatalog("mysql", "root", PASSWORD, MysqlUrlInfo);
+                new SqlServerCatalog("sqlserver", "sa", PASSWORD, sqlParse, "dbo", null);
+        MySqlCatalog mySqlCatalog = new MySqlCatalog("mysql", "root", PASSWORD, MysqlUrlInfo, null);
         PostgresCatalog postgresCatalog =
-                new PostgresCatalog("postgres", "testUser", PASSWORD, pg, "public");
+                new PostgresCatalog("postgres", "testUser", PASSWORD, pg, "public", null);
 
         mySqlCatalog.open();
         sqlServerCatalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-4/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSqlServerCreateTableIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-4/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSqlServerCreateTableIT.java
@@ -282,10 +282,10 @@ public class JdbcSqlServerCreateTableIT extends TestSuiteBase implements TestRes
         TablePath tablePathPG = TablePath.of("pg", "public", "sqlserver_auto_create_pg");
 
         SqlServerCatalog sqlServerCatalog =
-                new SqlServerCatalog("sqlserver", "sa", password, sqlParse, "dbo");
-        MySqlCatalog mySqlCatalog = new MySqlCatalog("mysql", "root", PASSWORD, MysqlUrlInfo);
+                new SqlServerCatalog("sqlserver", "sa", password, sqlParse, "dbo", null);
+        MySqlCatalog mySqlCatalog = new MySqlCatalog("mysql", "root", PASSWORD, MysqlUrlInfo, null);
         PostgresCatalog postgresCatalog =
-                new PostgresCatalog("postgres", "testUser", PASSWORD, pg, "public");
+                new PostgresCatalog("postgres", "testUser", PASSWORD, pg, "public", null);
 
         mySqlCatalog.open();
         sqlServerCatalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleLowercaseTableIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleLowercaseTableIT.java
@@ -234,7 +234,8 @@ public class JdbcOracleLowercaseTableIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         OracleURLParser.parse(jdbcUrl),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         catalog.open();
     }
 
@@ -250,7 +251,8 @@ public class JdbcOracleLowercaseTableIT extends AbstractJdbcIT {
                         jdbcCase.getPassword(),
                         OracleURLParser.parse(
                                 jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         oracleCatalog.open();
         catalog.executeSql(
                 tablePathOracle,

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHighGoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHighGoIT.java
@@ -303,7 +303,8 @@ public class JdbcHighGoIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         JdbcUrlUtil.getUrlInfo(jdbcUrl),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         catalog.open();
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcIrisIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcIrisIT.java
@@ -585,7 +585,8 @@ public class JdbcIrisIT extends AbstractJdbcIT {
                         "iris",
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
-                        JdbcUrlUtil.getUrlInfo(jdbcUrl));
+                        JdbcUrlUtil.getUrlInfo(jdbcUrl),
+                        "com.intersystems.jdbc.IRISDriver");
         // set connection
         ((IrisCatalog) catalog).setConnection(jdbcUrl, connection);
         catalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
@@ -156,7 +156,8 @@ public class JdbcMySqlSaveModeCatalogIT extends TestSuiteBase implements TestRes
     public void testCatalog() {
         TablePath tablePathMySql = TablePath.of("auto", "mysql_auto_create");
         TablePath tablePathMySqlSink = TablePath.of("auto", "mysql_auto_create_sink");
-        MySqlCatalog mySqlCatalog = new MySqlCatalog("mysql", "root", MYSQL_PASSWORD, MysqlUrlInfo);
+        MySqlCatalog mySqlCatalog =
+                new MySqlCatalog("mysql", "root", MYSQL_PASSWORD, MysqlUrlInfo, null);
         mySqlCatalog.open();
         CatalogTable catalogTable = mySqlCatalog.getTable(tablePathMySql);
         // source comment

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSaveModeHandlerIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSaveModeHandlerIT.java
@@ -323,7 +323,8 @@ public class JdbcMysqlSaveModeHandlerIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         JdbcUrlUtil.getUrlInfo(
-                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())));
+                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
+                        null);
         catalog.open();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
@@ -362,7 +362,7 @@ public class JdbcMysqlSplitIT extends TestSuiteBase implements TestResource {
 
         TablePath tablePathMySql = TablePath.of(MYSQL_DATABASE, MYSQL_TABLE);
         MySqlCatalog mySqlCatalog =
-                new MySqlCatalog("mysql", MYSQL_USERNAME, MYSQL_PASSWORD, mysqlUrlInfo);
+                new MySqlCatalog("mysql", MYSQL_USERNAME, MYSQL_PASSWORD, mysqlUrlInfo, null);
         mySqlCatalog.open();
         Assertions.assertTrue(mySqlCatalog.tableExists(tablePathMySql));
         CatalogTable table = mySqlCatalog.getTable(tablePathMySql);

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOpenGaussIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOpenGaussIT.java
@@ -325,7 +325,8 @@ public class JdbcOpenGaussIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         JdbcUrlUtil.getUrlInfo(jdbcUrl),
-                        SCHEMA);
+                        SCHEMA,
+                        null);
         // set connection
         ((OpenGaussCatalog) catalog).setConnection(jdbcUrl, connection);
         catalog.open();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcXuguIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcXuguIT.java
@@ -244,7 +244,8 @@ public class JdbcXuguIT extends AbstractJdbcIT {
                         jdbcCase.getUserName(),
                         jdbcCase.getPassword(),
                         JdbcUrlUtil.getUrlInfo(jdbcUrl),
-                        XUGU_SCHEMA);
+                        XUGU_SCHEMA,
+                        null);
         catalog.open();
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
@@ -368,7 +368,8 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
                         "mysql",
                         MYSQL_USER_NAME,
                         MYSQL_USER_PASSWORD,
-                        JdbcUrlUtil.getUrlInfo(MYSQL_CONTAINER.getJdbcUrl()))) {
+                        JdbcUrlUtil.getUrlInfo(MYSQL_CONTAINER.getJdbcUrl()),
+                        null)) {
             mySqlCatalog.open();
             CatalogTable mySqlCatalogTable =
                     mySqlCatalog.getTable(TablePath.of(MYSQL_DATABASE, SOURCE_TABLE));


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes an issue with JDBC driver selection when dealing with heterogeneous data sources. In the current implementation, DriverManager may select the wrong driver when multiple compatible drivers are available in the classpath. This can cause problems when transferring data between similar databases (like Greenplum to PostgreSQL or MySQL 5 to MySQL 8), where driver "drift" can occur.

The underlying issue exists in the DriverManager's getConnection method implementation: it iterates through all registered drivers and uses the first one that successfully connects to the given URL. As shown in the Java source code, it doesn't prioritize drivers by class name but simply tries each registered driver in sequence:

```java
for(DriverInfo aDriver : registeredDrivers) {
    if(isDriverAllowed(aDriver.driver, callerCL)) {
        try {
            Connection con = aDriver.driver.connect(url, info);
            if (con != null) {
                // Success!
                return (con);
            }
        } catch (SQLException ex) {
            if (reason == null) {
                reason = ex;
            }
        }
    }
}
```

This behavior means that if multiple drivers can handle the same URL format (e.g., both MySQL 5 and MySQL 8 drivers can handle "jdbc:mysql://..." URLs), the one loaded first will be used, regardless of which one is more appropriate for the specific database version being connected to.

The fix explicitly finds and uses the driver specified by class name before falling back to the default DriverManager behavior, ensuring that the correct driver is used for the connection.

### Does this PR introduce _any_ user-facing change?

This PR improves the reliability of JDBC connections when working with heterogeneous data sources, but doesn't change any user-facing API or configuration. Users may notice improved stability when transferring data between similar database systems that require different drivers.

### How was this patch tested?

The implementation was tested with various database connections where driver drift could occur, particularly focusing on:
- MySQL 5 to MySQL 8 connections
- PostgreSQL to Greenplum connections
- Multiple JDBC drivers in the classpath

The tests verified that the correct driver is selected when explicitly specified, even when multiple compatible drivers are available.

### Check list

* [x] The main modification is an improvement to the `org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.AbstractJdbcCatalog#getConnection` method, prioritizing the use of the specified driver class to establish connections and avoid driver drift issues
* [x] Related changes include ensuring the `driverClass` parameter is correctly passed to the getConnection method, allowing the specified driver priority to take effect