### PR TITLE
[Hotfix][Connector-Jdbc] Write MySQL to support set collection data type

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MySqlTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MySqlTypeConverter.java
@@ -75,6 +75,7 @@ public class MySqlTypeConverter implements TypeConverter<BasicTypeDefine<MysqlTy
     static final String MYSQL_LONGTEXT = "LONGTEXT";
     static final String MYSQL_JSON = "JSON";
     static final String MYSQL_ENUM = "ENUM";
+    static final String MYSQL_SET = "SET";
 
     // ------------------------------time-------------------------
     static final String MYSQL_DATE = "DATE";
@@ -243,6 +244,7 @@ public class MySqlTypeConverter implements TypeConverter<BasicTypeDefine<MysqlTy
                 builder.scale(decimalUnsignedType.getScale());
                 break;
             case MYSQL_ENUM:
+            case MYSQL_SET:
                 builder.dataType(BasicType.STRING_TYPE);
                 if (typeDefine.getLength() == null || typeDefine.getLength() <= 0) {
                     builder.columnLength(100L);

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MySqlTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MySqlTypeConverterTest.java
@@ -1082,4 +1082,20 @@ public class MySqlTypeConverterTest {
         Assertions.assertEquals(MySqlTypeConverter.MYSQL_DATETIME, typeDefine.getColumnType());
         Assertions.assertEquals(MySqlTypeConverter.MYSQL_DATETIME, typeDefine.getDataType());
     }
+
+    @Test
+    public void testConvertSet() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("SET('reading','sports','music','travel')")
+                        .dataType("SET")
+                        .length(3L)
+                        .build();
+        Column column = MySqlTypeConverter.DEFAULT_INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(3, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+    }
 }


### PR DESCRIPTION
### Purpose of this pull request

Write MySQL to support set collection data type. fix issues: https://github.com/apache/seatunnel/issues/9551


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
After modification, local operation writes mysql set data type normally

<img width="1360" alt="企业微信截图_bd2727a8-4bdf-425a-8e88-729fc6399f5e" src="https://github.com/user-attachments/assets/d6b8f474-d920-40ee-a564-6c8745bef54e" />

<img width="1060" alt="企业微信截图_e929ad9a-8a18-427c-81ed-dc7e8cf31c02" src="https://github.com/user-attachments/assets/313f2cef-70da-4623-b61c-1251b3451089" />

<img width="1401" alt="企业微信截图_54283ff9-2e4d-4c58-9d83-03f7ccddfab4" src="https://github.com/user-attachments/assets/96c0956d-0a87-40e8-8cce-24b4e34a122b" />


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)