### PR TITLE
[Improve][Connector-V2] Replace deprecated createDownloadSession by buildDownloadSession

### DIFF
--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
@@ -68,15 +68,17 @@ public class MaxcomputeUtil {
                 PartitionSpec partitionSpec =
                         new PartitionSpec(readonlyConfig.get(MaxcomputeBaseOptions.PARTITION_SPEC));
                 session =
-                        tunnel.createDownloadSession(
-                                readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
-                                readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME),
-                                partitionSpec);
+                        tunnel.buildDownloadSession(
+                                        readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
+                                        readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
+                                .setPartitionSpec(partitionSpec)
+                                .build();
             } else {
                 session =
-                        tunnel.createDownloadSession(
-                                readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
-                                readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME));
+                        tunnel.buildDownloadSession(
+                                        readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
+                                        readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
+                                .build();
             }
         } catch (Exception e) {
             throw new MaxcomputeConnectorException(
@@ -93,12 +95,15 @@ public class MaxcomputeUtil {
             if (StringUtils.isNotEmpty(partitionSpec)) {
                 PartitionSpec partition = new PartitionSpec(partitionSpec);
                 session =
-                        tunnel.createDownloadSession(
-                                tablePath.getDatabaseName(), tablePath.getTableName(), partition);
+                        tunnel.buildDownloadSession(
+                                        tablePath.getDatabaseName(), tablePath.getTableName())
+                                .setPartitionSpec(partition)
+                                .build();
             } else {
                 session =
-                        tunnel.createDownloadSession(
-                                tablePath.getDatabaseName(), tablePath.getTableName());
+                        tunnel.buildDownloadSession(
+                                        tablePath.getDatabaseName(), tablePath.getTableName())
+                                .build();
             }
         } catch (Exception e) {
             throw new MaxcomputeConnectorException(

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
@@ -31,6 +31,7 @@ import com.aliyun.odps.Table;
 import com.aliyun.odps.account.Account;
 import com.aliyun.odps.account.AliyunAccount;
 import com.aliyun.odps.tunnel.TableTunnel;
+import com.aliyun.odps.tunnel.TunnelException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -68,19 +69,18 @@ public class MaxcomputeUtil {
                 PartitionSpec partitionSpec =
                         new PartitionSpec(readonlyConfig.get(MaxcomputeBaseOptions.PARTITION_SPEC));
                 session =
-                        tunnel.buildDownloadSession(
-                                        readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
-                                        readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
-                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
-                                .setPartitionSpec(partitionSpec)
-                                .build();
+                        buildDownloadSession(
+                                tunnel,
+                                readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
+                                readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME),
+                                partitionSpec);
             } else {
                 session =
-                        tunnel.buildDownloadSession(
-                                        readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
-                                        readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
-                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
-                                .build();
+                        buildDownloadSession(
+                                tunnel,
+                                readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
+                                readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME),
+                                null);
             }
         } catch (Exception e) {
             throw new MaxcomputeConnectorException(
@@ -97,17 +97,18 @@ public class MaxcomputeUtil {
             if (StringUtils.isNotEmpty(partitionSpec)) {
                 PartitionSpec partition = new PartitionSpec(partitionSpec);
                 session =
-                        tunnel.buildDownloadSession(
-                                        tablePath.getDatabaseName(), tablePath.getTableName())
-                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
-                                .setPartitionSpec(partition)
-                                .build();
+                        buildDownloadSession(
+                                tunnel,
+                                tablePath.getDatabaseName(),
+                                tablePath.getTableName(),
+                                partition);
             } else {
                 session =
-                        tunnel.buildDownloadSession(
-                                        tablePath.getDatabaseName(), tablePath.getTableName())
-                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
-                                .build();
+                        buildDownloadSession(
+                                tunnel,
+                                tablePath.getDatabaseName(),
+                                tablePath.getTableName(),
+                                null);
             }
         } catch (Exception e) {
             throw new MaxcomputeConnectorException(
@@ -129,5 +130,14 @@ public class MaxcomputeUtil {
                             projectName, tableName, ex.getMessage()),
                     ex);
         }
+    }
+
+    private static TableTunnel.DownloadSession buildDownloadSession(
+            TableTunnel tunnel, String projectName, String tableName, PartitionSpec partitionSpec)
+            throws TunnelException {
+        return tunnel.buildDownloadSession(projectName, tableName)
+                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
+                .setPartitionSpec(partitionSpec)
+                .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/util/MaxcomputeUtil.java
@@ -71,6 +71,7 @@ public class MaxcomputeUtil {
                         tunnel.buildDownloadSession(
                                         readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
                                         readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
+                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
                                 .setPartitionSpec(partitionSpec)
                                 .build();
             } else {
@@ -78,6 +79,7 @@ public class MaxcomputeUtil {
                         tunnel.buildDownloadSession(
                                         readonlyConfig.get(MaxcomputeBaseOptions.PROJECT),
                                         readonlyConfig.get(MaxcomputeBaseOptions.TABLE_NAME))
+                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
                                 .build();
             }
         } catch (Exception e) {
@@ -97,12 +99,14 @@ public class MaxcomputeUtil {
                 session =
                         tunnel.buildDownloadSession(
                                         tablePath.getDatabaseName(), tablePath.getTableName())
+                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
                                 .setPartitionSpec(partition)
                                 .build();
             } else {
                 session =
                         tunnel.buildDownloadSession(
                                         tablePath.getDatabaseName(), tablePath.getTableName())
+                                .setSchemaName(tunnel.getConfig().getOdps().getCurrentSchema())
                                 .build();
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Purpose of this pull request

The method createDownloadSession has been deprecated since version 0.41.x.
As of 0.52.x, it still exists but may be removed in future releases.
This PR replaces it with buildDownloadSession to ensure forward compatibility.

For reference, see the following code in the 0.41.x branch where the method was marked as deprecated: 
[deprecated](https://github.com/aliyun/aliyun-odps-java-sdk/blob/release/0.41.x/odps-sdk/odps-sdk-core/src/main/java/com/aliyun/odps/tunnel/TableTunnel.java)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Covered by existing tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)