### PR TITLE
[Fix][Zeta] Fix double-checked locking without volatile in HdfsStorage

### DIFF
--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
@@ -77,7 +77,7 @@ public class HdfsStorage extends AbstractCheckpointStorage {
                 config.getOrDefault(STORAGE_TYPE_KEY, FileConfiguration.LOCAL.toString());
         config.remove(STORAGE_TYPE_KEY);
         AbstractConfiguration configuration =
-                FileConfiguration.valueOf(storageType.toUpperCase()).getConfiguration(storageType);
+                FileConfiguration.valueOf(storageType.toUpperCase()).getConfiguration();
         return configuration.buildConfiguration(config);
     }
 
@@ -179,7 +179,7 @@ public class HdfsStorage extends AbstractCheckpointStorage {
                 });
 
         if (latestPipelineStates.isEmpty()) {
-            log.info("No checkpoint found for this job,  the job id:{} " + jobId);
+            log.info("No checkpoint found for this job, the job id:{} ", jobId);
         }
         return latestPipelineStates;
     }

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/common/FileConfiguration.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/common/FileConfiguration.java
@@ -38,7 +38,7 @@ public enum FileConfiguration {
         this.configuration = configuration;
     }
 
-    public AbstractConfiguration getConfiguration(String name) {
+    public AbstractConfiguration getConfiguration() {
         return configuration;
     }
 

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/common/HdfsFileStorageInstance.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/common/HdfsFileStorageInstance.java
@@ -30,7 +30,7 @@ public class HdfsFileStorageInstance {
         throw new IllegalStateException("Utility class");
     }
 
-    private static HdfsStorage HDFS_STORAGE;
+    private static volatile HdfsStorage HDFS_STORAGE;
     private static final Object LOCK = new Object();
 
     public static boolean isFsNull() {


### PR DESCRIPTION

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
This pull request addresses two issues identified in the HDFS checkpoint storage code:
- Fix Double-Checked Locking: Ensures proper thread safety and lazy initialization.
- Improve Logging: Enhances log messages for better debugging and clarity.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This patch primarily involves minor changes to logging and the addition of the volatile keyword to a field. Given the nature of these changes, no new test cases were added. The existing test suite covers the functionality of the HdfsStorage class, and these changes do not introduce new logic that requires additional testing.
The changes made are:
Logging Improvements: Enhanced log messages for better clarity and debugging.
Volatile Keyword: Added the volatile keyword to ensure visibility of changes to the fs field across threads.
These modifications are unlikely to affect the existing behavior, and thus, the existing test cases are sufficient to validate the changes.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).