### PR TITLE
[Feature][connector-tdengine] Support subtable and fieldNames in tdengine source

### DIFF
--- a/docs/en/connector-v2/sink/TDengine.md
+++ b/docs/en/connector-v2/sink/TDengine.md
@@ -15,14 +15,15 @@ Used to write data to TDengine. You need to create stable before running seatunn
 
 ## Options
 
-|   name   |  type  | required | default value |
-|----------|--------|----------|---------------|
-| url      | string | yes      | -             |
-| username | string | yes      | -             |
-| password | string | yes      | -             |
-| database | string | yes      |               |
-| stable   | string | yes      | -             |
-| timezone | string | no       | UTC           |
+| name         | type   | required | default value |
+|--------------|--------|----------|---------------|
+| url          | string | yes      | -             |
+| username     | string | yes      | -             |
+| password     | string | yes      | -             |
+| database     | string | yes      |               |
+| stable       | string | yes      | -             |
+| timezone     | string | no       | UTC           |
+| write_columns| list   | no       | -             |
 
 ### url [string]
 
@@ -54,6 +55,9 @@ the stable of the TDengine when you select
 
 the timeznoe of the TDengine sever, it's important to the ts field
 
+### write_columns [list]
+The field names to be inserted into TDengine. If not set, all fields will be written. The plugin will automatically append TAGS columns, so please do not include TAGS columns in this option.
+
 ## Example
 
 ### sink
@@ -67,6 +71,7 @@ sink {
           database : "power2"
           stable : "meters2"
           timezone: UTC
+          write_columns: ["ts", "voltage", "current", "power"]
         }
 }
 ```

--- a/docs/en/connector-v2/source/TDengine.md
+++ b/docs/en/connector-v2/source/TDengine.md
@@ -22,15 +22,17 @@ supports query SQL and can achieve projection effect.
 
 ## Options
 
-|    name     |  type  | required | default value |
-|-------------|--------|----------|---------------|
-| url         | string | yes      | -             |
-| username    | string | yes      | -             |
-| password    | string | yes      | -             |
-| database    | string | yes      |               |
-| stable      | string | yes      | -             |
-| lower_bound | long   | yes      | -             |
-| upper_bound | long   | yes      | -             |
+| name         | type   | required | default value |
+|--------------|--------|----------|---------------|
+| url          | string | yes      | -             |
+| username     | string | yes      | -             |
+| password     | string | yes      | -             |
+| database     | string | yes      |               |
+| stable       | string | yes      | -             |
+| sub_tables   | list   | no       | -             |
+| lower_bound  | long   | yes      | -             |
+| upper_bound  | long   | yes      | -             |
+| read_columns | list   | no       | -             |
 
 ### url [string]
 
@@ -58,6 +60,9 @@ the database of the TDengine when you select
 
 the stable of the TDengine when you select
 
+### sub_tables [list]
+A list of sub_table names. If not specified, all sub-tables will be selected. If specified, only the specified sub-tables will be selected.
+
 ### lower_bound [long]
 
 the lower_bound of the migration period
@@ -65,6 +70,10 @@ the lower_bound of the migration period
 ### upper_bound [long]
 
 the upper_bound of the migration period
+
+### read_columns [list]
+A list of column names to read. If not specified, all columns will be selected. 
+When reading from a super table, please make sure to put the TAGS columns at the end of the list.
 
 ## Example
 
@@ -78,9 +87,11 @@ source {
           password : "taosdata"
           database : "power"
           stable : "meters"
+          sub_tables : ["meter_1","meter_2"]
           lower_bound : "2018-10-03 14:38:05.000"
           upper_bound : "2018-10-03 14:38:16.800"
-          plugin_output = "tdengine_result"
+          plugin_output : "tdengine_result"
+          read_columns : ["ts","voltage","current","power"]
         }
 }
 ```

--- a/docs/zh/connector-v2/sink/TDengine.md
+++ b/docs/zh/connector-v2/sink/TDengine.md
@@ -15,7 +15,7 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 ## 选项
 
-|   名称   |  类型  | 是否必传 | 默认值 |
+|   名称   | 类型     | 是否必传 | 默认值 |
 |----------|--------|----------|---------------|
 | url      | string | 是      | -             |
 | username | string | 是      | -             |
@@ -23,6 +23,7 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 | database | string | 是      |               |
 | stable   | string | 是      | -             |
 | timezone | string | 否       | UTC           |
+| write_columns | list   | 否       | -             |
 
 ### url [string]
 
@@ -54,6 +55,10 @@ TDengine的超级表
 
 TDengine服务器的时间，对ts字段很重要
 
+### write_columns [list]
+TDengine的写入列，默认为所有列。无需包含 TAGS 字段，插件会自动处理 TAGS 字段的写入。
+
+
 ## 示例
 
 ### sink
@@ -67,9 +72,11 @@ sink {
           database : "power2"
           stable : "meters2"
           timezone: UTC
+          write_columns: ["ts", "voltage", "current", "power"]
         }
 }
 ```
+
 
 ## 变更日志
 

--- a/docs/zh/connector-v2/source/TDengine.md
+++ b/docs/zh/connector-v2/source/TDengine.md
@@ -1,0 +1,102 @@
+import ChangeLog from '../changelog/connector-tdengine.md';
+
+# TDengine
+
+> TDengine 源端连接器
+
+## 描述
+
+通过 TDengine 读取外部数据源的数据。
+
+## 主要特性
+
+- [x] [批处理](../../concept/connector-v2-features.md)
+- [ ] [流式](../../concept/connector-v2-features.md)
+- [x] [精确一次](../../concept/connector-v2-features.md)
+- [ ] [列投影](../../concept/connector-v2-features.md)
+
+支持查询 SQL，并可实现投影效果。
+
+- [x] [并行度](../../concept/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../concept/connector-v2-features.md)
+
+## 配置项
+
+| 名称           | 类型   | 必填 | 默认值         |
+|----------------|--------|------|----------------|
+| url            | string | 是   | -              |
+| username       | string | 是   | -              |
+| password       | string | 是   | -              |
+| database       | string | 是   |                |
+| stable         | string | 是   | -              |
+| sub_tables     | list   | 否   | -              |
+| lower_bound    | long   | 是   | -              |
+| upper_bound    | long   | 是   | -              |
+| read_columns   | list   | 否   | -              |
+
+### url [string]
+
+选择 TDengine 时的连接 URL
+
+例如：
+
+```
+jdbc:TAOS-RS://localhost:6041/
+```
+
+### username [string]
+
+选择 TDengine 时的用户名
+
+### password [string]
+
+选择 TDengine 时的密码
+
+### database [string]
+
+选择 TDengine 时的数据库名
+
+### stable [string]
+
+选择 TDengine 时的超级表名
+
+### sub_tables [list]
+
+TDengine 的子表名。如果不指定，则会选择所有子表；如果指定，则只选择指定的子表。
+
+### lower_bound [long]
+
+迁移时间段的下界
+
+### upper_bound [long]
+
+迁移时间段的上界
+
+### read_columns [list]
+
+选择 TDengine 时的列名。如果不指定，则选择所有字段；如果指定，则只选择指定的字段。读取超级表时，请包含TAGS 字段，并放在末尾。
+
+## 示例
+
+### source 配置示例
+
+```hocon
+source {
+        TDengine {
+          url : "jdbc:TAOS-RS://localhost:6041/"
+          username : "root"
+          password : "taosdata"
+          database : "power"
+          stable : "meters"
+          sub_tables : ["meter_1","meter_2"]
+          lower_bound : "2018-10-03 14:38:05.000"
+          upper_bound : "2018-10-03 14:38:16.800"
+          plugin_output = "tdengine_result"
+          read_columns : ["ts","voltage","current","power"]
+        }
+}
+```
+
+## 变更日志
+
+<ChangeLog />

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSinkConfig.java
@@ -23,6 +23,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 
 @Data
@@ -37,6 +38,7 @@ public class TDengineSinkConfig implements Serializable {
     private String database;
     private String stable;
     private String timezone;
+    private String writeColumns;
 
     public static TDengineSinkConfig of(ReadonlyConfig config) {
         Builder builder = TDengineSinkConfig.builder();
@@ -50,7 +52,11 @@ public class TDengineSinkConfig implements Serializable {
         Optional<String> optionalTimezone = config.getOptional(TDengineSinkOptions.TIMEZONE);
 
         builder.timezone(optionalTimezone.orElseGet(TDengineSinkOptions.TIMEZONE::defaultValue));
-
+        Optional<List<String>> optionalWriteColumns =
+                config.getOptional(TDengineSinkOptions.WRITE_COLUMNS);
+        if (optionalWriteColumns.isPresent()) {
+            builder.writeColumns(String.join(",", optionalWriteColumns.get()));
+        }
         return builder.build();
     }
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSinkOptions.java
@@ -23,6 +23,8 @@ import org.apache.seatunnel.api.configuration.Options;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public class TDengineSinkOptions extends TDengineCommonOptions {
@@ -32,4 +34,13 @@ public class TDengineSinkOptions extends TDengineCommonOptions {
                     .stringType()
                     .defaultValue("UTC")
                     .withDescription("The timezone used for timestamp conversion, default is UTC");
+
+    public static final Option<List<String>> WRITE_COLUMNS =
+            Options.key("write_columns")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The field names to be written to TDengine "
+                                    + "If not specified, all fields will be written. "
+                                    + "This option is useful when the source schema does not match the TDengine table schema.");
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceConfig.java
@@ -23,6 +23,8 @@ import lombok.Data;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 public class TDengineSourceConfig implements Serializable {
@@ -36,8 +38,9 @@ public class TDengineSourceConfig implements Serializable {
     private String stable;
     private String lowerBound;
     private String upperBound;
-    private List<String> fields;
     private List<String> tags;
+    private Set<String> subTables;
+    private Set<String> readColumns;
 
     public static TDengineSourceConfig buildSourceConfig(ReadonlyConfig pluginConfig) {
         TDengineSourceConfig tdengineSourceConfig = new TDengineSourceConfig();
@@ -48,6 +51,18 @@ public class TDengineSourceConfig implements Serializable {
         tdengineSourceConfig.setPassword(pluginConfig.get(TDengineSourceOptions.PASSWORD));
         tdengineSourceConfig.setUpperBound(pluginConfig.get(TDengineSourceOptions.UPPER_BOUND));
         tdengineSourceConfig.setLowerBound(pluginConfig.get(TDengineSourceOptions.LOWER_BOUND));
+        if (pluginConfig.getOptional(TDengineSourceOptions.SUB_TABLES).isPresent()) {
+            tdengineSourceConfig.setSubTables(
+                    pluginConfig.get(TDengineSourceOptions.SUB_TABLES).stream()
+                            .collect(Collectors.toSet()));
+        }
+        if (pluginConfig.getOptional(TDengineSourceOptions.READ_COLUMNS).isPresent()) {
+            tdengineSourceConfig.setReadColumns(
+                    pluginConfig.get(TDengineSourceOptions.READ_COLUMNS).stream()
+                            .collect(Collectors.toSet()));
+        } else {
+            tdengineSourceConfig.setReadColumns(null);
+        }
         return tdengineSourceConfig;
     }
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/config/TDengineSourceOptions.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.connectors.seatunnel.tdengine.config;
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 
+import java.util.List;
+
 public class TDengineSourceOptions extends TDengineCommonOptions {
 
     public static final Option<String> LOWER_BOUND =
@@ -33,4 +35,21 @@ public class TDengineSourceOptions extends TDengineCommonOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The upper bound for data query range");
+
+    public static final Option<List<String>> SUB_TABLES =
+            Options.key("sub_tables")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The sub table names to query data from, separated by comma , "
+                                    + "if not specified, all sub tables will be queried");
+
+    public static final Option<List<String>> READ_COLUMNS =
+            Options.key("read_columns")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The field names to be read from TDengine "
+                                    + "If not specified, all columns will be read. "
+                                    + "This option is useful for selecting specific columns when querying data from TDengine.");
 }

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/sink/TDengineSinkWriter.java
@@ -103,10 +103,13 @@ public class TDengineSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                 conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
             String sql =
                     String.format(
-                            "INSERT INTO %s using %s tags ( %s ) VALUES ( %s );",
+                            "INSERT INTO %s using %s tags ( %s ) %s VALUES ( %s );",
                             element.getField(0),
                             config.getStable(),
                             tagValues,
+                            StringUtils.isEmpty(config.getWriteColumns())
+                                    ? ""
+                                    : "( " + config.getWriteColumns() + " )",
                             StringUtils.join(convertDataType(metrics), ","));
             final int rowCount = statement.executeUpdate(sql);
             if (rowCount == 0) {
@@ -140,6 +143,7 @@ public class TDengineSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                             if (object == null) {
                                 return null;
                             }
+
                             if (LocalDateTime.class.equals(object.getClass())) {
                                 // transform timezone according to the config
                                 return "'"

--- a/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
+++ b/seatunnel-connectors-v2/connector-tdengine/src/main/java/org/apache/seatunnel/connectors/seatunnel/tdengine/source/TDengineSource.java
@@ -36,6 +36,7 @@ import org.apache.seatunnel.connectors.seatunnel.tdengine.typemapper.TDengineTyp
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.taosdata.jdbc.TSDBDriver;
+import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.sql.Connection;
@@ -59,8 +60,7 @@ import static org.apache.seatunnel.connectors.seatunnel.tdengine.utils.TDengineU
  */
 public class TDengineSource
         implements SeaTunnelSource<SeaTunnelRow, TDengineSourceSplit, TDengineSourceState> {
-
-    private final StableMetadata stableMetadata;
+    @Getter private final StableMetadata stableMetadata;
     private final TDengineSourceConfig tdengineSourceConfig;
     private final CatalogTable catalogTable;
 
@@ -137,12 +137,22 @@ public class TDengineSource
                 if (timestampFieldName == null) {
                     timestampFieldName = metaResultSet.getString(1);
                 }
+                if (config.getReadColumns() != null
+                        && !config.getReadColumns().isEmpty()
+                        && !config.getReadColumns().contains(metaResultSet.getString(1))) {
+                    continue;
+                }
                 fieldNames.add(metaResultSet.getString(1));
                 fieldTypes.add(TDengineTypeMapper.mapping(metaResultSet.getString(2)));
             }
 
             while (subTableNameResultSet.next()) {
                 String subTableName = subTableNameResultSet.getString(1);
+                if (config.getSubTables() != null
+                        && !config.getSubTables().isEmpty()
+                        && !config.getSubTables().contains(subTableName)) {
+                    continue;
+                }
                 subTableNames.add(subTableName);
             }
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tdengine-e2e/src/test/resources/tdengine/tdengine_source_to_sink_filter_by_fieldNames.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tdengine-e2e/src/test/resources/tdengine/tdengine_source_to_sink_filter_by_fieldNames.conf
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+      url: "jdbc:TAOS-RS://flink_e2e_tdengine_src:6041/"
+      username: "root"
+      password: "taosdata"
+      database: "power"
+      stable: "meters"
+      lower_bound: "2018-10-03 14:38:05.000"
+      upper_bound: "2018-10-03 14:38:16.801"
+      sub_tables: ["d1001","d1002"]
+      read_columns: ["ts","current","voltage","phase","off","nc","location","groupid"]
+  }
+}
+
+transform {
+}
+
+sink {
+  TDengine {
+    url: "jdbc:TAOS-RS://flink_e2e_tdengine_sink:6041/"
+    username: "root"
+    password: "taosdata"
+    database: "power3"
+    stable: "meters5"
+    timezone: "UTC"
+    write_columns: ["ts","current","voltage","phase","off","nc"]
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request
This pr close https://github.com/apache/seatunnel/issues/9592. It adds two options into source : sub_table and field_names, one option to sink : field_names.


### Does this PR introduce _any_ user-facing change?
Yes. New tdengine connector options are added . Users can specify sub_table and field_name when retrieving data from tdengine; and specify field_name when inserting into tdegnine. However, these are optional. Meaning old tdengine source and sink pipelines are not affected by the change, they still work as expected. 

The documentation is updated in this PR.  

### How to use new options to retreive data
The following pipeline retrieves 3 sub tables of super table signal_data, ignoring the rest. And only selects specified fields.
Please note that the tags should always be the last element of field_names, in our case  it's signal_id. 

```
env {
  execution.parallelism = 1
  job.mode = "BATCH"
}

source {
  TDengine {
    url : "jdbc:TAOS-RS://192.168.1.1:6041/"
    username : "root"
    password : "taosdata"
    database : "signal"
    stable : "signal_data"
    lower_bound : "2024-07-15 00:00:00.000"
    upper_bound : "2025-07-11 00:00:00.000"
    sub_table: "signal_data_342,signal_data_358,signal_data_349"
    field_names = "ts,gateway_id,signal_name,return_value,signal_id"
  }
}

sink {
  LocalFile {
    path = "/mnt/sdc/data/taos/"
    file_format_type = "parquet"
    compress_codec = "snappy"
  }
}
```

### How to use new options on the sink side
```
env {
  execution.parallelism = 2
  job.mode = "BATCH"
}

source {
  LocalFile {
    path = "/work/data/taos_mfrs_signal_data_current/"
    file_format_type = "parquet"
    compress_codec = "snappy"
  }
}


sink {
  TDengine {
    url : "jdbc:TAOS-RS://192.168.1.1:6041/"
    username : "root"
    password : "taosdata"
    database : "signal"
    stable : "signal_data"
    field_names = "ts,gateway_id,signal_name,return_value"
  }
}
```
When specifying field_names on the sink side, please ignore the tag column, "signal_id" in the example. The tdegnine automatically puts the tags column in the insert statement.  Here's an example.
```sql
insert into signal.signal_data_342 
using (signal_data) 
tags ( 1 )
( ts,gateway_id,signal_name,return_value) 
values ("2025-01-01 00:00:00", 1, "name", 0.1)
```

### How was this patch tested?
- Added unit test to cover sub_table and field_name on the source side. Please see TDengineSourceReaderTest.java 
- Added e2e test to cover sub_table and field_name on the source side, field_name on the sink side. Please see TDengine.java 


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)