### PR TITLE
[Feature][Connector-V2] Add Apache InLong Connector Support

### DIFF
--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -144,6 +144,7 @@ seatunnel.source.Opengauss-CDC = connector-cdc-opengauss
 seatunnel.source.GraphQL = connector-graphql
 seatunnel.sink.GraphQL = connector-graphql
 seatunnel.sink.Aerospike = connector-aerospike
+seatunnel.sink.Inlong = connector-inlong
 
 seatunnel.transform.Sql = seatunnel-transforms-v2
 seatunnel.transform.FieldMapper = seatunnel-transforms-v2

--- a/seatunnel-connectors-v2/connector-inlong/pom.xml
+++ b/seatunnel-connectors-v2/connector-inlong/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-inlong</artifactId>
+    <name>SeaTunnel : Connectors V2 : Pulsar</name>
+
+    <properties>
+        <pulsar.version>2.11.0</pulsar.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>dataproxy-sdk</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-text</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/config/InlongSemantics.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/config/InlongSemantics.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.config;
+
+public enum InlongSemantics {
+
+    /**
+     * At this semantics, we will directly send the message to pulsar, the data may duplicat/lost if
+     * job restart/retry or network error.
+     */
+    NON,
+
+    /** At this semantics, we will send at least one */
+    AT_LEAST_ONCE,
+
+    /**
+     * AT this semantics, we will use 2pc to guarantee the message is sent to pulsar exactly once.
+     */
+    EXACTLY_ONCE;
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/config/SinkProperties.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/config/SinkProperties.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.List;
+
+public class SinkProperties {
+
+    public static final String IDENTIFIER = "Inlong";
+
+    /** The default field delimiter is “,” */
+    public static final String DEFAULT_FIELD_DELIMITER = "|";
+
+    public static final Option<String> FIELD_DELIMITER =
+            Options.key("field_delimiter")
+                    .stringType()
+                    .defaultValue(DEFAULT_FIELD_DELIMITER)
+                    .withDescription(
+                            "Customize the field delimiter for data format.The default field_delimiter is ',' ");
+
+    public static final Option<InlongSemantics> SEMANTICS =
+            Options.key("semantics")
+                    .enumType(InlongSemantics.class)
+                    .defaultValue(InlongSemantics.AT_LEAST_ONCE)
+                    .withDescription(
+                            "If semantic is specified as EXACTLY_ONCE, the producer will write all messages in a transaction.");
+
+    public static final Option<List<String>> PARTITION_KEY_FIELDS =
+            Options.key("partition_key_fields")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Configure which fields are used as the key of the pulsar message.");
+    public static final Option<String> MANAGER_URL =
+            Options.key("manager-url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("manager url provider for Inlong manager");
+    public static final Option<String> GROUP_ID =
+            Options.key("group-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("groupId for Inlong");
+    public static final Option<Boolean> ENABLE_AUTH =
+            Options.key("enable-auth")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("if to enable auth for Inlong");
+    public static final Option<String> STREAM_ID =
+            Options.key("stream-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("streamId for Inlong");
+    public static final Option<String> SECRET_ID =
+            Options.key("secret-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("secretId for Inlong");
+    public static final Option<String> SECRET_KEY =
+            Options.key("secret-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("secretKey for Inlong");
+
+    public static final int DEFAULT_ASYNC_BUFFER_SIZE_KB = 200 * 1024;
+    public static final Option<Integer> ASYNC_BUFFER_SIZE =
+            Options.key("async-buffer-size")
+                    .intType()
+                    .defaultValue(DEFAULT_ASYNC_BUFFER_SIZE_KB)
+                    .withDescription("async buffer size for Inlong sdk");
+
+    public static final int DEFAULT_ACTIVE_CONNECT_NUM = 10;
+    public static final Option<Integer> ACTIVE_CONNECT_NUM =
+            Options.key("active-connect-num")
+                    .intType()
+                    .defaultValue(DEFAULT_ACTIVE_CONNECT_NUM)
+                    .withDescription("active connect num for Inlong sdk");
+
+    public static final int DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
+    public static final Option<Integer> REQUEST_TIMEOUT =
+            Options.key("request-timeout")
+                    .intType()
+                    .defaultValue(DEFAULT_REQUEST_TIMEOUT_MS)
+                    .withDescription("request timeout for Inlong sdk");
+
+    public static final int DEFAULT_THREAD_NUM = Runtime.getRuntime().availableProcessors();
+    public static final Option<Integer> THREAD_NUM =
+            Options.key("thread-num")
+                    .intType()
+                    .defaultValue(DEFAULT_THREAD_NUM)
+                    .withDescription("thread num for Inlong sdk");
+
+    public static final int DEFAULT_BATCH_SEND_LEN = 500 * 1024;
+    public static final Option<Integer> BATCH_SEND_LEN =
+            Options.key("batch-send-len")
+                    .intType()
+                    .defaultValue(DEFAULT_BATCH_SEND_LEN)
+                    .withDescription("batch send length for Inlong sdk");
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/exception/InlongErrorCode.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/exception/InlongErrorCode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum InlongErrorCode implements SeaTunnelErrorCode {
+    SENDING_THREAD_NOT_RUNNING("INLONG-01", "sending thread not running"),
+    RESEND_THREAD_NOT_RUNNING("INLONG-02", "resend thread not running"),
+    ;
+
+    private final String code;
+    private final String description;
+
+    InlongErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/exception/InlongException.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/exception/InlongException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class InlongException extends SeaTunnelRuntimeException {
+    public InlongException(SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage) {
+        super(seaTunnelErrorCode, errorMessage);
+    }
+
+    public InlongException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage, Throwable cause) {
+        super(seaTunnelErrorCode, errorMessage, cause);
+    }
+
+    public InlongException(SeaTunnelErrorCode seaTunnelErrorCode, Throwable cause) {
+        super(seaTunnelErrorCode, cause);
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSink.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSink.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.serialization.DefaultSerializer;
+import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.sink.SinkCommitter;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongAggregatedCommitInfo;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongCommitInfo;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongSinkState;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.IDENTIFIER;
+
+/**
+ * Inlong Sink implementation by using SeaTunnel sink API. This class contains the method to create
+ * {@link InlongSinkWriter} and {@link InlongSinkCommitter}.
+ */
+public class InlongSink
+        implements SeaTunnelSink<
+                SeaTunnelRow, InlongSinkState, InlongCommitInfo, InlongAggregatedCommitInfo> {
+
+    private final SeaTunnelRowType seaTunnelRowType;
+    private final ReadonlyConfig readonlyConfig;
+    private final CatalogTable catalogTable;
+
+    public InlongSink(ReadonlyConfig readonlyConfig, CatalogTable catalogTable) {
+        this.readonlyConfig = readonlyConfig;
+        this.seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
+        this.catalogTable = catalogTable;
+    }
+
+    @Override
+    public SinkWriter<SeaTunnelRow, InlongCommitInfo, InlongSinkState> createWriter(
+            SinkWriter.Context context) {
+        return new InlongSinkWriter(
+                context, readonlyConfig, seaTunnelRowType, Collections.emptyList());
+    }
+
+    @Override
+    public SinkWriter<SeaTunnelRow, InlongCommitInfo, InlongSinkState> restoreWriter(
+            SinkWriter.Context context, List<InlongSinkState> states) {
+        return new InlongSinkWriter(context, readonlyConfig, seaTunnelRowType, states);
+    }
+
+    @Override
+    public Optional<Serializer<InlongSinkState>> getWriterStateSerializer() {
+        return Optional.of(new DefaultSerializer<>());
+    }
+
+    @Override
+    public Optional<SinkCommitter<InlongCommitInfo>> createCommitter() {
+        return Optional.of(new InlongSinkCommitter(readonlyConfig));
+    }
+
+    @Override
+    public Optional<Serializer<InlongCommitInfo>> getCommitInfoSerializer() {
+        return Optional.of(new DefaultSerializer<>());
+    }
+
+    @Override
+    public String getPluginName() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.ofNullable(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkCommitter.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkCommitter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SinkCommitter;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongCommitInfo;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class InlongSinkCommitter implements SinkCommitter<InlongCommitInfo> {
+
+    public InlongSinkCommitter(ReadonlyConfig config) {}
+
+    @Override
+    public List<InlongCommitInfo> commit(List<InlongCommitInfo> commitInfos) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void abort(List<InlongCommitInfo> commitInfos) throws IOException {}
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+
+import com.google.auto.service.AutoService;
+
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.GROUP_ID;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.IDENTIFIER;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.MANAGER_URL;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.SECRET_ID;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.SECRET_KEY;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.STREAM_ID;
+
+@AutoService(Factory.class)
+public class InlongSinkFactory implements TableSinkFactory {
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(MANAGER_URL, GROUP_ID, STREAM_ID)
+                .bundled(SECRET_ID, SECRET_KEY)
+                .build();
+    }
+
+    @Override
+    public TableSink createSink(TableSinkFactoryContext context) {
+        return () -> new InlongSink(context.getOptions(), context.getCatalogTable());
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongSinkWriter.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.serialization.SerializationSchema;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.inlong.config.InlongSemantics;
+import org.apache.seatunnel.connectors.seatunnel.inlong.exception.InlongErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.inlong.exception.InlongException;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongCommitInfo;
+import org.apache.seatunnel.connectors.seatunnel.inlong.state.InlongSinkState;
+import org.apache.seatunnel.connectors.seatunnel.inlong.util.InlongUtil;
+import org.apache.seatunnel.format.text.TextSerializationSchema;
+
+import org.apache.inlong.sdk.dataproxy.common.ProcessResult;
+import org.apache.inlong.sdk.dataproxy.exception.ProxySdkException;
+import org.apache.inlong.sdk.dataproxy.sender.MsgSendCallback;
+import org.apache.inlong.sdk.dataproxy.sender.tcp.InLongTcpMsgSender;
+import org.apache.inlong.sdk.dataproxy.sender.tcp.TcpEventInfo;
+import org.apache.inlong.sdk.dataproxy.sender.tcp.TcpMsgSenderConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.ACTIVE_CONNECT_NUM;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.ASYNC_BUFFER_SIZE;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.BATCH_SEND_LEN;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.ENABLE_AUTH;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.FIELD_DELIMITER;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.GROUP_ID;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.MANAGER_URL;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.REQUEST_TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.SECRET_ID;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.SECRET_KEY;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.SEMANTICS;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.STREAM_ID;
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.THREAD_NUM;
+
+class InlongSinkWriter implements SinkWriter<SeaTunnelRow, InlongCommitInfo, InlongSinkState> {
+
+    public static final int BATCH_SEND_INTERVAL = 1;
+    public static final int MAX_RETRY = 5;
+    public static final int ERROR_LOG_SAMPLE = 10;
+    public static final int RESEND_QUEUE_WAIT_MS = 10;
+    private final long WRITE_INTERVAL_MS = 10;
+    private final long CACHE_LIMIT = 100 * 1024 * 1024;
+    private final long THREAD_ALIVE_TIME_MS = 60 * 1000;
+    private InLongTcpMsgSender sender;
+    private InlongSemantics inlongSemantics;
+    private final String groupId;
+    private final String streamId;
+    private LinkedBlockingQueue<byte[]> rowQue;
+    private LinkedBlockingQueue<SenderCallback> resendQue;
+    private AtomicLong cacheLen = new AtomicLong(0);
+    private final int batchSendLen;
+    private static ThreadPoolExecutor EXECUTOR_SERVICE =
+            new ThreadPoolExecutor(
+                    0,
+                    Integer.MAX_VALUE,
+                    1L,
+                    TimeUnit.SECONDS,
+                    new SynchronousQueue<>(),
+                    new InlongThreadFactory("inlong-sink"));
+    private volatile boolean shutdown = false;
+    private static final Logger LOG = LoggerFactory.getLogger(InlongSinkWriter.class);
+    private final SerializationSchema schema;
+    private volatile long sendThreadHeartbeatTime;
+    private volatile long resendThreadHeartbeatTime;
+
+    public InlongSinkWriter(
+            Context context,
+            ReadonlyConfig inlongConfig,
+            SeaTunnelRowType seaTunnelRowType,
+            List<InlongSinkState> pulsarStates) {
+        inlongSemantics = inlongConfig.get(SEMANTICS);
+        TcpMsgSenderConfig proxyClientConfig = null;
+        rowQue = new LinkedBlockingQueue<>();
+        resendQue = new LinkedBlockingQueue<>();
+        batchSendLen = inlongConfig.get(BATCH_SEND_LEN);
+        groupId = inlongConfig.get(GROUP_ID);
+        streamId = inlongConfig.get(STREAM_ID);
+        schema =
+                TextSerializationSchema.builder()
+                        .seaTunnelRowType(seaTunnelRowType)
+                        .delimiter(inlongConfig.get(FIELD_DELIMITER))
+                        .build();
+        try {
+            if (inlongConfig.get(ENABLE_AUTH)) {
+                proxyClientConfig =
+                        new TcpMsgSenderConfig(
+                                inlongConfig.get(MANAGER_URL),
+                                groupId,
+                                inlongConfig.get(SECRET_ID),
+                                inlongConfig.get(SECRET_KEY));
+            } else {
+                proxyClientConfig = new TcpMsgSenderConfig(inlongConfig.get(MANAGER_URL), groupId);
+            }
+        } catch (ProxySdkException e) {
+            LOG.error("Failed to create TcpMsgSenderConfig", e);
+            throw new RuntimeException(e);
+        }
+        proxyClientConfig.setMaxInFlightSizeInKb(inlongConfig.get(ASYNC_BUFFER_SIZE));
+        proxyClientConfig.setAliveConnections(inlongConfig.get(ACTIVE_CONNECT_NUM));
+        proxyClientConfig.setRequestTimeoutMs(inlongConfig.get(REQUEST_TIMEOUT));
+        proxyClientConfig.setNettyWorkerThreadNum(inlongConfig.get(THREAD_NUM));
+        sender =
+                new InLongTcpMsgSender(
+                        proxyClientConfig,
+                        new DefaultThreadFactory(
+                                "inlong-sender", Thread.currentThread().isDaemon()));
+        ProcessResult procResult = new ProcessResult();
+        if (!sender.start(procResult)) {
+            LOG.error("Failed to start InLongTcpMsgSender");
+            sender.close();
+        }
+        sendThreadHeartbeatTime = System.currentTimeMillis();
+        resendThreadHeartbeatTime = System.currentTimeMillis();
+        EXECUTOR_SERVICE.submit(coreThread());
+        EXECUTOR_SERVICE.submit(resend());
+    }
+
+    @Override
+    public void write(SeaTunnelRow element) {
+        checkSinkState();
+        while (!shutdown && !resendQue.isEmpty()) {
+            InlongUtil.silenceSleepInMs(WRITE_INTERVAL_MS);
+        }
+        while (cacheLen.get() > CACHE_LIMIT) {
+            InlongUtil.silenceSleepInMs(WRITE_INTERVAL_MS);
+        }
+        byte[] data = schema.serialize(element);
+        while (!shutdown && !rowQue.offer(data)) {
+            InlongUtil.silenceSleepInMs(WRITE_INTERVAL_MS);
+        }
+        cacheLen.addAndGet(data.length);
+    }
+
+    private void checkSinkState() throws InlongException {
+        if (System.currentTimeMillis() - sendThreadHeartbeatTime > THREAD_ALIVE_TIME_MS) {
+            throw new InlongException(
+                    InlongErrorCode.SENDING_THREAD_NOT_RUNNING,
+                    "Sending thread heartbeat timeout exceeded");
+        }
+        if (System.currentTimeMillis() - resendThreadHeartbeatTime > THREAD_ALIVE_TIME_MS) {
+            throw new InlongException(
+                    InlongErrorCode.RESEND_THREAD_NOT_RUNNING,
+                    "Resend thread heartbeat timeout exceeded");
+        }
+    }
+
+    private Runnable coreThread() {
+        return () -> {
+            LOG.info("start send {}:{}", groupId, streamId);
+            while (!shutdown) {
+                try {
+                    SenderMessage msg = fetchSenderMessage();
+                    sendThreadHeartbeatTime = System.currentTimeMillis();
+                    if (msg != null) {
+                        sendBatchWithRetryCount(msg, 0);
+                    }
+                } catch (Throwable e) {
+                    LOG.error("send message failed: ", e);
+                }
+                InlongUtil.silenceSleepInMs(BATCH_SEND_INTERVAL);
+            }
+            LOG.info("start send {}:{}", groupId, streamId);
+        };
+    }
+
+    private Runnable resend() {
+        return () -> {
+            LOG.info("start resend {}:{}", groupId, streamId);
+            while (!shutdown) {
+                try {
+                    SenderCallback callback =
+                            resendQue.poll(RESEND_QUEUE_WAIT_MS, TimeUnit.MILLISECONDS);
+                    resendThreadHeartbeatTime = System.currentTimeMillis();
+                    if (callback != null) {
+                        sendBatchWithRetryCount(callback.message, callback.retry + 1);
+                    }
+                } catch (Throwable e) {
+                    LOG.error("resend message failed: ", e);
+                } finally {
+                    InlongUtil.silenceSleepInMs(BATCH_SEND_INTERVAL);
+                }
+            }
+            LOG.info("stop resend {}:{}", groupId, streamId);
+        };
+    }
+
+    private void sendBatchWithRetryCount(SenderMessage message, int retry) {
+        boolean suc = false;
+        while (!suc && !shutdown) {
+            try {
+                SenderCallback cb = new SenderCallback(message, retry);
+                ProcessResult procResult = new ProcessResult();
+                boolean isSuccess =
+                        sender.asyncSendMessage(
+                                new TcpEventInfo(
+                                        groupId,
+                                        streamId,
+                                        message.getDataTime(),
+                                        0,
+                                        message.getExtraMap(),
+                                        message.getDataList()),
+                                cb,
+                                procResult);
+                if (!isSuccess) {
+                    throw new ProxySdkException("Send message failure, " + procResult);
+                }
+                suc = true;
+            } catch (Exception e) {
+                suc = false;
+                if (retry > MAX_RETRY) {
+                    if (retry % ERROR_LOG_SAMPLE == 0) {
+                        LOG.error("max retry reached, sample log error: ", e);
+                    }
+                } else {
+                    LOG.error("exception caught", e);
+                }
+                retry++;
+                InlongUtil.silenceSleepInMs(WRITE_INTERVAL_MS);
+            }
+        }
+    }
+
+    @Override
+    public Optional<InlongCommitInfo> prepareCommit() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<InlongSinkState> snapshotState(long checkpointId) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void abortPrepare() {}
+
+    @Override
+    public void close() {
+        shutdown = true;
+        sender.close();
+    }
+
+    public SenderMessage fetchSenderMessage() {
+        int resultBatchSize = 0;
+        List<byte[]> bodyList = new ArrayList<>();
+        while (!rowQue.isEmpty()) {
+            byte[] peekMessage = rowQue.peek();
+            int peekMessageLength = peekMessage.length;
+            if (resultBatchSize + peekMessageLength > batchSendLen) {
+                break;
+            }
+            byte[] data = rowQue.remove();
+            int bodySize = data.length;
+            if (peekMessageLength > batchSendLen) {
+                LOG.warn(
+                        "message size is {}, greater than max pack size {}, drop it!",
+                        peekMessage.length,
+                        batchSendLen);
+                rowQue.remove();
+                break;
+            }
+            resultBatchSize += bodySize;
+            bodyList.add(data);
+        }
+        if (!bodyList.isEmpty()) {
+            Map<String, String> extraMap = new HashMap<>();
+            SenderMessage senderMessage =
+                    new SenderMessage(
+                            groupId, streamId, bodyList, System.currentTimeMillis(), extraMap);
+            return senderMessage;
+        }
+        return null;
+    }
+
+    /** sender callback */
+    private class SenderCallback implements MsgSendCallback {
+
+        private final int retry;
+        private final SenderMessage message;
+        private final int msgCnt;
+
+        SenderCallback(SenderMessage message, int retry) {
+            this.message = message;
+            this.retry = retry;
+            this.msgCnt = message.getDataList().size();
+        }
+
+        @Override
+        public void onMessageAck(ProcessResult result) {
+            if (result.isSuccess()) {
+                cacheLen.addAndGet(-message.getTotalSize());
+            } else {
+                LOG.error(
+                        "send groupId {}, streamId {}, dataTime {} fail with times {}, error {}",
+                        groupId,
+                        streamId,
+                        message.getDataTime(),
+                        retry,
+                        result);
+                try {
+                    resendQue.put(new SenderCallback(message, retry));
+                } catch (Throwable throwable) {
+                    LOG.error("putInResendQueue error: ", throwable);
+                }
+            }
+        }
+
+        @Override
+        public void onException(Throwable e) {
+            LOG.error("SenderCallback error: ", e);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongThreadFactory.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/InlongThreadFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** InlongThreadFactory, used for creating thread. */
+public class InlongThreadFactory implements ThreadFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InlongThreadFactory.class);
+
+    public static final String NAMED_THREAD_PLACEHOLDER = "inlong-thread-factory";
+
+    private final AtomicInteger mThreadNum = new AtomicInteger(1);
+
+    private final String threadType;
+
+    public InlongThreadFactory(String threadType) {
+        this.threadType = threadType;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t =
+                new Thread(
+                        r,
+                        threadType
+                                + "-"
+                                + NAMED_THREAD_PLACEHOLDER
+                                + "-"
+                                + mThreadNum.getAndIncrement());
+        LOGGER.debug("{} created", t.getName());
+        return t;
+    }
+
+    /**
+     * Replace a unique name for thread factory created thread, replace this name for placeholder
+     *
+     * @param uniqueName
+     */
+    public static void nameThread(String uniqueName) {
+        Thread.currentThread()
+                .setName(
+                        Thread.currentThread()
+                                .getName()
+                                .replace(NAMED_THREAD_PLACEHOLDER, uniqueName));
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/SenderMessage.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/sink/SenderMessage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.sink;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/** A batch of seatunnel row used for batch sending, produced by InlongSinkWriter */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SenderMessage {
+
+    private String groupId;
+    private String streamId;
+    private List<byte[]> dataList;
+    private long dataTime;
+    private Map<String, String> extraMap;
+
+    public long getTotalSize() {
+        return CollectionUtils.isEmpty(dataList)
+                ? 0
+                : dataList.stream().mapToLong(body -> body.length).sum();
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongAggregatedCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongAggregatedCommitInfo.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.state;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class InlongAggregatedCommitInfo implements Serializable {
+    List<InlongCommitInfo> commitInfos;
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongCommitInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.state;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+public class InlongCommitInfo implements Serializable {}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongSinkState.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/state/InlongSinkState.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong.state;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+public class InlongSinkState implements Serializable {}

--- a/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/util/InlongUtil.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/main/java/org/apache/seatunnel/connectors/seatunnel/inlong/util/InlongUtil.java
@@ -1,0 +1,18 @@
+package org.apache.seatunnel.connectors.seatunnel.inlong.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class InlongUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(InlongUtil.class);
+
+    public static void silenceSleepInMs(long millisecond) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(millisecond);
+        } catch (Exception e) {
+            LOG.warn("error in silence sleep: ", e);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-inlong/src/test/java/org/apache/seatunnel/connectors/seatunnel/inlong/InlongFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-inlong/src/test/java/org/apache/seatunnel/connectors/seatunnel/inlong/InlongFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.inlong;
+
+import org.apache.seatunnel.connectors.seatunnel.inlong.sink.InlongSinkFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.seatunnel.connectors.seatunnel.inlong.config.SinkProperties.IDENTIFIER;
+
+class InlongFactoryTest {
+
+    @Test
+    void factoryIdentifier() {
+        Assertions.assertEquals(IDENTIFIER, (new InlongSinkFactory()).factoryIdentifier());
+    }
+
+    @Test
+    void optionRule() {
+        Assertions.assertNotNull((new InlongSinkFactory()).optionRule());
+    }
+}


### PR DESCRIPTION
### Description

**Background**​​
[Apache InLong](https://inlong.apache.org/) is a one-stop data integration framework that supports efficient streaming/batch data collection, aggregation, and distribution from diverse sources. 

Apache InLong primarily focuses on ultra-large-scale data integration but lacks support for diverse data sources. In contrast, SeaTunnel provides extensive data source compatibility. By adding an ​​InLong Sink Connector​​ to SeaTunnel, users can reuse SeaTunnel's rich data sources to feed data into InLong, bridging the gap between versatile data ingestion and large-scale integration capabilities, and gain seamless integration with the InLong ecosystem, enhancing real-time data pipeline capabilities for scenarios like log/metrics synchronization and multi-system data distribution.

​​**Proposal​​**
Implement an Apache InLong Connector for SeaTunnel with the following features:

- ​​InLong Sink Connector​​: Write processed data to InLong clusters for downstream consumption or governance.
- Support core InLong configurations (e.g., groupId, streamId, authentication).

**​​Module Structure​​**
- Create a new module: seatunnel-connectors/connector-inlong, referencing existing message queue connectors (e.g., Pulsar).
- Leverage the InLong Java SDK (e.g., inlong-sdk-java) or direct API calls.


### Usage Scenario

Distributing SeaTunnel-processed results through InLong to downstream systems (e.g., real-time dashboards, risk engines).
Suggested Solution

### Purpose of this pull request

Add Apache InLong Connector Support

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)