### PR TITLE
[Fix][Zeta] Fix `seatunnel.sh - j` command not working

### DIFF
--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelEngineClusterRoleTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelEngineClusterRoleTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.common.config.Common;
 import org.apache.seatunnel.common.config.DeployMode;
 import org.apache.seatunnel.engine.client.job.ClientJobExecutionEnvironment;
 import org.apache.seatunnel.engine.client.job.ClientJobProxy;
+import org.apache.seatunnel.engine.client.job.JobClient;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.JobConfig;
@@ -37,14 +38,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.awaitility.Awaitility.await;
 
@@ -351,6 +360,120 @@ public class SeaTunnelEngineClusterRoleTest {
                 () -> {
                     SeaTunnelServerStarter.createWorkerHazelcastInstance(seaTunnelConfig);
                 });
+    }
+
+    @SneakyThrows
+    @Test
+    public void testWorkerIsFirstMemberThenGetJobDetailStatus() {
+        HazelcastInstanceImpl workerNode1 = null;
+        HazelcastInstanceImpl workerNode2 = null;
+        HazelcastInstanceImpl masterNode1 = null;
+        HazelcastInstanceImpl masterNode2 = null;
+        SeaTunnelClient seatunnelClient = null;
+        HazelcastClientInstanceImpl hazelcastClient = null;
+
+        String testClusterName = "Test_testClusterWillDownWhenNoMasterNode";
+
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setClusterName(ContentFormatUtilTest.getClusterName(testClusterName));
+
+        try {
+            // master node must start first in ci
+            masterNode1 = SeaTunnelServerStarter.createMasterHazelcastInstance(seaTunnelConfig);
+            HazelcastInstanceImpl finalMasterNode1 = masterNode1;
+            Awaitility.await()
+                    .atMost(10000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            1, finalMasterNode1.getCluster().getMembers().size()));
+            // start two worker nodes
+            workerNode1 = SeaTunnelServerStarter.createWorkerHazelcastInstance(seaTunnelConfig);
+            workerNode2 = SeaTunnelServerStarter.createWorkerHazelcastInstance(seaTunnelConfig);
+            // start another master node
+            masterNode2 = SeaTunnelServerStarter.createMasterHazelcastInstance(seaTunnelConfig);
+
+            HazelcastInstanceImpl finalWorkerNode = workerNode1;
+            Awaitility.await()
+                    .atMost(10000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            4, finalWorkerNode.getCluster().getMembers().size()));
+            // shutdown master node1
+            masterNode1.shutdown();
+            Awaitility.await()
+                    .atMost(10000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            3, finalWorkerNode.getCluster().getMembers().size()));
+            Set<Member> members = workerNode1.getCluster().getMembers();
+            Map<UUID, Member> memberMap =
+                    members.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            Member::getUuid, member -> member, (a, b) -> b));
+
+            // get master member
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            hazelcastClient =
+                    ((HazelcastClientProxy) HazelcastClient.newHazelcastClient(clientConfig))
+                            .client;
+            HazelcastClientInstanceImpl finalHazelcastClient = hazelcastClient;
+            Awaitility.await()
+                    .atMost(10000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () -> {
+                                UUID masterUuid =
+                                        finalHazelcastClient
+                                                .getClientClusterService()
+                                                .getMasterMember()
+                                                .getUuid();
+                                Assertions.assertTrue(memberMap.get(masterUuid).isLiteMember());
+                            });
+
+            // start client job
+            Common.setDeployMode(DeployMode.CLIENT);
+            String filePath = ContentFormatUtilTest.getResource("/streaming_fake_to_console.conf");
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.setName("testGetJobState");
+            seatunnelClient = createSeaTunnelClient(testClusterName);
+            JobClient jobClient = seatunnelClient.getJobClient();
+            ClientJobExecutionEnvironment jobExecutionEnv =
+                    seatunnelClient.createExecutionContext(filePath, jobConfig, seaTunnelConfig);
+            final ClientJobProxy clientJobProxy = jobExecutionEnv.execute();
+            long jobId = clientJobProxy.getJobId();
+            await().atMost(30000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertTrue(
+                                            jobClient.getJobDetailStatus(jobId).contains("RUNNING")
+                                                    && jobClient
+                                                            .listJobStatus(true)
+                                                            .contains("RUNNING")));
+        } finally {
+            if (hazelcastClient != null) {
+                hazelcastClient.shutdown();
+            }
+            if (seatunnelClient != null) {
+                seatunnelClient.close();
+            }
+            if (workerNode1 != null) {
+                workerNode1.shutdown();
+            }
+            if (workerNode2 != null) {
+                workerNode2.shutdown();
+            }
+            if (masterNode1 != null) {
+                masterNode1.shutdown();
+            }
+            if (masterNode2 != null) {
+                masterNode2.shutdown();
+            }
+        }
     }
 
     private String getMulticastConfig() {

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelEngineClusterRoleTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelEngineClusterRoleTest.java
@@ -371,14 +371,11 @@ public class SeaTunnelEngineClusterRoleTest {
         HazelcastInstanceImpl masterNode2 = null;
         SeaTunnelClient seatunnelClient = null;
         HazelcastClientInstanceImpl hazelcastClient = null;
-
-        String testClusterName = "Test_testClusterWillDownWhenNoMasterNode";
-
+        String testClusterName = "Test_testWorkerIsFirstMemberThenGetJobDetailStatus";
         SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
         seaTunnelConfig
                 .getHazelcastConfig()
                 .setClusterName(ContentFormatUtilTest.getClusterName(testClusterName));
-
         try {
             // master node must start first in ci
             masterNode1 = SeaTunnelServerStarter.createMasterHazelcastInstance(seaTunnelConfig);
@@ -393,8 +390,11 @@ public class SeaTunnelEngineClusterRoleTest {
             workerNode1 = SeaTunnelServerStarter.createWorkerHazelcastInstance(seaTunnelConfig);
             workerNode2 = SeaTunnelServerStarter.createWorkerHazelcastInstance(seaTunnelConfig);
             // start another master node
-            masterNode2 = SeaTunnelServerStarter.createMasterHazelcastInstance(seaTunnelConfig);
-
+            SeaTunnelConfig seaTunnelConfig2 = ConfigProvider.locateAndGetSeaTunnelConfig();
+            seaTunnelConfig2
+                    .getHazelcastConfig()
+                    .setClusterName(ContentFormatUtilTest.getClusterName(testClusterName));
+            masterNode2 = SeaTunnelServerStarter.createMasterHazelcastInstance(seaTunnelConfig2);
             HazelcastInstanceImpl finalWorkerNode = workerNode1;
             Awaitility.await()
                     .atMost(10000, TimeUnit.MILLISECONDS)
@@ -402,7 +402,6 @@ public class SeaTunnelEngineClusterRoleTest {
                             () ->
                                     Assertions.assertEquals(
                                             4, finalWorkerNode.getCluster().getMembers().size()));
-            // shutdown master node1
             masterNode1.shutdown();
             Awaitility.await()
                     .atMost(10000, TimeUnit.MILLISECONDS)
@@ -416,9 +415,9 @@ public class SeaTunnelEngineClusterRoleTest {
                             .collect(
                                     Collectors.toMap(
                                             Member::getUuid, member -> member, (a, b) -> b));
-
             // get master member
             ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(ContentFormatUtilTest.getClusterName(testClusterName));
             hazelcastClient =
                     ((HazelcastClientProxy) HazelcastClient.newHazelcastClient(clientConfig))
                             .client;
@@ -434,7 +433,6 @@ public class SeaTunnelEngineClusterRoleTest {
                                                 .getUuid();
                                 Assertions.assertTrue(memberMap.get(masterUuid).isLiteMember());
                             });
-
             // start client job
             Common.setDeployMode(DeployMode.CLIENT);
             String filePath = ContentFormatUtilTest.getResource("/streaming_fake_to_console.conf");
@@ -454,6 +452,12 @@ public class SeaTunnelEngineClusterRoleTest {
                                                     && jobClient
                                                             .listJobStatus(true)
                                                             .contains("RUNNING")));
+            jobClient.cancelJob(jobId);
+            await().atMost(30000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            "CANCELED", jobClient.getJobStatus(jobId)));
         } finally {
             if (hazelcastClient != null) {
                 hazelcastClient.shutdown();

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetJobDetailStatusOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetJobDetailStatusOperation.java
@@ -50,7 +50,7 @@ public class GetJobDetailStatusOperation extends Operation
 
     @Override
     public int getClassId() {
-        return ClientToServerOperationDataSerializerHook.PRINT_MESSAGE_OPERATOR;
+        return ClientToServerOperationDataSerializerHook.GET_JOB_STATE_OPERATION;
     }
 
     @Override


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
close https://github.com/apache/seatunnel/issues/9831
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

I tested this issue in my local

Executing `seatunnel.sh - j 10165375033953321986` before updating will result in an error:
```
2025-09-06 17:02:21,417 ERROR [o.a.s.c.s.SeaTunnel           ] [main] - Exception StackTrace:org.apache.seatunnel.core.starter.exception.CommandExecuteException: SeaTunnel job executed failed
        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:211)
        at org.apache.seatunnel.core.starter.SeaTunnel.run(SeaTunnel.java:40)
        at org.apache.seatunnel.core.starter.seatunnel.SeaTunnelClient.main(SeaTunnelClient.java:34)
Caused by: com.hazelcast.nio.serialization.HazelcastSerializationException: Problem while reading DataSerializable, namespace: -30001, ID: 0, class: 'null', exception: String index out of range: 236681170
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.rethrowReadException(DataSerializableSerializer.java:183)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:164)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:106)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:51)
        at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:44)
        at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toObject(AbstractSerializationService.java:268)
        at com.hazelcast.spi.impl.NodeEngineImpl.toObject(NodeEngineImpl.java:385)
        at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:456)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:197)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:137)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
        at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
        at ------ submitted from ------.()
        at com.hazelcast.internal.util.ExceptionUtil.cloneExceptionWithFixedAsyncStackTrace(ExceptionUtil.java:336)
        at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.returnOrThrowWithGetConventions(InvocationFuture.java:112)
        at com.hazelcast.client.impl.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:95)
        at com.hazelcast.client.impl.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:40)
        at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:617)
        at org.apache.seatunnel.engine.client.SeaTunnelHazelcastClient.requestAndDecodeResponse(SeaTunnelHazelcastClient.java:80)
        at org.apache.seatunnel.engine.client.SeaTunnelHazelcastClient.requestOnMasterAndDecodeResponse(SeaTunnelHazelcastClient.java:71)
        at org.apache.seatunnel.engine.client.job.JobClient.getJobDetailStatus(JobClient.java:70)
        at org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand.execute(ClientExecuteCommand.java:113)
        ... 2 more
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 236681170
        at java.lang.String.checkBounds(String.java:385)
        at java.lang.String.<init>(String.java:462)
        at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readUTFInternal(ByteArrayObjectDataInput.java:720)
        at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readString(ByteArrayObjectDataInput.java:594)
        at org.apache.seatunnel.engine.server.operation.PrintMessageOperation.readInternal(PrintMessageOperation.java:62)
        at com.hazelcast.spi.impl.operationservice.Operation.readData(Operation.java:763)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:160)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:106)
        at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:51)
        at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:44)
        at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toObject(AbstractSerializationService.java:268)
        at com.hazelcast.spi.impl.NodeEngineImpl.toObject(NodeEngineImpl.java:385)
        at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:456)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:197)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:137)
        at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.executeRun(OperationThread.java:123)
        at com.hazelcast.internal.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:102)
```

After updating, data can be queried:
`{"jobId":1016537503953321986,"jobName":"seatunnel_web_job_18905065889632","jobStatus":"RUNNING","submitTime":1757126227596,"finishTime":null,"pipelineStateMapperMap":{"PipelineLocation(jobId=1016537503953321986, pipelineId=1)":{"pipelineStatus":"RUNNING","executionStateMap":{"TaskGroupLocation{jobId=1016537503953321986, pipelineId=1, taskGroupId=1}":"RUNNING","TaskGroupLocation{jobId=1016537503953321986, pipelineId=1, taskGroupId=30000}":"RUNNING"}}},"errorMessage":null}`


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)