### PR TITLE
[Feature][connector-paimon] Paimon connector supports paimon privilege

### DIFF
--- a/docs/en/connector-v2/sink/Paimon.md
+++ b/docs/en/connector-v2/sink/Paimon.md
@@ -67,6 +67,8 @@ libfb303-xxx.jar
 | catalog_uri                  | String  | No       | -                            | Catalog uri of Paimon, only needed when catalog_type is hive                                                                                                     |
 | database                     | String  | Yes      | -                            | The database you want to access                                                                                                                                  |
 | table                        | String  | Yes      | -                            | The table you want to access                                                                                                                                     |
+| user                         | String  | No       | -                            | Paimon user to access table                                                                                                                                      |
+| password                     | String  | No      | -                            | Paimon user password to access table                                                                                                                             |
 | hdfs_site_path               | String  | No       | -                            | The path of hdfs-site.xml                                                                                                                                        |
 | schema_save_mode             | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | The schema save mode                                                                                                                                             |
 | data_save_mode               | Enum    | No       | APPEND_DATA                  | The data save mode                                                                                                                                               |
@@ -590,6 +592,41 @@ sink {
     warehouse="file:///tmp/seatunnel/paimon/hadoop-sink/"
     database="${schema_name}_test"
     table="${table_name}_test"
+  }
+}
+```
+
+### paimon enable privilege
+
+#### example1
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  Mysql-CDC {
+    url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
+    username = "root"
+    password = "******"
+    table-names = ["seatunnel.role","seatunnel.user","galileo.Bucket"]
+  }
+}
+
+transform {
+}
+
+sink {
+  Paimon {
+    catalog_name = "seatunnel_test"
+    warehouse = "file:///tmp/seatunnel/paimon/hadoop-sink/"
+    database = "${database_name}"
+    table = "${table_name}"
+    user = "paimon"
+    password = "******"
   }
 }
 ```

--- a/docs/en/connector-v2/source/Paimon.md
+++ b/docs/en/connector-v2/source/Paimon.md
@@ -46,13 +46,15 @@ Read data from Apache Paimon.
 
 ## Options
 
-|          name           |  type  | required | default value |
+| name                    |  type  | required | default value |
 |-------------------------|--------|----------|---------------|
 | warehouse               | String | Yes      | -             |
 | catalog_type            | String | No       | filesystem    |
 | catalog_uri             | String | No       | -             |
 | database                | String | Yes      | -             |
 | table                   | String | Yes      | -             |
+| user                    | String | No       | -             |
+| password                | String | No      | -             |
 | hdfs_site_path          | String | No       | -             |
 | query                   | String | No       | -             |
 | paimon.hadoop.conf      | Map    | No       | -             |
@@ -249,6 +251,20 @@ sink {
     table = "st_test_sink"
     paimon.table.primary-keys = "c_tinyint"
   }
+}
+```
+
+### paimon enable privilege example
+
+```hocon
+source {
+ Paimon {
+     warehouse = "/tmp/paimon"
+     database = "default"
+     table = "st_test"
+     user = "paimon"
+     password = "******"
+   }
 }
 ```
 

--- a/docs/zh/connector-v2/sink/Paimon.md
+++ b/docs/zh/connector-v2/sink/Paimon.md
@@ -59,22 +59,24 @@ libfb303-xxx.jar
 
 ## 连接器选项
 
-| 名称                          | 类型   | 是否必须 | 默认值                          | 描述                                                                                                   |
-|-----------------------------|------|------|------------------------------|------------------------------------------------------------------------------------------------------|
-| warehouse                   | 字符串  | 是    | -                            | Paimon warehouse路径                                                                                   |
-| catalog_type                | 字符串  | 否    | filesystem                   | Paimon的catalog类型，目前支持filesystem和hive                                                                 |
-| catalog_uri                 | 字符串  | 否    | -                            | Paimon catalog的uri，仅当catalog_type为hive时需要配置                                                          |
-| database                    | 字符串  | 是    | -                            | 数据库名称                                                                                                |
-| table                       | 字符串  | 是    | -                            | 表名                                                                                                   |
-| hdfs_site_path              | 字符串  | 否    | -                            | hdfs-site.xml文件路径                                                                                    |
-| schema_save_mode            | 枚举   | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST | Schema保存模式                                                                                           |
-| data_save_mode              | 枚举   | 否    | APPEND_DATA                  | 数据保存模式                                                                                               |
-| paimon.table.primary-keys   | 字符串  | 否    | -                            | 主键字段列表，联合主键使用逗号分隔(注意：分区字段需要包含在主键字段中)                                                                 |
-| paimon.table.partition-keys | 字符串  | 否    | -                            | 分区字段列表，多字段使用逗号分隔                                                                                     |
-| paimon.table.write-props    | Map  | 否    | -                            | Paimon表初始化指定的属性, [参考](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions) |
-| paimon.hadoop.conf          | Map  | 否    | -                            | Hadoop配置文件属性信息                                                                                       |
-| paimon.hadoop.conf-path     | 字符串  | 否    | -                            | Hadoop配置文件目录，用于加载'core-site.xml', 'hdfs-site.xml', 'hive-site.xml'文件配置                               |
-| paimon.table.non-primary-key | Boolean | false    | -                            | 控制创建主键表或者非主键表. 当为true时,创建非主键表, 为false时,创建主键表                                                                   |
+| 名称                           | 类型   | 是否必须 | 默认值                          | 描述                                                                                                   |
+|------------------------------|------|------|------------------------------|------------------------------------------------------------------------------------------------------|
+| warehouse                    | 字符串  | 是    | -                            | Paimon warehouse路径                                                                                   |
+| catalog_type                 | 字符串  | 否    | filesystem                   | Paimon的catalog类型，目前支持filesystem和hive                                                                 |
+| catalog_uri                  | 字符串  | 否    | -                            | Paimon catalog的uri，仅当catalog_type为hive时需要配置                                                          |
+| database                     | 字符串  | 是    | -                            | 数据库名称                                                                                                |
+| table                        | 字符串  | 是    | -                            | 表名                                                                                                   |
+| user                         | 字符串  | 否    | -                            | paimon开启权限后，用户名                                                                                      |
+| password                     | 字符串  | 否    | -                            | paimon开启权限后，用户名对应密码                                                                                  |
+| hdfs_site_path               | 字符串  | 否    | -                            | hdfs-site.xml文件路径                                                                                    |
+| schema_save_mode             | 枚举   | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST | Schema保存模式                                                                                           |
+| data_save_mode               | 枚举   | 否    | APPEND_DATA                  | 数据保存模式                                                                                               |
+| paimon.table.primary-keys    | 字符串  | 否    | -                            | 主键字段列表，联合主键使用逗号分隔(注意：分区字段需要包含在主键字段中)                                                                 |
+| paimon.table.partition-keys  | 字符串  | 否    | -                            | 分区字段列表，多字段使用逗号分隔                                                                                     |
+| paimon.table.write-props     | Map  | 否    | -                            | Paimon表初始化指定的属性, [参考](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions) |
+| paimon.hadoop.conf           | Map  | 否    | -                            | Hadoop配置文件属性信息                                                                                       |
+| paimon.hadoop.conf-path      | 字符串  | 否    | -                            | Hadoop配置文件目录，用于加载'core-site.xml', 'hdfs-site.xml', 'hive-site.xml'文件配置                               |
+| paimon.table.non-primary-key | Boolean | false    | -                            | 控制创建主键表或者非主键表. 当为true时,创建非主键表, 为false时,创建主键表                                                         |
 
 ## 批模式下的checkpoint
 
@@ -582,6 +584,41 @@ sink {
     warehouse="file:///tmp/seatunnel/paimon/hadoop-sink/"
     database="${schema_name}_test"
     table="${table_name}_test"
+  }
+}
+```
+
+### paimon开启权限认证
+
+#### 示例1
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  Mysql-CDC {
+    url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
+    username = "root"
+    password = "******"
+    table-names = ["seatunnel.role","seatunnel.user","galileo.Bucket"]
+  }
+}
+
+transform {
+}
+
+sink {
+  Paimon {
+    catalog_name = "seatunnel_test"
+    warehouse = "file:///tmp/seatunnel/paimon/hadoop-sink/"
+    database = "${database_name}"
+    table = "${table_name}"
+    user = "paimon"
+    password = "******"
   }
 }
 ```

--- a/docs/zh/connector-v2/source/Paimon.md
+++ b/docs/zh/connector-v2/source/Paimon.md
@@ -46,13 +46,15 @@ import ChangeLog from '../changelog/connector-paimon.md';
 
 ## 配置选项
 
-|          名称           |  类型  | 是否必须 | 默认值 |
+| 名称                      |  类型  | 是否必须 | 默认值 |
 |-------------------------|--------|----------|---------------|
 | warehouse               | String | 是      | -             |
 | catalog_type            | String | 否       | filesystem    |
 | catalog_uri             | String | 否       | -             |
 | database                | String | 是      | -             |
 | table                   | String | 是      | -             |
+| user                    | String | 否      | -             |
+| password                | String | 否      | -             |
 | hdfs_site_path          | String | 否       | -             |
 | query                   | String | 否       | -             |
 | paimon.hadoop.conf      | Map    | 否       | -             |
@@ -220,6 +222,20 @@ source {
       dfs.client.use.datanode.hostname = "true"
     }
   }
+}
+```
+
+### paimon开启权限示例
+
+```hocon
+source {
+ Paimon {
+     warehouse = "/tmp/paimon"
+     database = "default"
+     table = "st_test"
+     user = "paimon"
+     password = "******"
+   }
 }
 ```
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoader.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoader.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
 
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
 import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonConfig;
 import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonHadoopConfiguration;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorErrorCode;
@@ -31,6 +32,7 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.privilege.PrivilegedCatalog;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,7 +48,7 @@ public class PaimonCatalogLoader implements Serializable {
 
     private static final String HDFS_PREFIX = "hdfs://";
     private static final String S3A_PREFIX = "s3a://";
-    /** ********* Hdfs constants ************* */
+    /** ******* Hdfs constants ************* */
     private static final String HDFS_IMPL = "org.apache.hadoop.hdfs.DistributedFileSystem";
 
     private static final String HDFS_IMPL_KEY = "fs.hdfs.impl";
@@ -58,12 +60,16 @@ public class PaimonCatalogLoader implements Serializable {
     private String catalogUri;
 
     private PaimonHadoopConfiguration paimonHadoopConfiguration;
+    protected String user;
+    protected String password;
 
     public PaimonCatalogLoader(PaimonConfig paimonConfig) {
         this.warehouse = paimonConfig.getWarehouse();
         this.catalogType = paimonConfig.getCatalogType();
         this.catalogUri = paimonConfig.getCatalogUri();
         this.paimonHadoopConfiguration = PaimonSecurityContext.loadHadoopConfig(paimonConfig);
+        this.user = paimonConfig.getUser();
+        this.password = paimonConfig.getPassword();
     }
 
     public Catalog loadCatalog() {
@@ -72,6 +78,10 @@ public class PaimonCatalogLoader implements Serializable {
         final Map<String, String> optionsMap = new HashMap<>(1);
         optionsMap.put(CatalogOptions.WAREHOUSE.key(), warehouse);
         optionsMap.put(CatalogOptions.METASTORE.key(), catalogType.getType());
+        if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password)) {
+            optionsMap.put(PaimonBaseOptions.USER.key(), user);
+            optionsMap.put(PaimonBaseOptions.PASSWORD.key(), password);
+        }
         if (warehouse.startsWith(HDFS_PREFIX)) {
             checkConfiguration(paimonHadoopConfiguration, HDFS_DEF_FS_NAME);
             paimonHadoopConfiguration.set(HDFS_IMPL_KEY, HDFS_IMPL);
@@ -91,13 +101,23 @@ public class PaimonCatalogLoader implements Serializable {
         final CatalogContext catalogContext =
                 CatalogContext.create(options, paimonHadoopConfiguration);
         try {
-            return PaimonSecurityContext.runSecured(
-                    () -> CatalogFactory.createCatalog(catalogContext));
+            // If paimon privilege enabled, there will be system tables named user.sys and
+            // privilege.sys in the warehouse.
+            // It returns a PrivilegedCatalog. Otherwise, it returns a CachingCatalog.
+            // If paimon privilege enabled, perform user and password verification accordingly.
+            Catalog catalog =
+                    PaimonSecurityContext.runSecured(
+                            () -> CatalogFactory.createCatalog(catalogContext));
+            if (catalog instanceof PrivilegedCatalog
+                    && StringUtils.isBlank(user)
+                    && StringUtils.isBlank(password)) {
+                throw new IllegalArgumentException(
+                        "paimon privilege is enabled, user and password is required");
+            }
+            return catalog;
         } catch (Exception e) {
             throw new PaimonConnectorException(
-                    PaimonConnectorErrorCode.LOAD_CATALOG,
-                    "Failed to perform SecurityContext.runSecured",
-                    e);
+                    PaimonConnectorErrorCode.LOAD_CATALOG, e.getMessage(), e);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonBaseOptions.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonBaseOptions.java
@@ -83,4 +83,16 @@ public class PaimonBaseOptions {
                     .noDefaultValue()
                     .withDescription(
                             "The specified loading path for the 'core-site.xml', 'hdfs-site.xml', 'hive-site.xml' files");
+
+    public static final Option<String> USER =
+            Options.key("user")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The paimon user to access table");
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The paimon user password");
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonConfig.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonConfig.java
@@ -53,6 +53,8 @@ public class PaimonConfig implements Serializable {
     protected String hdfsSitePath;
     protected Map<String, String> hadoopConfProps;
     protected String hadoopConfPath;
+    protected String user;
+    protected String password;
 
     public PaimonConfig(ReadonlyConfig readonlyConfig) {
         this.catalogName =
@@ -80,6 +82,8 @@ public class PaimonConfig implements Serializable {
                             readonlyConfig.get(PaimonBaseOptions.CATALOG_URI),
                             PaimonBaseOptions.CATALOG_URI.key());
         }
+        this.user = readonlyConfig.get(PaimonBaseOptions.USER);
+        this.password = readonlyConfig.get(PaimonBaseOptions.PASSWORD);
     }
 
     protected String checkArgumentNotBlank(String propValue, String propKey) {

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonPrivilegeCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonPrivilegeCatalogTest.java
@@ -18,10 +18,24 @@
 package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
 
 import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.metrics.AbstractMetricsContext;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
+import org.apache.seatunnel.api.sink.MultiTableResourceManager;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.sink.SinkAggregatedCommitter;
+import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SupportMultiTableSinkAggregatedCommitter;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.PrimaryKey;
@@ -32,16 +46,16 @@ import org.apache.seatunnel.api.table.catalog.exception.CatalogException;
 import org.apache.seatunnel.api.table.catalog.exception.DatabaseAlreadyExistException;
 import org.apache.seatunnel.api.table.catalog.exception.DatabaseNotExistException;
 import org.apache.seatunnel.api.table.catalog.exception.TableNotExistException;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
-import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonHadoopConfiguration;
-import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonSinkConfig;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
-import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkWriter;
-import org.apache.seatunnel.connectors.seatunnel.paimon.sink.bucket.PaimonBucketAssignerFactory;
+import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkFactory;
+import org.apache.seatunnel.connectors.seatunnel.paimon.source.PaimonSourceFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.paimon.catalog.CatalogContext;
@@ -53,52 +67,63 @@ import org.apache.paimon.privilege.FileBasedPrivilegeManagerLoader;
 import org.apache.paimon.privilege.NoPrivilegeException;
 import org.apache.paimon.privilege.PrivilegeType;
 import org.apache.paimon.privilege.PrivilegedCatalog;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class PaimonPrivilegeCatalogTest {
 
-    private static PaimonCatalog authorizedCatalog;
-    private static PaimonCatalog unAuthorizedCatalog;
-    private static PaimonCatalog rootUserPaimonCatalog;
-    private static String CATALOG_NAME = "paimon_catalog";
-    private static String DATABASE_NAME = "test_db";
-    private static String TABLE_NAME = "test_table";
-
-    private PaimonSinkWriter paimonSinkWriter;
-    private static SinkWriter.Context context;
-    private final String commitUser = UUID.randomUUID().toString();
-    private static CatalogTable catalogTable;
+    private PaimonCatalog authorizedCatalog;
+    private PaimonCatalog unAuthorizedCatalog;
+    private PaimonCatalog rootUserPaimonCatalog;
+    private String CATALOG_NAME = "paimon_catalog";
+    private String DATABASE_NAME = "test_db";
+    private String TABLE_NAME = "test_table";
+    private CatalogTable catalogTable;
     @TempDir protected static java.nio.file.Path temporaryFolder;
-    private static String warehouse;
-    private static String rootUser = "root";
-    private static String rootPassword = "123456";
-    private static String bucketKey = "f0";
-    private static String authorizeUser = "paimon";
-    private static String authorizeUserPassword = "123456";
-    private static String unAuthorizeUser = "unauthorized_paimon";
-    private static String unAuthorizeUserPassword = "123456";
+    private String warehouse;
+    private String rootUser = "root";
+    private String rootPassword = "123456";
+    private String bucketKey = "f0";
+    private String authorizeUser = "paimon";
+    private String authorizeUserPassword = "123456";
+    private String unAuthorizeUser = "unauthorized_paimon";
+    private String unAuthorizeUserPassword = "123456";
+
+    private int writeRows = 0;
 
     @BeforeAll
-    public static void before() {
+    public void before() {
         warehouse = new File(temporaryFolder.toFile(), UUID.randomUUID().toString()).toString();
         initPrivilege();
         rootUserPaimonCatalog = createPaimonCatalog(rootUser, rootPassword);
@@ -121,27 +146,9 @@ public class PaimonPrivilegeCatalogTest {
 
         TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
         rootUserPaimonCatalog.createTable(tablePath, catalogTable, false);
-
-        context =
-                new SinkWriter.Context() {
-                    @Override
-                    public int getIndexOfSubtask() {
-                        return 0;
-                    }
-
-                    @Override
-                    public MetricsContext getMetricsContext() {
-                        return null;
-                    }
-
-                    @Override
-                    public EventListener getEventListener() {
-                        return null;
-                    }
-                };
     }
 
-    private static CatalogTable buildTable(String tableName) {
+    private CatalogTable buildTable(String tableName) {
         TableSchema.Builder schemaBuilder = TableSchema.builder();
         for (int i = 0; i < 5; i++) {
             schemaBuilder.column(
@@ -167,7 +174,7 @@ public class PaimonPrivilegeCatalogTest {
         return cTable;
     }
 
-    private static void initPrivilege() {
+    private void initPrivilege() {
         org.apache.paimon.options.Options catalogOptions = new org.apache.paimon.options.Options();
         catalogOptions.set(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
         CatalogContext catalogContext = CatalogContext.create(catalogOptions);
@@ -184,14 +191,14 @@ public class PaimonPrivilegeCatalogTest {
         }
     }
 
-    private static void createUser(String user, String password) {
+    private void createUser(String user, String password) {
         Optional<Object> catalog = ReflectionUtils.getField(rootUserPaimonCatalog, "catalog");
         assertTrue(catalog.isPresent() && catalog.get() instanceof PrivilegedCatalog);
         PrivilegedCatalog priCatalog = (PrivilegedCatalog) catalog.get();
         priCatalog.privilegeManager().createUser(user, password);
     }
 
-    private static void grantPrivilege(String user, PrivilegeType[] privilegeTypes) {
+    private void grantPrivilege(String user, PrivilegeType[] privilegeTypes) {
         Optional<Object> catalog = ReflectionUtils.getField(rootUserPaimonCatalog, "catalog");
         assertTrue(catalog.isPresent() && catalog.get() instanceof PrivilegedCatalog);
         PrivilegedCatalog priCatalog = (PrivilegedCatalog) catalog.get();
@@ -207,7 +214,7 @@ public class PaimonPrivilegeCatalogTest {
         }
     }
 
-    private static void createDatabase() {
+    private void createDatabase() {
         try {
             TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
             rootUserPaimonCatalog.createDatabase(tablePath, false);
@@ -216,7 +223,7 @@ public class PaimonPrivilegeCatalogTest {
         }
     }
 
-    private static Map<String, Object> getPaimonProperties() {
+    private Map<String, Object> getPaimonProperties() {
         Map<String, Object> properties = new HashMap<>();
         properties.put("warehouse", warehouse);
         properties.put("plugin_name", "Paimon");
@@ -229,7 +236,7 @@ public class PaimonPrivilegeCatalogTest {
         return properties;
     }
 
-    private static PaimonCatalog createPaimonCatalog(String user, String password) {
+    private PaimonCatalog createPaimonCatalog(String user, String password) {
         Map<String, Object> properties = getPaimonProperties();
         if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password)) {
             properties.put("user", user);
@@ -307,14 +314,40 @@ public class PaimonPrivilegeCatalogTest {
     }
 
     @Test
-    public void testWriteTable() {
-        writeTable(authorizedCatalog);
+    public void testAlertTable() {
+        Identifier identifier = Identifier.create(DATABASE_NAME, TABLE_NAME);
+        SchemaChange change = SchemaChange.addColumn("f5", DataTypes.STRING());
+        authorizedCatalog.alterTable(identifier, change, false);
 
         assertThrows(
                 NoPrivilegeException.class,
                 () -> {
                     try {
-                        writeTable(unAuthorizedCatalog);
+                        unAuthorizedCatalog.alterTable(identifier, change, false);
+                    } catch (NoPrivilegeException e) {
+                        assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                "User "
+                                                        + unAuthorizeUser
+                                                        + " doesn't have privilege ALTER_TABLE on table"));
+                        throw e;
+                    }
+                });
+    }
+
+    @Test
+    @Order(2)
+    public void testWriteTable() throws IOException {
+        List<SeaTunnelRow> rows = getWriteRows();
+        writeTable(authorizedCatalog, rows);
+        writeRows = rows.size();
+
+        assertThrows(
+                NoPrivilegeException.class,
+                () -> {
+                    try {
+                        writeTable(unAuthorizedCatalog, rows);
                     } catch (NoPrivilegeException e) {
                         assertTrue(
                                 e.getMessage()
@@ -327,42 +360,253 @@ public class PaimonPrivilegeCatalogTest {
                 });
     }
 
-    private void writeTable(PaimonCatalog paimonCatalog) {
-        TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+    @Test
+    @Order(3)
+    public void testReadTable() throws Exception {
+        List<SeaTunnelRow> rows = readTable(authorizedCatalog);
+        assertTrue(rows.size() == writeRows);
 
-        JobContext jobContext = new JobContext();
-        jobContext.setJobMode(JobMode.BATCH);
+        assertThrows(
+                NoPrivilegeException.class,
+                () -> {
+                    try {
+                        readTable(unAuthorizedCatalog);
+                    } catch (NoPrivilegeException e) {
+                        assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                "User "
+                                                        + unAuthorizeUser
+                                                        + " doesn't have privilege SELECT on table"));
+                        throw e;
+                    }
+                });
+    }
+
+    private List<SeaTunnelRow> readTable(PaimonCatalog paimonCatalog) throws Exception {
+        JobContext context = new JobContext(System.currentTimeMillis());
+        context.setJobMode(JobMode.BATCH);
+        context.setEnableCheckpoint(false);
 
         Optional<Object> config = ReflectionUtils.getField(paimonCatalog, "readonlyConfig");
         assertTrue(config.isPresent() && config.get() instanceof ReadonlyConfig);
         ReadonlyConfig readonlyConfig = (ReadonlyConfig) config.get();
 
-        paimonSinkWriter =
-                new PaimonSinkWriter(
-                        context,
-                        readonlyConfig,
-                        paimonCatalog.getTable(tablePath),
-                        paimonCatalog.getPaimonTable(tablePath),
-                        commitUser,
-                        jobContext,
-                        new PaimonSinkConfig(readonlyConfig),
-                        new PaimonHadoopConfiguration(),
-                        new PaimonBucketAssignerFactory());
+        PaimonSourceFactory factory = new PaimonSourceFactory();
+        SeaTunnelSource<Object, SourceSplit, Serializable> source =
+                factory.createSource(
+                                new TableSourceFactoryContext(
+                                        readonlyConfig,
+                                        Thread.currentThread().getContextClassLoader()))
+                        .createSource();
+        source.setJobContext(context);
+        Set<Integer> registeredReaders = new HashSet<>();
+        List<SourceReader> readers = new ArrayList<>();
+        Set<Integer> unfinishedReaders = new HashSet<>();
+        int parallelism = 1;
+        SourceSplitEnumerator enumerator =
+                source.createEnumerator(
+                        new SourceSplitEnumerator.Context<SourceSplit>() {
+                            @Override
+                            public int currentParallelism() {
+                                return parallelism;
+                            }
 
-        String[] fields = catalogTable.getTableSchema().getFieldNames();
-        SeaTunnelRow row = new SeaTunnelRow(fields.length);
-        try {
-            for (int j = 0; j < fields.length; j++) {
-                row.setField(j, "val" + j);
+                            @Override
+                            public Set<Integer> registeredReaders() {
+                                return registeredReaders;
+                            }
+
+                            @Override
+                            public void assignSplit(int subtaskId, List<SourceSplit> splits) {
+                                if (registeredReaders().isEmpty()) {
+                                    return;
+                                }
+                                SourceReader reader = readers.get(subtaskId);
+                                if (splits.isEmpty()) {
+                                    reader.handleNoMoreSplits();
+                                } else {
+                                    reader.addSplits(splits);
+                                }
+                            }
+
+                            @Override
+                            public void signalNoMoreSplits(int subtask) {
+                                SourceReader reader = readers.get(subtask);
+                                reader.handleNoMoreSplits();
+                            }
+
+                            @Override
+                            public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+                                SourceReader reader = readers.get(subtaskId);
+                                reader.handleSourceEvent(event);
+                            }
+
+                            @Override
+                            public MetricsContext getMetricsContext() {
+                                return new AbstractMetricsContext() {};
+                            }
+
+                            @Override
+                            public EventListener getEventListener() {
+                                return event -> {};
+                            }
+                        });
+        enumerator.open();
+        for (int i = 0; i < parallelism; i++) {
+            int finalI = i;
+            SourceReader<Object, SourceSplit> reader =
+                    source.createReader(
+                            new SourceReader.Context() {
+                                @Override
+                                public int getIndexOfSubtask() {
+                                    return finalI;
+                                }
+
+                                @Override
+                                public Boundedness getBoundedness() {
+                                    return Boundedness.BOUNDED;
+                                }
+
+                                @Override
+                                public void signalNoMoreElement() {
+                                    unfinishedReaders.remove(finalI);
+                                }
+
+                                @Override
+                                public void sendSplitRequest() {
+                                    enumerator.handleSplitRequest(finalI);
+                                }
+
+                                @Override
+                                public void sendSourceEventToEnumerator(SourceEvent sourceEvent) {
+                                    enumerator.handleSourceEvent(finalI, sourceEvent);
+                                }
+
+                                @Override
+                                public MetricsContext getMetricsContext() {
+                                    return new AbstractMetricsContext() {};
+                                }
+
+                                @Override
+                                public EventListener getEventListener() {
+                                    return event -> {};
+                                }
+                            });
+            unfinishedReaders.add(i);
+            registeredReaders.add(i);
+            readers.add(reader);
+            enumerator.registerReader(i);
+        }
+        enumerator.run();
+
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        while (!unfinishedReaders.isEmpty()) {
+            for (int i = 0; i < parallelism; i++) {
+                SourceReader reader = readers.get(i);
+                if (unfinishedReaders.contains(i)) {
+                    reader.pollNext(
+                            new Collector() {
+                                @Override
+                                public void collect(Object record) {
+                                    rows.add((SeaTunnelRow) record);
+                                }
+
+                                @Override
+                                public Object getCheckpointLock() {
+                                    return reader;
+                                }
+                            });
+                }
             }
-            paimonSinkWriter.write(row);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        }
+        enumerator.close();
+        for (SourceReader reader : readers) {
+            reader.close();
+        }
+
+        return rows;
+    }
+
+    private List<SeaTunnelRow> getWriteRows() {
+        List<SeaTunnelRow> rows =
+                Arrays.asList(
+                        new SeaTunnelRow(new Object[] {"f0", "f1", "f2", "f3", "f4"}),
+                        new SeaTunnelRow(new Object[] {"f10", "f11", "f12", "f13", "f14"}));
+        return rows;
+    }
+
+    private void writeTable(PaimonCatalog paimonCatalog, List<SeaTunnelRow> rows)
+            throws IOException {
+        JobContext context = new JobContext(System.currentTimeMillis());
+        context.setJobMode(JobMode.BATCH);
+        context.setEnableCheckpoint(false);
+
+        Optional<Object> config = ReflectionUtils.getField(paimonCatalog, "readonlyConfig");
+        assertTrue(config.isPresent() && config.get() instanceof ReadonlyConfig);
+        ReadonlyConfig readonlyConfig = (ReadonlyConfig) config.get();
+        TableSinkFactoryContext tableSinkFactoryContext =
+                new TableSinkFactoryContext(
+                        catalogTable,
+                        readonlyConfig,
+                        Thread.currentThread().getContextClassLoader());
+
+        PaimonSinkFactory factory = new PaimonSinkFactory();
+        SeaTunnelSink<SeaTunnelRow, ?, ?, ?> sink =
+                factory.createSink(tableSinkFactoryContext).createSink();
+        sink.setJobContext(context);
+        int parallelism = 1;
+        List<Object> commitInfos = new ArrayList<>();
+
+        for (int i = 0; i < parallelism; i++) {
+            SinkWriter<SeaTunnelRow, ?, ?> sinkWriter =
+                    sink.createWriter(new DefaultSinkWriterContext(i, parallelism));
+            for (SeaTunnelRow row : rows) {
+                sinkWriter.write(row);
+            }
+            Optional<?> commitInfo = sinkWriter.prepareCommit(1);
+            sinkWriter.snapshotState(1);
+            sinkWriter.close();
+            if (commitInfo.isPresent()) {
+                commitInfos.add(commitInfo.get());
+            }
+        }
+
+        Optional<? extends SinkCommitter<?>> sinkCommitter = sink.createCommitter();
+        Optional<? extends SinkAggregatedCommitter<?, ?>> aggregatedCommitterOptional =
+                sink.createAggregatedCommitter();
+
+        if (!commitInfos.isEmpty()) {
+            if (aggregatedCommitterOptional.isPresent()) {
+                SinkAggregatedCommitter<?, ?> aggregatedCommitter =
+                        aggregatedCommitterOptional.get();
+                MultiTableResourceManager resourceManager = null;
+                if (aggregatedCommitter instanceof SupportMultiTableSinkAggregatedCommitter) {
+                    resourceManager =
+                            ((SupportMultiTableSinkAggregatedCommitter<?>) aggregatedCommitter)
+                                    .initMultiTableResourceManager(1, 1);
+                }
+                aggregatedCommitter.init();
+                if (resourceManager != null) {
+                    ((SupportMultiTableSinkAggregatedCommitter<?>) aggregatedCommitter)
+                            .setMultiTableResourceManager(resourceManager, 0);
+                }
+
+                Object aggregatedCommitInfoT =
+                        ((SinkAggregatedCommitter) aggregatedCommitter).combine(commitInfos);
+                ((SinkAggregatedCommitter) aggregatedCommitter)
+                        .commit(Collections.singletonList(aggregatedCommitInfoT));
+                aggregatedCommitter.close();
+            } else if (sinkCommitter.isPresent()) {
+                ((SinkCommitter) sinkCommitter.get()).commit(commitInfos);
+            } else {
+                throw new RuntimeException("No committer found");
+            }
         }
     }
 
     @AfterAll
-    public static void after() {
+    public void after() {
         TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
         try {
             rootUserPaimonCatalog.dropTable(tablePath, false);

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonPrivilegeCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonPrivilegeCatalogTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.catalog.exception.CatalogException;
+import org.apache.seatunnel.api.table.catalog.exception.DatabaseAlreadyExistException;
+import org.apache.seatunnel.api.table.catalog.exception.DatabaseNotExistException;
+import org.apache.seatunnel.api.table.catalog.exception.TableNotExistException;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.utils.ReflectionUtils;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonHadoopConfiguration;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkWriter;
+import org.apache.seatunnel.connectors.seatunnel.paimon.sink.bucket.PaimonBucketAssignerFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.ResolvingFileIO;
+import org.apache.paimon.privilege.FileBasedPrivilegeManagerLoader;
+import org.apache.paimon.privilege.NoPrivilegeException;
+import org.apache.paimon.privilege.PrivilegeType;
+import org.apache.paimon.privilege.PrivilegedCatalog;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class PaimonPrivilegeCatalogTest {
+
+    private static PaimonCatalog authorizedCatalog;
+    private static PaimonCatalog unAuthorizedCatalog;
+    private static PaimonCatalog rootUserPaimonCatalog;
+    private static String CATALOG_NAME = "paimon_catalog";
+    private static String DATABASE_NAME = "test_db";
+    private static String TABLE_NAME = "test_table";
+
+    private PaimonSinkWriter paimonSinkWriter;
+    private static SinkWriter.Context context;
+    private final String commitUser = UUID.randomUUID().toString();
+    private static CatalogTable catalogTable;
+    @TempDir protected static java.nio.file.Path temporaryFolder;
+    private static String warehouse;
+    private static String rootUser = "root";
+    private static String rootPassword = "123456";
+    private static String bucketKey = "f0";
+    private static String authorizeUser = "paimon";
+    private static String authorizeUserPassword = "123456";
+    private static String unAuthorizeUser = "unauthorized_paimon";
+    private static String unAuthorizeUserPassword = "123456";
+
+    @BeforeAll
+    public static void before() {
+        warehouse = new File(temporaryFolder.toFile(), UUID.randomUUID().toString()).toString();
+        initPrivilege();
+        rootUserPaimonCatalog = createPaimonCatalog(rootUser, rootPassword);
+        authorizedCatalog = createPaimonCatalog(authorizeUser, authorizeUserPassword);
+        unAuthorizedCatalog = createPaimonCatalog(unAuthorizeUser, unAuthorizeUserPassword);
+
+        createUser(authorizeUser, authorizeUserPassword);
+        grantPrivilege(
+                authorizeUser,
+                new PrivilegeType[] {
+                    PrivilegeType.CREATE_TABLE,
+                    PrivilegeType.ALTER_TABLE,
+                    PrivilegeType.SELECT,
+                    PrivilegeType.INSERT
+                });
+        createUser(unAuthorizeUser, unAuthorizeUserPassword);
+
+        createDatabase();
+        catalogTable = buildTable(TABLE_NAME);
+
+        TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+        rootUserPaimonCatalog.createTable(tablePath, catalogTable, false);
+
+        context =
+                new SinkWriter.Context() {
+                    @Override
+                    public int getIndexOfSubtask() {
+                        return 0;
+                    }
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+    }
+
+    private static CatalogTable buildTable(String tableName) {
+        TableSchema.Builder schemaBuilder = TableSchema.builder();
+        for (int i = 0; i < 5; i++) {
+            schemaBuilder.column(
+                    PhysicalColumn.of(
+                            "f" + i,
+                            BasicType.STRING_TYPE,
+                            (Long) null,
+                            false,
+                            null,
+                            String.format("f%s col", i)));
+        }
+
+        TableSchema tableSchema =
+                schemaBuilder.primaryKey(PrimaryKey.of("pk", Arrays.asList("f0"))).build();
+
+        CatalogTable cTable =
+                CatalogTable.of(
+                        TableIdentifier.of(CATALOG_NAME, DATABASE_NAME, tableName),
+                        tableSchema,
+                        new HashMap<>(),
+                        new ArrayList<>(),
+                        "test table");
+        return cTable;
+    }
+
+    private static void initPrivilege() {
+        org.apache.paimon.options.Options catalogOptions = new org.apache.paimon.options.Options();
+        catalogOptions.set(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        CatalogContext catalogContext = CatalogContext.create(catalogOptions);
+        FileIO fileIO = new ResolvingFileIO();
+        fileIO.configure(catalogContext);
+
+        PrivilegedCatalog priCatalog =
+                new PrivilegedCatalog(
+                        CatalogFactory.createCatalog(catalogContext),
+                        new FileBasedPrivilegeManagerLoader(
+                                warehouse, fileIO, rootUser, rootPassword));
+        if (!priCatalog.privilegeManager().privilegeEnabled()) {
+            priCatalog.privilegeManager().initializePrivilege(rootPassword);
+        }
+    }
+
+    private static void createUser(String user, String password) {
+        Optional<Object> catalog = ReflectionUtils.getField(rootUserPaimonCatalog, "catalog");
+        assertTrue(catalog.isPresent() && catalog.get() instanceof PrivilegedCatalog);
+        PrivilegedCatalog priCatalog = (PrivilegedCatalog) catalog.get();
+        priCatalog.privilegeManager().createUser(user, password);
+    }
+
+    private static void grantPrivilege(String user, PrivilegeType[] privilegeTypes) {
+        Optional<Object> catalog = ReflectionUtils.getField(rootUserPaimonCatalog, "catalog");
+        assertTrue(catalog.isPresent() && catalog.get() instanceof PrivilegedCatalog);
+        PrivilegedCatalog priCatalog = (PrivilegedCatalog) catalog.get();
+        String fullTableName = Identifier.create(DATABASE_NAME, TABLE_NAME).getFullName();
+        for (PrivilegeType type : privilegeTypes) {
+            if (type == PrivilegeType.CREATE_TABLE) {
+                priCatalog
+                        .privilegeManager()
+                        .grant(user, DATABASE_NAME, PrivilegeType.CREATE_TABLE);
+            } else {
+                priCatalog.privilegeManager().grant(user, fullTableName, type);
+            }
+        }
+    }
+
+    private static void createDatabase() {
+        try {
+            TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+            rootUserPaimonCatalog.createDatabase(tablePath, false);
+        } catch (DatabaseAlreadyExistException e) {
+            log.info("database already exist");
+        }
+    }
+
+    private static Map<String, Object> getPaimonProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("warehouse", warehouse);
+        properties.put("plugin_name", "Paimon");
+        properties.put("database", DATABASE_NAME);
+        properties.put("table", TABLE_NAME);
+        Map<String, String> writeProps = new HashMap<>();
+        writeProps.put("bucket", "2");
+        writeProps.put("bucket-key", bucketKey);
+        properties.put("paimon.table.write-props", writeProps);
+        return properties;
+    }
+
+    private static PaimonCatalog createPaimonCatalog(String user, String password) {
+        Map<String, Object> properties = getPaimonProperties();
+        if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(password)) {
+            properties.put("user", user);
+            properties.put("password", password);
+        }
+        PaimonCatalog pCatalog =
+                new PaimonCatalog(CATALOG_NAME, ReadonlyConfig.fromMap(properties));
+        pCatalog.open();
+        return pCatalog;
+    }
+
+    @Test
+    public void createCatalogWithNotUserAndPassword() {
+        assertThrows(
+                PaimonConnectorException.class,
+                () -> {
+                    try {
+                        createPaimonCatalog(null, null);
+                    } catch (PaimonConnectorException e) {
+                        assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                "paimon privilege is enabled, user and password is required"));
+                        throw e;
+                    }
+                });
+    }
+
+    @Test
+    public void createCatalogWithErrorPassword() {
+        PaimonCatalog catalog = createPaimonCatalog(authorizeUser, "errorpassword");
+        assertThrows(
+                CatalogException.class,
+                () -> {
+                    TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+                    try {
+                        catalog.createTable(tablePath, catalogTable, false);
+                    } catch (CatalogException e) {
+                        assertTrue(
+                                e.getCause()
+                                        .getMessage()
+                                        .contains(
+                                                String.format(
+                                                        "User %s not found, or password incorrect.",
+                                                        authorizeUser)));
+                        throw e;
+                    }
+                });
+    }
+
+    @Test
+    public void testCreateTable() {
+        TablePath tablePath = TablePath.of(DATABASE_NAME, "privilege_test_table");
+        CatalogTable catalogTable = buildTable("privilege_test_table");
+        // The permission to create tables
+        authorizedCatalog.createTable(tablePath, catalogTable, false);
+
+        // No permission to create tables
+        assertThrows(
+                CatalogException.class,
+                () -> {
+                    try {
+                        unAuthorizedCatalog.createTable(tablePath, catalogTable, false);
+                    } catch (CatalogException e) {
+                        assertTrue(
+                                e.getCause()
+                                        .getMessage()
+                                        .contains(
+                                                String.format(
+                                                        "User %s doesn't have privilege CREATE_TABLE on",
+                                                        unAuthorizeUser)));
+                        throw e;
+                    }
+                });
+    }
+
+    @Test
+    public void testWriteTable() {
+        writeTable(authorizedCatalog);
+
+        assertThrows(
+                NoPrivilegeException.class,
+                () -> {
+                    try {
+                        writeTable(unAuthorizedCatalog);
+                    } catch (NoPrivilegeException e) {
+                        assertTrue(
+                                e.getMessage()
+                                        .contains(
+                                                String.format(
+                                                        "User %s doesn't have privilege INSERT on table",
+                                                        unAuthorizeUser)));
+                        throw e;
+                    }
+                });
+    }
+
+    private void writeTable(PaimonCatalog paimonCatalog) {
+        TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+
+        JobContext jobContext = new JobContext();
+        jobContext.setJobMode(JobMode.BATCH);
+
+        Optional<Object> config = ReflectionUtils.getField(paimonCatalog, "readonlyConfig");
+        assertTrue(config.isPresent() && config.get() instanceof ReadonlyConfig);
+        ReadonlyConfig readonlyConfig = (ReadonlyConfig) config.get();
+
+        paimonSinkWriter =
+                new PaimonSinkWriter(
+                        context,
+                        readonlyConfig,
+                        paimonCatalog.getTable(tablePath),
+                        paimonCatalog.getPaimonTable(tablePath),
+                        commitUser,
+                        jobContext,
+                        new PaimonSinkConfig(readonlyConfig),
+                        new PaimonHadoopConfiguration(),
+                        new PaimonBucketAssignerFactory());
+
+        String[] fields = catalogTable.getTableSchema().getFieldNames();
+        SeaTunnelRow row = new SeaTunnelRow(fields.length);
+        try {
+            for (int j = 0; j < fields.length; j++) {
+                row.setField(j, "val" + j);
+            }
+            paimonSinkWriter.write(row);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    public static void after() {
+        TablePath tablePath = TablePath.of(DATABASE_NAME, TABLE_NAME);
+        try {
+            rootUserPaimonCatalog.dropTable(tablePath, false);
+            rootUserPaimonCatalog.dropDatabase(tablePath, false);
+        } catch (TableNotExistException e) {
+            log.info("table not exist");
+        } catch (DatabaseNotExistException e) {
+            log.info("database not exist");
+        }
+        rootUserPaimonCatalog.close();
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
@@ -59,12 +59,6 @@
 
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
-            <artifactId>seatunnel-hadoop3-3.1.4-uber</artifactId>
-            <classifier>optional</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-fake</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -94,6 +88,13 @@
             <artifactId>connector-cdc-mysql</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-hadoop3-3.1.4-uber</artifactId>
+            <classifier>optional</classifier>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
@@ -63,6 +63,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- To ensure the SemaphoredDelegatingExecutor class in paimon-s3-impl.jar is loaded first, place the connector-paimon dependency before seatunnel-hadoop3-3.1.4-uber -->
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-paimon</artifactId>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.e2e.connector.paimon;
 
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
@@ -26,6 +27,16 @@ import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
 import org.apache.seatunnel.e2e.common.util.ContainerUtil;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.ResolvingFileIO;
+import org.apache.paimon.privilege.FileBasedPrivilegeManagerLoader;
+import org.apache.paimon.privilege.PrivilegeType;
+import org.apache.paimon.privilege.PrivilegedCatalog;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
@@ -34,12 +45,22 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 @DisabledOnContainer(
         value = {TestContainerId.FLINK_1_13, TestContainerId.SPARK_2_4},
         disabledReason =
                 "Paimon does not support flink 1.13, Spark 2.4.6 has a jar package(zstd-jni-version.jar) version compatibility issue.")
 public class PaimonIT extends TestSuiteBase implements TestResource {
+    private String rootUser = "root";
+    private String rootPassword = "123456";
+    private String paimonUser = "paimon";
+    private String paimonUserPassword = "123456";
+
+    private PrivilegedCatalog privilegedCatalog;
+    private final String DATABASE_NAME = "default";
+    private final String TABLE_NAME = "st_test_p";
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
@@ -48,6 +69,12 @@ public class PaimonIT extends TestSuiteBase implements TestResource {
                 container.copyFileToContainer(
                         MountableFile.forHostPath(schemaPath),
                         "/tmp/seatunnel_mnt/paimon/default.db/st_test/schema/schema-0");
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(schemaPath),
+                        "/tmp/seatunnel_mnt/paimon/default.db/st_test_p/schema/schema-0");
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(schemaPath),
+                        "/tmp/seatunnel_mnt/paimon/default.db/st_test_p1/schema/schema-0");
                 container.execInContainer("chmod", "777", "-R", "/tmp/seatunnel_mnt/");
             };
 
@@ -69,4 +96,80 @@ public class PaimonIT extends TestSuiteBase implements TestResource {
     @Override
     @AfterEach
     public void tearDown() throws Exception {}
+
+    private void initPrivilege(List<PrivilegeType> privilegeTypes, String warehouse) {
+        org.apache.paimon.options.Options catalogOptions = new org.apache.paimon.options.Options();
+        catalogOptions.set(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        final CatalogContext catalogContext = CatalogContext.create(catalogOptions);
+
+        FileIO fileIO = new ResolvingFileIO();
+        fileIO.configure(catalogContext);
+
+        privilegedCatalog =
+                new PrivilegedCatalog(
+                        CatalogFactory.createCatalog(catalogContext),
+                        new FileBasedPrivilegeManagerLoader(
+                                warehouse, fileIO, rootUser, rootPassword));
+        if (!privilegedCatalog.privilegeManager().privilegeEnabled()) {
+            privilegedCatalog.privilegeManager().initializePrivilege(rootPassword);
+        }
+
+        // create user and grant privilege on table
+        privilegedCatalog.privilegeManager().createUser(paimonUser, paimonUserPassword);
+        String fullTableName = Identifier.create(DATABASE_NAME, TABLE_NAME).getFullName();
+        String fullTableName1 = Identifier.create(DATABASE_NAME, "st_test_p1").getFullName();
+        privilegedCatalog.privilegeManager().grant(paimonUser, "", PrivilegeType.CREATE_DATABASE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, DATABASE_NAME, PrivilegeType.DROP_DATABASE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, fullTableName, PrivilegeType.DROP_TABLE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, fullTableName1, PrivilegeType.DROP_TABLE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, DATABASE_NAME, PrivilegeType.CREATE_TABLE);
+        if (!CollectionUtils.isEmpty(privilegeTypes)) {
+            for (PrivilegeType type : privilegeTypes) {
+                privilegedCatalog.privilegeManager().grant(paimonUser, fullTableName, type);
+                privilegedCatalog.privilegeManager().grant(paimonUser, fullTableName1, type);
+            }
+        }
+    }
+
+    /** User not grant read privilege read data test cases for the Paimon table */
+    @TestTemplate
+    public void privilegeEnabledPaimonSourceAuthorized(TestContainer container) throws Exception {
+        String warehouse = "/tmp/seatunnel_mnt/paimon";
+        List<PrivilegeType> privilegeTypes = new ArrayList<>();
+        privilegeTypes.add(PrivilegeType.SELECT);
+        privilegeTypes.add(PrivilegeType.INSERT);
+        initPrivilege(privilegeTypes, warehouse);
+        // fake to paimon
+        Container.ExecResult execResult = container.executeJob("/fake_to_paimon_privilege.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        // paimon to paimon
+        Container.ExecResult execResult1 = container.executeJob("/paimon_to_paimon_privilege.conf");
+        Assertions.assertEquals(0, execResult1.getExitCode());
+    }
+
+    /** User not grant read privilege read data test cases for the Paimon table */
+    @TestTemplate
+    public void privilegeEnabledPaimonSourceUnAuthorized(TestContainer container) throws Exception {
+        String warehouse = "/tmp/seatunnel_mnt/paimon";
+        List<PrivilegeType> privilegeTypes = new ArrayList<>();
+        privilegeTypes.add(PrivilegeType.INSERT);
+        initPrivilege(privilegeTypes, warehouse);
+        // fake to paimon
+        Container.ExecResult execResult = container.executeJob("/fake_to_paimon_privilege1.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        // paimon to paimon
+        Container.ExecResult execResult1 =
+                container.executeJob("/paimon_to_paimon_privilege1.conf");
+        Assertions.assertEquals(1, execResult1.getExitCode());
+    }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonWithS3IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonWithS3IT.java
@@ -17,8 +17,19 @@
 
 package org.apache.seatunnel.e2e.connector.paimon;
 
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
 import org.apache.seatunnel.e2e.common.container.seatunnel.SeaTunnelContainer;
 import org.apache.seatunnel.e2e.common.util.ContainerUtil;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.ResolvingFileIO;
+import org.apache.paimon.privilege.FileBasedPrivilegeManagerLoader;
+import org.apache.paimon.privilege.PrivilegeType;
+import org.apache.paimon.privilege.PrivilegedCatalog;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -33,7 +44,8 @@ import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 
 import java.nio.file.Paths;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PaimonWithS3IT extends SeaTunnelContainer {
@@ -45,11 +57,20 @@ public class PaimonWithS3IT extends SeaTunnelContainer {
     private static final String MINIO_USER_PASSWORD = "miniominio";
 
     private static final String BUCKET = "test";
+    private static final String PRIVILEGE_BUCKET = "privilegetest";
 
     private MinIOContainer container;
     private MinioClient minioClient;
 
-    private Map<String, Object> PAIMON_SINK_PROPERTIES;
+    private String warehouse = "s3a://privilegetest/";
+    private String rootUser = "root";
+    private String rootPassword = "123456";
+    private String paimonUser = "paimon";
+    private String paimonUserPassword = "123456";
+
+    private PrivilegedCatalog privilegedCatalog;
+    private final String DATABASE_NAME = "seatunnel_namespace11";
+    private final String TABLE_NAME = "st_test";
 
     protected static final String AWS_SDK_DOWNLOAD =
             "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar";
@@ -79,9 +100,16 @@ public class PaimonWithS3IT extends SeaTunnelContainer {
 
         // create bucket
         minioClient.makeBucket(MakeBucketArgs.builder().bucket(BUCKET).build());
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket(PRIVILEGE_BUCKET).build());
 
         BucketExistsArgs existsArgs = BucketExistsArgs.builder().bucket(BUCKET).build();
         Assertions.assertTrue(minioClient.bucketExists(existsArgs));
+        BucketExistsArgs privExistsArgs =
+                BucketExistsArgs.builder().bucket(PRIVILEGE_BUCKET).build();
+        Assertions.assertTrue(minioClient.bucketExists(privExistsArgs));
+
+        initPrivilege();
+
         super.startUp();
     }
 
@@ -138,5 +166,100 @@ public class PaimonWithS3IT extends SeaTunnelContainer {
 
         Container.ExecResult readResult = executeJob("/fake_2_paimon_with_s3_to_assert.conf");
         Assertions.assertEquals(0, readResult.getExitCode());
+    }
+
+    private void initPrivilege() {
+        org.apache.paimon.options.Options catalogOptions = new org.apache.paimon.options.Options();
+        catalogOptions.set(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        catalogOptions.set("fs.s3a.endpoint", container.getS3URL());
+        catalogOptions.set("fs.s3a.access-key", MINIO_USER_NAME);
+        catalogOptions.set("fs.s3a.secret-key", MINIO_USER_PASSWORD);
+        catalogOptions.set("fs.s3a.buffer.dir", "/tmp/s3abuffer");
+        catalogOptions.set("fs.s3a.change.detection.mode", "NONE");
+        catalogOptions.set("fs.s3a.change.detection.version.required", "false");
+        catalogOptions.set("fs.s3a.path.style.access", "true");
+        catalogOptions.set(
+                "fs.s3a.aws.credentials.provider",
+                "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider");
+        final CatalogContext catalogContext = CatalogContext.create(catalogOptions);
+
+        FileIO fileIO = new ResolvingFileIO();
+        fileIO.configure(catalogContext);
+
+        privilegedCatalog =
+                new PrivilegedCatalog(
+                        CatalogFactory.createCatalog(catalogContext),
+                        new FileBasedPrivilegeManagerLoader(
+                                warehouse, fileIO, rootUser, rootPassword));
+        if (!privilegedCatalog.privilegeManager().privilegeEnabled()) {
+            privilegedCatalog.privilegeManager().initializePrivilege(rootPassword);
+        }
+
+        // create user and grant privilege on table
+        privilegedCatalog.privilegeManager().createUser(paimonUser, paimonUserPassword);
+        String fullTableName = Identifier.create(DATABASE_NAME, TABLE_NAME).getFullName();
+        privilegedCatalog.privilegeManager().grant(paimonUser, "", PrivilegeType.CREATE_DATABASE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, DATABASE_NAME, PrivilegeType.DROP_DATABASE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, fullTableName, PrivilegeType.DROP_TABLE);
+        privilegedCatalog
+                .privilegeManager()
+                .grant(paimonUser, DATABASE_NAME, PrivilegeType.CREATE_TABLE);
+    }
+
+    private void grantPrivilege(List<PrivilegeType> privilegeTypes) {
+        String fullTableName = Identifier.create(DATABASE_NAME, TABLE_NAME).getFullName();
+        if (!CollectionUtils.isEmpty(privilegeTypes)) {
+            for (PrivilegeType type : privilegeTypes) {
+                privilegedCatalog.privilegeManager().grant(paimonUser, fullTableName, type);
+            }
+        }
+    }
+
+    private void revokePrivilege(List<PrivilegeType> privilegeTypes) {
+        String fullTableName = Identifier.create(DATABASE_NAME, TABLE_NAME).getFullName();
+        if (!CollectionUtils.isEmpty(privilegeTypes)) {
+            for (PrivilegeType type : privilegeTypes) {
+                privilegedCatalog.privilegeManager().revoke(paimonUser, fullTableName, type);
+            }
+        }
+    }
+
+    /** User not grant read privilege read data test cases for the Paimon table. */
+    @Test
+    public void privilegeEnabledPaimonSourceAuthorized() throws Exception {
+        List<PrivilegeType> privilegeTypes = new ArrayList<>();
+        privilegeTypes.add(PrivilegeType.SELECT);
+        privilegeTypes.add(PrivilegeType.INSERT);
+        grantPrivilege(privilegeTypes);
+        // fake to paimon
+        Container.ExecResult execResult = executeJob("/fake_to_paimon_with_s3_with_privilege.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        // paimon to paimon
+        Container.ExecResult execResult1 =
+                executeJob("/paimon_to_paimon_with_s3_with_privilege.conf");
+        Assertions.assertEquals(0, execResult1.getExitCode());
+        revokePrivilege(privilegeTypes);
+    }
+
+    /** User not grant read privilege read data test cases for the Paimon table. */
+    @Test
+    public void privilegeEnabledPaimonSourceUnAuthorized() throws Exception {
+        List<PrivilegeType> privilegeTypes = new ArrayList<>();
+        privilegeTypes.add(PrivilegeType.INSERT);
+        grantPrivilege(privilegeTypes);
+        // fake to paimon
+        Container.ExecResult execResult = executeJob("/fake_to_paimon_with_s3_with_privilege.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        // paimon to paimon
+        Container.ExecResult execResult1 =
+                executeJob("/paimon_to_paimon_with_s3_with_privilege.conf");
+        Assertions.assertEquals(1, execResult1.getExitCode());
+        revokePrivilege(privilegeTypes);
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_privilege.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_privilege.conf
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+
+  # You can set spark configuration here
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  FakeSource {
+    auto.increment.enabled = true
+    auto.increment.start = 1
+    row.num = 100
+    schema = {
+      fields {
+        pk_id = bigint
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+        c_time = time
+      }
+      primaryKey {
+        name = "pk_id"
+        columnNames = [pk_id]
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "file:///tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p"
+    user = "paimon"
+    password = "123456"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_privilege1.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_privilege1.conf
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+
+  # You can set spark configuration here
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  FakeSource {
+    auto.increment.enabled = true
+    auto.increment.start = 1
+    row.num = 100
+    schema = {
+      fields {
+        pk_id = bigint
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+        c_time = time
+      }
+      primaryKey {
+        name = "pk_id"
+        columnNames = [pk_id]
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "/tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p"
+    user = "paimon"
+    password = "123456"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_with_s3_with_privilege.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_with_s3_with_privilege.conf
@@ -1,0 +1,97 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        pk_id = bigint
+        name = string
+        score = int
+      }
+      primaryKey {
+        name = "pk_id"
+        columnNames = [pk_id]
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [1, "A", 100]
+      },
+      {
+        kind = INSERT
+        fields = [2, "B", 100]
+      },
+      {
+        kind = INSERT
+        fields = [3, "C", 100]
+      },
+      {
+        kind = INSERT
+        fields = [3, "C", 100]
+      },
+      {
+        kind = INSERT
+        fields = [3, "C", 100]
+      },
+      {
+        kind = INSERT
+        fields = [3, "C", 100]
+      }
+      {
+        kind = UPDATE_BEFORE
+        fields = [1, "A", 100]
+      },
+      {
+        kind = UPDATE_AFTER
+        fields = [1, "A_1", 100]
+      },
+      {
+        kind = DELETE
+        fields = [2, "B", 100]
+      }
+    ]
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "s3a://privilegetest/"
+    database = "seatunnel_namespace11"
+    table = "st_test"
+    user = "paimon"
+    password = "123456"
+    paimon.hadoop.conf = {
+      fs.s3a.access-key = minio
+      fs.s3a.secret-key = miniominio
+      fs.s3a.endpoint = "http://minio:9000"
+      fs.s3a.path.style.access = true
+      fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_privilege.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_privilege.conf
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Paimon {
+    warehouse = "file:///tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p"
+    user = "paimon"
+    password = "123456"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "file:///tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p1"
+    user = "paimon"
+    password = "123456"
+    paimon.table.primary-keys = "pk_id"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_privilege1.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_privilege1.conf
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Paimon {
+    warehouse = "/tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p"
+    user = "paimon"
+    password = "123456"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "/tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test_p1"
+    user = "paimon"
+    password = "123456"
+    paimon.table.primary-keys = "pk_id"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_with_s3_with_privilege.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/paimon_to_paimon_with_s3_with_privilege.conf
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 2
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+  job.mode = "BATCH"
+}
+
+source {
+  Paimon {
+    warehouse = "s3a://privilegetest/"
+    database = "seatunnel_namespace11"
+    table = "st_test"
+    user = "paimon"
+    password = "123456"
+    paimon.hadoop.conf = {
+          fs.s3a.access-key = minio
+          fs.s3a.secret-key = miniominio
+          fs.s3a.endpoint = "http://minio:9000"
+          fs.s3a.path.style.access = true
+          fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+        }
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "s3a://test/"
+    database = "seatunnel_namespace13"
+    table = "st_test_sink_priv"
+    paimon.hadoop.conf = {
+      fs.s3a.access-key = minio
+      fs.s3a.secret-key = miniominio
+      fs.s3a.endpoint = "http://minio:9000"
+      fs.s3a.path.style.access = true
+      fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+    }
+  }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

With privilege enabled in Paimon, the Paimon connector supports username/password authentication for secure access to Paimon tables


### Does this PR introduce _any_ user-facing change?
1.add tow parameter in paimon connector sink ,user and password
<img width="2252" height="676" alt="image" src="https://github.com/user-attachments/assets/7440dc0e-fd7a-433a-a705-51501f8bbc5f" />
<img width="1744" height="1186" alt="image" src="https://github.com/user-attachments/assets/2e2340ff-6df9-4267-ae75-89d458723c88" />


2.add tow parameter in paimon connector source ,user and password
<img width="1254" height="990" alt="image" src="https://github.com/user-attachments/assets/9c78775b-32fa-4a08-bb49-af710dc0e1cd" />
<img width="1138" height="506" alt="image" src="https://github.com/user-attachments/assets/fc2b23aa-3869-4a17-88a3-0597d57452ff" />


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
1. Added unit test class PaimonPrivilegeCatalogTest to simulate scenarios with/without privileges for writing to and creating Paimon tables.
2. e2e test
Added integration test method in PaimonT to test Paimon table write(sink) and read(source) operations under local filesystem environment.
Added integration test method in PaimonWithS3T to verify Paimon table operations via S3 protocol (using MinIO storage), including both sink writes and source reads.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  4. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  5. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  6. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  7. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)