### PR TITLE
[Fix][Doc] Delete space before _test and _sink

### DIFF
--- a/docs/en/connector-v2/sink/Jdbc.md
+++ b/docs/en/connector-v2/sink/Jdbc.md
@@ -130,8 +130,8 @@ mysql sink for example:
 
 pgsql (Oracle Sqlserver ...) Sink for example:
 
-1. ${schema_name}.${table_name} _test
-2. dbo.tt_${table_name} _sink
+1. ${schema_name}.${table_name}_test
+2. dbo.tt_${table_name}_sink
 3. public.sink_table
 
 Tip: If the target database has the concept of SCHEMA, the table parameter must be written as `xxx.xxx`

--- a/docs/en/connector-v2/sink/PostgreSql.md
+++ b/docs/en/connector-v2/sink/PostgreSql.md
@@ -110,8 +110,8 @@ This option is mutually exclusive with `query` and has a higher priority.
 The table parameter can fill in the name of an unwilling table, which will eventually be used as the table name of the creation table, and supports variables (`${table_name}`, `${schema_name}`). Replacement rules: `${schema_name}` will replace the SCHEMA name passed to the target side, and `${table_name}` will replace the name of the table passed to the table at the target side.
 
 for example:
-1. ${schema_name}.${table_name} _test
-2. dbo.tt_${table_name} _sink
+1. ${schema_name}.${table_name}_test
+2. dbo.tt_${table_name}_sink
 3. public.sink_table
 
 ### schema_save_mode[Enum]

--- a/docs/zh/connector-v2/sink/PostgreSql.md
+++ b/docs/zh/connector-v2/sink/PostgreSql.md
@@ -106,8 +106,8 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 表参数可以填写一个不想的表的名称，最终将作为创建表的表名，并支持变量（`${table_name}`，`${schema_name}`）。替换规则：`${schema_name}` 将替换为传递给目标端的 SCHEMA 名称，`${table_name}` 将替换为传递给目标端的表名称。
 
 例如：
-1. `${schema_name}.${table_name} _test`
-2. `dbo.tt_${table_name} _sink`
+1. `${schema_name}.${table_name}_test`
+2. `dbo.tt_${table_name}_sink`
 3. `public.sink_table`
 
 ### schema_save_mode [枚举]


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes formatting issues in the PostgreSQL documentation where a space was mistakenly added before suffixes like `_test` and `_sink` in example table names.  
Examples fixed:
- `${schema_name}.${table_name} _test` → `${schema_name}.${table_name}_test`
- `dbo.tt_${table_name} _sink` → `dbo.tt_${table_name}_sink`

This improves accuracy and consistency in documentation.

Related Issue: Fixes #9214

---

### Does this PR introduce _any_ user-facing change?

Yes. It corrects table name formatting in the documentation, which users may refer to when configuring connectors or writing SQL.  
There is no behavioral change to SeaTunnel itself.

---

### How was this patch tested?

This patch was tested by manually reviewing the affected documentation files to ensure the formatting was corrected.

---

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  - [ ] Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  - [ ] Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  - [ ] Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  - [ ] Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-connector-v2-e2e/)
  - [ ] Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md)
