### PR TITLE
[Improve][Connector-V2] Use key_field_name option when reading Redis hash data

### DIFF
--- a/docs/en/connector-v2/source/Redis.md
+++ b/docs/en/connector-v2/source/Redis.md
@@ -144,7 +144,7 @@ schema {
 
 Specifies the field name to store the Redis key in the output record  when `read_key_enabled = true` or `data_type = hash`.
 
-- When read_key_enabled = true, this option must be set explicitly.
+- When read_key_enabled = true, the default field name will be `key`.
 
 - When data_type = hash and this option is not set, the default field name will be `hash_key`.
 

--- a/docs/en/connector-v2/source/Redis.md
+++ b/docs/en/connector-v2/source/Redis.md
@@ -146,7 +146,7 @@ Specifies the field name to store the Redis key in the output record  when `read
 
 - When read_key_enabled = true, this option must be set explicitly.
 
-- When data_type = hash and this option is not set, the default field name will be hash_key.
+- When data_type = hash and this option is not set, the default field name will be `hash_key`.
 
 This field is useful when the default field name conflicts with existing schema fields, or if a more descriptive name is preferred.
 

--- a/docs/en/connector-v2/source/Redis.md
+++ b/docs/en/connector-v2/source/Redis.md
@@ -142,7 +142,7 @@ schema {
 
 ### key_field_name [string]
 
-Specifies the field name to store the Redis key in the output record  when `read_key_enabled = true`.
+Specifies the field name to store the Redis key in the output record  when `read_key_enabled = true` or `data_type = hash`.
 
 If not set, the default field name `key` will be used.
 

--- a/docs/en/connector-v2/source/Redis.md
+++ b/docs/en/connector-v2/source/Redis.md
@@ -144,9 +144,24 @@ schema {
 
 Specifies the field name to store the Redis key in the output record  when `read_key_enabled = true` or `data_type = hash`.
 
-If not set, the default field name `key` will be used.
+- When read_key_enabled = true, this option must be set explicitly.
 
-This field is useful when the default `key` field name conflicts with existing schema fields, or if a more descriptive name is preferred.
+- When data_type = hash and this option is not set, the default field name will be hash_key.
+
+This field is useful when the default field name conflicts with existing schema fields, or if a more descriptive name is preferred.
+
+Example :
+```hocon
+key_field_name = custom_key
+hash_key_parse_mode = kv
+format = "json"
+schema = {
+  fields {
+      custom_key = string
+      name = string
+  }
+}
+```
 
 ### batch_size [int]
 
@@ -269,6 +284,7 @@ This name is used in the schema to map the value field.
 Example :
 ```hocon
 read_key_enabled = true
+key_field_name = key
 single_field_name = value
 schema {
   fields {

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/client/RedisClusterClient.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/client/RedisClusterClient.java
@@ -79,7 +79,7 @@ public class RedisClusterClient extends RedisClient {
         List<Map<String, String>> result = new ArrayList<>(keys.size());
         for (String key : keys) {
             Map<String, String> map = jedis.hgetAll(key);
-            map.put("hash_key", key);
+            map.put(redisParameters.getKeyFieldName(), key);
             result.add(map);
         }
         return result;

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/client/RedisSingleClient.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/client/RedisSingleClient.java
@@ -115,7 +115,7 @@ public class RedisSingleClient extends RedisClient {
             Response<Map<String, String>> response = responses.get(i);
             Map<String, String> map = response.get();
             if (map != null) {
-                map.put("hash_key", keys.get(i));
+                map.put(redisParameters.getKeyFieldName(), keys.get(i));
             }
             resultList.add(map);
         }

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
@@ -84,8 +84,8 @@ public class RedisParameters implements Serializable {
             this.singleFieldName = config.get(RedisSourceOptions.SINGLE_FIELD_NAME);
         }
         // set key name
-        if(!config.getOptional(RedisSourceOptions.KEY_FIELD_NAME).isPresent()){
-            if(config.get(RedisBaseOptions.DATA_TYPE) == RedisDataType.HASH){
+        if (!config.getOptional(RedisSourceOptions.KEY_FIELD_NAME).isPresent()) {
+            if (config.get(RedisBaseOptions.DATA_TYPE) == RedisDataType.HASH) {
                 this.keyFieldName = "hash_key";
             } else {
                 this.keyFieldName = "key";

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
@@ -84,7 +84,15 @@ public class RedisParameters implements Serializable {
             this.singleFieldName = config.get(RedisSourceOptions.SINGLE_FIELD_NAME);
         }
         // set key name
-        this.keyFieldName = config.get(RedisSourceOptions.KEY_FIELD_NAME);
+        if(!config.getOptional(RedisSourceOptions.KEY_FIELD_NAME).isPresent()){
+            if(config.get(RedisBaseOptions.DATA_TYPE) == RedisDataType.HASH){
+                this.keyFieldName = "hash_key";
+            } else {
+                this.keyFieldName = "key";
+            }
+        } else {
+            this.keyFieldName = config.get(RedisSourceOptions.KEY_FIELD_NAME);
+        }
         // set expire
         this.expire = config.get(RedisSinkOptions.EXPIRE);
         // set auth
@@ -111,9 +119,6 @@ public class RedisParameters implements Serializable {
         }
         // set redis data type verification factory createAndPrepareSource
         this.redisDataType = config.get(RedisBaseOptions.DATA_TYPE);
-        if (this.redisDataType == RedisDataType.HASH && this.keyFieldName == null) {
-            keyFieldName = "hash_key";
-        }
         // Indicates the number of keys to attempt to return per iteration.default 10
         this.batchSize = config.get(RedisBaseOptions.BATCH_SIZE);
         // set support custom key

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisParameters.java
@@ -111,6 +111,9 @@ public class RedisParameters implements Serializable {
         }
         // set redis data type verification factory createAndPrepareSource
         this.redisDataType = config.get(RedisBaseOptions.DATA_TYPE);
+        if (this.redisDataType == RedisDataType.HASH && this.keyFieldName == null) {
+            keyFieldName = "hash_key";
+        }
         // Indicates the number of keys to attempt to return per iteration.default 10
         this.batchSize = config.get(RedisBaseOptions.BATCH_SIZE);
         // set support custom key

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
@@ -51,6 +51,6 @@ public class RedisSourceOptions extends RedisBaseOptions {
     public static final Option<String> KEY_FIELD_NAME =
             Options.key("key_field_name")
                     .stringType()
-                    .defaultValue("key")
+                    .noDefaultValue()
                     .withDescription("Specifies the key field name to be used in the output row");
 }

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
@@ -52,5 +52,5 @@ public class RedisSourceOptions extends RedisBaseOptions {
             Options.key("key_field_name")
                     .stringType()
                     .defaultValue("key")
-                    .withDescription("The value of key you want to write to redis.");
+                    .withDescription("Specifies the key field name to be used in the output row");
 }

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/config/RedisSourceOptions.java
@@ -52,5 +52,5 @@ public class RedisSourceOptions extends RedisBaseOptions {
             Options.key("key_field_name")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("Specifies the key field name to be used in the output row");
+                    .withDescription("Specifies the key field name to be used in the output row.");
 }

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/source/RedisSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/source/RedisSourceFactory.java
@@ -70,8 +70,7 @@ public class RedisSourceFactory implements TableSourceFactory {
                 .conditional(
                         RedisSourceOptions.READ_KEY_ENABLED,
                         true,
-                        RedisSourceOptions.SINGLE_FIELD_NAME,
-                        RedisSourceOptions.KEY_FIELD_NAME)
+                        RedisSourceOptions.SINGLE_FIELD_NAME)
                 .bundled(RedisBaseOptions.FORMAT, SinkConnectorCommonOptions.SCHEMA)
                 .build();
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
@@ -448,6 +448,7 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
 
         for (int i = 0; i < 100; i++) {
             Map<String, String> map = jedis.hgetAll("key-test-check:" + hashKeyPrefix + i);
+            Assertions.assertEquals(2, map.size());
         }
 
         for (int i = 0; i < 100; i++) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
@@ -434,7 +434,18 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
     }
 
     @TestTemplate
+    public void testScanHashTypeWriteRedisWithDefaultKey(TestContainer container)
+            throws IOException, InterruptedException {
+        testScanHashTypeWithKey(container, "/scan-hash-to-redis-with-default-key.conf");
+    }
+
+    @TestTemplate
     public void testScanHashTypeWriteRedisWithKey(TestContainer container)
+            throws IOException, InterruptedException {
+        testScanHashTypeWithKey(container, "/scan-hash-to-redis-with-key.conf");
+    }
+
+    private void testScanHashTypeWithKey(TestContainer container, String confFile)
             throws IOException, InterruptedException {
         String hashKeyPrefix = "key-test-hash";
         for (int i = 0; i < 100; i++) {
@@ -443,7 +454,7 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
             map.put("name", "dybyte");
             jedis.hset(setKey, map);
         }
-        Container.ExecResult execResult = container.executeJob("/scan-hash-to-redis-with-key.conf");
+        Container.ExecResult execResult = container.executeJob(confFile);
         Assertions.assertEquals(0, execResult.getExitCode());
 
         for (int i = 0; i < 100; i++) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
@@ -434,6 +434,32 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
     }
 
     @TestTemplate
+    public void testScanHashTypeWriteRedisWithKey(TestContainer container)
+            throws IOException, InterruptedException {
+        String hashKeyPrefix = "key-test-hash";
+        for (int i = 0; i < 100; i++) {
+            String setKey = hashKeyPrefix + i;
+            Map<String, String> map = new HashMap<>();
+            map.put("name", "dybyte");
+            jedis.hset(setKey, map);
+        }
+        Container.ExecResult execResult = container.executeJob("/scan-hash-to-redis-with-key.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        for (int i = 0; i < 100; i++) {
+            Map<String, String> map = jedis.hgetAll("key-test-check:" + hashKeyPrefix + i);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            String hashKey = hashKeyPrefix + i;
+            jedis.del(hashKey);
+        }
+        for (int i = 0; i < 100; i++) {
+            jedis.del("key-test-check:" + hashKeyPrefix + i);
+        }
+    }
+
+    @TestTemplate
     public void testScanZsetTypeWriteRedisWithKey(TestContainer container)
             throws IOException, InterruptedException {
         String zSetKeyPrefix = "key-test-zset";
@@ -471,7 +497,7 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
             Assertions.assertTrue(jedis.exists("redis-key-check:" + "key_test" + i));
         }
         for (int i = 0; i < 100; i++) {
-            jedis.del("redis-key-check:" + i);
+            jedis.del("redis-key-check:" + "key_test" + i);
         }
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/scan-hash-to-redis-with-default-key.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/scan-hash-to-redis-with-default-key.conf
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  shade.identifier = "base64"
+
+  #spark config
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key-test-hash*"
+    data_type = hash
+    batch_size = 33
+    hash_key_parse_mode = kv
+    format = "json"
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "hash_key"
+          type = "string"
+        },
+        {
+          name = "name"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "key-test-check:{hash_key}"
+    support_custom_key = true
+    data_type = hash
+    batch_size = 33
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/scan-hash-to-redis-with-key.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/scan-hash-to-redis-with-key.conf
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  shade.identifier = "base64"
+
+  #spark config
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key-test-hash*"
+    data_type = hash
+    batch_size = 33
+    key_field_name = custom_key
+    hash_key_parse_mode = kv
+    format = "json"
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "custom_key"
+          type = "string"
+        },
+        {
+          name = "name"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "key-test-check:{custom_key}"
+    support_custom_key = true
+    data_type = hash
+    batch_size = 33
+  }
+}


### PR DESCRIPTION

### Purpose of this pull request

This PR enables customizing the key field name when reading Redis hash data types. By default, the key is read and stored under "hash_key", but now users can specify a custom field name via key_field_name.

### Question

I have a question about the consistency of the current behavior regarding key_field_name and read_key_enabled when reading Redis data.

For the hash data type, the key is always read by default — even without setting read_key_enabled = true. The key is included as a field named "hash_key".
However, for other Redis data types, the key is not read unless read_key_enabled is explicitly set to true.

In this PR, I made it possible to customize the key field name using key_field_name when reading the hash type — even without setting read_key_enabled.
But I’m concerned this might introduce inconsistency, since the behavior for other types still depends on the read_key_enabled flag.

Should we:

1. Align all types to require read_key_enabled = true before reading the key, or

2. Keep the current behavior as-is, where hash types always read the key by default?

I'd appreciate your thoughts on whether this default behavior should be unified or if it's acceptable for hash types to remain an exception.


### Does this PR introduce _any_ user-facing change?

This PR allows users to specify the name of the field that stores the Redis key when reading hash data types via the key_field_name option.

### How was this patch tested?

A test was added that reads the key from Redis hash data using a custom field name and verifies that the key is correctly utilized on the sink side.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)