### PR TITLE
[Feature][connector-doris] adds case insensitivity feature to the Doris connector

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
@@ -36,6 +36,7 @@ import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.PASS
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.QUERY_PORT;
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.TABLE;
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.USERNAME;
+import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.CASE_SENSITIVE;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.DORIS_SINK_CONFIG_PREFIX;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.NEEDS_UNSUPPORTED_TYPE_CASTING;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SAVE_MODE_CREATE_TEMPLATE;
@@ -46,7 +47,6 @@ import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_ENABLE_DELETE;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_LABEL_PREFIX;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_MAX_RETRIES;
-import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.CASE_SENSITIVE;
 
 @Setter
 @Getter
@@ -72,6 +72,7 @@ public class DorisSinkConfig implements Serializable {
     private Integer bufferCount;
     private Properties streamLoadProps;
     private boolean needsUnsupportedTypeCasting;
+    private boolean caseSensitive;
 
     // create table option
     private String createTableTemplate;

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
@@ -46,6 +46,7 @@ import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_ENABLE_DELETE;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_LABEL_PREFIX;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_MAX_RETRIES;
+import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.CASE_SENSITIVE;
 
 @Setter
 @Getter
@@ -102,7 +103,7 @@ public class DorisSinkConfig implements Serializable {
         dorisSinkConfig.setBufferCount(config.get(SINK_BUFFER_COUNT));
         dorisSinkConfig.setEnableDelete(config.get(SINK_ENABLE_DELETE));
         dorisSinkConfig.setNeedsUnsupportedTypeCasting(config.get(NEEDS_UNSUPPORTED_TYPE_CASTING));
-
+        dorisSinkConfig.setCaseSensitive(config.get(CASE_SENSITIVE));
         // create table option
         dorisSinkConfig.setCreateTableTemplate(config.get(SAVE_MODE_CREATE_TEMPLATE));
 

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
@@ -107,6 +107,14 @@ public class DorisSinkOptions extends DorisBaseOptions {
                     .withDescription(
                             "Whether to enable the unsupported type casting, such as Decimal64 to Double");
 
+    // 添加大小写敏感配置选项
+    Option<Boolean> CASE_SENSITIVE =
+            Options.key("case_sensitive")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to preserve the original case of table and column names. Default is true (case sensitive)");
+
     // create table
     public static final Option<String> SAVE_MODE_CREATE_TEMPLATE =
             Options.key("save_mode_create_template")

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
@@ -107,8 +107,7 @@ public class DorisSinkOptions extends DorisBaseOptions {
                     .withDescription(
                             "Whether to enable the unsupported type casting, such as Decimal64 to Double");
 
-    // 添加大小写敏感配置选项
-    Option<Boolean> CASE_SENSITIVE =
+    public static final Option<Boolean> CASE_SENSITIVE =
             Options.key("case_sensitive")
                     .booleanType()
                     .defaultValue(true)

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisTableConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisTableConfig.java
@@ -83,7 +83,6 @@ public class DorisTableConfig implements Serializable {
             dorisTableConfig.setDatabase(connectorConfig.get(DATABASE));
             dorisTableConfig.setTable(connectorConfig.get(TABLE));
 
-            // 处理大小写敏感
             boolean caseSensitive = true;
             if (connectorConfig.getOptional(CASE_SENSITIVE).isPresent()) {
                 caseSensitive = connectorConfig.get(CASE_SENSITIVE);

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisTableConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisTableConfig.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.DATABASE;
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.DORIS_BATCH_SIZE;
 import static org.apache.seatunnel.connectors.doris.config.DorisBaseOptions.TABLE;
+import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.CASE_SENSITIVE;
 import static org.apache.seatunnel.connectors.doris.config.DorisSourceOptions.DORIS_EXEC_MEM_LIMIT;
 import static org.apache.seatunnel.connectors.doris.config.DorisSourceOptions.DORIS_FILTER_QUERY;
 import static org.apache.seatunnel.connectors.doris.config.DorisSourceOptions.DORIS_READ_FIELD;
@@ -78,6 +79,21 @@ public class DorisTableConfig implements Serializable {
         if (connectorConfig.getOptional(TABLE_LIST).isPresent()) {
             tableList = connectorConfig.get(TABLE_LIST);
         } else {
+            DorisTableConfig dorisTableConfig = new DorisTableConfig();
+            dorisTableConfig.setDatabase(connectorConfig.get(DATABASE));
+            dorisTableConfig.setTable(connectorConfig.get(TABLE));
+
+            // 处理大小写敏感
+            boolean caseSensitive = true;
+            if (connectorConfig.getOptional(CASE_SENSITIVE).isPresent()) {
+                caseSensitive = connectorConfig.get(CASE_SENSITIVE);
+            }
+
+            if (!caseSensitive) {
+                dorisTableConfig.setDatabase(dorisTableConfig.getDatabase().toLowerCase());
+                dorisTableConfig.setTable(dorisTableConfig.getTable().toLowerCase());
+            }
+
             DorisTableConfig tableProperty =
                     DorisTableConfig.builder()
                             .table(connectorConfig.get(TABLE))

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
@@ -94,26 +94,17 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
     public static final long MAX_STRING_LENGTH = 2147483643;
 
     protected PhysicalColumn.PhysicalColumnBuilder getPhysicalColumnBuilder(
-            BasicTypeDefine typeDefine) {
+            BasicTypeDefine typeDefine, boolean caseSensitive) {
+        String columnName =
+                caseSensitive ? typeDefine.getName() : typeDefine.getName().toLowerCase();
         PhysicalColumn.PhysicalColumnBuilder builder =
                 PhysicalColumn.builder()
-                        .name(typeDefine.getName())
+                        .name(columnName)
                         .sourceType(typeDefine.getColumnType())
                         .nullable(typeDefine.isNullable())
                         .defaultValue(typeDefine.getDefaultValue())
                         .comment(typeDefine.getComment());
         return builder;
-    }
-
-    protected PhysicalColumn.PhysicalColumnBuilder getPhysicalColumnBuilder(
-            BasicTypeDefine typeDefine, boolean caseSensitive) {
-        String columnName =
-                caseSensitive ? typeDefine.getName() : typeDefine.getName().toLowerCase();
-        return PhysicalColumn.builder()
-                .name(columnName)
-                .nullable(typeDefine.isNullable())
-                .comment(typeDefine.getComment())
-                .defaultValue(typeDefine.getDefaultValue());
     }
 
     protected BasicTypeDefine.BasicTypeDefineBuilder getBasicTypeDefineBuilder(Column column) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
@@ -105,6 +105,18 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
         return builder;
     }
 
+    // 添加处理字段名大小写的方法
+    protected PhysicalColumn.PhysicalColumnBuilder getPhysicalColumnBuilder(
+            BasicTypeDefine typeDefine, boolean caseSensitive) {
+        String columnName =
+                caseSensitive ? typeDefine.getName() : typeDefine.getName().toLowerCase();
+        return PhysicalColumn.builder()
+                .name(columnName)
+                .nullable(typeDefine.isNullable())
+                .comment(typeDefine.getComment())
+                .defaultValue(typeDefine.getDefaultValue());
+    }
+
     protected BasicTypeDefine.BasicTypeDefineBuilder getBasicTypeDefineBuilder(Column column) {
         BasicTypeDefine.BasicTypeDefineBuilder builder =
                 BasicTypeDefine.builder()

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
@@ -105,7 +105,6 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
         return builder;
     }
 
-    // 添加处理字段名大小写的方法
     protected PhysicalColumn.PhysicalColumnBuilder getPhysicalColumnBuilder(
             BasicTypeDefine typeDefine, boolean caseSensitive) {
         String columnName =

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
@@ -48,11 +48,9 @@ public class DorisTypeConverterV1 extends AbstractDorisTypeConverter {
 
     @Override
     public Column convert(BasicTypeDefine typeDefine) {
-        // 默认使用大小写敏感
         return convert(typeDefine, true);
     }
 
-    // 添加支持大小写敏感参数的转换方法
     public Column convert(BasicTypeDefine typeDefine, boolean caseSensitive) {
         PhysicalColumn.PhysicalColumnBuilder builder =
                 getPhysicalColumnBuilder(typeDefine, caseSensitive);

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
@@ -48,7 +48,14 @@ public class DorisTypeConverterV1 extends AbstractDorisTypeConverter {
 
     @Override
     public Column convert(BasicTypeDefine typeDefine) {
-        PhysicalColumn.PhysicalColumnBuilder builder = getPhysicalColumnBuilder(typeDefine);
+        // 默认使用大小写敏感
+        return convert(typeDefine, true);
+    }
+
+    // 添加支持大小写敏感参数的转换方法
+    public Column convert(BasicTypeDefine typeDefine, boolean caseSensitive) {
+        PhysicalColumn.PhysicalColumnBuilder builder =
+                getPhysicalColumnBuilder(typeDefine, caseSensitive);
         String dorisColumnType = getDorisColumnName(typeDefine);
 
         switch (dorisColumnType) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
@@ -68,11 +68,9 @@ public class DorisTypeConverterV2 extends AbstractDorisTypeConverter {
 
     @Override
     public Column convert(BasicTypeDefine typeDefine) {
-        // 默认使用大小写敏感
         return convert(typeDefine, true);
     }
 
-    // 添加支持大小写敏感参数的转换方法
     public Column convert(BasicTypeDefine typeDefine, boolean caseSensitive) {
         PhysicalColumn.PhysicalColumnBuilder builder =
                 getPhysicalColumnBuilder(typeDefine, caseSensitive);

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
@@ -68,7 +68,14 @@ public class DorisTypeConverterV2 extends AbstractDorisTypeConverter {
 
     @Override
     public Column convert(BasicTypeDefine typeDefine) {
-        PhysicalColumn.PhysicalColumnBuilder builder = getPhysicalColumnBuilder(typeDefine);
+        // 默认使用大小写敏感
+        return convert(typeDefine, true);
+    }
+
+    // 添加支持大小写敏感参数的转换方法
+    public Column convert(BasicTypeDefine typeDefine, boolean caseSensitive) {
+        PhysicalColumn.PhysicalColumnBuilder builder =
+                getPhysicalColumnBuilder(typeDefine, caseSensitive);
         String dorisColumnType = getDorisColumnName(typeDefine);
 
         switch (dorisColumnType) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializer.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializer.java
@@ -45,7 +45,6 @@ public class SeaTunnelRowSerializer implements DorisSerializer {
     private final String fieldDelimiter;
     private final boolean enableDelete;
     private final SerializationSchema serialize;
-    // 添加大小写敏感参数
     private final boolean caseSensitive;
 
     public SeaTunnelRowSerializer(
@@ -53,11 +52,9 @@ public class SeaTunnelRowSerializer implements DorisSerializer {
             SeaTunnelRowType seaTunnelRowType,
             String fieldDelimiter,
             boolean enableDelete) {
-        // 默认大小写敏感为 true
         this(type, seaTunnelRowType, fieldDelimiter, enableDelete, true);
     }
 
-    // 添加新的构造函数，包含 caseSensitive 参数
     public SeaTunnelRowSerializer(
             String type,
             SeaTunnelRowType seaTunnelRowType,
@@ -69,7 +66,6 @@ public class SeaTunnelRowSerializer implements DorisSerializer {
         this.enableDelete = enableDelete;
         this.caseSensitive = caseSensitive;
 
-        // 处理字段名大小写
         String[] fieldNames = seaTunnelRowType.getFieldNames();
         String[] processedFieldNames = new String[fieldNames.length];
         for (int i = 0; i < fieldNames.length; i++) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializer.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializer.java
@@ -45,27 +45,49 @@ public class SeaTunnelRowSerializer implements DorisSerializer {
     private final String fieldDelimiter;
     private final boolean enableDelete;
     private final SerializationSchema serialize;
+    // 添加大小写敏感参数
+    private final boolean caseSensitive;
 
     public SeaTunnelRowSerializer(
             String type,
             SeaTunnelRowType seaTunnelRowType,
             String fieldDelimiter,
             boolean enableDelete) {
+        // 默认大小写敏感为 true
+        this(type, seaTunnelRowType, fieldDelimiter, enableDelete, true);
+    }
+
+    // 添加新的构造函数，包含 caseSensitive 参数
+    public SeaTunnelRowSerializer(
+            String type,
+            SeaTunnelRowType seaTunnelRowType,
+            String fieldDelimiter,
+            boolean enableDelete,
+            boolean caseSensitive) {
         this.type = type;
         this.fieldDelimiter = fieldDelimiter;
         this.enableDelete = enableDelete;
-        List<Object> fieldNames = new ArrayList<>(Arrays.asList(seaTunnelRowType.getFieldNames()));
+        this.caseSensitive = caseSensitive;
+
+        // 处理字段名大小写
+        String[] fieldNames = seaTunnelRowType.getFieldNames();
+        String[] processedFieldNames = new String[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; i++) {
+            processedFieldNames[i] = caseSensitive ? fieldNames[i] : fieldNames[i].toLowerCase();
+        }
+
+        List<Object> fieldNamesList = new ArrayList<>(Arrays.asList(processedFieldNames));
         List<SeaTunnelDataType<?>> fieldTypes =
                 new ArrayList<>(Arrays.asList(seaTunnelRowType.getFieldTypes()));
 
         if (enableDelete) {
-            fieldNames.add(LoadConstants.DORIS_DELETE_SIGN);
+            fieldNamesList.add(LoadConstants.DORIS_DELETE_SIGN);
             fieldTypes.add(STRING_TYPE);
         }
 
         this.seaTunnelRowType =
                 new SeaTunnelRowType(
-                        fieldNames.toArray(new String[0]),
+                        fieldNamesList.toArray(new String[0]),
                         fieldTypes.toArray(new SeaTunnelDataType<?>[0]));
 
         if (JSON.equals(type)) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializerFactory.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.doris.serialize;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.doris.config.DorisSinkConfig;
+import org.apache.seatunnel.connectors.doris.sink.writer.LoadConstants;
+
+public class SeaTunnelRowSerializerFactory {
+
+    /**
+     * 创建 DorisSerializer 实例
+     *
+     * @param dorisSinkConfig Doris 配置
+     * @param seaTunnelRowType 行类型
+     * @return DorisSerializer 实例
+     */
+    public static DorisSerializer createSerializer(
+            DorisSinkConfig dorisSinkConfig, SeaTunnelRowType seaTunnelRowType) {
+        return new SeaTunnelRowSerializer(
+                dorisSinkConfig
+                        .getStreamLoadProps()
+                        .getProperty(LoadConstants.FORMAT_KEY)
+                        .toLowerCase(),
+                seaTunnelRowType,
+                dorisSinkConfig.getStreamLoadProps().getProperty(LoadConstants.FIELD_DELIMITER_KEY),
+                dorisSinkConfig.getEnableDelete(),
+                dorisSinkConfig.isCaseSensitive());
+    }
+}

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializerFactory.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/serialize/SeaTunnelRowSerializerFactory.java
@@ -24,11 +24,11 @@ import org.apache.seatunnel.connectors.doris.sink.writer.LoadConstants;
 public class SeaTunnelRowSerializerFactory {
 
     /**
-     * 创建 DorisSerializer 实例
+     * Create a DorisSerializer instance
      *
-     * @param dorisSinkConfig Doris 配置
-     * @param seaTunnelRowType 行类型
-     * @return DorisSerializer 实例
+     * @param dorisSinkConfig
+     * @param seaTunnelRowType
+     * @return DorisSerializer
      */
     public static DorisSerializer createSerializer(
             DorisSinkConfig dorisSinkConfig, SeaTunnelRowType seaTunnelRowType) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -36,7 +36,7 @@ import org.apache.seatunnel.connectors.doris.exception.DorisSchemaChangeExceptio
 import org.apache.seatunnel.connectors.doris.rest.models.RespContent;
 import org.apache.seatunnel.connectors.doris.schema.SchemaChangeManager;
 import org.apache.seatunnel.connectors.doris.serialize.DorisSerializer;
-import org.apache.seatunnel.connectors.doris.serialize.SeaTunnelRowSerializer;
+import org.apache.seatunnel.connectors.doris.serialize.SeaTunnelRowSerializerFactory;
 import org.apache.seatunnel.connectors.doris.sink.LoadStatus;
 import org.apache.seatunnel.connectors.doris.sink.committer.DorisCommitInfo;
 import org.apache.seatunnel.connectors.doris.util.HttpUtil;
@@ -266,13 +266,6 @@ public class DorisSinkWriter
 
     private DorisSerializer createSerializer(
             DorisSinkConfig dorisSinkConfig, SeaTunnelRowType seaTunnelRowType) {
-        return new SeaTunnelRowSerializer(
-                dorisSinkConfig
-                        .getStreamLoadProps()
-                        .getProperty(LoadConstants.FORMAT_KEY)
-                        .toLowerCase(),
-                seaTunnelRowType,
-                dorisSinkConfig.getStreamLoadProps().getProperty(LoadConstants.FIELD_DELIMITER_KEY),
-                dorisSinkConfig.getEnableDelete());
+        return SeaTunnelRowSerializerFactory.createSerializer(dorisSinkConfig, seaTunnelRowType);
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
@@ -94,7 +94,11 @@ public class DorisStreamLoad implements Serializable {
             CloseableHttpClient httpClient) {
         this.hostPort = hostPort;
         this.db = tablePath.getDatabaseName();
-        this.table = tablePath.getTableName();
+        // 根据大小写敏感配置决定是否保留原始表名
+        this.table =
+                dorisSinkConfig.isCaseSensitive()
+                        ? tablePath.getTableName()
+                        : tablePath.getTableName().toLowerCase();
         this.user = dorisSinkConfig.getUsername();
         this.passwd = dorisSinkConfig.getPassword();
         this.labelGenerator = labelGenerator;

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
@@ -94,7 +94,6 @@ public class DorisStreamLoad implements Serializable {
             CloseableHttpClient httpClient) {
         this.hostPort = hostPort;
         this.db = tablePath.getDatabaseName();
-        // 根据大小写敏感配置决定是否保留原始表名
         this.table =
                 dorisSinkConfig.isCaseSensitive()
                         ? tablePath.getTableName()

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
@@ -873,4 +873,64 @@ public class DorisTypeConvertorV1Test {
         Assertions.assertEquals("ARRAY<DECIMALV3(20, 0)>", typeDefine.getColumnType());
         Assertions.assertEquals("ARRAY<DECIMALV3>", typeDefine.getDataType());
     }
+
+    @Test
+    public void testCaseSensitiveDefault() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("Test_Column")
+                        .columnType("varchar(255)")
+                        .dataType("varchar")
+                        .build();
+
+        Column column = DorisTypeConverterV1.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals("Test_Column", column.getName());
+    }
+
+    @Test
+    public void testCaseSensitiveFalse() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("Test_Column")
+                        .columnType("varchar(255)")
+                        .dataType("varchar")
+                        .build();
+
+        Column column = DorisTypeConverterV1.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("test_column", column.getName());
+    }
+
+    @Test
+    public void testCaseSensitiveWithMixedCaseTypes() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("mixed_case_column")
+                        .columnType("VarChar(255)")  // 混合大小写类型
+                        .dataType("VARCHAR")
+                        .build();
+
+        Column columnSensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, true);
+        Assertions.assertEquals("mixed_case_column", columnSensitive.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, columnSensitive.getDataType());
+
+        Column columnInsensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("mixed_case_column", columnInsensitive.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, columnInsensitive.getDataType());
+    }
+
+    @Test
+    public void testArrayTypeCaseSensitivity() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("array_column")
+                        .columnType("ARRAY<VARCHAR(255)>")
+                        .dataType("ARRAY")
+                        .build();
+
+        Column columnSensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, true);
+        Assertions.assertEquals("array_column", columnSensitive.getName());
+
+        Column columnInsensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("array_column", columnInsensitive.getName());
+    }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
@@ -905,7 +905,7 @@ public class DorisTypeConvertorV1Test {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()
                         .name("mixed_case_column")
-                        .columnType("VarChar(255)")  // 混合大小写类型
+                        .columnType("VarChar(255)")
                         .dataType("VARCHAR")
                         .build();
 
@@ -916,21 +916,5 @@ public class DorisTypeConvertorV1Test {
         Column columnInsensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, false);
         Assertions.assertEquals("mixed_case_column", columnInsensitive.getName());
         Assertions.assertEquals(BasicType.STRING_TYPE, columnInsensitive.getDataType());
-    }
-
-    @Test
-    public void testArrayTypeCaseSensitivity() {
-        BasicTypeDefine<Object> typeDefine =
-                BasicTypeDefine.builder()
-                        .name("array_column")
-                        .columnType("ARRAY<VARCHAR(255)>")
-                        .dataType("ARRAY")
-                        .build();
-
-        Column columnSensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, true);
-        Assertions.assertEquals("array_column", columnSensitive.getName());
-
-        Column columnInsensitive = DorisTypeConverterV1.INSTANCE.convert(typeDefine, false);
-        Assertions.assertEquals("array_column", columnInsensitive.getName());
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
@@ -1250,7 +1250,6 @@ public class DorisTypeConvertorV2Test {
 
     @Test
     public void testCaseSensitiveFalse() {
-        // 测试设置大小写不敏感时的行为
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()
                         .name("Test_Column")
@@ -1267,7 +1266,7 @@ public class DorisTypeConvertorV2Test {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()
                         .name("mixed_case_column")
-                        .columnType("VarChar(255)")  // 混合大小写类型
+                        .columnType("VarChar(255)")
                         .dataType("VARCHAR")
                         .build();
 
@@ -1278,21 +1277,5 @@ public class DorisTypeConvertorV2Test {
         Column columnInsensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, false);
         Assertions.assertEquals("mixed_case_column", columnInsensitive.getName());
         Assertions.assertEquals(BasicType.STRING_TYPE, columnInsensitive.getDataType());
-    }
-
-    @Test
-    public void testArrayTypeCaseSensitivity() {
-        BasicTypeDefine<Object> typeDefine =
-                BasicTypeDefine.builder()
-                        .name("array_column")
-                        .columnType("ARRAY<VARCHAR(255)>")
-                        .dataType("ARRAY")
-                        .build();
-
-        Column columnSensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, true);
-        Assertions.assertEquals("array_column", columnSensitive.getName());
-
-        Column columnInsensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, false);
-        Assertions.assertEquals("array_column", columnInsensitive.getName());
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
@@ -1234,4 +1234,65 @@ public class DorisTypeConvertorV2Test {
         Assertions.assertEquals("MAP<DATETIME(6), STRING>", typeDefine.getColumnType());
         Assertions.assertEquals("MAP<DATETIME(6), STRING>", typeDefine.getDataType());
     }
+
+    @Test
+    public void testCaseSensitiveDefault() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("Test_Column")
+                        .columnType("varchar(255)")
+                        .dataType("varchar")
+                        .build();
+
+        Column column = DorisTypeConverterV2.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals("Test_Column", column.getName());
+    }
+
+    @Test
+    public void testCaseSensitiveFalse() {
+        // 测试设置大小写不敏感时的行为
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("Test_Column")
+                        .columnType("varchar(255)")
+                        .dataType("varchar")
+                        .build();
+
+        Column column = DorisTypeConverterV2.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("test_column", column.getName());
+    }
+
+    @Test
+    public void testCaseSensitiveWithMixedCaseTypes() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("mixed_case_column")
+                        .columnType("VarChar(255)")  // 混合大小写类型
+                        .dataType("VARCHAR")
+                        .build();
+
+        Column columnSensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, true);
+        Assertions.assertEquals("mixed_case_column", columnSensitive.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, columnSensitive.getDataType());
+
+        Column columnInsensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("mixed_case_column", columnInsensitive.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, columnInsensitive.getDataType());
+    }
+
+    @Test
+    public void testArrayTypeCaseSensitivity() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("array_column")
+                        .columnType("ARRAY<VARCHAR(255)>")
+                        .dataType("ARRAY")
+                        .build();
+
+        Column columnSensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, true);
+        Assertions.assertEquals("array_column", columnSensitive.getName());
+
+        Column columnInsensitive = DorisTypeConverterV2.INSTANCE.convert(typeDefine, false);
+        Assertions.assertEquals("array_column", columnInsensitive.getName());
+    }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
https://github.com/apache/seatunnel/issues/9272

This PR adds case insensitivity feature to the Doris connector. During data synchronization, especially in migration scenarios from Oracle to Doris, column name matching issues often occur because Oracle stores table and field names in uppercase by default, while Doris typically uses lowercase identifiers. By adding a case_sensitive configuration option, users can control whether column names are case-sensitive, thus resolving case difference issues during cross-database system migration.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
Yes, this PR introduces a new configuration option case_sensitive that allows users to control whether the Doris connector is case-sensitive when processing column names. When set to false , the connector automatically converts column names to lowercase, achieving case-insensitive column name matching. This is particularly useful when migrating data from databases like Oracle that use uppercase identifiers by default to Doris.


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
- Integration tests: Tested actual data synchronization scenarios using Oracle and Doris environments to ensure column name case differences do not affect data synchronization
- Manual testing: Verified the stability and compatibility of the feature under different configuration combinations
- Scenario testing: Mainly tested single table, multiple tables with parameter set to false, and scenarios without setting parameters, all results met the requirements


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ x ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ x ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).