### PR TITLE
[Fix][Connector-Iceberg] Fix Time Zone Issue for Iceberg Timestamp Type

### DIFF
--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverter.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverter.java
@@ -51,6 +51,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -429,7 +430,11 @@ public class RowConverter {
         } else if (value instanceof OffsetDateTime) {
             return (OffsetDateTime) value;
         } else if (value instanceof LocalDateTime) {
-            return ((LocalDateTime) value).atOffset(ZoneOffset.UTC);
+            // Convert to OffsetDateTime using the system(jvm) default timezone
+            return ((LocalDateTime) value)
+                    .atZone(ZoneId.systemDefault())
+                    .withZoneSameInstant(ZoneOffset.UTC)
+                    .toOffsetDateTime();
         } else if (value instanceof Date) {
             return DateTimeUtil.timestamptzFromMicros(((Date) value).getTime() * 1000);
         }

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.iceberg.data;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.iceberg.config.IcebergSinkConfig;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+public class RowConverterTest {
+
+    @Mock private Table table;
+
+    @Mock private IcebergSinkConfig config;
+
+    private RowConverter converter;
+    private Schema schema;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        // Create a schema with various field types
+        schema =
+                new Schema(
+                        Types.NestedField.required(1, "int_field", Types.IntegerType.get()),
+                        Types.NestedField.required(2, "long_field", Types.LongType.get()),
+                        Types.NestedField.required(3, "float_field", Types.FloatType.get()),
+                        Types.NestedField.required(4, "double_field", Types.DoubleType.get()),
+                        Types.NestedField.required(5, "decimal_field", Types.DecimalType.of(10, 2)),
+                        Types.NestedField.required(6, "boolean_field", Types.BooleanType.get()),
+                        Types.NestedField.required(7, "string_field", Types.StringType.get()),
+                        Types.NestedField.required(8, "uuid_field", Types.UUIDType.get()),
+                        Types.NestedField.required(9, "binary_field", Types.BinaryType.get()),
+                        Types.NestedField.required(10, "date_field", Types.DateType.get()),
+                        Types.NestedField.required(11, "time_field", Types.TimeType.get()),
+                        Types.NestedField.required(
+                                12, "timestamp_field", Types.TimestampType.withoutZone()));
+
+        when(table.schema()).thenReturn(schema);
+        when(config.isCaseSensitive()).thenReturn(true);
+        when(config.isTableSchemaEvolutionEnabled()).thenReturn(false);
+
+        converter = new RowConverter(table, config);
+    }
+
+    @Test
+    public void testConvertBasicTypes() {
+        // Create test data
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {
+                            "int_field",
+                            "long_field",
+                            "float_field",
+                            "double_field",
+                            "decimal_field",
+                            "boolean_field",
+                            "string_field",
+                            "uuid_field",
+                            "binary_field",
+                            "date_field",
+                            "time_field",
+                            "timestamp_field"
+                        },
+                        new SeaTunnelDataType[] {
+                            BasicType.INT_TYPE,
+                            BasicType.LONG_TYPE,
+                            BasicType.FLOAT_TYPE,
+                            BasicType.DOUBLE_TYPE,
+                            new DecimalType(10, 2),
+                            BasicType.BOOLEAN_TYPE,
+                            BasicType.STRING_TYPE,
+                            BasicType.STRING_TYPE,
+                            PrimitiveByteArrayType.INSTANCE,
+                            LocalTimeType.LOCAL_DATE_TYPE,
+                            LocalTimeType.LOCAL_TIME_TYPE,
+                            LocalTimeType.LOCAL_DATE_TIME_TYPE
+                        });
+
+        UUID testUuid = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = LocalDate.now();
+        LocalTime time = LocalTime.now();
+        byte[] binaryData = "test binary".getBytes();
+
+        Object[] fields =
+                new Object[] {
+                    42, // int
+                    123456789L, // long
+                    3.14f, // float
+                    2.71828, // double
+                    new BigDecimal("123.45"), // decimal
+                    true, // boolean
+                    "test string", // string
+                    testUuid.toString(), // UUID as string
+                    binaryData, // binary
+                    today, // date
+                    time, // time
+                    now // timestamp
+                };
+
+        SeaTunnelRow row = new SeaTunnelRow(fields);
+
+        // Convert and verify
+        org.apache.iceberg.data.Record result = converter.convert(row, rowType);
+
+        assertNotNull(result);
+        assertEquals(42, result.getField("int_field"));
+        assertEquals(123456789L, result.getField("long_field"));
+        assertEquals(3.14f, result.getField("float_field"));
+        assertEquals(2.71828, result.getField("double_field"));
+        assertEquals(new BigDecimal("123.45"), result.getField("decimal_field"));
+        assertEquals(true, result.getField("boolean_field"));
+        assertEquals("test string", result.getField("string_field"));
+        assertEquals(testUuid, result.getField("uuid_field"));
+        assertNotNull(result.getField("binary_field"));
+        assertEquals(today, result.getField("date_field"));
+        assertEquals(time, result.getField("time_field"));
+        assertEquals(now, result.getField("timestamp_field"));
+    }
+
+    @Test
+    public void testOffsetDateTimeWithZone() {
+        // Create a schema with timestamp with timezone
+        Schema timestampSchema =
+                new Schema(
+                        Types.NestedField.required(
+                                1, "timestamp_field", Types.TimestampType.withZone()));
+
+        when(table.schema()).thenReturn(timestampSchema);
+        converter = new RowConverter(table, config);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"timestamp_field"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // create local timestamp
+        LocalDateTime localDateTime = LocalDateTime.of(2024, 12, 7, 11, 42, 52);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {localDateTime});
+
+        // convert and verify
+        org.apache.iceberg.data.Record result = converter.convert(row, rowType);
+        OffsetDateTime converted = (OffsetDateTime) result.getField("timestamp_field");
+
+        System.out.println("Input LocalDateTime: " + localDateTime);
+        System.out.println("Converted Result: " + converted);
+
+        // get system offset for the local timestamp
+        ZoneOffset systemOffset = ZoneId.systemDefault().getRules().getOffset(localDateTime);
+        // convert local timestamp to UTC
+        OffsetDateTime expected = localDateTime.minusSeconds(systemOffset.getTotalSeconds())
+                .atOffset(ZoneOffset.UTC);
+
+        assertEquals(expected, converted, "Should convert to correct UTC time");
+    }
+
+    @Test
+    public void testInvalidTypeConversion() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"int_field"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {"not an integer"});
+
+        assertThrows(IllegalArgumentException.class, () -> converter.convert(row, rowType));
+    }
+
+    @Test
+    public void testNullValues() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"int_field", "string_field"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {null, null});
+
+        org.apache.iceberg.data.Record result = converter.convert(row, rowType);
+        assertNotNull(result);
+        assertEquals(null, result.getField("int_field"));
+        assertEquals(null, result.getField("string_field"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
@@ -188,7 +188,7 @@ public class RowConverterTest {
         org.apache.iceberg.data.Record result = converter.convert(row, rowType);
         OffsetDateTime converted = (OffsetDateTime) result.getField("timestamp_field");
 
-// Debug print statements removed to keep test output clean and focused.
+        // Debug print statements removed to keep test output clean and focused.
 
         // get system offset for the local timestamp
         ZoneOffset systemOffset = ZoneId.systemDefault().getRules().getOffset(localDateTime);

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
@@ -188,8 +188,7 @@ public class RowConverterTest {
         org.apache.iceberg.data.Record result = converter.convert(row, rowType);
         OffsetDateTime converted = (OffsetDateTime) result.getField("timestamp_field");
 
-        System.out.println("Input LocalDateTime: " + localDateTime);
-        System.out.println("Converted Result: " + converted);
+// Debug print statements removed to keep test output clean and focused.
 
         // get system offset for the local timestamp
         ZoneOffset systemOffset = ZoneId.systemDefault().getRules().getOffset(localDateTime);

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/data/RowConverterTest.java
@@ -194,8 +194,8 @@ public class RowConverterTest {
         // get system offset for the local timestamp
         ZoneOffset systemOffset = ZoneId.systemDefault().getRules().getOffset(localDateTime);
         // convert local timestamp to UTC
-        OffsetDateTime expected = localDateTime.minusSeconds(systemOffset.getTotalSeconds())
-                .atOffset(ZoneOffset.UTC);
+        OffsetDateTime expected =
+                localDateTime.minusSeconds(systemOffset.getTotalSeconds()).atOffset(ZoneOffset.UTC);
 
         assertEquals(expected, converted, "Should convert to correct UTC time");
     }


### PR DESCRIPTION
https://github.com/apache/seatunnel/issues/9457
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This PR fixes a timezone issue in the Iceberg connector when converting LocalDateTime to OffsetDateTime. Previously, LocalDateTime values were directly converted to UTC timezone without considering the system's local timezone, which could lead to incorrect timestamp values in Iceberg tables. This PR ensures that LocalDateTime values are properly interpreted in the system's timezone before being converted to UTC, preserving the correct instant in time.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
Yes, this PR introduces a user-facing change in how timestamps are handled when writing data to Iceberg tables. Previously, LocalDateTime values were directly converted to UTC without considering the system timezone, which could result in incorrect timestamp values. After this change, LocalDateTime values will be correctly interpreted in the system's timezone before being converted to UTC, ensuring that the same instant in time is preserved. This change affects users who are writing timestamp data to Iceberg tables using the SeaTunnel Iceberg connector.


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

This patch was tested by adding a comprehensive test class RowConverterTest.java that verifies various data type conversions, with special focus on timestamp handling. The test includes:
A basic test that verifies conversion of all supported data types
A specific test for timestamp with timezone conversion that:
Creates a LocalDateTime instance
Converts it using the RowConverter
Verifies that the conversion correctly interprets the timestamp in the system timezone before converting to UTC
Compares the result with a manually calculated expected value
The test ensures that the same instant in time is preserved when converting from LocalDateTime to OffsetDateTime, regardless of the system's timezone settings.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)