### PR TITLE
[Improve][API] Add convenience methods for creating nested ArrayType

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/ArrayType.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/ArrayType.java
@@ -17,6 +17,9 @@
 
 package org.apache.seatunnel.api.table.type;
 
+import org.apache.seatunnel.common.exception.CommonError;
+
+import java.lang.reflect.Array;
 import java.util.Objects;
 
 public class ArrayType<T, E> implements SeaTunnelDataType<T> {
@@ -51,6 +54,8 @@ public class ArrayType<T, E> implements SeaTunnelDataType<T> {
     public static final ArrayType<LocalTimeType[], LocalTimeType> OFFSET_DATE_TIME_ARRAY_TYPE =
             new ArrayType(LocalTimeType[].class, LocalTimeType.OFFSET_DATE_TIME_TYPE);
 
+    public static final String OPERATION = "create ArrayType";
+
     // --------------------------------------------------------------------------------------------
 
     private final Class<T> arrayClass;
@@ -59,6 +64,33 @@ public class ArrayType<T, E> implements SeaTunnelDataType<T> {
     public ArrayType(Class<T> arrayClass, SeaTunnelDataType<E> elementType) {
         this.arrayClass = arrayClass;
         this.elementType = elementType;
+    }
+
+    public static <E> ArrayType<E[], E> of(SeaTunnelDataType<E> elementType) {
+        if (elementType == null) {
+            throw CommonError.illegalArgument("elementType is null", OPERATION);
+        }
+        Class<E[]> arrayClass = (Class<E[]>) toArrayClass(elementType);
+        return new ArrayType<>(arrayClass, elementType);
+    }
+
+    public static <E> ArrayType<?, ?> of(SeaTunnelDataType<E> elementType, int dimensions) {
+        if (dimensions < 1) {
+            throw CommonError.illegalArgument("dimensions must be >= 1", OPERATION);
+        }
+        SeaTunnelDataType<?> current = elementType;
+        for (int i = 0; i < dimensions; i++) {
+            current = of(current);
+        }
+        return (ArrayType<?, ?>) current;
+    }
+
+    public ArrayType<T[], T> addDimension() {
+        return ArrayType.of(this);
+    }
+
+    public int getDimensions() {
+        return dimensionOf(arrayClass);
     }
 
     public SeaTunnelDataType<E> getElementType() {
@@ -96,5 +128,20 @@ public class ArrayType<T, E> implements SeaTunnelDataType<T> {
     @Override
     public String toString() {
         return String.format("ARRAY<%s>", elementType);
+    }
+
+    private int dimensionOf(Class<?> cls) {
+        int dimension = 0;
+        Class<?> c = cls;
+        while (c.isArray()) {
+            dimension++;
+            c = c.getComponentType();
+        }
+        return dimension;
+    }
+
+    private static Class<?> toArrayClass(SeaTunnelDataType<?> elementType) {
+        Class<?> elementClass = elementType.getTypeClass();
+        return Array.newInstance(elementClass, 0).getClass();
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/ArrayType.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/ArrayType.java
@@ -66,6 +66,7 @@ public class ArrayType<T, E> implements SeaTunnelDataType<T> {
         this.elementType = elementType;
     }
 
+    @SuppressWarnings("unchecked")
     public static <E> ArrayType<E[], E> of(SeaTunnelDataType<E> elementType) {
         if (elementType == null) {
             throw CommonError.illegalArgument("elementType is null", OPERATION);
@@ -74,6 +75,7 @@ public class ArrayType<T, E> implements SeaTunnelDataType<T> {
         return new ArrayType<>(arrayClass, elementType);
     }
 
+    @SuppressWarnings("unchecked")
     public static <E> ArrayType<?, ?> of(SeaTunnelDataType<E> elementType, int dimensions) {
         if (dimensions < 1) {
             throw CommonError.illegalArgument("dimensions must be >= 1", OPERATION);

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/ArrayTypeTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/ArrayTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.table.type;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ArrayTypeTest {
+
+    @Test
+    void testSingleDimensionArray() {
+        ArrayType<String[], String> stringArrayType = ArrayType.of(BasicType.STRING_TYPE);
+        Assertions.assertEquals(1, stringArrayType.getDimensions());
+        Assertions.assertEquals(BasicType.STRING_TYPE, stringArrayType.getElementType());
+        Assertions.assertEquals(String[].class, stringArrayType.getTypeClass());
+    }
+
+    @Test
+    void testMultiDimensionArray() {
+        ArrayType<?, ?> nestedArrayType1 = ArrayType.of(ArrayType.of(BasicType.STRING_TYPE));
+        Assertions.assertEquals(2, nestedArrayType1.getDimensions());
+        Assertions.assertEquals(String[].class, nestedArrayType1.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][].class, nestedArrayType1.getTypeClass());
+
+        ArrayType<String[][], String[]> nestedArrayType2 =
+                ArrayType.of(ArrayType.STRING_ARRAY_TYPE);
+        Assertions.assertEquals(2, nestedArrayType2.getDimensions());
+        Assertions.assertEquals(String[].class, nestedArrayType2.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][].class, nestedArrayType2.getTypeClass());
+
+        ArrayType<String[][], String[]> nestedArrayType3 =
+                new ArrayType(String[][].class, ArrayType.STRING_ARRAY_TYPE);
+        Assertions.assertEquals(2, nestedArrayType3.getDimensions());
+        Assertions.assertEquals(String[].class, nestedArrayType3.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][].class, nestedArrayType3.getTypeClass());
+    }
+
+    @Test
+    void testMultiDimensionArrayWithDimensions() {
+        ArrayType<?, ?> threeDimensionArrayType = ArrayType.of(BasicType.STRING_TYPE, 3);
+        Assertions.assertEquals(3, threeDimensionArrayType.getDimensions());
+        Assertions.assertEquals(
+                String[][].class, threeDimensionArrayType.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][][].class, threeDimensionArrayType.getTypeClass());
+
+        ArrayType<?, ?> fourDimensionArrayType = ArrayType.of(BasicType.STRING_TYPE, 4);
+        Assertions.assertEquals(4, fourDimensionArrayType.getDimensions());
+        Assertions.assertEquals(
+                String[][][].class, fourDimensionArrayType.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][][][].class, fourDimensionArrayType.getTypeClass());
+    }
+
+    @Test
+    void testAddDimension() {
+        ArrayType<String[], String> stringArrayType = ArrayType.of(BasicType.STRING_TYPE);
+        ArrayType<?, ?> multiDimArrayType = stringArrayType.addDimension();
+        Assertions.assertEquals(2, multiDimArrayType.getDimensions());
+        Assertions.assertEquals(String[].class, multiDimArrayType.getElementType().getTypeClass());
+        Assertions.assertEquals(String[][].class, multiDimArrayType.getTypeClass());
+    }
+
+    @Test
+    void testToString() {
+        ArrayType<String[], String> stringArrayType = ArrayType.of(BasicType.STRING_TYPE);
+        Assertions.assertEquals("ARRAY<STRING>", stringArrayType.toString());
+
+        ArrayType<?, ?> nestedArrayType = ArrayType.of(BasicType.STRING_TYPE, 2);
+        Assertions.assertEquals("ARRAY<ARRAY<STRING>>", nestedArrayType.toString());
+
+        ArrayType<?, ?> nestedArrayType2 = ArrayType.of(BasicType.STRING_TYPE, 3);
+        Assertions.assertEquals("ARRAY<ARRAY<ARRAY<STRING>>>", nestedArrayType2.toString());
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

This PR introduces convenience methods in `ArrayType` to simplify the creation of nested arrays. 
These methods do not change any existing behavior; they are purely helper functions to reduce boilerplate and potential mistakes when defining nested arrays.
They will also be useful for future features that require nested type support.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Add `ArrayTypeTest`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)