### PR TITLE
[Improve][Connectors-http] Add valid verification for http type URLs

### DIFF
--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -18,7 +18,14 @@
 package org.apache.seatunnel.connectors.seatunnel.http.client;
 
 import lombok.SneakyThrows;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.seatunnel.shade.com.google.common.base.Strings;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -17,15 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.http.client;
 
-import lombok.SneakyThrows;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.seatunnel.shade.com.google.common.base.Strings;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
@@ -39,6 +30,14 @@ import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
@@ -56,6 +55,7 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -90,7 +90,6 @@ public class HttpClientProvider implements AutoCloseable {
                         .setConnectTimeout(httpParameter.getConnectTimeoutMs())
                         .setSocketTimeout(httpParameter.getSocketTimeoutMs())
                         .build();
-        // verify that the provided URL is reachable
         this.checkUrlAccessibility(httpParameter);
     }
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.http.client;
 
+import lombok.SneakyThrows;
+import org.apache.http.client.methods.*;
 import org.apache.seatunnel.shade.com.google.common.base.Strings;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
@@ -30,13 +32,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
@@ -58,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,6 +83,8 @@ public class HttpClientProvider implements AutoCloseable {
                         .setConnectTimeout(httpParameter.getConnectTimeoutMs())
                         .setSocketTimeout(httpParameter.getSocketTimeoutMs())
                         .build();
+        // verify that the provided URL is reachable
+        this.checkUrlAccessibility(httpParameter);
     }
 
     private Retryer<CloseableHttpResponse> buildRetryer(HttpParameter httpParameter) {
@@ -526,6 +524,26 @@ public class HttpClientProvider implements AutoCloseable {
     public void close() throws IOException {
         if (Objects.nonNull(httpClient)) {
             httpClient.close();
+        }
+    }
+
+    /**
+     * Check if the url is available by sending a simple HEAD request.
+     *
+     * @param httpParameter the http parameter
+     */
+    @SneakyThrows
+    public void checkUrlAccessibility(HttpParameter httpParameter) {
+        HttpHead request = new HttpHead(httpParameter.getUrl());
+        Map<String, String> headers = httpParameter.getHeaders();
+        if (Objects.nonNull(headers)) {
+            headers.forEach(request::addHeader);
+        }
+        CloseableHttpResponse response = httpClient.execute(request);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (!(statusCode >= HttpStatus.SC_OK && statusCode < HttpStatus.SC_MULTIPLE_CHOICES)) {
+            log.warn("Failed to connect to host: {}", httpParameter.getUrl());
+            throw new ConnectException("URL is not accessible. status code: " + statusCode);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.seatunnel.connectors.seatunnel.http.client;
 
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
+
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicHeader;
@@ -27,8 +29,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HttpClientProviderTest {
+
+    private static final String TEST_URL = "http://example.com/test";
+    private static final String TEST_BAD_URL = "http://localhost/test/webhook";
 
     @Test
     void testAddDefaultJsonContentTypeWhenNotPresent() throws Exception {
@@ -83,5 +89,39 @@ class HttpClientProviderTest {
         }
         // ensure no manually set content type or encoding
         Assertions.assertNull(post.getEntity().getContentEncoding());
+    }
+
+    @Test
+    void testCheckBadInterfaceUrlAccessibility() {
+        // Setting HTTP Parameters
+        HttpParameter httpParameter = new HttpParameter();
+        httpParameter.setUrl(TEST_URL);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        httpParameter.setHeaders(headers);
+
+        // The test interface does not exist, but the domain name is normal URL.
+        try (HttpClientProvider httpClientProvider = new HttpClientProvider(httpParameter)) {
+            // Ignore
+        } catch (Exception e) {
+            assertTrue(e instanceof java.net.ConnectException);
+        }
+    }
+
+    @Test
+    void testCheckBadUrlAccessibility() {
+        // Setting HTTP Parameters
+        HttpParameter httpParameter = new HttpParameter();
+        httpParameter.setUrl(TEST_BAD_URL);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        httpParameter.setHeaders(headers);
+
+        // Test the scenario where the target URL does not exist
+        try (HttpClientProvider httpClientProvider = new HttpClientProvider(httpParameter)) {
+            // Ignore
+        } catch (Exception e) {
+            assertTrue(e instanceof org.apache.http.conn.HttpHostConnectException);
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HttpClientProviderTest {
 
     private static final String TEST_URL = "http://example.com/test";
-    private static final String TEST_BAD_URL = "http://localhost/test/webhook";
+    private static final String TEST_BAD_URL = "http://test123:8080/test/webhook";
 
     @Test
     void testAddDefaultJsonContentTypeWhenNotPresent() throws Exception {
@@ -121,7 +121,7 @@ class HttpClientProviderTest {
         try (HttpClientProvider httpClientProvider = new HttpClientProvider(httpParameter)) {
             // Ignore
         } catch (Exception e) {
-            assertTrue(e instanceof org.apache.http.conn.HttpHostConnectException);
+            assertTrue(e instanceof java.net.UnknownHostException);
         }
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

 Added a check on the URL to prevent the task from running successfully even though the writing failed, close https://github.com/apache/seatunnel/issues/9572


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Test normal url and abnormal url, whether HttpClientProvider can be created normally.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)