### PR TITLE
[fix][connectors-v2] repeated commit cause task exceptions

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/handler/PaimonSaveModeHandler.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/handler/PaimonSaveModeHandler.java
@@ -53,6 +53,9 @@ public class PaimonSaveModeHandler extends DefaultSaveModeHandler {
         TablePath tablePath = catalogTable.getTablePath();
         Table paimonTable = ((PaimonCatalog) catalog).getPaimonTable(tablePath);
         // load paimon table and set it into paimon sink
-        this.supportLoadTable.setLoadTable(paimonTable);
+        Table loadTable = this.supportLoadTable.getLoadTable();
+        if (loadTable == null || this.schemaSaveMode == SchemaSaveMode.RECREATE_SCHEMA) {
+            this.supportLoadTable.setLoadTable(paimonTable);
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public class PaimonSink
         implements SeaTunnelSink<
@@ -78,6 +79,8 @@ public class PaimonSink
     private final PaimonHadoopConfiguration paimonHadoopConfiguration;
 
     private final PaimonBucketAssignerFactory paimonBucketAssignerFactory;
+
+    private final String commitUser = UUID.randomUUID().toString();
 
     public PaimonSink(ReadonlyConfig readonlyConfig, CatalogTable catalogTable) {
         this.readonlyConfig = readonlyConfig;
@@ -111,6 +114,7 @@ public class PaimonSink
                 readonlyConfig,
                 catalogTable,
                 paimonTable,
+                commitUser,
                 jobContext,
                 paimonSinkConfig,
                 paimonHadoopConfiguration,
@@ -120,7 +124,8 @@ public class PaimonSink
     @Override
     public Optional<SinkAggregatedCommitter<PaimonCommitInfo, PaimonAggregatedCommitInfo>>
             createAggregatedCommitter() throws IOException {
-        return Optional.of(new PaimonAggregatedCommitter(paimonTable, paimonHadoopConfiguration));
+        return Optional.of(
+                new PaimonAggregatedCommitter(paimonTable, paimonHadoopConfiguration, commitUser));
     }
 
     @Override
@@ -131,6 +136,7 @@ public class PaimonSink
                 readonlyConfig,
                 catalogTable,
                 paimonTable,
+                commitUser,
                 states,
                 jobContext,
                 paimonSinkConfig,

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.api.sink.SupportMultiTableSink;
 import org.apache.seatunnel.api.sink.SupportSaveMode;
 import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.schema.SchemaChangeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.connectors.seatunnel.paimon.catalog.PaimonCatalog;
@@ -84,6 +85,18 @@ public class PaimonSink
         this.catalogTable = catalogTable;
         this.paimonHadoopConfiguration = PaimonSecurityContext.loadHadoopConfig(paimonSinkConfig);
         this.paimonBucketAssignerFactory = new PaimonBucketAssignerFactory();
+        try (PaimonCatalog paimonCatalog = PaimonCatalog.loadPaimonCatalog(readonlyConfig)) {
+            paimonCatalog.open();
+            boolean databaseExists =
+                    paimonCatalog.databaseExists(this.paimonSinkConfig.getNamespace());
+            if (databaseExists) {
+                TablePath tablePath = catalogTable.getTablePath();
+                boolean tableExists = paimonCatalog.tableExists(tablePath);
+                if (tableExists) {
+                    this.paimonTable = paimonCatalog.getPaimonTable(tablePath);
+                }
+            }
+        }
     }
 
     @Override
@@ -156,6 +169,11 @@ public class PaimonSink
     @Override
     public void setLoadTable(Table table) {
         this.paimonTable = table;
+    }
+
+    @Override
+    public Table getLoadTable() {
+        return paimonTable;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSink.java
@@ -124,8 +124,7 @@ public class PaimonSink
     @Override
     public Optional<SinkAggregatedCommitter<PaimonCommitInfo, PaimonAggregatedCommitInfo>>
             createAggregatedCommitter() throws IOException {
-        return Optional.of(
-                new PaimonAggregatedCommitter(paimonTable, paimonHadoopConfiguration, commitUser));
+        return Optional.of(new PaimonAggregatedCommitter(paimonTable, paimonHadoopConfiguration));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -299,7 +299,7 @@ public class PaimonSinkWriter
                 bucketAssigners.clear();
                 assigners.forEach(assigner -> assigner.prepareCommit(checkpointId));
             }
-            return Optional.of(new PaimonCommitInfo(fileCommittables, checkpointId));
+            return Optional.of(new PaimonCommitInfo(fileCommittables, checkpointId, commitUser));
         } catch (Exception e) {
             throw new PaimonConnectorException(
                     PaimonConnectorErrorCode.TABLE_PRE_COMMIT_FAILED,

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -204,7 +204,7 @@ public class PaimonSinkWriter
                             .collect(
                                     Collectors.toMap(
                                             PaimonSinkState::getCheckpointId,
-                                            PaimonSinkState::getCommittables));
+                                            PaimonSinkState::getCommitTables));
             // batch mode without checkpoint has no state to commit
             if (commitMessagesMap.isEmpty()) {
                 return;

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -54,11 +54,9 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
-import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
-import org.apache.paimon.table.sink.TableCommit;
+import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.sink.TableWrite;
-import org.apache.paimon.table.sink.WriteBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -71,8 +69,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.disk.IOManagerImpl.splitPaths;
@@ -83,11 +79,9 @@ public class PaimonSinkWriter
                 SupportMultiTableSinkWriter<Void>,
                 SupportSchemaEvolutionSinkWriter {
 
-    private String commitUser = UUID.randomUUID().toString();
+    private final String commitUser;
 
-    private FileStoreTable paimonFileStoretable;
-
-    private WriteBuilder tableWriteBuilder;
+    private FileStoreTable paimonTable;
 
     private TableWrite tableWrite;
 
@@ -126,7 +120,8 @@ public class PaimonSinkWriter
             Context context,
             ReadonlyConfig readonlyConfig,
             CatalogTable catalogTable,
-            Table paimonTable,
+            Table paimonFileStoretable,
+            String commitUser,
             JobContext jobContext,
             PaimonSinkConfig paimonSinkConfig,
             PaimonHadoopConfiguration paimonHadoopConfiguration,
@@ -137,9 +132,10 @@ public class PaimonSinkWriter
         this.paimonTablePath = catalogTable.getTablePath();
         this.paimonCatalog = PaimonCatalog.loadPaimonCatalog(readonlyConfig);
         this.paimonCatalog.open();
-        this.paimonFileStoretable = (FileStoreTable) paimonTable;
+        this.paimonTable = (FileStoreTable) paimonFileStoretable;
+        this.commitUser = commitUser;
         CoreOptions.ChangelogProducer changelogProducer =
-                this.paimonFileStoretable.coreOptions().changelogProducer();
+                this.paimonTable.coreOptions().changelogProducer();
         if (Objects.nonNull(paimonSinkConfig.getChangelogProducer())
                 && changelogProducer != paimonSinkConfig.getChangelogProducer()) {
             log.warn(
@@ -147,15 +143,15 @@ public class PaimonSinkWriter
         }
         this.rowAssignerChannelComputer =
                 new RowAssignerChannelComputer(
-                        paimonFileStoretable.schema(), context.getNumberOfParallelSubtasks());
+                        paimonTable.schema(), context.getNumberOfParallelSubtasks());
         rowAssignerChannelComputer.setup(context.getNumberOfParallelSubtasks());
         this.paimonBucketAssignerFactory = paimonBucketAssignerFactory;
         this.parallelism = context.getNumberOfParallelSubtasks();
         this.taskIndex = context.getIndexOfSubtask();
         this.paimonSinkConfig = paimonSinkConfig;
-        this.sinkPaimonTableSchema = this.paimonFileStoretable.schema();
+        this.sinkPaimonTableSchema = this.paimonTable.schema();
         this.newTableWrite();
-        BucketMode bucketMode = this.paimonFileStoretable.bucketMode();
+        BucketMode bucketMode = this.paimonTable.bucketMode();
         // https://paimon.apache.org/docs/master/primary-key-table/data-distribution/#dynamic-bucket
         // When you need cross partition upsert (primary keys not contain all partition fields),
         // Dynamic Bucket mode directly maintains the mapping of keys to partition and bucket, uses
@@ -168,7 +164,7 @@ public class PaimonSinkWriter
                     "Cross Partitions Upsert Dynamic Bucket Mode is not supported.");
         }
         this.dynamicBucket = BucketMode.HASH_DYNAMIC == bucketMode;
-        int bucket = ((FileStoreTable) paimonTable).coreOptions().bucket();
+        int bucket = paimonTable.coreOptions().bucket();
         if (bucket == -1 && BucketMode.BUCKET_UNAWARE == bucketMode) {
             log.warn("Append only table currently do not support dynamic bucket");
         }
@@ -183,6 +179,7 @@ public class PaimonSinkWriter
             ReadonlyConfig readonlyConfig,
             CatalogTable catalogTable,
             Table paimonFileStoretable,
+            String commitUser,
             List<PaimonSinkState> states,
             JobContext jobContext,
             PaimonSinkConfig paimonSinkConfig,
@@ -193,6 +190,7 @@ public class PaimonSinkWriter
                 readonlyConfig,
                 catalogTable,
                 paimonFileStoretable,
+                commitUser,
                 jobContext,
                 paimonSinkConfig,
                 paimonHadoopConfiguration,
@@ -200,8 +198,7 @@ public class PaimonSinkWriter
         if (Objects.isNull(states) || states.isEmpty()) {
             return;
         }
-        this.commitUser = states.get(0).getCommitUser();
-        try (TableCommit tableCommit = tableWriteBuilder.newCommit()) {
+        try (TableCommitImpl tableCommit = paimonTable.newCommit(states.get(0).getCommitUser())) {
             Map<Long, List<CommitMessage>> commitMessagesMap =
                     states.stream()
                             .collect(
@@ -214,19 +211,10 @@ public class PaimonSinkWriter
             }
             // streaming mode or batch mode with checkpoint need to recommit by stream api
             log.info("Trying to recommit states {}", commitMessagesMap);
-            ((StreamTableCommit) tableCommit).filterAndCommit(commitMessagesMap);
+            tableCommit.filterAndCommit(commitMessagesMap);
         } catch (Exception e) {
-            if (!(e.getCause() instanceof IllegalStateException)) {
-                throw new PaimonConnectorException(
-                        PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
-            }
-            Pattern pattern =
-                    Pattern.compile("Trying to add file .*? which is already added\\.\\s*");
-            if (!pattern.matcher(e.getCause().getMessage()).matches()) {
-                throw new PaimonConnectorException(
-                        PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
-            }
-            log.warn("commit message already added, skip it.");
+            throw new PaimonConnectorException(
+                    PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
         }
     }
 
@@ -279,21 +267,20 @@ public class PaimonSinkWriter
 
     private void reOpenTableWrite() {
         this.seaTunnelRowType = this.sourceTableSchema.toPhysicalRowDataType();
-        this.paimonFileStoretable = (FileStoreTable) paimonCatalog.getPaimonTable(paimonTablePath);
-        this.sinkPaimonTableSchema = this.paimonFileStoretable.schema();
+        this.paimonTable = (FileStoreTable) paimonCatalog.getPaimonTable(paimonTablePath);
+        this.sinkPaimonTableSchema = this.paimonTable.schema();
         this.newTableWrite();
     }
 
     private void newTableWrite() {
-        this.tableWriteBuilder = this.paimonFileStoretable.newStreamWriteBuilder();
         TableWrite oldTableWrite = this.tableWrite;
+        tableWriteClose(oldTableWrite);
         this.tableWrite =
-                tableWriteBuilder
-                        .newWrite()
+                this.paimonTable
+                        .newWrite(commitUser)
                         .withIOManager(
                                 IOManager.create(
                                         splitPaths(paimonSinkConfig.getChangelogTmpPath())));
-        tableWriteClose(oldTableWrite);
     }
 
     @Override
@@ -361,7 +348,7 @@ public class PaimonSinkWriter
         if (JobMode.BATCH.equals(jobContext.getJobMode())) {
             return true;
         }
-        CoreOptions coreOptions = this.paimonFileStoretable.coreOptions();
+        CoreOptions coreOptions = this.paimonTable.coreOptions();
         if (coreOptions.writeOnly()) {
             return false;
         }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java
@@ -67,10 +67,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.disk.IOManagerImpl.splitPaths;
@@ -199,23 +201,32 @@ public class PaimonSinkWriter
             return;
         }
         this.commitUser = states.get(0).getCommitUser();
-        long checkpointId = states.get(0).getCheckpointId();
         try (TableCommit tableCommit = tableWriteBuilder.newCommit()) {
-            List<CommitMessage> commitables =
+            Map<Long, List<CommitMessage>> commitMessagesMap =
                     states.stream()
-                            .map(PaimonSinkState::getCommittables)
-                            .flatMap(List::stream)
-                            .collect(Collectors.toList());
+                            .collect(
+                                    Collectors.toMap(
+                                            PaimonSinkState::getCheckpointId,
+                                            PaimonSinkState::getCommittables));
             // batch mode without checkpoint has no state to commit
-            if (commitables.isEmpty()) {
+            if (commitMessagesMap.isEmpty()) {
                 return;
             }
             // streaming mode or batch mode with checkpoint need to recommit by stream api
-            log.info("Trying to recommit states {}", commitables);
-            ((StreamTableCommit) tableCommit).commit(checkpointId, commitables);
+            log.info("Trying to recommit states {}", commitMessagesMap);
+            ((StreamTableCommit) tableCommit).filterAndCommit(commitMessagesMap);
         } catch (Exception e) {
-            throw new PaimonConnectorException(
-                    PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
+            if (!(e.getCause() instanceof IllegalStateException)) {
+                throw new PaimonConnectorException(
+                        PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
+            }
+            Pattern pattern =
+                    Pattern.compile("Trying to add file .*? which is already added\\.\\s*");
+            if (!pattern.matcher(e.getCause().getMessage()).matches()) {
+                throw new PaimonConnectorException(
+                        PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
+            }
+            log.warn("commit message already added, skip it.");
         }
     }
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/SupportLoadTable.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/SupportLoadTable.java
@@ -19,4 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.sink;
 
 public interface SupportLoadTable<T> {
     void setLoadTable(T table);
+
+    T getLoadTable();
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitInfo.java
@@ -35,4 +35,6 @@ public class PaimonAggregatedCommitInfo implements Serializable {
 
     // key: checkpointId value: Paimon commit message List
     private Map<Long, List<CommitMessage>> committablesMap;
+
+    private String commitUser;
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
@@ -127,7 +127,7 @@ public class PaimonAggregatedCommitter
                                                 Collectors.toMap(
                                                         Map.Entry::getKey, Map.Entry::getValue));
                         if (!committablesMap.isEmpty()) {
-                            committablesMap.forEach(tableCommit::commit);
+                            committablesMap.values().forEach(tableCommit::abort);
                         }
                         return null;
                     });

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
@@ -27,7 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.paimon.security.PaimonSecurityC
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
-import org.apache.paimon.table.sink.TableCommit;
 import org.apache.paimon.table.sink.TableCommitImpl;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,18 +49,69 @@ public class PaimonAggregatedCommitter
 
     private final FileStoreTable table;
 
-    private final String commitUser;
-
     public PaimonAggregatedCommitter(
-            Table table, PaimonHadoopConfiguration paimonHadoopConfiguration, String commitUser) {
+            Table table, PaimonHadoopConfiguration paimonHadoopConfiguration) {
         this.table = (FileStoreTable) table;
-        this.commitUser = commitUser;
         PaimonSecurityContext.shouldEnableKerberos(paimonHadoopConfiguration);
     }
 
     @Override
     public List<PaimonAggregatedCommitInfo> commit(
             List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws IOException {
+        aggregatedCommitInfo.stream()
+                .collect(Collectors.groupingBy(PaimonAggregatedCommitInfo::getCommitUser))
+                .forEach(this::commit);
+        return Collections.emptyList();
+    }
+
+    private void commit(String commitUser, List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) {
+        try (TableCommitImpl tableCommit = table.newCommit(commitUser)) {
+            PaimonSecurityContext.runSecured(
+                    () -> {
+                        log.debug("Trying to commit states streaming mode");
+                        Map<Long, List<CommitMessage>> committablesMap =
+                                aggregatedCommitInfo.stream()
+                                        .flatMap(
+                                                paimonAggregatedCommitInfo ->
+                                                        paimonAggregatedCommitInfo
+                                                                .getCommittablesMap().entrySet()
+                                                                .stream())
+                                        .collect(
+                                                Collectors.toMap(
+                                                        Map.Entry::getKey, Map.Entry::getValue));
+                        if (!committablesMap.isEmpty()) {
+                            tableCommit.filterAndCommit(committablesMap);
+                        }
+                        return null;
+                    });
+        } catch (Exception e) {
+            throw new PaimonConnectorException(
+                    PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
+        }
+    }
+
+    @Override
+    public PaimonAggregatedCommitInfo combine(List<PaimonCommitInfo> commitInfos) {
+        String commitUser = commitInfos.get(0).getCommitUser();
+        Map<Long, List<CommitMessage>> commitTables = new HashMap<>();
+        commitInfos.forEach(
+                commitInfo ->
+                        commitTables
+                                .computeIfAbsent(
+                                        commitInfo.getCheckpointId(),
+                                        id -> new CopyOnWriteArrayList<>())
+                                .addAll(commitInfo.getCommittables()));
+        return new PaimonAggregatedCommitInfo(commitTables, commitUser);
+    }
+
+    @Override
+    public void abort(List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws Exception {
+        aggregatedCommitInfo.stream()
+                .collect(Collectors.groupingBy(PaimonAggregatedCommitInfo::getCommitUser))
+                .forEach(this::abort);
+    }
+
+    private void abort(String commitUser, List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) {
         try (TableCommitImpl tableCommit = table.newCommit(commitUser)) {
             PaimonSecurityContext.runSecured(
                     () -> {
@@ -84,43 +134,6 @@ public class PaimonAggregatedCommitter
         } catch (Exception e) {
             throw new PaimonConnectorException(
                     PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
-        }
-        return Collections.emptyList();
-    }
-
-    @Override
-    public PaimonAggregatedCommitInfo combine(List<PaimonCommitInfo> commitInfos) {
-        Map<Long, List<CommitMessage>> committables = new HashMap<>();
-        commitInfos.forEach(
-                commitInfo ->
-                        committables
-                                .computeIfAbsent(
-                                        commitInfo.getCheckpointId(),
-                                        id -> new CopyOnWriteArrayList<>())
-                                .addAll(commitInfo.getCommittables()));
-        return new PaimonAggregatedCommitInfo(committables);
-    }
-
-    @Override
-    public void abort(List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws Exception {
-        try (TableCommit tableCommit = table.newCommit(commitUser)) {
-            PaimonSecurityContext.runSecured(
-                    () -> {
-                        log.debug("Trying to abort states streaming mode");
-                        List<CommitMessage> commitMessageList =
-                                aggregatedCommitInfo.stream()
-                                        .flatMap(
-                                                paimonAggregatedCommitInfo ->
-                                                        paimonAggregatedCommitInfo
-                                                                .getCommittablesMap().values()
-                                                                .stream())
-                                        .flatMap(List::stream)
-                                        .collect(Collectors.toList());
-                        if (!commitMessageList.isEmpty()) {
-                            tableCommit.abort(commitMessageList);
-                        }
-                        return null;
-                    });
         }
     }
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /** Paimon connector aggregated committer class */
 @Slf4j
@@ -62,22 +63,24 @@ public class PaimonAggregatedCommitter
             PaimonSecurityContext.runSecured(
                     () -> {
                         log.debug("Trying to commit states streaming mode");
-                        aggregatedCommitInfo.stream()
-                                .flatMap(
-                                        paimonAggregatedCommitInfo ->
-                                                paimonAggregatedCommitInfo.getCommittablesMap()
-                                                        .entrySet().stream())
-                                .forEach(
-                                        entry ->
-                                                ((StreamTableCommit) tableCommit)
-                                                        .commit(entry.getKey(), entry.getValue()));
+                        Map<Long, List<CommitMessage>> committablesMap =
+                                aggregatedCommitInfo.stream()
+                                        .flatMap(
+                                                paimonAggregatedCommitInfo ->
+                                                        paimonAggregatedCommitInfo
+                                                                .getCommittablesMap().entrySet()
+                                                                .stream())
+                                        .collect(
+                                                Collectors.toMap(
+                                                        Map.Entry::getKey, Map.Entry::getValue));
+                        if (!committablesMap.isEmpty()) {
+                            ((StreamTableCommit) tableCommit).filterAndCommit(committablesMap);
+                        }
                         return null;
                     });
         } catch (Exception e) {
             throw new PaimonConnectorException(
-                    PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED,
-                    "Paimon table storage write-commit Failed.",
-                    e);
+                    PaimonConnectorErrorCode.TABLE_WRITE_COMMIT_FAILED, e);
         }
         return Collections.emptyList();
     }
@@ -97,7 +100,25 @@ public class PaimonAggregatedCommitter
 
     @Override
     public void abort(List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws Exception {
-        // TODO find the right way to abort
+        try (TableCommit tableCommit = tableWriteBuilder.newCommit()) {
+            PaimonSecurityContext.runSecured(
+                    () -> {
+                        log.debug("Trying to abort states streaming mode");
+                        List<CommitMessage> commitMessageList =
+                                aggregatedCommitInfo.stream()
+                                        .flatMap(
+                                                paimonAggregatedCommitInfo ->
+                                                        paimonAggregatedCommitInfo
+                                                                .getCommittablesMap().values()
+                                                                .stream())
+                                        .flatMap(List::stream)
+                                        .collect(Collectors.toList());
+                        if (!commitMessageList.isEmpty()) {
+                            tableCommit.abort(commitMessageList);
+                        }
+                        return null;
+                    });
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonAggregatedCommitter.java
@@ -24,11 +24,11 @@ import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnecto
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.paimon.security.PaimonSecurityContext;
 
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
-import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.TableCommit;
-import org.apache.paimon.table.sink.WriteBuilder;
+import org.apache.paimon.table.sink.TableCommitImpl;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,18 +48,21 @@ public class PaimonAggregatedCommitter
 
     private static final long serialVersionUID = 1L;
 
-    private final WriteBuilder tableWriteBuilder;
+    private final FileStoreTable table;
+
+    private final String commitUser;
 
     public PaimonAggregatedCommitter(
-            Table table, PaimonHadoopConfiguration paimonHadoopConfiguration) {
-        this.tableWriteBuilder = table.newStreamWriteBuilder();
+            Table table, PaimonHadoopConfiguration paimonHadoopConfiguration, String commitUser) {
+        this.table = (FileStoreTable) table;
+        this.commitUser = commitUser;
         PaimonSecurityContext.shouldEnableKerberos(paimonHadoopConfiguration);
     }
 
     @Override
     public List<PaimonAggregatedCommitInfo> commit(
             List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws IOException {
-        try (TableCommit tableCommit = tableWriteBuilder.newCommit()) {
+        try (TableCommitImpl tableCommit = table.newCommit(commitUser)) {
             PaimonSecurityContext.runSecured(
                     () -> {
                         log.debug("Trying to commit states streaming mode");
@@ -74,7 +77,7 @@ public class PaimonAggregatedCommitter
                                                 Collectors.toMap(
                                                         Map.Entry::getKey, Map.Entry::getValue));
                         if (!committablesMap.isEmpty()) {
-                            ((StreamTableCommit) tableCommit).filterAndCommit(committablesMap);
+                            committablesMap.forEach(tableCommit::commit);
                         }
                         return null;
                     });
@@ -100,7 +103,7 @@ public class PaimonAggregatedCommitter
 
     @Override
     public void abort(List<PaimonAggregatedCommitInfo> aggregatedCommitInfo) throws Exception {
-        try (TableCommit tableCommit = tableWriteBuilder.newCommit()) {
+        try (TableCommit tableCommit = table.newCommit(commitUser)) {
             PaimonSecurityContext.runSecured(
                     () -> {
                         log.debug("Trying to abort states streaming mode");

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/commit/PaimonCommitInfo.java
@@ -34,4 +34,6 @@ public class PaimonCommitInfo implements Serializable {
     List<CommitMessage> committables;
 
     Long checkpointId;
+
+    String commitUser;
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/state/PaimonSinkState.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/state/PaimonSinkState.java
@@ -32,7 +32,7 @@ public class PaimonSinkState implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private List<CommitMessage> committables;
+    private List<CommitMessage> commitTables;
 
     private String commitUser;
 

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class PaimonWriteTest {
 
@@ -58,6 +59,7 @@ public class PaimonWriteTest {
     private PaimonSinkWriter paimonSinkWriter;
     private ReadonlyConfig readonlyConfig;
     private SinkWriter.Context context;
+    private final String commitUser = UUID.randomUUID().toString();
 
     @BeforeEach
     public void before() {
@@ -237,6 +239,7 @@ public class PaimonWriteTest {
                         readonlyConfig,
                         paimonCatalog.getTable(tablePath),
                         paimonCatalog.getPaimonTable(tablePath),
+                        commitUser,
                         jobContext,
                         new PaimonSinkConfig(readonlyConfig),
                         new PaimonHadoopConfiguration(),
@@ -250,6 +253,7 @@ public class PaimonWriteTest {
                         readonlyConfig,
                         paimonCatalog.getTable(tablePath),
                         paimonCatalog.getPaimonTable(tablePath),
+                        commitUser,
                         jobContext,
                         new PaimonSinkConfig(readonlyConfig),
                         new PaimonHadoopConfiguration(),
@@ -271,6 +275,7 @@ public class PaimonWriteTest {
                         readonlyConfig,
                         paimonCatalog.getTable(tablePath),
                         paimonCatalog.getPaimonTable(tablePath),
+                        commitUser,
                         jobContext,
                         new PaimonSinkConfig(readonlyConfig),
                         new PaimonHadoopConfiguration(),
@@ -285,6 +290,7 @@ public class PaimonWriteTest {
                         readonlyConfig,
                         paimonCatalog.getTable(tablePath),
                         paimonCatalog.getPaimonTable(tablePath),
+                        commitUser,
                         jobContext,
                         new PaimonSinkConfig(readonlyConfig),
                         new PaimonHadoopConfiguration(),

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
@@ -33,6 +33,7 @@ import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
@@ -153,20 +154,21 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
     }
 
     @TestTemplate
-    public void testMysqlCdcSinkPaimonWithSchemaChange(TestContainer container) throws Exception {
+    public void testMysqlCdcSinkPaimonWithSchemaChangeAndRestore(TestContainer container)
+            throws Exception {
+        String jobId = String.valueOf(JobIdGenerator.newJobId());
         String jobConfigFile = "/mysql_cdc_to_paimon_with_schema_change.conf";
         CompletableFuture.runAsync(
                 () -> {
                     try {
-                        container.executeJob(jobConfigFile);
+                        container.executeJob(jobConfigFile, jobId);
                     } catch (Exception e) {
                         log.error("Commit task exception :" + e.getMessage());
                         throw new RuntimeException(e);
                     }
                 });
 
-        // Waiting for auto create sink table
-        Thread.sleep(15000);
+        vertifyJobStatus(container, jobId);
 
         await().atMost(30, TimeUnit.SECONDS)
                 .untilAsserted(
@@ -183,6 +185,21 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection1 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase1();
         vertifySchemaAndData(container, idRangesWithFiledProjection1);
+
+        // savepoint job
+        Container.ExecResult execResult = container.savepointJob(jobId);
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+        // restore job
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        container.restoreJob(jobConfigFile, jobId);
+                    } catch (Exception e) {
+                        log.error("Commit task exception :" + e.getMessage());
+                        throw new RuntimeException(e);
+                    }
+                });
+        vertifyJobStatus(container, jobId);
 
         // Case 2: Drop columns with data at same time
         shopDatabase.setTemplateName("drop_columns").createAndInitialize();
@@ -201,6 +218,16 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection4 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase4();
         vertifySchemaAndData(container, idRangesWithFiledProjection4);
+    }
+
+    private void vertifyJobStatus(TestContainer container, String jobId) {
+        await().pollDelay(30, TimeUnit.SECONDS)
+                .atMost(45, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            String jobStatus = container.getJobStatus(jobId);
+                            Assertions.assertEquals("RUNNING", jobStatus);
+                        });
     }
 
     private List<ImmutableTriple<String[], Integer, Integer>>
@@ -331,8 +358,8 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
     private void vertifySchemaAndData(
             TestContainer container,
             List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection) {
-        await().pollDelay(3, TimeUnit.SECONDS)
-                .atMost(30, TimeUnit.SECONDS)
+        await().pollDelay(5, TimeUnit.SECONDS)
+                .atMost(40, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             // 1. Vertify the schema

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonSinkWithSchemaEvolutionIT.java
@@ -167,8 +167,7 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
                         throw new RuntimeException(e);
                     }
                 });
-
-        vertifyJobStatus(container, jobId);
+        verifyJobStatus(container, jobId);
 
         await().atMost(30, TimeUnit.SECONDS)
                 .untilAsserted(
@@ -184,7 +183,7 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
         // with default value at same time, the history data in paimon has no value.
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection1 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase1();
-        vertifySchemaAndData(container, idRangesWithFiledProjection1);
+        verifySchemaAndData(container, idRangesWithFiledProjection1);
 
         // savepoint job
         Container.ExecResult execResult = container.savepointJob(jobId);
@@ -199,28 +198,28 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
                         throw new RuntimeException(e);
                     }
                 });
-        vertifyJobStatus(container, jobId);
+        verifyJobStatus(container, jobId);
 
         // Case 2: Drop columns with data at same time
         shopDatabase.setTemplateName("drop_columns").createAndInitialize();
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection2 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase2();
-        vertifySchemaAndData(container, idRangesWithFiledProjection2);
+        verifySchemaAndData(container, idRangesWithFiledProjection2);
 
         // Case 3: Change columns with data at same time
         shopDatabase.setTemplateName("change_columns").createAndInitialize();
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection3 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase3();
-        vertifySchemaAndData(container, idRangesWithFiledProjection3);
+        verifySchemaAndData(container, idRangesWithFiledProjection3);
 
         // Case 4: Modify columns with data at same time
         shopDatabase.setTemplateName("modify_columns").createAndInitialize();
         List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection4 =
                 getIdRangesWithFiledProjectionImmutableTriplesCase4();
-        vertifySchemaAndData(container, idRangesWithFiledProjection4);
+        verifySchemaAndData(container, idRangesWithFiledProjection4);
     }
 
-    private void vertifyJobStatus(TestContainer container, String jobId) {
+    private void verifyJobStatus(TestContainer container, String jobId) {
         await().pollDelay(30, TimeUnit.SECONDS)
                 .atMost(45, TimeUnit.SECONDS)
                 .untilAsserted(
@@ -355,7 +354,7 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
         };
     }
 
-    private void vertifySchemaAndData(
+    private void verifySchemaAndData(
             TestContainer container,
             List<ImmutableTriple<String[], Integer, Integer>> idRangesWithFiledProjection) {
         await().pollDelay(5, TimeUnit.SECONDS)
@@ -363,7 +362,7 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
                 .untilAsserted(
                         () -> {
                             // 1. Vertify the schema
-                            vertifySchema();
+                            verifySchema();
 
                             // 2. Vertify the data
                             idRangesWithFiledProjection.forEach(
@@ -389,7 +388,7 @@ public class PaimonSinkWithSchemaEvolutionIT extends AbstractPaimonIT implements
                         });
     }
 
-    private void vertifySchema() {
+    private void verifySchema() {
         try (MySqlCatalog mySqlCatalog =
                 new MySqlCatalog(
                         "mysql",

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_ddl.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_ddl.conf
@@ -48,7 +48,7 @@ sink {
     paimon.table.write-props = {
       changelog-producer = lookup
       changelog-tmp-path = "/tmp/paimon/changelog"
-      file-format = parquet
+      file.format = parquet
     }
   }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_insert_data.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_insert_data.conf
@@ -62,7 +62,7 @@ sink {
     paimon.table.write-props = {
       changelog-producer = lookup
       changelog-tmp-path = "/tmp/paimon/changelog"
-      file-format = parquet
+      file.format = parquet
     }
   }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_update_data.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case1_update_data.conf
@@ -66,7 +66,7 @@ sink {
     paimon.table.write-props = {
       changelog-producer = lookup
       changelog-tmp-path = "/tmp/paimon/changelog"
-      file-format = parquet
+      file.format = parquet
     }
   }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case2.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_fake_cdc_sink_paimon_case2.conf
@@ -78,7 +78,7 @@ sink {
     paimon.table.write-props = {
       changelog-producer = full-compaction
       changelog-tmp-path = "/tmp/paimon/changelog"
-      file-format = parquet
+      file.format = parquet
     }
   }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_paimon_to_paimon.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/changelog_paimon_to_paimon.conf
@@ -44,7 +44,7 @@ sink {
     paimon.table.non-primary-key = true
     paimon.table.write-props = {
       write-only = true
-      file-format = parquet
+      file.format = parquet
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
#8730  has been merged into this PR. 
repeated commit cause task exceptions when restore from checkpoint in paimon task.   

savepoint process :  
 * step1. serialize the state to local   
 * step2. commit the state
 
restore process:
 *  step1.  deserialize the state from local file
 *  step2.  commit the state

When `step2 of the savepoint process` succeeds, the repeated submission of `step2 in the restore job` throws an exception and the task exits.
```
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: java.lang.RuntimeException: File deletion conflicts detected! Give up committing.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Don't panic!
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Conflicts during commits are normal and this failure is intended to resolve the conflicts.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Conflicts are mainly caused by the following scenarios:
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 1. Multiple jobs are writing into the same partition at the same time, or you use STATEMENT SET to execute multiple INSERT statements into the same Paimon table.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR:    You'll probably see different base commit user and current commit user below.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR:    You can use https://paimon.apache.org/docs/master/maintenance/dedicated-compaction#dedicated-compaction-job to support multiple writing.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 2. You're recovering from an old savepoint, or you're creating multiple jobs from a savepoint.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR:    The job will fail continuously in this scenario to protect metadata from corruption.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDOUT: [8949219017735335991] 2025-08-05 11:12:18,986 INFO  org.apache.seatunnel.api.sink.multitablesink.MultiTableSinkWriter - init multi table sink writer, queue size: 1
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR:    You can either recover from the latest savepoint, or you can revert the table to the snapshot corresponding to the old savepoint.
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Base commit user is: dd52504a-9c42-451a-a035-02e091307c3a; Current commit user is: d6f5e340-c66d-49d7-ba8d-0a6af5fe33b5
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Base entries are:
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=4, level=0, fileName=data-2593dd91-d35a-4013-904d-0a0742f4191e-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@dfacb5f1, maxKey=org.apache.paimon.data.BinaryRow@6f3ed396, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=4, level=0, fileName=data-2593dd91-d35a-4013-904d-0a0742f4191e-1.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@ec9064de, maxKey=org.apache.paimon.data.BinaryRow@2d99e697, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=4, level=0, fileName=data-e6510d9e-9af5-41f3-971c-f2623b8c925a-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@2d99e697, maxKey=org.apache.paimon.data.BinaryRow@1dd4c70e, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=4, level=0, fileName=data-46c9959e-786c-4395-8f8e-12340381d2e9-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@58b0535c, maxKey=org.apache.paimon.data.BinaryRow@58b0535c, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=5, fileName=data-52776f55-19a4-4596-a1ce-9f8685394576-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@89fba125, maxKey=org.apache.paimon.data.BinaryRow@a3c9fbe7, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=5, fileName=data-21c2cf99-4600-410f-8074-2376842e6a85-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@4b1a2337, maxKey=org.apache.paimon.data.BinaryRow@c8b1eb4, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=5, fileName=data-4d4f3189-0548-4a7c-826e-8e5273a932f2-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@af534502, maxKey=org.apache.paimon.data.BinaryRow@1853dc50, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=5, fileName=data-09e88d85-43da-44ca-a813-00bb8e3d525f-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@b0db094a, maxKey=org.apache.paimon.data.BinaryRow@a1a8ed70, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Changes are:
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=0, fileName=data-5ae74afe-e93e-4db2-a22b-ec32724e85f4-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@89fba125, maxKey=org.apache.paimon.data.BinaryRow@89fba125, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=0, fileName=data-5ae74afe-e93e-4db2-a22b-ec32724e85f4-1.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@26985dc0, maxKey=org.apache.paimon.data.BinaryRow@912ecf17, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=0, fileName=data-f2c71d58-f3e5-438a-85a9-a4e007ca229a-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@c730df2e, maxKey=org.apache.paimon.data.BinaryRow@90c9c338, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=0, fileName=data-e21604b9-ee26-4066-b1aa-d17be4a26f54-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@26985dc0, maxKey=org.apache.paimon.data.BinaryRow@4956887d, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=0, fileName=data-2becabb0-abd5-4510-be71-fd3cd0538345-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@6163a3bf, maxKey=org.apache.paimon.data.BinaryRow@a3c9fbe7, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=5, fileName=data-52776f55-19a4-4596-a1ce-9f8685394576-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@89fba125, maxKey=org.apache.paimon.data.BinaryRow@a3c9fbe7, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=0, fileName=data-1727e4df-7eed-4fae-b6ee-0943d96d7231-1.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@7e025d0a, maxKey=org.apache.paimon.data.BinaryRow@6e990cbf, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=0, fileName=data-f93ac8f3-5ab8-4457-a5f8-10cccbbc98e3-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@4b1a2337, maxKey=org.apache.paimon.data.BinaryRow@4b1a2337, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=0, fileName=data-0d92da45-2a92-40aa-ae45-8a99e9bab6ce-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@a0c0c097, maxKey=org.apache.paimon.data.BinaryRow@a0c0c097, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=0, fileName=data-1727e4df-7eed-4fae-b6ee-0943d96d7231-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@7e025d0a, maxKey=org.apache.paimon.data.BinaryRow@7e025d0a, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=0, fileName=data-d4b16677-8cb5-4d57-b321-dbeb8512de67-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@6e990cbf, maxKey=org.apache.paimon.data.BinaryRow@c8b1eb4, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=1, level=5, fileName=data-21c2cf99-4600-410f-8074-2376842e6a85-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@4b1a2337, maxKey=org.apache.paimon.data.BinaryRow@c8b1eb4, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=0, fileName=data-53d2dba3-62e6-4afb-83d7-52edbb1c8deb-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@af534502, maxKey=org.apache.paimon.data.BinaryRow@47791d15, externalPath=null}
[] 2025-08-05 19:12:18,998 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=0, fileName=data-53d2dba3-62e6-4afb-83d7-52edbb1c8deb-1.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@af534502, maxKey=org.apache.paimon.data.BinaryRow@e1e383e, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=0, fileName=data-d749957c-8d65-43f5-8883-4d00e14f83ae-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@6a2ddf4e, maxKey=org.apache.paimon.data.BinaryRow@6a2ddf4e, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=0, fileName=data-1886c467-2463-435d-a0ff-242d2a475c6c-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@b6e6e602, maxKey=org.apache.paimon.data.BinaryRow@2ea9cff, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=0, fileName=data-f85e0e3a-0b6f-4919-9ca1-52b03c14d7b6-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@1853dc50, maxKey=org.apache.paimon.data.BinaryRow@1853dc50, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=2, level=5, fileName=data-4d4f3189-0548-4a7c-826e-8e5273a932f2-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@af534502, maxKey=org.apache.paimon.data.BinaryRow@1853dc50, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=0, fileName=data-6bd42ab0-b3e8-40b4-8fef-0af4cfb9ea68-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@b0db094a, maxKey=org.apache.paimon.data.BinaryRow@b0db094a, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=0, fileName=data-6bd42ab0-b3e8-40b4-8fef-0af4cfb9ea68-1.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@1909a1e4, maxKey=org.apache.paimon.data.BinaryRow@9614fcf1, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=0, fileName=data-add6291e-afc9-40e9-a37d-ab9e382a87f2-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@e03ea962, maxKey=org.apache.paimon.data.BinaryRow@28a2140b, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=0, fileName=data-b75e709d-3e2d-4fa8-ad74-0a5d2f1c39e4-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@fbc59803, maxKey=org.apache.paimon.data.BinaryRow@fbc59803, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=DELETE, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=0, fileName=data-0aa86945-1552-477c-808a-3b9c8eefb646-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@a1a8ed70, maxKey=org.apache.paimon.data.BinaryRow@a1a8ed70, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: {kind=ADD, partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=3, level=5, fileName=data-09e88d85-43da-44ca-a813-00bb8e3d525f-0.orc, extraFiles=[], minKey=org.apache.paimon.data.BinaryRow@b0db094a, maxKey=org.apache.paimon.data.BinaryRow@a1a8ed70, externalPath=null}
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.operation.FileStoreCommitImpl.createConflictException(FileStoreCommitImpl.java:1370) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.operation.FileStoreCommitImpl.lambda$noConflictsOrFail$16(FileStoreCommitImpl.java:1226) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.operation.FileStoreCommitImpl.noConflictsOrFail(FileStoreCommitImpl.java:1242) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.operation.FileStoreCommitImpl.commit(FileStoreCommitImpl.java:348) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.table.sink.TableCommitImpl.commitMultiple(TableCommitImpl.java:218) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.table.sink.TableCommitImpl.filterAndCommitMultiple(TableCommitImpl.java:257) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.table.sink.TableCommitImpl.filterAndCommitMultiple(TableCommitImpl.java:243) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.table.sink.TableCommitImpl.filterAndCommit(TableCommitImpl.java:196) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkWriter.<init>(PaimonSinkWriter.java:217) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSink.restoreWriter(PaimonSink.java:129) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.api.sink.multitablesink.MultiTableSink.restoreWriter(MultiTableSink.java:115) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle.restoreState(SinkFlowLifeCycle.java:345) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.engine.server.task.SeaTunnelTask.lambda$restoreState$16(SeaTunnelTask.java:401) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.engine.server.task.SeaTunnelTask.restoreState(SeaTunnelTask.java:398) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.engine.server.checkpoint.operation.NotifyTaskRestoreOperation.lambda$null$0(NotifyTaskRestoreOperation.java:107) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1640) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.seatunnel.api.tracing.MDCRunnable.run(MDCRunnable.java:43) ~[seatunnel-starter.jar:2.3.12-SNAPSHOT]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_342]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: Caused by: java.lang.IllegalStateException: Trying to add file {partition=org.apache.paimon.data.BinaryRow@9c67b85d, bucket=0, level=5, fileName=data-52776f55-19a4-4596-a1ce-9f8685394576-0.orc, extraFiles=[], embeddedIndex=null, externalPath=null} which is already added.
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.utils.Preconditions.checkState(Preconditions.java:204) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.manifest.FileEntry.mergeEntries(FileEntry.java:191) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.manifest.FileEntry.mergeEntries(FileEntry.java:173) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	at org.apache.paimon.operation.FileStoreCommitImpl.noConflictsOrFail(FileStoreCommitImpl.java:1240) ~[?:?]
[] 2025-08-05 19:12:18,999 INFO  tc.seatunnel-engine:openjdk:8 - STDERR: 	... 27 more
```


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
PaimonSinkWithSchemaEvolutionIT#testMysqlCdcSinkPaimonWithSchemaChangeAndRestore

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)