### PR TITLE
[improve]improve FE node failover logging for better observability

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -140,6 +140,11 @@ public class DorisSinkWriter
                         "stream load error for feNode: {} with exception: {}",
                         feNodes.get(i),
                         e.getMessage());
+                if (i < feNodesNum - 1) {
+                    log.info("Trying next FE node: {}", feNodes.get(i+1));
+                } else {
+                    log.error("All {} FE nodes failed, no more nodes to try", feNodesNum);
+                }
             }
         }
 

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -120,6 +120,9 @@ public class DorisSinkWriter
 
         for (int i = 0; i < feNodesNum; i++) {
             try {
+                if (i > 0) {
+                    log.info("Trying next FE node: {}", feNodes.get(i));
+                }
                 this.dorisStreamLoad =
                         new DorisStreamLoad(
                                 feNodes.get(i),
@@ -133,6 +136,7 @@ public class DorisSinkWriter
                 break;
             } catch (Exception e) {
                 if (i == feNodesNum - 1) {
+                    log.error("All {} FE nodes failed, no more nodes to try", feNodesNum);
                     throw new DorisConnectorException(
                             DorisConnectorErrorCode.STREAM_LOAD_FAILED, e);
                 }
@@ -140,11 +144,6 @@ public class DorisSinkWriter
                         "stream load error for feNode: {} with exception: {}",
                         feNodes.get(i),
                         e.getMessage());
-                if (i < feNodesNum - 1) {
-                    log.info("Trying next FE node: {}", feNodes.get(i+1));
-                } else {
-                    log.error("All {} FE nodes failed, no more nodes to try", feNodesNum);
-                }
             }
         }
 

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -120,9 +120,7 @@ public class DorisSinkWriter
 
         for (int i = 0; i < feNodesNum; i++) {
             try {
-                if (i > 0) {
-                    log.info("Trying next FE node: {}", feNodes.get(i));
-                }
+                log.info("Trying FE node {}  for stream load.", feNodes.get(i));
                 this.dorisStreamLoad =
                         new DorisStreamLoad(
                                 feNodes.get(i),


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
This pull request improves the FE node failover logging in Doris connector to enhance observability during connection failures. When multiple FE nodes are configured, the system now provides clear progress information when trying each node and explicit error messages when all nodes are exhausted.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

Yes, this PR introduces user-facing changes in logging output:

**Before:**
```
stream load error for feNode: node1:8030 with exception: Connection refused
stream load error for feNode: node2:8030 with exception: Connection refused
DorisConnectorException: STREAM_LOAD_FAILED
```

**After:**
```
stream load error for feNode: node1:8030 with exception: Connection refused
Trying next FE node: node2:8030
stream load error for feNode: node2:8030 with exception: Connection refused
All 2 FE nodes failed, no more nodes to try
DorisConnectorException: STREAM_LOAD_FAILED
```

This change improves operational visibility by:
1. Showing which specific node will be tried next
2. Providing clear summary when all nodes are exhausted
3. Making the failover process more transparent for troubleshooting

The functionality and APIs remain unchanged.
