### PR TITLE
[Fix][Paimon] nullable and comment attribute was lost during automatic table creation

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/AbstractJdbcCatalog.java
@@ -176,6 +176,7 @@ public abstract class AbstractJdbcCatalog implements Catalog {
         Connection conn = getConnection(dbUrl);
         try {
             DatabaseMetaData metaData = conn.getMetaData();
+            Optional<String> comment = getTableComment(metaData, tablePath);
             Optional<PrimaryKey> primaryKey = getPrimaryKey(metaData, tablePath);
             List<ConstraintKey> constraintKeys = getConstraintKeys(metaData, tablePath);
             TableSchema.Builder tableSchemaBuilder =
@@ -190,7 +191,7 @@ public abstract class AbstractJdbcCatalog implements Catalog {
                     tableSchemaBuilder.build(),
                     buildConnectorOptions(tablePath),
                     Collections.emptyList(),
-                    "",
+                    comment.orElse(""),
                     catalogName);
 
         } catch (SeaTunnelRuntimeException e) {
@@ -246,6 +247,21 @@ public abstract class AbstractJdbcCatalog implements Catalog {
             DatabaseMetaData metaData, String database, String schema, String table)
             throws SQLException {
         return CatalogUtils.getPrimaryKey(metaData, TablePath.of(database, schema, table));
+    }
+
+    protected Optional<String> getTableComment(DatabaseMetaData metaData, TablePath tablePath)
+            throws SQLException {
+        return getTableComment(
+                metaData,
+                tablePath.getDatabaseName(),
+                tablePath.getSchemaName(),
+                tablePath.getTableName());
+    }
+
+    protected Optional<String> getTableComment(
+            DatabaseMetaData metaData, String database, String schema, String table)
+            throws SQLException {
+        return CatalogUtils.getTableComment(metaData, TablePath.of(database, schema, table));
     }
 
     protected List<ConstraintKey> getConstraintKeys(DatabaseMetaData metaData, TablePath tablePath)

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtils.java
@@ -101,6 +101,21 @@ public class CatalogUtils {
         return getFieldIde(identifier, fieldIde);
     }
 
+    public static Optional<String> getTableComment(DatabaseMetaData metaData, TablePath tablePath)
+            throws SQLException {
+        try (ResultSet rs =
+                metaData.getTables(
+                        tablePath.getDatabaseName(),
+                        tablePath.getSchemaName(),
+                        tablePath.getTableName(),
+                        new String[] {"TABLE"})) {
+            if (rs.next()) {
+                return Optional.ofNullable(rs.getString("REMARKS"));
+            }
+        }
+        return Optional.empty();
+    }
+
     public static Optional<PrimaryKey> getPrimaryKey(DatabaseMetaData metaData, TablePath tablePath)
             throws SQLException {
         // According to the Javadoc of java.sql.DatabaseMetaData#getPrimaryKeys,

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
@@ -52,7 +52,7 @@ public class CatalogUtilsTest {
     }
 
     @Test
-    void testGetCommentWithJdbcDialectTypeMapper() throws SQLException {
+    void testGetTableCommentWithJdbcDialectTypeMapper() throws SQLException {
         TableSchema tableSchema =
                 CatalogUtils.getTableSchema(
                         new TestDatabaseMetaData(),

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverter.java
@@ -284,7 +284,7 @@ public class RowTypeConverter {
                     int timestampScale =
                             Objects.isNull(scale) ? TimestampType.DEFAULT_PRECISION : scale;
                     TimestampType timestampType = DataTypes.TIMESTAMP(timestampScale);
-                    builder.nativeType(timestampType);
+                    builder.nativeType(timestampType.copy(column.isNullable()));
                     builder.dataType(timestampType.getTypeRoot().name());
                     builder.columnType(timestampType.toString());
                     builder.scale(timestampScale);
@@ -293,7 +293,7 @@ public class RowTypeConverter {
                 case TIME:
                     int timeScale = Objects.isNull(scale) ? TimeType.DEFAULT_PRECISION : scale;
                     TimeType timeType = DataTypes.TIME(timeScale);
-                    builder.nativeType(timeType);
+                    builder.nativeType(timeType.copy(column.isNullable()));
                     builder.columnType(timeType.toString());
                     builder.dataType(timeType.getTypeRoot().name());
                     builder.scale(timeScale);
@@ -356,7 +356,7 @@ public class RowTypeConverter {
                     }
 
                     DecimalType paimonDecimalType = DataTypes.DECIMAL(precision, scale);
-                    builder.nativeType(paimonDecimalType);
+                    builder.nativeType(paimonDecimalType.copy(column.isNullable()));
                     builder.columnType(paimonDecimalType.toString());
                     builder.dataType(paimonDecimalType.getTypeRoot().name());
                     builder.scale(scale);
@@ -364,7 +364,7 @@ public class RowTypeConverter {
                     builder.length(column.getColumnLength());
                     return builder.build();
                 default:
-                    builder.nativeType(visit(column.getName(), dataType));
+                    builder.nativeType(visit(column.getName(), dataType).copy(column.isNullable()));
                     builder.columnType(dataType.toString());
                     builder.length(column.getColumnLength());
                     builder.dataType(dataType.getSqlType().name());

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonWithCommentTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonWithCommentTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class PaimonWithCommentTest {
+
+    private PaimonCatalog paimonCatalog;
+    private TableSchema.Builder schemaBuilder;
+    private final String CATALOG_NAME = "paimon_catalog";
+    private final String DATABASE_NAME = "default";
+    private final String TABLE_NAME = "test_with_comment";
+    private final String warehousePath = "/tmp/paimon";
+    private Catalog catalog;
+
+    @BeforeEach
+    public void before() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("warehouse", warehousePath);
+        properties.put("plugin_name", "Paimon");
+        properties.put("database", DATABASE_NAME);
+        properties.put("table", TABLE_NAME);
+        Map<String, String> writeProps = new HashMap<>();
+        writeProps.put("bucket", "1");
+        properties.put("paimon.table.write-props", writeProps);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(properties);
+        CatalogContext catalogContext = CatalogContext.create(new Path(warehousePath));
+        catalog = CatalogFactory.createCatalog(catalogContext);
+        paimonCatalog = new PaimonCatalog(CATALOG_NAME, config);
+        paimonCatalog.open();
+        paimonCatalog.createDatabase(TablePath.of(DATABASE_NAME, TABLE_NAME), true);
+        this.schemaBuilder =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_string",
+                                        BasicType.STRING_TYPE,
+                                        (Long) null,
+                                        true,
+                                        null,
+                                        "c_string"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_int",
+                                        BasicType.INT_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_int"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "c_bigint",
+                                        BasicType.LONG_TYPE,
+                                        (Long) null,
+                                        false,
+                                        null,
+                                        "c_bigint"));
+    }
+
+    @Test
+    public void testCreateTableWithCommentAndNullable() throws Catalog.TableNotExistException {
+        TableSchema tableSchema =
+                schemaBuilder
+                        .primaryKey(PrimaryKey.of("pk", Collections.singletonList("c_int")))
+                        .build();
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(CATALOG_NAME, DATABASE_NAME, TABLE_NAME),
+                        tableSchema,
+                        new HashMap<>(),
+                        new ArrayList<>(),
+                        "test table");
+        paimonCatalog.createTable(
+                TablePath.of(DATABASE_NAME, null, TABLE_NAME), catalogTable, true);
+
+        FileStoreTable table =
+                (FileStoreTable) catalog.getTable(Identifier.create(DATABASE_NAME, TABLE_NAME));
+        Assertions.assertEquals("test table", table.comment().get());
+        table.schema()
+                .fields()
+                .forEach(
+                        field -> {
+                            Assertions.assertEquals(field.name(), field.description());
+                            if (field.name().equals("c_string")) {
+                                Assertions.assertTrue(field.type().isNullable());
+                            } else {
+                                Assertions.assertFalse(field.type().isNullable());
+                            }
+                        });
+    }
+
+    @AfterEach
+    public void after() {
+        paimonCatalog.dropDatabase(TablePath.of(DATABASE_NAME, TABLE_NAME), false);
+        paimonCatalog.close();
+    }
+}

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverterTest.java
@@ -54,6 +54,8 @@ public class RowTypeConverterTest {
 
     private Column column;
 
+    private Column columnNotNull;
+
     private TableSchema tableSchema;
 
     public static final RowType DEFAULT_ROW_TYPE =
@@ -187,7 +189,7 @@ public class RowTypeConverterTest {
 
         column =
                 PhysicalColumn.builder()
-                        .name("c_decimal")
+                        .name("c_decimal_null")
                         .sourceType(DataTypes.DECIMAL(30, 8).toString())
                         .nullable(true)
                         .dataType(dataType)
@@ -195,6 +197,18 @@ public class RowTypeConverterTest {
                         .defaultValue(3.0)
                         .scale(8)
                         .comment("c_decimal_type_define")
+                        .build();
+
+        columnNotNull =
+                PhysicalColumn.builder()
+                        .name("c_decimal_not_null")
+                        .sourceType(DataTypes.DECIMAL(30, 8).toString())
+                        .nullable(false)
+                        .dataType(dataType)
+                        .columnLength(30L)
+                        .defaultValue(3.0)
+                        .scale(8)
+                        .comment("c_decimal_not_null")
                         .build();
     }
 
@@ -227,6 +241,12 @@ public class RowTypeConverterTest {
     public void seaTunnelColumnToPaimonDataType() {
         BasicTypeDefine<DataType> dataTypeDefine = RowTypeConverter.reconvert(column);
         isEquals(column, dataTypeDefine);
+        Assertions.assertTrue(dataTypeDefine.isNullable());
+        Assertions.assertTrue(dataTypeDefine.getNativeType().isNullable());
+        BasicTypeDefine<DataType> dataTypeDefineNotNull = RowTypeConverter.reconvert(columnNotNull);
+        isEquals(columnNotNull, dataTypeDefineNotNull);
+        Assertions.assertFalse(dataTypeDefineNotNull.isNullable());
+        Assertions.assertFalse(dataTypeDefineNotNull.getNativeType().isNullable());
     }
 
     private void isEquals(Column column, BasicTypeDefine<DataType> dataTypeDefine) {

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowTypeConverterTest.java
@@ -189,7 +189,7 @@ public class RowTypeConverterTest {
                 PhysicalColumn.builder()
                         .name("c_decimal")
                         .sourceType(DataTypes.DECIMAL(30, 8).toString())
-                        .nullable(false)
+                        .nullable(true)
                         .dataType(dataType)
                         .columnLength(30L)
                         .defaultValue(3.0)

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/AbstractPaimonIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/AbstractPaimonIT.java
@@ -47,8 +47,9 @@ public abstract class AbstractPaimonIT extends TestSuiteBase {
     protected static final String FAKE_DATABASE1 = "FakeDatabase1";
     protected static final String FAKE_TABLE2 = "FakeTable1";
     protected static final String FAKE_DATABASE2 = "FakeDatabase2";
-    protected String CATALOG_ROOT_DIR_WIN = "C:/Users/";
-    protected String CATALOG_DIR_WIN = CATALOG_ROOT_DIR_WIN + NAMESPACE + "/";
+    private final String CATALOG_ROOT_DIR_WIN =
+            "C:/Users/" + System.getProperty("user.name") + "/tmp/";
+    private final String CATALOG_DIR_WIN = CATALOG_ROOT_DIR_WIN + NAMESPACE + "/";
     protected boolean isWindows;
     protected boolean changeLogEnabled = false;
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkCDCIT.java
@@ -69,8 +69,6 @@ public class PaimonSinkCDCIT extends AbstractPaimonIT implements TestResource {
     public void startUp() throws Exception {
         this.isWindows =
                 System.getProperties().getProperty("os.name").toUpperCase().contains("WINDOWS");
-        CATALOG_ROOT_DIR_WIN = CATALOG_ROOT_DIR_WIN + System.getProperty("user.name") + "/tmp/";
-        CATALOG_DIR_WIN = CATALOG_ROOT_DIR_WIN + NAMESPACE + "/";
     }
 
     @AfterAll

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
@@ -134,6 +134,8 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
     @BeforeAll
     @Override
     public void startUp() throws Exception {
+        this.isWindows =
+                System.getProperties().getProperty("os.name").toUpperCase().contains("WINDOWS");
         log.info("The second stage: Starting Mysql containers...");
         Startables.deepStart(Stream.of(MYSQL_CONTAINER)).join();
         log.info("Mysql Containers are started");


### PR DESCRIPTION
nullable , table comment  and column comment attribute was lost during automatic table creation

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
PaimonWithCommentTest#testCreateTableWithCommentAndNullable

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?



<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).