### PR TITLE
[Bug] [Connector-V2] Updates Iceberg version to 1.6.1 (#9387)

### DIFF
--- a/docs/en/connector-v2/sink/Iceberg.md
+++ b/docs/en/connector-v2/sink/Iceberg.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-iceberg.md';
 
 ## Support Iceberg Version
 
-- 1.4.2
+- 1.6.1
 
 ## Support Those Engines
 

--- a/docs/en/connector-v2/source/Iceberg.md
+++ b/docs/en/connector-v2/source/Iceberg.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-iceberg.md';
 
 ## Support Iceberg Version
 
-- 1.4.2
+- 1.6.1
 
 ## Support Those Engines
 

--- a/docs/zh/connector-v2/sink/Iceberg.md
+++ b/docs/zh/connector-v2/sink/Iceberg.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-iceberg.md';
 
 ## Iceberg 版本支持
 
-- 1.4.2
+- 1.6.1
 
 ## 引擎支持
 

--- a/seatunnel-connectors-v2/connector-iceberg/pom.xml
+++ b/seatunnel-connectors-v2/connector-iceberg/pom.xml
@@ -30,7 +30,7 @@
     <name>SeaTunnel : Connectors V2 : Iceberg</name>
 
     <properties>
-        <iceberg.version>1.4.2</iceberg.version>
+        <iceberg.version>1.6.1</iceberg.version>
         <parquet-avro.version>1.13.1</parquet-avro.version>
         <avro.version>1.11.3</avro.version>
         <hive.version>2.3.9</hive.version>


### PR DESCRIPTION
Upgrades the Iceberg dependency to version 1.6.1.

This ensures compatibility with custom oauth token uri.

This pull request updates the Iceberg dependency in the `seatunnel-connectors-v2/connector-iceberg/pom.xml` file to a newer version.

Dependency update:

* Updated the `iceberg.version` property from `1.4.2` to `1.6.1` to ensure compatibility with the latest features and fixes in Iceberg. (`[seatunnel-connectors-v2/connector-iceberg/pom.xmlL33-R33](diffhunk://#diff-cbb0301376499c039b2b41bd654c3a037e2ca60a0b21c0adaabaff7fded4dfceL33-R33)`)