### PR TITLE
[Fix] [connector-jdbc] prevent precision loss in Float to BigDecimal conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitter.java
@@ -387,7 +387,7 @@ public class FixedChunkSplitter extends ChunkSplitter {
         } else if (o instanceof Boolean) {
             return BigDecimal.valueOf((Boolean) o ? 1 : 0);
         } else if (o instanceof Float) {
-            return BigDecimal.valueOf((Float) o);
+            return new BigDecimal(o.toString());
         } else if (o instanceof Byte) {
             return BigDecimal.valueOf((Byte) o);
         } else if (o instanceof Short) {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtils.java
@@ -67,8 +67,8 @@ public class ObjectUtils {
             return BigDecimal.valueOf((long) minuend)
                     .subtract(BigDecimal.valueOf((long) subtrahend));
         } else if (minuend instanceof Float) {
-            return BigDecimal.valueOf((float) minuend)
-                    .subtract(BigDecimal.valueOf((float) subtrahend));
+            return new BigDecimal(minuend.toString())
+                    .subtract(new BigDecimal(subtrahend.toString()));
         } else if (minuend instanceof Double) {
             return BigDecimal.valueOf((double) minuend)
                     .subtract(BigDecimal.valueOf((double) subtrahend));

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.source;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Slf4j
+public class FixedChunkSplitterTest {
+
+    @Test
+    public void testConvertFloat() throws Exception {
+        JdbcSourceConfig config =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:postgresql://localhost:5432/test")
+                                        .driverName("org.postgresql.Driver")
+                                        .build())
+                        .build();
+
+        FixedChunkSplitter splitter = new FixedChunkSplitter(config);
+
+        // Use reflection to access private method
+        Method convertToBigDecimalMethod =
+                FixedChunkSplitter.class.getDeclaredMethod("convertToBigDecimal", Object.class);
+        convertToBigDecimalMethod.setAccessible(true);
+
+        // Test precision-sensitive Float values
+        Float testFloat = 123.456f;
+        BigDecimal result = (BigDecimal) convertToBigDecimalMethod.invoke(splitter, testFloat);
+
+        // Verify that using toString() method prevents precision loss
+        BigDecimal expected = new BigDecimal(testFloat.toString());
+        assertEquals(expected, result);
+
+        // Verify the difference from the old method (this test should demonstrate the fix
+        // necessity)
+        BigDecimal oldWay = BigDecimal.valueOf(testFloat);
+        assertNotEquals(oldWay, result);
+
+        // Test boundary values
+        Float maxFloat = Float.MAX_VALUE;
+        BigDecimal maxResult = (BigDecimal) convertToBigDecimalMethod.invoke(splitter, maxFloat);
+        assertEquals(new BigDecimal(maxFloat.toString()), maxResult);
+
+        Float minFloat = Float.MIN_VALUE;
+        BigDecimal minResult = (BigDecimal) convertToBigDecimalMethod.invoke(splitter, minFloat);
+        assertEquals(new BigDecimal(minFloat.toString()), minResult);
+
+        // Test values that better demonstrate precision issues
+        Float precisionTestFloat = 0.1f;
+        BigDecimal precisionResult =
+                (BigDecimal) convertToBigDecimalMethod.invoke(splitter, precisionTestFloat);
+        assertEquals(new BigDecimal("0.1"), precisionResult);
+
+        // Verify that the old method indeed has precision issues
+        BigDecimal oldPrecisionWay = BigDecimal.valueOf(precisionTestFloat);
+        assertNotEquals(new BigDecimal("0.1"), oldPrecisionWay);
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.utils;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Slf4j
+public class ObjectUtilsTest {
+    @Test
+    public void testObjectUtilsMinusWithFloat() throws Exception {
+        // Test precision-sensitive Float values
+        Float minuend = 123.456f;
+        Float subtrahend = 23.456f;
+
+        BigDecimal result = ObjectUtils.minus(minuend, subtrahend);
+
+        // Verify that using toString() method prevents precision loss
+        BigDecimal expected =
+                new BigDecimal(minuend.toString()).subtract(new BigDecimal(subtrahend.toString()));
+        assertEquals(expected, result);
+
+        // Verify the difference from the old method (this test should demonstrate the fix
+        // necessity)
+        BigDecimal oldMinuend = BigDecimal.valueOf(minuend);
+        BigDecimal oldSubtrahend = BigDecimal.valueOf(subtrahend);
+        BigDecimal oldWay = oldMinuend.subtract(oldSubtrahend);
+        assertNotEquals(oldWay, result);
+
+        // Test values that better demonstrate precision issues
+        Float precisionMinuend = 0.3f;
+        Float precisionSubtrahend = 0.1f;
+        BigDecimal precisionResult = ObjectUtils.minus(precisionMinuend, precisionSubtrahend);
+        BigDecimal precisionExpected =
+                new BigDecimal(precisionMinuend.toString())
+                        .subtract(new BigDecimal(precisionSubtrahend.toString()));
+        assertEquals(precisionExpected, precisionResult);
+
+        // Verify that the old method indeed has precision issues
+        BigDecimal oldPrecisionWay =
+                BigDecimal.valueOf(precisionMinuend)
+                        .subtract(BigDecimal.valueOf(precisionSubtrahend));
+        assertNotEquals(oldPrecisionWay, precisionResult);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes a precision loss issue in the JDBC connector when converting Float values to BigDecimal during data splitting and mathematical operations. The main improvements include:

1. **Fixed Float to BigDecimal conversion precision loss** in `FixedChunkSplitter.convertToBigDecimal()` method
2. **Fixed Float subtraction precision issues** in `ObjectUtils.minus()` method  
3. **Improved numerical accuracy** for JDBC data splitting operations involving Float values
4. **Enhanced data integrity** in scenarios where precise Float calculations are critical

This change addresses a critical precision issue where Float values were losing accuracy during BigDecimal conversions due to Java's automatic type promotion behavior.

### Does this PR introduce _any_ user-facing change?

**No**, this PR does not introduce any user-facing changes.

This is an internal bug fix that improves the precision of Float to BigDecimal conversions within the JDBC connector's data processing logic. Users will not notice any API changes, configuration changes, or behavioral differences in normal usage scenarios.

**Technical details of the fix**:

**Root cause**: Java's `BigDecimal.valueOf()` method does not have a `valueOf(float)` overload. When called with a Float parameter, the float value is automatically promoted to double, which can introduce precision errors.

**Previous behavior**: 
```java
Float f = 0.1f;
BigDecimal bd = BigDecimal.valueOf(f);  // Automatic promotion: float -> double
// Result: 0.10000000149011612 (precision loss due to float-to-double conversion)
```

**New behavior**:
```java
Float f = 0.1f;  
BigDecimal bd = new BigDecimal(f.toString());  
// Result: 0.1 (preserves original Float precision)
```

**Impact**: This fix ensures that Float values maintain their intended precision during JDBC data splitting operations, preventing potential data integrity issues in edge cases involving high-precision Float calculations.

**Backward compatibility**: Fully backward compatible - no changes to public APIs, configuration options, or expected user behavior.

### How was this patch tested?

This patch addresses a specific precision issue with Float to BigDecimal conversions. Testing approach:

1. **Root cause verification**:
   - Confirmed that `BigDecimal.valueOf()` lacks a `valueOf(float)` method in Java
   - Verified that automatic float-to-double promotion causes precision loss
   - Tested that `new BigDecimal(Float.toString())` preserves original Float precision

2. **Manual precision testing**:
   ```java
   Float testFloat = 0.1f;
   // Old approach
   BigDecimal oldWay = BigDecimal.valueOf(testFloat);  // 0.10000000149011612
   // New approach  
   BigDecimal newWay = new BigDecimal(testFloat.toString());  // 0.1
   ```

3. **Regression testing**:
   - Ran existing JDBC connector unit tests to ensure no functionality regression
   - Verified that all other numeric type conversions (Integer, Long, Double, etc.) continue to work correctly
   - Confirmed that the change only affects Float type processing

4. **Edge case validation**:
   - Tested with various Float values that commonly exhibit precision issues
   - Verified proper handling in both `convertToBigDecimal()` and `minus()` operations
   - Ensured consistent behavior across different Float value ranges

**Recommended additional testing**: Unit tests should be added to specifically validate Float precision in BigDecimal conversions, particularly for the edge cases where float-to-double promotion introduces measurable precision errors.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)