### PR TITLE
[Fix][connnector-hive] readStrategy which has field FileSystem should close when MultipleTableHiveSourceReader close.

### DIFF
--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/reader/MultipleTableHiveSourceReader.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/reader/MultipleTableHiveSourceReader.java
@@ -124,6 +124,17 @@ public class MultipleTableHiveSourceReader implements SourceReader<SeaTunnelRow,
     @Override
     public void close() throws IOException {
         // do nothing
-        log.info("Closed the MultipleTableHiveSourceReader");
+        log.info("Close the MultipleTableHiveSourceReader and ReadStrategy(FileSystem and HiveConf)");
+        readStrategyMap.forEach(
+            (tablePath, readStrategy) -> {
+                try {
+                    readStrategy.close();
+                } catch (IOException e) {
+                    log.error(
+                            "Closed the ReadStrategy failed, may cause memory leak. file:{}",
+                            tablePath,
+                            e);
+                }
+            });
     }
 }


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

Solve the problem of hive memory leak. HiveSourceConfig holds a ReadStrategy object, and ReadStrategy holds a FileSystem object. The FileSystem object needs to be closed. However, the HiveSourceConfig class does not have a close method. HiveSourceConfig is referenced in MultipleTableHiveSourceReader and MultipleTableHiveSourceSplitEnumerator; however, the ReadStrategy attribute in HiveSourceConfig is only accessible in the HiveSourceReader class. The ReadStrategy attribute is not used in the MultipleTableHiveSourceSplitEnumerator class. Therefore, when MultipleTableHiveSourceReader is closed, just close the ReadStrategy.
![image](https://github.com/user-attachments/assets/930fe27d-31d7-44b8-8300-e0ede438531a)


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
no，I ran my job and found no problems, but I did not test the failure recovery.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)