### PR TITLE
[Fix][Zeta] Occasional checkpoint failed when use COS as checkpoint storage

### DIFF
--- a/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/src/main/java/org/apache/hadoop/util/CleanerUtil.java
+++ b/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/src/main/java/org/apache/hadoop/util/CleanerUtil.java
@@ -1,0 +1,136 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by FernFlower decompiler)
+//
+
+package org.apache.hadoop.util;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Objects;
+
+@Private
+@Unstable
+public final class CleanerUtil {
+    public static final boolean UNMAP_SUPPORTED;
+    public static final String UNMAP_NOT_SUPPORTED_REASON;
+    private static final BufferCleaner CLEANER;
+
+    private CleanerUtil() {}
+
+    public static BufferCleaner getCleaner() {
+        return CLEANER;
+    }
+
+    private static Object unmapHackImpl() {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        try {
+            try {
+                Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+                MethodHandle unmapper =
+                        lookup.findVirtual(
+                                unsafeClass,
+                                "invokeCleaner",
+                                MethodType.methodType(Void.TYPE, ByteBuffer.class));
+                Field f = unsafeClass.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                Object theUnsafe = f.get((Object) null);
+                return newBufferCleaner(ByteBuffer.class, unmapper.bindTo(theUnsafe));
+            } catch (SecurityException var10) {
+                throw var10;
+            } catch (RuntimeException | ReflectiveOperationException var11) {
+                Class<?> directBufferClass = Class.forName("java.nio.DirectByteBuffer");
+                Method m = directBufferClass.getMethod("cleaner");
+                m.setAccessible(true);
+                MethodHandle directBufferCleanerMethod = lookup.unreflect(m);
+                Class<?> cleanerClass = directBufferCleanerMethod.type().returnType();
+                MethodHandle cleanMethod =
+                        lookup.findVirtual(cleanerClass, "clean", MethodType.methodType(Void.TYPE));
+                MethodHandle nonNullTest =
+                        lookup.findStatic(
+                                        Objects.class,
+                                        "nonNull",
+                                        MethodType.methodType(Boolean.TYPE, Object.class))
+                                .asType(MethodType.methodType(Boolean.TYPE, cleanerClass));
+                MethodHandle noop =
+                        MethodHandles.dropArguments(
+                                MethodHandles.constant(Void.class, (Object) null)
+                                        .asType(MethodType.methodType(Void.TYPE)),
+                                0,
+                                new Class[] {cleanerClass});
+                MethodHandle unmapper =
+                        MethodHandles.filterReturnValue(
+                                        directBufferCleanerMethod,
+                                        MethodHandles.guardWithTest(nonNullTest, cleanMethod, noop))
+                                .asType(MethodType.methodType(Void.TYPE, ByteBuffer.class));
+                return newBufferCleaner(directBufferClass, unmapper);
+            }
+        } catch (SecurityException var12) {
+            return "Unmapping is not supported, because not all required permissions are given to the Hadoop JAR file: "
+                    + var12
+                    + " [Please grant at least the following permissions: RuntimePermission(\"accessClassInPackage.sun.misc\")  and ReflectPermission(\"suppressAccessChecks\")]";
+        } catch (RuntimeException | ReflectiveOperationException var13) {
+            return "Unmapping is not supported on this platform, because internal Java APIs are not compatible with this Hadoop version: "
+                    + var13;
+        }
+    }
+
+    private static BufferCleaner newBufferCleaner(
+            Class<?> unmappableBufferClass, MethodHandle unmapper) {
+        assert Objects.equals(MethodType.methodType(Void.TYPE, ByteBuffer.class), unmapper.type());
+
+        return (buffer) -> {
+            if (!buffer.isDirect()) {
+                throw new IllegalArgumentException("unmapping only works with direct buffers");
+            } else if (!unmappableBufferClass.isInstance(buffer)) {
+                throw new IllegalArgumentException(
+                        "buffer is not an instance of " + unmappableBufferClass.getName());
+            } else {
+                Throwable error =
+                        (Throwable)
+                                AccessController.doPrivileged(
+                                        (PrivilegedAction)
+                                                () -> {
+                                                    try {
+                                                        unmapper.invokeExact(buffer);
+                                                        return null;
+                                                    } catch (Throwable var3) {
+                                                        return var3;
+                                                    }
+                                                });
+                if (error != null) {
+                    throw new IOException("Unable to unmap the mapped buffer", error);
+                }
+            }
+        };
+    }
+
+    static {
+        Object hack = AccessController.doPrivileged((PrivilegedAction) CleanerUtil::unmapHackImpl);
+        if (hack instanceof BufferCleaner) {
+            CLEANER = (BufferCleaner) hack;
+            UNMAP_SUPPORTED = true;
+            UNMAP_NOT_SUPPORTED_REASON = null;
+        } else {
+            CLEANER = null;
+            UNMAP_SUPPORTED = false;
+            UNMAP_NOT_SUPPORTED_REASON = hack.toString();
+        }
+    }
+
+    @FunctionalInterface
+    public interface BufferCleaner {
+        void freeBuffer(ByteBuffer var1) throws IOException;
+    }
+}

--- a/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/src/main/java/org/apache/hadoop/util/CleanerUtil.java
+++ b/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/src/main/java/org/apache/hadoop/util/CleanerUtil.java
@@ -1,7 +1,19 @@
-//
-// Source code recreated from a .class file by IntelliJ IDEA
-// (powered by FernFlower decompiler)
-//
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.hadoop.util;
 


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
close https://github.com/apache/seatunnel/issues/9124

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
In order to better reproduce this issue, I set `fs.cosn.buffer.size=8388608` in seatunnel.yaml, so that there will only be one ByteBuffer in the BufferPool, as follows:
```yaml
seatunnel:
    engine:
        backup-count: 1
        queue-type: blockingqueue
        print-execution-info-interval: 60
        print-job-metrics-info-interval: 60
        slot-service:
            dynamic-slot: true
        checkpoint:
            interval: 30000
            timeout: 60000
            storage:
                type: hdfs
                max-retained: 3
                plugin-config:
                    namespace: /seatunnel-test
                    storage.type: cos
                    cos.bucket: cosn://xxx
                    fs.AbstractFileSystem.cosn.impl: org.apache.hadoop.fs.CosN
                    fs.cosn.credentials.provider: org.apache.hadoop.fs.cosn.auth.SimpleCredentialsProvider
                    fs.cosn.userinfo.secretId: xxx
                    fs.cosn.userinfo.secretKey: xxx
                    fs.cosn.bucket.region: xxx
                    fs.cosn.impl: org.apache.hadoop.fs.cosn.CosNFileSystem
                    fs.cosn.buffer.size: 8388608
        jar-storage:
            enable: false
            connector-jar-storage-mode: SHARED
            connector-jar-storage-path: ""
            connector-jar-cleanup-task-interval: 3600
            connector-jar-expiry-time: 600
        telemetry:
            metric:
                enabled: false
        http:
            enable-http: true
            port: 8080
```
Then set `checkpoint.interval=1000` and start 2 tasks. The configuration file is as follows: 
```json
{
    "env" : {
        "parallelism" : 1,
        "job.mode" : "STREAMING",
        "checkpoint.interval" : 1000
    },
    "source" : [
        {
            "base-url" : "jdbc:mysql://xxx/sea_tunnel_test",
	    "username" : "xxx"
            "password" : "xxx",
            "table-names" : ["sea_tunnel_test.xxx"],
            "plugin_name" : "MySQL-CDC"
        }
    ],
    "sink" : [
        {
            "db_num" : 1,
            "port" : 6379,
            "auth" : "xxx",
            "host" : "xxx",
            "data_type" : "key",
            "support_custom_key" : true,
            "second_value_serialize" : true,
            "plugin_name" : "Redis",
            "key" : "test"
        }
    ]
}
```
and
```json
{
    "env" : {
        "parallelism" : 1,
        "job.mode" : "STREAMING",
        "checkpoint.interval" : 1000
    },
    "source" : [
        {
            "base-url" : "jdbc:mysql://xxx/sea_tunnel_test",
	    "username" : "xxx"
            "password" : "xxx",
            "table-names" : ["sea_tunnel_test.xxx"],
            "plugin_name" : "MySQL-CDC"
        }
    ],
    "sink" : [
        {
            "db_num" : 2,
            "port" : 6379,
            "auth" : "xxx",
            "host" : "xxx",
            "data_type" : "key",
            "support_custom_key" : true,
            "second_value_serialize" : true,
            "plugin_name" : "Redis",
            "key" : "test"
        }
    ]
}
```

before change:
![before](https://github.com/user-attachments/assets/cfca9bf1-0a61-489e-830c-cdf8d79c2f0b)
```text
java.lang.NoClassDefFoundError: org/apache/hadoop/util/CleanerUtil
	at org.apache.hadoop.fs.cosn.ByteBufferWrapper.munmap(ByteBufferWrapper.java:61) ~[hadoop-cos-3.4.1.jar:?]
	at org.apache.hadoop.fs.cosn.ByteBufferWrapper.close(ByteBufferWrapper.java:89) ~[hadoop-cos-3.4.1.jar:?]
	at org.apache.hadoop.fs.cosn.BufferPool.returnBuffer(BufferPool.java:228) ~[hadoop-cos-3.4.1.jar:?]
	at org.apache.hadoop.fs.cosn.CosNOutputStream.close(CosNOutputStream.java:157) ~[hadoop-cos-3.4.1.jar:?]
	at org.apache.hadoop.fs.FSDataOutputStream$PositionCache.close(FSDataOutputStream.java:72) ~[seatunnel-hadoop3-3.1.4-uber.jar:2.3.8-SNAPSHOT]
	at org.apache.hadoop.fs.FSDataOutputStream.close(FSDataOutputStream.java:101) ~[seatunnel-hadoop3-3.1.4-uber.jar:2.3.8-SNAPSHOT]
	at org.apache.seatunnel.engine.checkpoint.storage.hdfs.HdfsStorage.storeCheckPoint(HdfsStorage.java:109) ~[seatunnel-starter.jar:2.3.8-SNAPSHOT]
	at org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator.completePendingCheckpoint(CheckpointCoordinator.java:850) ~[seatunnel-starter.jar:2.3.8-SNAPSHOT]
	at org.apache.seatunnel.engine.server.checkpoint.CheckpointCoordinator.lambda$startTriggerPendingCheckpoint$7(CheckpointCoordinator.java:600) ~[seatunnel-starter.jar:2.3.8-SNAPSHOT]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774) ~[?:1.8.0_341]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:750) ~[?:1.8.0_341]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:456) ~[?:1.8.0_341]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_341]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_341]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_341]
```

after change:
![after](https://github.com/user-attachments/assets/d1eaab90-61b8-4270-be02-5b3d26b17571)
No errors will be reported

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).