### PR TITLE
[Fix][Zeta] Avoid redundant checkpoint reads when disabled checkpoint

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CheckpointService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CheckpointService.java
@@ -30,6 +30,7 @@ import org.apache.seatunnel.engine.server.checkpoint.ActionStateKey;
 import org.apache.seatunnel.engine.server.checkpoint.ActionSubtaskState;
 import org.apache.seatunnel.engine.server.checkpoint.CompletedCheckpoint;
 
+import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ import java.util.stream.Collectors;
  * <p>The service provides the APIs to get the latest checkpoint data of a job.
  */
 public class CheckpointService {
-    private CheckpointStorage checkpointStorage;
+    @Getter private CheckpointStorage checkpointStorage;
     private Serializer serializer = new ProtoStuffSerializer();
 
     @SneakyThrows

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -345,7 +345,6 @@ public class JobMaster {
                 defaultCheckpointConfig.getStorage().getStoragePluginConfig());
         jobCheckpointStorageConfig.setMaxRetainedCheckpoints(
                 defaultCheckpointConfig.getStorage().getMaxRetainedCheckpoints());
-        jobCheckpointConfig.setStorage(jobCheckpointStorageConfig);
 
         if (jobEnv.containsKey(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
             jobCheckpointConfig.setCheckpointInterval(
@@ -355,7 +354,11 @@ public class JobMaster {
             LOGGER.info(
                     "in batch mode, the 'checkpoint.interval' configuration of env is missing, so checkpoint will be disabled");
             jobCheckpointConfig.setCheckpointEnable(false);
+            // Reset the storage configuration to ensure no checkpoint storage is used when checkpointing is disabled.
+            jobCheckpointStorageConfig = new CheckpointStorageConfig();
         }
+        jobCheckpointConfig.setStorage(jobCheckpointStorageConfig);
+
         if (jobEnv.containsKey(EnvCommonOptions.CHECKPOINT_TIMEOUT.key())) {
             jobCheckpointConfig.setCheckpointTimeout(
                     Long.parseLong(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -354,7 +354,8 @@ public class JobMaster {
             LOGGER.info(
                     "in batch mode, the 'checkpoint.interval' configuration of env is missing, so checkpoint will be disabled");
             jobCheckpointConfig.setCheckpointEnable(false);
-            // Reset the storage configuration to ensure no checkpoint storage is used when checkpointing is disabled.
+            // Reset the storage configuration to ensure no checkpoint storage is used when
+            // checkpointing is disabled.
             jobCheckpointStorageConfig = new CheckpointStorageConfig();
         }
         jobCheckpointConfig.setStorage(jobCheckpointStorageConfig);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -32,7 +32,6 @@ import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.common.utils.ExceptionUtils;
 import org.apache.seatunnel.common.utils.RetryUtils;
 import org.apache.seatunnel.common.utils.SeaTunnelException;
-import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.JobConfig;
@@ -317,7 +316,7 @@ public class JobMaster {
         }
     }
 
-    public void initCheckPointManager(boolean restart) throws CheckpointStorageException {
+    public void initCheckPointManager(boolean restart) {
         this.checkpointManager =
                 new CheckpointManager(
                         jobImmutableInformation.getJobId(),
@@ -326,6 +325,7 @@ public class JobMaster {
                         this,
                         checkpointPlanMap,
                         jobCheckpointConfig,
+                        seaTunnelServer.getCheckpointService().getCheckpointStorage(),
                         executorService,
                         runningJobStateIMap);
     }
@@ -345,6 +345,7 @@ public class JobMaster {
                 defaultCheckpointConfig.getStorage().getStoragePluginConfig());
         jobCheckpointStorageConfig.setMaxRetainedCheckpoints(
                 defaultCheckpointConfig.getStorage().getMaxRetainedCheckpoints());
+        jobCheckpointConfig.setStorage(jobCheckpointStorageConfig);
 
         if (jobEnv.containsKey(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
             jobCheckpointConfig.setCheckpointInterval(
@@ -354,12 +355,7 @@ public class JobMaster {
             LOGGER.info(
                     "in batch mode, the 'checkpoint.interval' configuration of env is missing, so checkpoint will be disabled");
             jobCheckpointConfig.setCheckpointEnable(false);
-            // Reset the storage configuration to ensure no checkpoint storage is used when
-            // checkpointing is disabled.
-            jobCheckpointStorageConfig = new CheckpointStorageConfig();
         }
-        jobCheckpointConfig.setStorage(jobCheckpointStorageConfig);
-
         if (jobEnv.containsKey(EnvCommonOptions.CHECKPOINT_TIMEOUT.key())) {
             jobCheckpointConfig.setCheckpointTimeout(
                     Long.parseLong(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -64,6 +64,7 @@ public class CheckpointCoordinatorTest
                         null,
                         planMap,
                         checkpointConfig,
+                        server.getCheckpointService().getCheckpointStorage(),
                         instance.getExecutorService("test"),
                         nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE));
         checkpointManager.acknowledgeTask(
@@ -100,6 +101,7 @@ public class CheckpointCoordinatorTest
                             null,
                             planMap,
                             checkpointConfig,
+                            server.getCheckpointService().getCheckpointStorage(),
                             executorService,
                             nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE)) {
 
@@ -144,6 +146,7 @@ public class CheckpointCoordinatorTest
                             null,
                             planMap,
                             checkpointConfig,
+                            server.getCheckpointService().getCheckpointStorage(),
                             executorService,
                             nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE)) {
                         @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
@@ -88,6 +88,7 @@ public class CheckpointManagerTest extends AbstractSeaTunnelServerTest {
                         null,
                         planMap,
                         new CheckpointConfig(),
+                        server.getCheckpointService().getCheckpointStorage(),
                         instance.getExecutorService("test"),
                         nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE));
         Assertions.assertTrue(checkpointManager.isCompletedPipeline(1));

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.checkpoint;
 
+import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorageFactory;
@@ -34,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -185,8 +185,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
     }
 
     @Test
-    public void testBatchJobResetCheckpointStorage()
-            throws CheckpointStorageException, NoSuchFieldException, IllegalAccessException {
+    public void testBatchJobResetCheckpointStorage() throws CheckpointStorageException {
         long jobId = System.currentTimeMillis();
         CheckpointConfig checkpointConfig =
                 server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
@@ -264,13 +263,9 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
 
         // replace the checkpoint storage reused by the system
         CheckpointService checkpointService = server.getCheckpointService();
-        Field checkpointStorageField =
-                checkpointService.getClass().getDeclaredField("checkpointStorage");
-        checkpointStorageField.setAccessible(true);
-        checkpointStorageField.set(checkpointService, checkpointStorage);
+        ReflectionUtils.setField(checkpointService, "checkpointStorage", checkpointStorage);
 
         startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
-
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
@@ -278,9 +273,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                         server.getCoordinatorService().getJobStatus(jobId),
                                         JobStatus.FINISHED));
 
-        List<PipelineState> allCheckpoints =
-                checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
-        Assertions.assertEquals(0, allCheckpoints.size());
+        checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
         Assertions.assertEquals(1, accessCnt.get());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -20,11 +20,9 @@ package org.apache.seatunnel.engine.server.checkpoint;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
-import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorageFactory;
 import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
-import org.apache.seatunnel.engine.common.utils.FactoryUtil;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.job.JobStatus;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
@@ -70,15 +68,8 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
     public void testGenerateFileWhenSavepoint()
             throws CheckpointStorageException, InterruptedException {
         long jobId = System.currentTimeMillis();
-        CheckpointConfig checkpointConfig =
-                server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
 
-        CheckpointStorage checkpointStorage =
-                FactoryUtil.discoverFactory(
-                                Thread.currentThread().getContextClassLoader(),
-                                CheckpointStorageFactory.class,
-                                checkpointConfig.getStorage().getStorage())
-                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+        CheckpointStorage checkpointStorage = server.getCheckpointService().getCheckpointStorage();
         startJob(jobId, STREAM_CONF_PATH, false);
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
@@ -104,15 +95,8 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
     @Test
     public void testBatchJob() throws CheckpointStorageException {
         long jobId = System.currentTimeMillis();
-        CheckpointConfig checkpointConfig =
-                server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
 
-        CheckpointStorage checkpointStorage =
-                FactoryUtil.discoverFactory(
-                                Thread.currentThread().getContextClassLoader(),
-                                CheckpointStorageFactory.class,
-                                checkpointConfig.getStorage().getStorage())
-                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+        CheckpointStorage checkpointStorage = server.getCheckpointService().getCheckpointStorage();
         startJob(jobId, BATCH_CONF_PATH, false);
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
@@ -132,12 +116,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                 server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
         server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
 
-        CheckpointStorage checkpointStorage =
-                FactoryUtil.discoverFactory(
-                                Thread.currentThread().getContextClassLoader(),
-                                CheckpointStorageFactory.class,
-                                checkpointConfig.getStorage().getStorage())
-                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+        CheckpointStorage checkpointStorage = server.getCheckpointService().getCheckpointStorage();
         startJob(jobId, BATCH_CONF_WITH_CHECKPOINT_PATH, false);
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
@@ -157,12 +136,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                 server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
         server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
 
-        CheckpointStorage checkpointStorage =
-                FactoryUtil.discoverFactory(
-                                Thread.currentThread().getContextClassLoader(),
-                                CheckpointStorageFactory.class,
-                                checkpointConfig.getStorage().getStorage())
-                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+        CheckpointStorage checkpointStorage = server.getCheckpointService().getCheckpointStorage();
         startJob(jobId, STREAM_CONF_WITH_CHECKPOINT_PATH, false);
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -164,6 +164,8 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
         CheckpointConfig checkpointConfig =
                 server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
         server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
+        final CheckpointStorage originalCheckpointStorage =
+                server.getCheckpointService().getCheckpointStorage();
 
         // access checkpoint storage counter
         AtomicInteger accessCounter = new AtomicInteger(0);
@@ -249,5 +251,8 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
 
         checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
         Assertions.assertEquals(1, accessCounter.get());
+
+        // restore the server's checkpointStorage to avoid affecting other unit cases
+        ReflectionUtils.setField(checkpointService, "checkpointStorage", originalCheckpointStorage);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -166,72 +166,72 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
         server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
 
         // access checkpoint storage counter
-        AtomicInteger accessCnt = new AtomicInteger(0);
+        AtomicInteger accessCounter = new AtomicInteger(0);
         CheckpointStorage checkpointStorage =
                 new CheckpointStorage() {
                     @Override
                     public String storeCheckPoint(PipelineState pipelineState)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return "";
                     }
 
                     @Override
                     public void asyncStoreCheckPoint(PipelineState pipelineState)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                     }
 
                     @Override
                     public List<PipelineState> getAllCheckpoints(String s)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return Collections.emptyList();
                     }
 
                     @Override
                     public List<PipelineState> getLatestCheckpoint(String s)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return Collections.emptyList();
                     }
 
                     @Override
                     public PipelineState getLatestCheckpointByJobIdAndPipelineId(
                             String s, String s1) throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return null;
                     }
 
                     @Override
                     public List<PipelineState> getCheckpointsByJobIdAndPipelineId(
                             String s, String s1) throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return Collections.emptyList();
                     }
 
                     @Override
                     public void deleteCheckpoint(String s) {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                     }
 
                     @Override
                     public PipelineState getCheckpoint(String s, String s1, String s2)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                         return null;
                     }
 
                     @Override
                     public void deleteCheckpoint(String s, String s1, String s2)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                     }
 
                     @Override
                     public void deleteCheckpoint(String s, String s1, List<String> list)
                             throws CheckpointStorageException {
-                        accessCnt.incrementAndGet();
+                        accessCounter.incrementAndGet();
                     }
                 };
 
@@ -248,6 +248,6 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                         JobStatus.FINISHED));
 
         checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
-        Assertions.assertEquals(1, accessCnt.get());
+        Assertions.assertEquals(1, accessCounter.get());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -27,14 +27,18 @@ import org.apache.seatunnel.engine.common.utils.FactoryUtil;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.job.JobStatus;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.CheckpointService;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
 
@@ -181,28 +185,102 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
     }
 
     @Test
-    public void testBatchJobResetCheckpointStorage() throws CheckpointStorageException {
+    public void testBatchJobResetCheckpointStorage()
+            throws CheckpointStorageException, NoSuchFieldException, IllegalAccessException {
         long jobId = System.currentTimeMillis();
         CheckpointConfig checkpointConfig =
                 server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
         server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
 
+        // access checkpoint storage counter
+        AtomicInteger accessCnt = new AtomicInteger(0);
         CheckpointStorage checkpointStorage =
-                FactoryUtil.discoverFactory(
-                                Thread.currentThread().getContextClassLoader(),
-                                CheckpointStorageFactory.class,
-                                checkpointConfig.getStorage().getStorage())
-                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+                new CheckpointStorage() {
+                    @Override
+                    public String storeCheckPoint(PipelineState pipelineState)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return "";
+                    }
+
+                    @Override
+                    public void asyncStoreCheckPoint(PipelineState pipelineState)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                    }
+
+                    @Override
+                    public List<PipelineState> getAllCheckpoints(String s)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public List<PipelineState> getLatestCheckpoint(String s)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public PipelineState getLatestCheckpointByJobIdAndPipelineId(
+                            String s, String s1) throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return null;
+                    }
+
+                    @Override
+                    public List<PipelineState> getCheckpointsByJobIdAndPipelineId(
+                            String s, String s1) throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public void deleteCheckpoint(String s) {
+                        accessCnt.incrementAndGet();
+                    }
+
+                    @Override
+                    public PipelineState getCheckpoint(String s, String s1, String s2)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                        return null;
+                    }
+
+                    @Override
+                    public void deleteCheckpoint(String s, String s1, String s2)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                    }
+
+                    @Override
+                    public void deleteCheckpoint(String s, String s1, List<String> list)
+                            throws CheckpointStorageException {
+                        accessCnt.incrementAndGet();
+                    }
+                };
+
+        // replace the checkpoint storage reused by the system
+        CheckpointService checkpointService = server.getCheckpointService();
+        Field checkpointStorageField =
+                checkpointService.getClass().getDeclaredField("checkpointStorage");
+        checkpointStorageField.setAccessible(true);
+        checkpointStorageField.set(checkpointService, checkpointStorage);
 
         startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
+
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertEquals(
                                         server.getCoordinatorService().getJobStatus(jobId),
                                         JobStatus.FINISHED));
+
         List<PipelineState> allCheckpoints =
                 checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
         Assertions.assertEquals(0, allCheckpoints.size());
+        Assertions.assertEquals(1, accessCnt.get());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -89,9 +89,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                         server.getCoordinatorService().getJobStatus(jobId),
                                         JobStatus.SAVEPOINT_DONE));
         List<PipelineState> savepoint1 = checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
-
-        await().atMost(5000, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> Assertions.assertEquals(1, savepoint1.size()));
+        Assertions.assertEquals(1, savepoint1.size());
     }
 
     @Test

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -193,6 +193,7 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                 CheckpointStorageFactory.class,
                                 checkpointConfig.getStorage().getStorage())
                         .create(checkpointConfig.getStorage().getStoragePluginConfig());
+
         startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -45,6 +45,8 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
     public static String BATCH_CONF_PATH = "batch_fakesource_to_file.conf";
     public static String BATCH_CONF_WITH_CHECKPOINT_PATH =
             "batch_fakesource_to_file_with_checkpoint.conf";
+    public static String BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH =
+            "batch_fake_to_console_without_checkpoint_interval.conf";
 
     public static String STREAM_CONF_WITH_CHECKPOINT_PATH =
             "stream_fake_to_console_with_checkpoint.conf";
@@ -173,6 +175,31 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                 Assertions.assertEquals(
                                         server.getCoordinatorService().getJobStatus(jobId),
                                         JobStatus.CANCELED));
+        List<PipelineState> allCheckpoints =
+                checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
+        Assertions.assertEquals(0, allCheckpoints.size());
+    }
+
+    @Test
+    public void testBatchJobResetCheckpointStorage() throws CheckpointStorageException {
+        long jobId = System.currentTimeMillis();
+        CheckpointConfig checkpointConfig =
+                server.getSeaTunnelConfig().getEngineConfig().getCheckpointConfig();
+        server.getSeaTunnelConfig().getEngineConfig().setCheckpointConfig(checkpointConfig);
+
+        CheckpointStorage checkpointStorage =
+                FactoryUtil.discoverFactory(
+                                Thread.currentThread().getContextClassLoader(),
+                                CheckpointStorageFactory.class,
+                                checkpointConfig.getStorage().getStorage())
+                        .create(checkpointConfig.getStorage().getStoragePluginConfig());
+        startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
+        await().atMost(120000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        server.getCoordinatorService().getJobStatus(jobId),
+                                        JobStatus.FINISHED));
         List<PipelineState> allCheckpoints =
                 checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
         Assertions.assertEquals(0, allCheckpoints.size());

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -89,7 +89,9 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
                                         server.getCoordinatorService().getJobStatus(jobId),
                                         JobStatus.SAVEPOINT_DONE));
         List<PipelineState> savepoint1 = checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
-        Assertions.assertEquals(1, savepoint1.size());
+
+        await().atMost(5000, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(1, savepoint1.size()));
     }
 
     @Test

--- a/seatunnel-engine/seatunnel-engine-server/src/test/resources/batch_fake_to_console_without_checkpoint_interval.conf
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/resources/batch_fake_to_console_without_checkpoint_interval.conf
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in SeaTunnel config
+######
+
+env {
+  # You can set SeaTunnel environment configuration here
+  parallelism = 2
+  job.mode = "BATCH"
+  # remove `checkpoint.interval` config
+  # checkpoint.interval = 10000
+}
+
+source {
+  # This is a example source plugin **only for test and demonstrate the feature source plugin**
+  FakeSource {
+    parallelism = 2
+    plugin_output = "fake"
+    row.num = 16
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request

If the batch task configuration property checkpoint.interval is missing or checkpointEnable=false, the checkpoint storage policy configured in seatunnel.yaml will not be triggered, and the default loaclfile will be used to avoid not enabling checkpoint but actually using the checkpoint storage configured in seatunnel.yaml. https://github.com/apache/seatunnel/issues/9542

Just like the PR I closed last time https://github.com/apache/seatunnel/pull/9543 , this time I resubmitted the PR after modification.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

yes,When running batch tasks locally, remove the task configuration checkpoint.interval, but the checkpoint storage configured in seatunnel.yaml is still hdfs. After the modification, the task runs normally.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)