### PR TITLE
[Fix][Zeta] Fix map store storage logic

### DIFF
--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorage.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorage.java
@@ -76,9 +76,6 @@ public class IMapFileStorage implements IMapStorage {
 
     public String namespace;
 
-    /** virtual region, Randomly generate a region name */
-    public String region;
-
     /**
      * like OSS bucket name It is used to distinguish data storage locations of different business.
      */
@@ -101,13 +98,7 @@ public class IMapFileStorage implements IMapStorage {
 
     private String businessRootPath = null;
 
-    public static final int DEFAULT_ARCHIVE_WAIT_TIME_MILLISECONDS = 1000 * 60;
-
-    public static final int DEFAULT_QUERY_LIST_SIZE = 256;
-
     public static final long DEFAULT_WRITE_DATA_TIMEOUT_MILLISECONDS = 1000 * 60;
-
-    private Configuration conf;
 
     private FileConfiguration fileConfiguration;
 
@@ -133,7 +124,6 @@ public class IMapFileStorage implements IMapStorage {
                                         Map.Entry::getKey, entry -> entry.getValue().toString()));
 
         Configuration hadoopConf = fileConfiguration.buildConfiguration(stringMap);
-        this.conf = hadoopConf;
         this.namespace = (String) configuration.getOrDefault(NAMESPACE_KEY, DEFAULT_IMAP_NAMESPACE);
         this.businessName = (String) configuration.get(BUSINESS_KEY);
 
@@ -144,7 +134,6 @@ public class IMapFileStorage implements IMapStorage {
                                 WRITE_DATA_TIMEOUT_MILLISECONDS_KEY,
                                 DEFAULT_WRITE_DATA_TIMEOUT_MILLISECONDS);
 
-        this.region = String.valueOf(System.nanoTime());
         this.businessRootPath =
                 namespace
                         + DEFAULT_IMAP_FILE_PATH_SPLIT
@@ -163,7 +152,7 @@ public class IMapFileStorage implements IMapStorage {
                 new WALDisruptor(
                         fs,
                         FileConfiguration.valueOf(storageType.toUpperCase()),
-                        businessRootPath + region + DEFAULT_IMAP_FILE_PATH_SPLIT,
+                        businessRootPath,
                         serializer);
     }
 
@@ -221,7 +210,6 @@ public class IMapFileStorage implements IMapStorage {
                     try {
                         IMapFileData data = buildDeleteIMapFileData(key);
                         long requestId = sendToDisruptorQueue(data, WALEventType.APPEND);
-                        walDisruptor.tryAppendPublish(data, requestId);
                         requestMap.put(requestId, data);
                     } catch (IOException e) {
                         log.error("parse to IMapFileData error", e);
@@ -254,10 +242,7 @@ public class IMapFileStorage implements IMapStorage {
 
     @Override
     public void destroy(boolean deleteAllFileFlag) {
-        log.info(
-                "start destroy IMapFileStorage, businessName is {}, cluster name is {}",
-                businessName,
-                region);
+        log.info("start destroy IMapFileStorage, businessName is {}", businessName);
         /**
          * 1. close current disruptor 2. delete all files notice: we can not delete the files in the
          * middle of the write, so some current file may be not deleted
@@ -274,11 +259,7 @@ public class IMapFileStorage implements IMapStorage {
             try {
                 fs.delete(new Path(parentPath), true);
             } catch (IOException e) {
-                log.error(
-                        "destroy IMapFileStorage error,businessName is {}, cluster name is {}",
-                        businessName,
-                        region,
-                        e);
+                log.error("destroy IMapFileStorage error,businessName is {}", businessName, e);
             }
         }
     }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
@@ -20,9 +20,28 @@
 
 package org.apache.seatunnel.engine.imap.storage.file.common;
 
+import org.apache.seatunnel.engine.imap.storage.api.exception.IMapStorageException;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class WALDataUtils {
 
     public static final int WAL_DATA_METADATA_LENGTH = 12;
+    public static final String FILE_NAME = "wal.txt";
+    public static final String PROGRESSING_SUFFIX = ".progressing";
 
     public static byte[] wrapperBytes(byte[] bytes) {
         byte[] metadata = new byte[WAL_DATA_METADATA_LENGTH];
@@ -49,5 +68,81 @@ public class WALDataUtils {
         encodedValue[1] = (byte) (value >> Byte.SIZE);
         encodedValue[0] = (byte) value;
         return encodedValue;
+    }
+
+    /**
+     * return direct data file names of the specified dir
+     *
+     * @param fs target file system
+     * @param parentPath parent dir
+     * @return file names
+     */
+    public static List<String> getDataFiles(FileSystem fs, Path parentPath, String suffix) {
+        try {
+            if (!fs.exists(parentPath)) {
+                return new ArrayList<>();
+            }
+            RemoteIterator<LocatedFileStatus> fileStatusRemoteIterator =
+                    fs.listFiles(parentPath, false);
+            List<String> fileNames = new ArrayList<>();
+            while (fileStatusRemoteIterator.hasNext()) {
+                LocatedFileStatus fileStatus = fileStatusRemoteIterator.next();
+                if (fileStatus.getPath().getName().endsWith(suffix)) {
+                    fileNames.add(fileStatus.getPath().toString());
+                }
+            }
+            return fileNames;
+        } catch (IOException e) {
+            throw new IMapStorageException(e, "get file names error,path is s%", parentPath);
+        }
+    }
+
+    /** open files by filenames, and compose InputStream in order as SequenceInputStream */
+    public static SequenceInputStream getComposedInputStream(FileSystem fs, List<String> filenames)
+            throws IOException {
+        List<Path> paths = filenames.stream().map(Path::new).collect(Collectors.toList());
+        // get file streams
+        List<FSDataInputStream> streams =
+                paths.stream()
+                        .sorted(Comparator.comparing(Path::getName)) // sort Path by filename asc
+                        .map(
+                                path -> {
+                                    try {
+                                        return fs.open(path);
+                                    } catch (IOException e) {
+                                        throw new IMapStorageException(e);
+                                    }
+                                }) // open files
+                        .collect(Collectors.toList());
+        return new SequenceInputStream(Collections.enumeration(streams));
+    }
+
+    public static byte[] readNextData(SequenceInputStream stream) throws IOException {
+        // read metadata
+        byte[] metadata = new byte[WAL_DATA_METADATA_LENGTH];
+        int readBytes = 0;
+        while (readBytes != WAL_DATA_METADATA_LENGTH) {
+            int read = stream.read(metadata, readBytes, metadata.length - readBytes);
+            if (read == -1) {
+                if (readBytes == 0) return null;
+                throw new IMapStorageException("imap file metadata broken!");
+            }
+            readBytes += read;
+        }
+
+        // read data entry
+        int dataLen = WALDataUtils.byteArrayToInt(metadata);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(dataLen);
+        readBytes = 0;
+        byte[] buffer = new byte[1024];
+        while (readBytes != dataLen) {
+            int len = Math.min(dataLen - readBytes, buffer.length);
+            int read = stream.read(buffer, 0, len);
+            if (read == -1) throw new IMapStorageException("imap file data broken!");
+            readBytes += read;
+            out.write(buffer, 0, read);
+        }
+
+        return out.toByteArray();
     }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
@@ -83,10 +83,11 @@ public class WALDataUtils {
                 return new ArrayList<>();
             }
             RemoteIterator<LocatedFileStatus> fileStatusRemoteIterator =
-                    fs.listFiles(parentPath, false);
+                    fs.listLocatedStatus(parentPath);
             List<String> fileNames = new ArrayList<>();
             while (fileStatusRemoteIterator.hasNext()) {
                 LocatedFileStatus fileStatus = fileStatusRemoteIterator.next();
+                if (fileStatus.isDirectory()) continue;
                 if (fileStatus.getPath().getName().endsWith(suffix)) {
                     fileNames.add(fileStatus.getPath().toString());
                 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
@@ -123,10 +123,7 @@ public class WALDataUtils {
         int readBytes = 0;
         while (readBytes != WAL_DATA_METADATA_LENGTH) {
             int read = stream.read(metadata, readBytes, metadata.length - readBytes);
-            if (read == -1) {
-                if (readBytes == 0) return null;
-                throw new IMapStorageException("imap file metadata broken!");
-            }
+            if (read == -1) return null;
             readBytes += read;
         }
 
@@ -138,7 +135,7 @@ public class WALDataUtils {
         while (readBytes != dataLen) {
             int len = Math.min(dataLen - readBytes, buffer.length);
             int read = stream.read(buffer, 0, len);
-            if (read == -1) throw new IMapStorageException("imap file data broken!");
+            if (read == -1) return null;
             readBytes += read;
             out.write(buffer, 0, read);
         }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALDataUtils.java
@@ -23,10 +23,9 @@ package org.apache.seatunnel.engine.imap.storage.file.common;
 import org.apache.seatunnel.engine.imap.storage.api.exception.IMapStorageException;
 
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -82,11 +81,10 @@ public class WALDataUtils {
             if (!fs.exists(parentPath)) {
                 return new ArrayList<>();
             }
-            RemoteIterator<LocatedFileStatus> fileStatusRemoteIterator =
-                    fs.listLocatedStatus(parentPath);
+            FileStatus[] fileStatuses = fs.listStatus(parentPath);
+
             List<String> fileNames = new ArrayList<>();
-            while (fileStatusRemoteIterator.hasNext()) {
-                LocatedFileStatus fileStatus = fileStatusRemoteIterator.next();
+            for (FileStatus fileStatus : fileStatuses) {
                 if (fileStatus.isDirectory()) continue;
                 if (fileStatus.getPath().getName().endsWith(suffix)) {
                     fileNames.add(fileStatus.getPath().toString());

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
@@ -39,6 +41,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
 
+@Slf4j
 public class DefaultReader implements IFileReader<IMapFileData> {
     private static final int DEFAULT_QUERY_LIST_SIZE = 1024;
     private FileSystem fs;
@@ -93,6 +96,9 @@ public class DefaultReader implements IFileReader<IMapFileData> {
                 IMapFileData diskData = serializer.deserialize(bytes, IMapFileData.class);
                 result.add(diskData);
             }
+        } catch (IOException e) {
+            log.warn("read next data entry failed, cause: {}", e.getMessage(), e);
+            return result;
         }
 
         return result;

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils;
 import org.apache.seatunnel.engine.serializer.api.Serializer;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.curator.shaded.com.google.common.io.ByteStreams;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -32,8 +33,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 
 import java.io.IOException;
+import java.io.SequenceInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.WAL_DATA_METADATA_LENGTH;
 
@@ -59,11 +65,12 @@ public class DefaultReader implements IFileReader<IMapFileData> {
         if (CollectionUtils.isEmpty(fileNames)) {
             return new ArrayList<>();
         }
-        List<IMapFileData> result = new ArrayList<>(DEFAULT_QUERY_LIST_SIZE);
-        for (String fileName : fileNames) {
-            result.addAll(readData(new Path(parentPath, fileName)));
-        }
-        return result;
+
+        List<Path> paths =
+                fileNames.stream()
+                        .map(filename -> new Path(parentPath, filename))
+                        .collect(Collectors.toList());
+        return readData(paths);
     }
 
     private List<String> getFileNames(Path parentPath) {
@@ -86,29 +93,46 @@ public class DefaultReader implements IFileReader<IMapFileData> {
         }
     }
 
-    private List<IMapFileData> readData(Path path) throws IOException {
+    public List<IMapFileData> readData(List<Path> paths) throws IOException {
         List<IMapFileData> result = new ArrayList<>(DEFAULT_QUERY_LIST_SIZE);
-        long length = fs.getFileStatus(path).getLen();
-        try (FSDataInputStream in = fs.open(path)) {
-            byte[] datas = new byte[(int) length];
-            in.readFully(datas);
-            int startIndex = 0;
-            while (startIndex + WAL_DATA_METADATA_LENGTH < datas.length) {
 
-                byte[] metadata = new byte[WAL_DATA_METADATA_LENGTH];
-                System.arraycopy(datas, startIndex, metadata, 0, WAL_DATA_METADATA_LENGTH);
-                int dataLength = WALDataUtils.byteArrayToInt(metadata);
-                startIndex += WAL_DATA_METADATA_LENGTH;
-                if (startIndex + dataLength > datas.length) {
-                    break;
-                }
-                byte[] data = new byte[dataLength];
-                System.arraycopy(datas, startIndex, data, 0, data.length);
-                IMapFileData fileData = serializer.deserialize(data, IMapFileData.class);
-                result.add(fileData);
-                startIndex += data.length;
-            }
+        // get file streams
+        List<FSDataInputStream> streams =
+                paths.stream()
+                        .sorted(Comparator.comparing(Path::getName)) // sort Path by filename asc
+                        .map(
+                                path -> {
+                                    try {
+                                        return fs.open(path);
+                                    } catch (IOException e) {
+                                        throw new IMapStorageException(e);
+                                    }
+                                }) // open files
+                        .collect(Collectors.toList());
+
+        // read data
+        byte[] dataWithMetadata;
+        try (SequenceInputStream in = new SequenceInputStream(Collections.enumeration(streams))) {
+            dataWithMetadata = ByteStreams.toByteArray(in);
         }
+
+        // resolve metadata
+        byte[] metadata = Arrays.copyOfRange(dataWithMetadata, 0, WAL_DATA_METADATA_LENGTH);
+        int dataLen = WALDataUtils.byteArrayToInt(metadata);
+        // verify metadata
+        if (dataLen != dataWithMetadata.length - WAL_DATA_METADATA_LENGTH)
+            throw new IMapStorageException("imap files were broken: " + paths);
+
+        // deserialize data
+        IMapFileData fileData =
+                serializer.deserialize(
+                        Arrays.copyOfRange(
+                                dataWithMetadata,
+                                WAL_DATA_METADATA_LENGTH,
+                                dataWithMetadata.length),
+                        IMapFileData.class);
+        result.add(fileData);
+
         return result;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/reader/DefaultReader.java
@@ -25,28 +25,24 @@ import org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils;
 import org.apache.seatunnel.engine.serializer.api.Serializer;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.curator.shaded.com.google.common.io.ByteStreams;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.WAL_DATA_METADATA_LENGTH;
+import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
 
 public class DefaultReader implements IFileReader<IMapFileData> {
     private static final int DEFAULT_QUERY_LIST_SIZE = 1024;
-    FileSystem fs;
-    Serializer serializer;
+    private FileSystem fs;
+    private Serializer serializer;
 
     @Override
     public String identifier() {
@@ -61,7 +57,7 @@ public class DefaultReader implements IFileReader<IMapFileData> {
 
     @Override
     public List<IMapFileData> readAllData(Path parentPath) throws IOException {
-        List<String> fileNames = getFileNames(parentPath);
+        List<String> fileNames = WALDataUtils.getDataFiles(fs, parentPath, FILE_NAME);
         if (CollectionUtils.isEmpty(fileNames)) {
             return new ArrayList<>();
         }
@@ -71,26 +67,6 @@ public class DefaultReader implements IFileReader<IMapFileData> {
                         .map(filename -> new Path(parentPath, filename))
                         .collect(Collectors.toList());
         return readData(paths);
-    }
-
-    private List<String> getFileNames(Path parentPath) {
-        try {
-            if (!fs.exists(parentPath)) {
-                return new ArrayList<>();
-            }
-            RemoteIterator<LocatedFileStatus> fileStatusRemoteIterator =
-                    fs.listFiles(parentPath, true);
-            List<String> fileNames = new ArrayList<>();
-            while (fileStatusRemoteIterator.hasNext()) {
-                LocatedFileStatus fileStatus = fileStatusRemoteIterator.next();
-                if (fileStatus.getPath().getName().endsWith("wal.txt")) {
-                    fileNames.add(fileStatus.getPath().toString());
-                }
-            }
-            return fileNames;
-        } catch (IOException e) {
-            throw new IMapStorageException(e, "get file names error,path is s%", parentPath);
-        }
     }
 
     public List<IMapFileData> readData(List<Path> paths) throws IOException {
@@ -111,27 +87,13 @@ public class DefaultReader implements IFileReader<IMapFileData> {
                         .collect(Collectors.toList());
 
         // read data
-        byte[] dataWithMetadata;
+        byte[] bytes;
         try (SequenceInputStream in = new SequenceInputStream(Collections.enumeration(streams))) {
-            dataWithMetadata = ByteStreams.toByteArray(in);
+            while ((bytes = WALDataUtils.readNextData(in)) != null) {
+                IMapFileData diskData = serializer.deserialize(bytes, IMapFileData.class);
+                result.add(diskData);
+            }
         }
-
-        // resolve metadata
-        byte[] metadata = Arrays.copyOfRange(dataWithMetadata, 0, WAL_DATA_METADATA_LENGTH);
-        int dataLen = WALDataUtils.byteArrayToInt(metadata);
-        // verify metadata
-        if (dataLen != dataWithMetadata.length - WAL_DATA_METADATA_LENGTH)
-            throw new IMapStorageException("imap files were broken: " + paths);
-
-        // deserialize data
-        IMapFileData fileData =
-                serializer.deserialize(
-                        Arrays.copyOfRange(
-                                dataWithMetadata,
-                                WAL_DATA_METADATA_LENGTH,
-                                dataWithMetadata.length),
-                        IMapFileData.class);
-        result.add(fileData);
 
         return result;
     }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
@@ -30,8 +30,14 @@ import org.apache.hadoop.fs.Path;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.io.SequenceInputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
+import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.PROGRESSING_SUFFIX;
 
 @Slf4j
 public abstract class CloudWriter implements IFileWriter<IMapFileData> {
@@ -40,6 +46,9 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
     private Serializer serializer;
     // block size,  default 1024*1024
     private long blockSize = 1024 * 1024;
+    private long blockRemaining;
+    private int currentBlock;
+    private FSDataOutputStream out;
 
     @Override
     public void initialize(FileSystem fs, Path parentPath, Serializer serializer)
@@ -59,41 +68,120 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
 
     // TODO Synchronous write, asynchronous write can be added in the future
     @Override
-    public void write(IMapFileData data) throws IOException {
-        byte[] bytes = serializer.serialize(data);
-        this.write(bytes);
+    public synchronized void write(IMapFileData data) throws IOException {
+        List<String> dataFiles = WALDataUtils.getDataFiles(fs, parentPath, FILE_NAME);
+        SequenceInputStream stream = WALDataUtils.getComposedInputStream(fs, dataFiles);
+        // reset block info
+        reset();
+
+        // write data
+        writeEntry(serializer.serialize(data));
+        byte[] bytes;
+        boolean encountered = false;
+        while ((bytes = WALDataUtils.readNextData(stream)) != null) {
+            IMapFileData diskData = serializer.deserialize(bytes, IMapFileData.class);
+
+            if (encountered) writeEntry(serializer.serialize(diskData));
+            else if (isKeyEquals(data, diskData))
+                encountered = true; // if current data is the entry which have be updated
+            else writeEntry(serializer.serialize(diskData));
+        }
+        stream.close();
+        commit(dataFiles);
     }
 
-    private void write(byte[] bytes) {
-        // delete old files, if delete failed, just ignore.
-        try {
-            fs.delete(parentPath, true);
-        } catch (IOException e) {
-            log.warn("Failed to delete old IMap files in S3, cause: {}", e.getMessage(), e);
-        }
+    public void commit(List<String> filenames) throws IOException {
+        // close last file stream
+        out.hsync();
+        out.close();
+        // delete old data file
+        filenames.forEach(
+                filename -> {
+                    try {
+                        fs.delete(new Path(filename), false);
+                    } catch (IOException e) {
+                        throw new IMapStorageException(
+                                e, "delete old imap file failed, cause: %s", e.getMessage());
+                    }
+                });
 
+        // move new data file
+        WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
+                .collect(
+                        Collectors.toMap(
+                                Path::new,
+                                filename -> new Path(filename.replace(PROGRESSING_SUFFIX, ""))))
+                .forEach(
+                        (src, dest) -> {
+                            try {
+                                fs.rename(src, dest);
+                            } catch (IOException e) {
+                                throw new IMapStorageException(
+                                        e, "rename imap file failed, cause: %s", e.getMessage());
+                            }
+                        });
+    }
+
+    public boolean isKeyEquals(IMapFileData left, IMapFileData right) throws IOException {
+        try {
+            Object leftKey =
+                    serializer.deserialize(left.getKey(), Class.forName(left.getKeyClassName()));
+            Object rightKey =
+                    serializer.deserialize(right.getKey(), Class.forName(right.getKeyClassName()));
+            return leftKey.equals(rightKey);
+        } catch (ClassNotFoundException e) {
+            throw new IMapStorageException(
+                    e, "imap data broken, cannot deserialize key, cause: %s", e.getMessage());
+        }
+    }
+
+    /** reset block info and create the first block file */
+    public void reset() throws IOException {
+        this.blockRemaining = blockSize;
+        this.currentBlock = 0;
+        this.out =
+                fs.create(
+                        new Path(parentPath, currentBlock + "_" + FILE_NAME + PROGRESSING_SUFFIX),
+                        true);
+    }
+
+    /** set block info to next block, and create new block file */
+    public void nextBlock() throws IOException {
+        out.hsync();
+        out.close();
+        blockRemaining = blockSize;
+        out =
+                fs.create(
+                        new Path(parentPath, ++currentBlock + "_" + FILE_NAME + PROGRESSING_SUFFIX),
+                        true);
+    }
+
+    private void writeEntry(byte[] bytes) throws IOException {
         // wrap data with metadata
         byte[] data = WALDataUtils.wrapperBytes(bytes);
+        int tobeWritten = data.length;
 
-        // write data into each block
-        long blocks = data.length / blockSize + (data.length % blockSize == 0 ? 0 : 1);
-        for (int i = 0; i < blocks; i++) {
-            Path path = new Path(parentPath, i + "_" + FILE_NAME);
-            // get block data
-            int start = (int) (i * blockSize);
-            int end = (int) Math.min(start + blockSize, data.length);
-            byte[] blockData = Arrays.copyOfRange(data, start, end);
+        // write data
+        ByteArrayInputStream in = new ByteArrayInputStream(data);
+        byte[] buffer = new byte[1024];
+        while (tobeWritten != 0) {
+            int len = (int) Math.min(buffer.length, Math.min(tobeWritten, blockRemaining));
+            int read = in.read(buffer, 0, len);
+            out.write(buffer, 0, read);
 
-            // write to file
-            try (FSDataOutputStream out = fs.create(path, true)) {
-                out.write(blockData);
-                out.hsync();
-            } catch (Exception e) {
-                throw new IMapStorageException(e);
-            }
+            tobeWritten -= read;
+            blockRemaining -= read;
+
+            // rolling to next block
+            if (blockRemaining == 0) nextBlock();
         }
     }
 
     @Override
-    public void close() throws Exception {}
+    public void close() throws Exception {
+        if (out != null) {
+            out.hsync();
+            out.close();
+        }
+    }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
@@ -33,7 +33,12 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
@@ -94,32 +99,43 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
         // close last file stream
         out.hsync();
         out.close();
-        // delete old data file
-        filenames.forEach(
-                filename -> {
+        out = null;
+
+        // collect files need to be moved
+        Map<String, String> fileMap =
+                WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Function.identity(),
+                                        filename -> filename.replace(PROGRESSING_SUFFIX, "")));
+
+        filenames.removeIf(filename -> !fileMap.containsKey(filename));
+        Set<Map.Entry<String, String>> entries =
+                filenames.stream()
+                        .map(
+                                filename ->
+                                        new AbstractMap.SimpleEntry<String, String>(null, filename))
+                        .collect(Collectors.toSet());
+
+        entries.addAll(fileMap.entrySet());
+
+        entries.forEach(
+                entry -> {
+                    Optional<Path> src = Optional.ofNullable(entry.getKey()).map(Path::new);
+                    Optional<Path> dest = Optional.ofNullable(entry.getValue()).map(Path::new);
                     try {
-                        fs.delete(new Path(filename), false);
+                        // delete target
+                        if (dest.isPresent()) fs.deleteOnExit(dest.get());
+
+                        // rename new data file
+                        if (src.isPresent()) {
+                            if (fs.exists(src.get()) && dest.isPresent())
+                                fs.rename(src.get(), dest.get());
+                        }
                     } catch (IOException e) {
-                        throw new IMapStorageException(
-                                e, "delete old imap file failed, cause: %s", e.getMessage());
+                        log.warn("move new data file failed, cause: {}", e.getMessage(), e);
                     }
                 });
-
-        // move new data file
-        WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
-                .collect(
-                        Collectors.toMap(
-                                Path::new,
-                                filename -> new Path(filename.replace(PROGRESSING_SUFFIX, ""))))
-                .forEach(
-                        (src, dest) -> {
-                            try {
-                                fs.rename(src, dest);
-                            } catch (IOException e) {
-                                throw new IMapStorageException(
-                                        e, "rename imap file failed, cause: %s", e.getMessage());
-                            }
-                        });
     }
 
     public boolean isKeyEquals(IMapFileData left, IMapFileData right) throws IOException {

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
@@ -34,10 +34,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -54,6 +56,7 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
     private long blockRemaining;
     private int currentBlock;
     private FSDataOutputStream out;
+    private static final Map<Path, ReentrantLock> LOCK_MAP = new HashMap<>();
 
     @Override
     public void initialize(FileSystem fs, Path parentPath, Serializer serializer)
@@ -73,7 +76,17 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
 
     // TODO Synchronous write, asynchronous write can be added in the future
     @Override
-    public synchronized void write(IMapFileData data) throws IOException {
+    public void write(IMapFileData data) throws IOException {
+        ReentrantLock lock = LOCK_MAP.computeIfAbsent(parentPath, path -> new ReentrantLock());
+        try {
+            lock.lock();
+            writeInternal(data);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void writeInternal(IMapFileData data) throws IOException {
         List<String> dataFiles = WALDataUtils.getDataFiles(fs, parentPath, FILE_NAME);
         SequenceInputStream stream = WALDataUtils.getComposedInputStream(fs, dataFiles);
         // reset block info
@@ -125,7 +138,7 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
                     Optional<Path> dest = Optional.ofNullable(entry.getValue()).map(Path::new);
                     try {
                         // delete target
-                        if (dest.isPresent()) fs.deleteOnExit(dest.get());
+                        if (dest.isPresent()) fs.delete(dest.get(), false);
 
                         // rename new data file
                         if (src.isPresent()) {

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
@@ -24,32 +24,22 @@ import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
 import org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils;
 import org.apache.seatunnel.engine.serializer.api.Serializer;
 
-import org.apache.curator.shaded.com.google.common.io.ByteStreams;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Arrays;
 
 @Slf4j
 public abstract class CloudWriter implements IFileWriter<IMapFileData> {
     private FileSystem fs;
     private Path parentPath;
-    private Path path;
     private Serializer serializer;
-
-    private ByteBuf bf = Unpooled.buffer(1024);
-
     // block size,  default 1024*1024
     private long blockSize = 1024 * 1024;
-
-    private AtomicLong index = new AtomicLong(0);
 
     @Override
     public void initialize(FileSystem fs, Path parentPath, Serializer serializer)
@@ -58,12 +48,6 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
         this.fs = fs;
         this.serializer = serializer;
         this.parentPath = parentPath;
-        this.path = createNewPath();
-        if (fs.exists(path)) {
-            try (FSDataInputStream fsDataInputStream = fs.open(path)) {
-                bf.writeBytes(ByteStreams.toByteArray(fsDataInputStream));
-            }
-        }
     }
 
     @Override
@@ -81,43 +65,35 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
     }
 
     private void write(byte[] bytes) {
-        try (FSDataOutputStream out = fs.create(path, true)) {
-            // Write to bytebuffer
-            byte[] data = WALDataUtils.wrapperBytes(bytes);
-            bf.writeBytes(data);
-
-            // Read all bytes
-            byte[] allBytes = new byte[bf.readableBytes()];
-            bf.readBytes(allBytes);
-
-            // write filesystem
-            out.write(allBytes);
-
-            // check and reset
-            checkAndSetNextScheduleRotation(allBytes.length);
-
-        } catch (Exception ex) {
-            throw new IMapStorageException(ex);
+        // delete old files, if delete failed, just ignore.
+        try {
+            fs.delete(parentPath, true);
+        } catch (IOException e) {
+            log.warn("Failed to delete old IMap files in S3, cause: {}", e.getMessage(), e);
         }
-    }
 
-    private void checkAndSetNextScheduleRotation(long allBytes) {
-        if (allBytes > blockSize) {
-            this.path = createNewPath();
-            this.bf.clear();
-        } else {
-            // reset index
-            bf.resetReaderIndex();
+        // wrap data with metadata
+        byte[] data = WALDataUtils.wrapperBytes(bytes);
+
+        // write data into each block
+        long blocks = data.length / blockSize + (data.length % blockSize == 0 ? 0 : 1);
+        for (int i = 0; i < blocks; i++) {
+            Path path = new Path(parentPath, i + "_" + FILE_NAME);
+            // get block data
+            int start = (int) (i * blockSize);
+            int end = (int) Math.min(start + blockSize, data.length);
+            byte[] blockData = Arrays.copyOfRange(data, start, end);
+
+            // write to file
+            try (FSDataOutputStream out = fs.create(path, true)) {
+                out.write(blockData);
+                out.hsync();
+            } catch (Exception e) {
+                throw new IMapStorageException(e);
+            }
         }
-    }
-
-    public Path createNewPath() {
-        return new Path(parentPath, index.incrementAndGet() + "_" + FILE_NAME);
     }
 
     @Override
-    public void close() throws Exception {
-        bf.clear();
-        this.bf = null;
-    }
+    public void close() throws Exception {}
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
@@ -34,7 +34,12 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
@@ -100,32 +105,43 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
         // close last file stream
         out.hsync();
         out.close();
-        // delete old data file
-        filenames.forEach(
-                filename -> {
+        out = null;
+
+        // collect files need to be moved
+        Map<String, String> fileMap =
+                WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Function.identity(),
+                                        filename -> filename.replace(PROGRESSING_SUFFIX, "")));
+
+        filenames.removeIf(filename -> !fileMap.containsKey(filename));
+        Set<Map.Entry<String, String>> entries =
+                filenames.stream()
+                        .map(
+                                filename ->
+                                        new AbstractMap.SimpleEntry<String, String>(null, filename))
+                        .collect(Collectors.toSet());
+
+        entries.addAll(fileMap.entrySet());
+
+        entries.forEach(
+                entry -> {
+                    Optional<Path> src = Optional.ofNullable(entry.getKey()).map(Path::new);
+                    Optional<Path> dest = Optional.ofNullable(entry.getValue()).map(Path::new);
                     try {
-                        fs.delete(new Path(filename), false);
+                        // delete target
+                        if (dest.isPresent()) fs.deleteOnExit(dest.get());
+
+                        // rename new data file
+                        if (src.isPresent()) {
+                            if (fs.exists(src.get()) && dest.isPresent())
+                                fs.rename(src.get(), dest.get());
+                        }
                     } catch (IOException e) {
-                        throw new IMapStorageException(
-                                "delete old imap file failed, cause: " + e.getMessage(), e);
+                        log.warn("move new data file failed, cause: {}", e.getMessage(), e);
                     }
                 });
-
-        // move new data file
-        WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
-                .collect(
-                        Collectors.toMap(
-                                Path::new,
-                                filename -> new Path(filename.replace(PROGRESSING_SUFFIX, ""))))
-                .forEach(
-                        (src, dest) -> {
-                            try {
-                                fs.rename(src, dest);
-                            } catch (IOException e) {
-                                throw new IMapStorageException(
-                                        "rename imap file failed, cause: " + e.getMessage(), e);
-                            }
-                        });
     }
 
     public boolean isKeyEquals(IMapFileData left, IMapFileData right) throws IOException {

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
@@ -31,8 +31,14 @@ import org.apache.hadoop.fs.Path;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.io.SequenceInputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.FILE_NAME;
+import static org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils.PROGRESSING_SUFFIX;
 
 @Slf4j
 public class HdfsWriter implements IFileWriter<IMapFileData> {
@@ -43,6 +49,9 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
 
     private FileSystem fs;
     private Path parentPath;
+    private long blockRemaining;
+    private int currentBlock;
+    private FSDataOutputStream out;
 
     @Override
     public String identifier() {
@@ -65,41 +74,120 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
     }
 
     @Override
-    public void write(IMapFileData data) throws IOException {
-        byte[] bytes = serializer.serialize(data);
-        this.write(bytes);
+    public synchronized void write(IMapFileData data) throws IOException {
+        List<String> dataFiles = WALDataUtils.getDataFiles(fs, parentPath, FILE_NAME);
+        SequenceInputStream stream = WALDataUtils.getComposedInputStream(fs, dataFiles);
+        // reset block info
+        reset();
+
+        // write data
+        writeEntry(serializer.serialize(data));
+        byte[] bytes;
+        boolean encountered = false;
+        while ((bytes = WALDataUtils.readNextData(stream)) != null) {
+            IMapFileData diskData = serializer.deserialize(bytes, IMapFileData.class);
+
+            if (encountered) writeEntry(serializer.serialize(diskData));
+            else if (isKeyEquals(data, diskData))
+                encountered = true; // if current data is the entry which have be updated
+            else writeEntry(serializer.serialize(diskData));
+        }
+        stream.close();
+        commit(dataFiles);
     }
 
-    private void write(byte[] bytes) {
-        // delete old files, if delete failed, just ignore.
-        try {
-            fs.delete(parentPath, true);
-        } catch (IOException e) {
-            log.warn("Failed to delete old IMap files in hdfs, cause: {}", e.getMessage(), e);
-        }
+    public void commit(List<String> filenames) throws IOException {
+        // close last file stream
+        out.hsync();
+        out.close();
+        // delete old data file
+        filenames.forEach(
+                filename -> {
+                    try {
+                        fs.delete(new Path(filename), false);
+                    } catch (IOException e) {
+                        throw new IMapStorageException(
+                                "delete old imap file failed, cause: " + e.getMessage(), e);
+                    }
+                });
 
+        // move new data file
+        WALDataUtils.getDataFiles(fs, parentPath, PROGRESSING_SUFFIX).stream()
+                .collect(
+                        Collectors.toMap(
+                                Path::new,
+                                filename -> new Path(filename.replace(PROGRESSING_SUFFIX, ""))))
+                .forEach(
+                        (src, dest) -> {
+                            try {
+                                fs.rename(src, dest);
+                            } catch (IOException e) {
+                                throw new IMapStorageException(
+                                        "rename imap file failed, cause: " + e.getMessage(), e);
+                            }
+                        });
+    }
+
+    public boolean isKeyEquals(IMapFileData left, IMapFileData right) throws IOException {
+        try {
+            Object leftKey =
+                    serializer.deserialize(left.getKey(), Class.forName(left.getKeyClassName()));
+            Object rightKey =
+                    serializer.deserialize(right.getKey(), Class.forName(right.getKeyClassName()));
+            return leftKey.equals(rightKey);
+        } catch (ClassNotFoundException e) {
+            throw new IMapStorageException(
+                    "imap data broken, cannot deserialize key, cause: %s" + e.getMessage(), e);
+        }
+    }
+
+    /** reset block info and create the first block file */
+    public void reset() throws IOException {
+        this.blockRemaining = blockSize;
+        this.currentBlock = 0;
+        this.out =
+                fs.create(
+                        new Path(parentPath, currentBlock + "_" + FILE_NAME + PROGRESSING_SUFFIX),
+                        true);
+    }
+
+    /** set block info to next block, and create new block file */
+    public void nextBlock() throws IOException {
+        out.hsync();
+        out.close();
+        blockRemaining = blockSize;
+        out =
+                fs.create(
+                        new Path(parentPath, ++currentBlock + "_" + FILE_NAME + PROGRESSING_SUFFIX),
+                        true);
+    }
+
+    private void writeEntry(byte[] bytes) throws IOException {
         // wrap data with metadata
         byte[] data = WALDataUtils.wrapperBytes(bytes);
+        int tobeWritten = data.length;
 
-        // write data into each block
-        long blocks = data.length / blockSize + (data.length % blockSize == 0 ? 0 : 1);
-        for (int i = 0; i < blocks; i++) {
-            Path path = new Path(parentPath, i + "_" + FILE_NAME);
-            // get block data
-            int start = (int) (i * blockSize);
-            int end = (int) Math.min(start + blockSize, data.length);
-            byte[] blockData = Arrays.copyOfRange(data, start, end);
+        // write data
+        ByteArrayInputStream in = new ByteArrayInputStream(data);
+        byte[] buffer = new byte[1024];
+        while (tobeWritten != 0) {
+            int len = (int) Math.min(buffer.length, Math.min(tobeWritten, blockRemaining));
+            int read = in.read(buffer, 0, len);
+            out.write(buffer, 0, read);
 
-            // write to file
-            try (FSDataOutputStream out = fs.create(path, true)) {
-                out.write(blockData);
-                out.hsync();
-            } catch (Exception e) {
-                throw new IMapStorageException(e);
-            }
+            tobeWritten -= read;
+            blockRemaining -= read;
+
+            // rolling to next block
+            if (blockRemaining == 0) nextBlock();
         }
     }
 
     @Override
-    public void close() throws Exception {}
+    public void close() throws Exception {
+        if (out != null) {
+            out.hsync();
+            out.close();
+        }
+    }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
@@ -20,6 +20,7 @@
 
 package org.apache.seatunnel.engine.imap.storage.file.wal.writer;
 
+import org.apache.seatunnel.engine.imap.storage.api.exception.IMapStorageException;
 import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
 import org.apache.seatunnel.engine.imap.storage.file.common.WALDataUtils;
 import org.apache.seatunnel.engine.serializer.api.Serializer;
@@ -27,17 +28,21 @@ import org.apache.seatunnel.engine.serializer.api.Serializer;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.DFSOutputStream;
-import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.EnumSet;
+import java.util.Arrays;
 
+@Slf4j
 public class HdfsWriter implements IFileWriter<IMapFileData> {
-
-    private FSDataOutputStream out;
+    // block size,  default 1024*1024
+    private long blockSize = 1024 * 1024;
 
     private Serializer serializer;
+
+    private FileSystem fs;
+    private Path parentPath;
 
     @Override
     public String identifier() {
@@ -47,9 +52,16 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
     @Override
     public void initialize(FileSystem fs, Path parentPath, Serializer serializer)
             throws IOException {
-        Path path = new Path(parentPath, FILE_NAME);
-        this.out = fs.create(path);
+        this.fs = fs;
         this.serializer = serializer;
+        this.parentPath = parentPath;
+    }
+
+    @Override
+    public void setBlockSize(Long blockSize) {
+        if (blockSize != null && blockSize > DEFAULT_BLOCK_SIZE) {
+            this.blockSize = blockSize;
+        }
     }
 
     @Override
@@ -58,31 +70,36 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
         this.write(bytes);
     }
 
-    public void flush() throws IOException {
-        // hsync to flag
-        if (out instanceof HdfsDataOutputStream) {
-            ((HdfsDataOutputStream) out)
-                    .hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
+    private void write(byte[] bytes) {
+        // delete old files, if delete failed, just ignore.
+        try {
+            fs.delete(parentPath, true);
+        } catch (IOException e) {
+            log.warn("Failed to delete old IMap files in hdfs, cause: {}", e.getMessage(), e);
         }
-        if (out.getWrappedStream() instanceof DFSOutputStream) {
-            ((DFSOutputStream) out.getWrappedStream())
-                    .hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
-        } else {
-            out.hsync();
-        }
-        this.out.hflush();
-    }
 
-    private void write(byte[] bytes) throws IOException {
+        // wrap data with metadata
         byte[] data = WALDataUtils.wrapperBytes(bytes);
-        this.out.write(data);
-        this.flush();
+
+        // write data into each block
+        long blocks = data.length / blockSize + (data.length % blockSize == 0 ? 0 : 1);
+        for (int i = 0; i < blocks; i++) {
+            Path path = new Path(parentPath, i + "_" + FILE_NAME);
+            // get block data
+            int start = (int) (i * blockSize);
+            int end = (int) Math.min(start + blockSize, data.length);
+            byte[] blockData = Arrays.copyOfRange(data, start, end);
+
+            // write to file
+            try (FSDataOutputStream out = fs.create(path, true)) {
+                out.write(blockData);
+                out.hsync();
+            } catch (Exception e) {
+                throw new IMapStorageException(e);
+            }
+        }
     }
 
     @Override
-    public void close() throws Exception {
-        if (out != null) {
-            out.close();
-        }
-    }
+    public void close() throws Exception {}
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/HdfsWriter.java
@@ -35,10 +35,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,6 +59,7 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
     private long blockRemaining;
     private int currentBlock;
     private FSDataOutputStream out;
+    private static final Map<Path, ReentrantLock> LOCK_MAP = new HashMap<>();
 
     @Override
     public String identifier() {
@@ -79,7 +82,17 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
     }
 
     @Override
-    public synchronized void write(IMapFileData data) throws IOException {
+    public void write(IMapFileData data) throws IOException {
+        ReentrantLock lock = LOCK_MAP.computeIfAbsent(parentPath, path -> new ReentrantLock());
+        try {
+            lock.lock();
+            writeInternal(data);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void writeInternal(IMapFileData data) throws IOException {
         List<String> dataFiles = WALDataUtils.getDataFiles(fs, parentPath, FILE_NAME);
         SequenceInputStream stream = WALDataUtils.getComposedInputStream(fs, dataFiles);
         // reset block info
@@ -131,7 +144,7 @@ public class HdfsWriter implements IFileWriter<IMapFileData> {
                     Optional<Path> dest = Optional.ofNullable(entry.getValue()).map(Path::new);
                     try {
                         // delete target
-                        if (dest.isPresent()) fs.deleteOnExit(dest.get());
+                        if (dest.isPresent()) fs.delete(dest.get(), false);
 
                         // rename new data file
                         if (src.isPresent()) {

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/IFileWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/IFileWriter.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.Path;
 import java.io.IOException;
 
 public interface IFileWriter<T> extends AutoCloseable {
-    String FILE_NAME = "wal.txt";
     Long DEFAULT_BLOCK_SIZE = 1024 * 1024L;
 
     String identifier();

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorageTest.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.seatunnel.engine.imap.storage.file.common.FileConstants.FileInitProperties.WRITE_DATA_TIMEOUT_MILLISECONDS_KEY;
 import static org.awaitility.Awaitility.await;
@@ -76,7 +75,6 @@ public class IMapFileStorageTest {
         String key2Index = "key2";
         String key50Index = "key50";
 
-        AtomicInteger dataSize = new AtomicInteger();
         Long keyValue = 123456789L;
         for (int i = 0; i < 100; i++) {
             String key = "key" + i;
@@ -90,7 +88,6 @@ public class IMapFileStorageTest {
                 STORAGE.store(key2Index, keyValue);
                 keys.add(key2Index);
                 value = keyValue;
-                new Thread(() -> dataSize.set(STORAGE.loadAll().size())).start();
             }
             STORAGE.store(key, value);
             keys.add(key);
@@ -98,9 +95,9 @@ public class IMapFileStorageTest {
             keys.remove(key1Index);
         }
 
-        await().atMost(1, TimeUnit.SECONDS).until(dataSize::get, size -> size > 0);
+        await().atMost(5, TimeUnit.SECONDS);
         Map<Object, Object> loadAllDatas = STORAGE.loadAll();
-        Assertions.assertTrue(dataSize.get() >= 50);
+        Assertions.assertEquals(99, loadAllDatas.size());
         Assertions.assertEquals(keyValue, loadAllDatas.get(key50Index));
         Assertions.assertEquals(keyValue, loadAllDatas.get(key2Index));
         Assertions.assertNull(loadAllDatas.get(key1Index));

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/IMapFileStorageTest.java
@@ -95,7 +95,8 @@ public class IMapFileStorageTest {
             keys.remove(key1Index);
         }
 
-        await().atMost(5, TimeUnit.SECONDS);
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(99, STORAGE.loadAll().size()));
         Map<Object, Object> loadAllDatas = STORAGE.loadAll();
         Assertions.assertEquals(99, loadAllDatas.size());
         Assertions.assertEquals(keyValue, loadAllDatas.get(key50Index));

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALDisruptorTest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/test/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALDisruptorTest.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
 import org.apache.seatunnel.engine.imap.storage.file.config.FileConfiguration;
 import org.apache.seatunnel.engine.imap.storage.file.future.RequestFuture;
 import org.apache.seatunnel.engine.imap.storage.file.future.RequestFutureCache;
+import org.apache.seatunnel.engine.serializer.api.Serializer;
 import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -50,6 +51,7 @@ public class WALDisruptorTest {
     private static FileSystem FS;
 
     private static final Configuration CONF;
+    private static final Serializer SERIALIZER = new ProtoStuffSerializer();
 
     static {
         CONF = new Configuration();
@@ -60,16 +62,15 @@ public class WALDisruptorTest {
     @Test
     void testProducerAndConsumer() throws IOException {
         FS = FileSystem.get(CONF);
-        DISRUPTOR =
-                new WALDisruptor(FS, FileConfiguration.HDFS, FILEPATH, new ProtoStuffSerializer());
+        DISRUPTOR = new WALDisruptor(FS, FileConfiguration.HDFS, FILEPATH, SERIALIZER);
         IMapFileData data;
         for (int i = 0; i < 100; i++) {
             data =
                     IMapFileData.builder()
                             .deleted(false)
-                            .key(("key" + i).getBytes())
+                            .key(SERIALIZER.serialize("key" + i))
                             .keyClassName(String.class.getName())
-                            .value(("value" + i).getBytes())
+                            .value(SERIALIZER.serialize("value" + i))
                             .valueClassName(String.class.getName())
                             .timestamp(System.nanoTime())
                             .build();


### PR DESCRIPTION

1. modify imap storage path
2. hdfs and cloud writer split write data by block
3. rewrite read imap file logic

Close #9482

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
case issue #9482,#9472,#8558, fix IMAP persistent file infinite expansion
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
set map store to persist imap data to file, then start seatunnel cluster, and submit a streaming job,  see the persist file structure, like:
![image](https://github.com/user-attachments/assets/19c94b64-9abf-4077-88e7-5b3491fd98f7)
then  restart the cluster, see that if cluster recover correct.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  5. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  6. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)