### PR TITLE
[Feature][Jdbc]added contents about multiple tables and regular expre…

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectLoader.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectLoader.java
@@ -40,6 +40,10 @@ public final class JdbcDialectLoader {
         return load(url, compatibleMode, dialect, "");
     }
 
+    public static JdbcDialect load(String url, String compatibleMode) {
+        return load(url, compatibleMode, "");
+    }
+
     /**
      * Loads the unique JDBC Dialect that can handle the given database url.
      *

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
@@ -201,7 +201,11 @@ public class OracleDialect implements JdbcDialect {
         // tablePath is TablePath.DEFAULT, use COUNT(*).
 
         String query = table.getQuery();
-
+        // Add null value judgment
+        if (table.getTablePath() == null) {
+            Long count = SQLUtils.countForSubquery(connection, query);
+            return count;
+        }
         boolean useTableStats =
                 StringUtils.isBlank(query)
                         || (!query.toLowerCase().contains("where")
@@ -210,7 +214,9 @@ public class OracleDialect implements JdbcDialect {
                                         .getFullName()
                                         .equals(table.getTablePath().getFullName()));
 
-        if (table.getUseSelectCount()) {
+        // Add null value judgment
+        Boolean useSelectCount = table.getUseSelectCount();
+        if (useSelectCount != null && useSelectCount) {
             useTableStats = false;
             if (StringUtils.isBlank(query)) {
                 query = "SELECT * FROM " + tableIdentifier(table.getTablePath());

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sourcetype/DatabaseTypeEnum.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sourcetype/DatabaseTypeEnum.java
@@ -1,0 +1,17 @@
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.sourcetype;
+
+public enum DatabaseTypeEnum {
+    MYSQL("MySQL"),
+    ORACLE("Oracle"),
+    SQLSERVER("SqlServer"),
+    POSTGRESQL("Postgres");
+    private final String value;
+
+    DatabaseTypeEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSource.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSource.java
@@ -27,18 +27,31 @@ import org.apache.seatunnel.api.source.SupportParallelism;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectLoader;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.sourcetype.DatabaseTypeEnum;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.state.JdbcSourceState;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.JdbcCatalogUtils;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import lombok.SneakyThrows;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class JdbcSource
@@ -46,17 +59,173 @@ public class JdbcSource
                 SupportParallelism,
                 SupportColumnProjection {
     protected static final Logger LOG = LoggerFactory.getLogger(JdbcSource.class);
-
+    private static final String POINT = ".";
     private final JdbcSourceConfig jdbcSourceConfig;
     private final Map<TablePath, JdbcSourceTable> jdbcSourceTables;
 
     @SneakyThrows
     public JdbcSource(JdbcSourceConfig jdbcSourceConfig) {
         this.jdbcSourceConfig = jdbcSourceConfig;
+        JdbcConnectionConfig jdbcConnectionConfig = jdbcSourceConfig.getJdbcConnectionConfig();
+        JdbcDialect jdbcDialect =
+                JdbcDialectLoader.load(
+                        jdbcConnectionConfig.getUrl(), jdbcConnectionConfig.getCompatibleMode());
+        LOG.info("Using JDBC dialect: {}", jdbcDialect.dialectName());
+        JdbcConnectionProvider connectionProvider =
+                jdbcDialect.getJdbcConnectionProvider(jdbcSourceConfig.getJdbcConnectionConfig());
+        Connection connection = connectionProvider.getOrEstablishConnection();
+        List<JdbcSourceTableConfig> jdbcSourceTableConfigs = new ArrayList<>();
+        ResultSet rs = null;
+        PreparedStatement ps = null;
+        List<JdbcSourceTableConfig> tablePaths = jdbcSourceConfig.getTableConfigList();
+        try {
+            for (JdbcSourceTableConfig tableConfig : tablePaths) {
+                List<String> schemaTables = new ArrayList<>();
+                String tablePath = tableConfig.getTablePath();
+                String query = tableConfig.getQuery();
+                String sql;
+                if (StringUtils.isBlank(query)) {
+                    String schemaName;
+                    if (jdbcDialect.dialectName().startsWith(DatabaseTypeEnum.ORACLE.getValue())) {
+                        schemaName = tablePath.split("\\.")[0];
+                        sql = "SELECT OWNER, TABLE_NAME FROM dba_tables where OWNER=?";
+                        ps = connection.prepareStatement(sql);
+                        ps.setString(1, schemaName);
+                        rs = ps.executeQuery();
+                        while (rs.next()) {
+                            // For Oracle: schema.table
+                            String foundTable =
+                                    rs.getString("OWNER") + POINT + rs.getString("TABLE_NAME");
+                            schemaTables.add(foundTable);
+                        }
+                    } else if (jdbcDialect
+                            .dialectName()
+                            .equals(DatabaseTypeEnum.MYSQL.getValue())) {
+                        schemaName = tablePath.split("\\.")[0];
+                        sql =
+                                "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA =?";
+                        ps = connection.prepareStatement(sql);
+                        ps.setString(1, schemaName);
+                        rs = ps.executeQuery();
+                        while (rs.next()) {
+                            // For MySQL: database.table
+                            String foundTable =
+                                    rs.getString("TABLE_SCHEMA")
+                                            + POINT
+                                            + rs.getString("TABLE_NAME");
+                            schemaTables.add(foundTable);
+                        }
+                    } else if (jdbcDialect
+                            .dialectName()
+                            .equals(DatabaseTypeEnum.SQLSERVER.getValue())) {
+                        String[] pathParts = tablePath.split("\\.");
+                        String databaseName = pathParts[0];
+                        schemaName = pathParts[1];
+                        sql =
+                                "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+                                        + " WHERE TABLE_SCHEMA =? AND TABLE_CATALOG = DB_NAME()"
+                                        + " AND TABLE_TYPE ='BASE TABLE'";
+                        ps = connection.prepareStatement(sql);
+                        ps.setString(1, schemaName);
+                        rs = ps.executeQuery();
+                        while (rs.next()) {
+                            // For SQLServer: database.schema.table
+                            String foundTable =
+                                    databaseName
+                                            + POINT
+                                            + rs.getString("TABLE_SCHEMA")
+                                            + POINT
+                                            + rs.getString("TABLE_NAME");
+                            schemaTables.add(foundTable);
+                        }
+                    } else if (jdbcDialect
+                            .dialectName()
+                            .equals(DatabaseTypeEnum.POSTGRESQL.getValue())) {
+                        String[] pathParts = tablePath.split("\\.");
+                        String databaseName = pathParts[0];
+                        schemaName = pathParts[1];
+                        LOG.info(
+                                "PostgreSQL: Processing database: {}, schema: {}",
+                                databaseName,
+                                schemaName);
+                        sql =
+                                "SELECT table_schema, table_name FROM information_schema.tables "
+                                        + "WHERE table_schema = ? AND table_type = 'BASE TABLE' "
+                                        + "AND table_catalog = current_database()";
+                        ps = connection.prepareStatement(sql);
+                        ps.setString(1, schemaName);
+                        rs = ps.executeQuery();
+                        while (rs.next()) {
+                            // For PostgreSQL: database.schema.table
+                            String foundTable =
+                                    databaseName
+                                            + POINT
+                                            + rs.getString("table_schema")
+                                            + POINT
+                                            + rs.getString("table_name");
+                            schemaTables.add(foundTable);
+                        }
+                    } else {
+                        throw new RuntimeException(
+                                "not support dialect " + jdbcDialect.dialectName());
+                    }
+                    filterCapturedTablesByRegrex(
+                            jdbcSourceTableConfigs, tableConfig, schemaTables, tablePath);
+                } else {
+                    jdbcSourceTableConfigs.add(tableConfig);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Regular expression match failed:", e);
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (ps != null) {
+                ps.close();
+            }
+            connectionProvider.closeConnection();
+        }
+
         this.jdbcSourceTables =
                 JdbcCatalogUtils.getTables(
-                        jdbcSourceConfig.getJdbcConnectionConfig(),
-                        jdbcSourceConfig.getTableConfigList());
+                        jdbcSourceConfig.getJdbcConnectionConfig(), jdbcSourceTableConfigs);
+    }
+
+    private void filterCapturedTablesByRegrex(
+            List<JdbcSourceTableConfig> jdbcSourceTableConfigs,
+            JdbcSourceTableConfig tableConfig,
+            List<String> schemaTables,
+            String tablePath) {
+        LOG.info("Filtering tables with regex pattern: {}", tablePath);
+
+        // Try exact match first
+        if (schemaTables.contains(tablePath)) {
+            LOG.info("Found exact table match: {}", tablePath);
+            jdbcSourceTableConfigs.add(tableConfig);
+            return;
+        }
+
+        // If no exact match, try pattern matching
+        LOG.info(
+                "No exact match found, trying pattern matching against {} tables",
+                schemaTables.size());
+        try {
+            Pattern pattern = Pattern.compile(tablePath);
+            for (String table : schemaTables) {
+                if (pattern.matcher(table).find()) {
+                    JdbcSourceTableConfig jdbcSourceTableConfig = new JdbcSourceTableConfig();
+                    jdbcSourceTableConfig.setTablePath(table);
+                    if (tableConfig.getQuery() != null) {
+                        jdbcSourceTableConfig.setQuery(tableConfig.getQuery());
+                    }
+                    jdbcSourceTableConfigs.add(jdbcSourceTableConfig);
+                }
+            }
+            LOG.info("Total tables matched after filtering: {}", jdbcSourceTableConfigs.size());
+        } catch (Exception e) {
+            LOG.error("Error while matching regex pattern: {}", tablePath, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
…ssions in PostgreSQL/mysql/oracle/sqlserver, and fix the null pointer issue in the regular expression

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

https://github.com/apache/seatunnel/issues/9209

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
added contents about multiple tables and regular expressions in PostgreSQL/mysql/oracle/sqlserver, and fix the null pointer issue in the regular expression.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

Yes.
This PR enhances the table_list parameter to directly support regex patterns for table filtering, while maintaining backward compatibility.
Here's the detailed breakdown:

- New Feature: Direct Use of Regular Expressions in table_path

Purpose: Allow users to write regular expressions directly in the table_path field within table_list to filter tables.
Example Configuration:
"table_list"=[
    {
        "table_path"="TEST.TEST_DB_*"  # Matches all tables with the "TEST_DB" prefix
    }
]
This configuration matches all tables prefixed with TEST_DB (e.g., TEST_DB_2023, TEST_DB_2024).

- Improvement and Fix:

Enhanced the robustness of the approximateRowCntStatement method in OracleDialect.
Fixed a null pointer error in Oracle when executing queries with empty or invalid parameters.
Key Notes:
The table_path now supports regex syntax (e.g., TEST.TEST_DB_* → matches all tables under the TEST schema with names starting with TEST_DB_).
The Oracle fix ensures stable execution of row count estimation logic, avoiding crashes due to unhandled edge cases.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

- Testing Environment

OS: Linux (Ubuntu 20.04)
SeaTunnel Version: 2.3.9
Execution Mode: Flink on YARN (yarn-application)
Databases:
PostgreSQL 16.0(Source)
Iceberg (Sink)

- Test Configuration:

Created a configuration file pg2iceberg.conf to read tables matching the regex TEST.TEST_DB_* from PostgreSQL:
{
  env {
    execution.parallelism = 1
    job.mode = "BATCH"
    job.name = "seatunnel_batch_job"
  }
  # source配置
  source {
    JDBC {
      url = "jdbc:postgresql://xxxxxxx:xxxxx/xxxxx"
      driver = "org.postgresql.Driver"
      user = "xxxxxxxx"
      password = "xxxxxxx"
      "table_list" = [
        {
          "table_path" = "postgres.public.test_db_2.*"
        }
      ]
      split.size = 5000
      fetch_size = 2000
    }
  }
  # sink配置
  sink {
    Iceberg {
      ........
    }
  }
}

- Execution Command:

./bin/start-seatunnel-flink-15-connector-v2.sh --config pg2iceberg.conf   --deploy-mode run-application --target yarn-application --name multitable_pg2Iceberg

- Check log：
Filtering tables with regex pattern: postgres.public.test_db_2.*
Found regex match table: postgres.public.test_db_20
Found regex match table: postgres.public.test_db_21
Found regex match table: postgres.public.test_db_22
Found regex match table: postgres.public.test_db_20250324
Found regex match table: postgres.public.test_db_202502
Found regex match table: postgres.public.test_db_202501
Total tables matched after filtering: 6

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).