### PR TITLE
[Fix][Zeta] Fix `JobStateEventTest` to use await conditions for accessCounter assertions

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobStateEventTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobStateEventTest.java
@@ -79,7 +79,8 @@ public class JobStateEventTest extends AbstractSeaTunnelServerTest {
                                         server.getCoordinatorService()
                                                 .getJobStatus(jobId_finished)));
         // check whether the event handler is executed
-        Assertions.assertEquals(1, accessCounter.get());
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(1, accessCounter.get()));
         JobStateEvent jobStateEventFinished = jobStateEventReference.get();
         Assertions.assertEquals(String.valueOf(jobId_finished), jobStateEventFinished.getJobId());
         Assertions.assertEquals(JobStatus.FINISHED, jobStateEventFinished.getJobStatus());
@@ -95,7 +96,8 @@ public class JobStateEventTest extends AbstractSeaTunnelServerTest {
                                         JobStatus.FAILED,
                                         server.getCoordinatorService().getJobStatus(jobId_failed)));
 
-        Assertions.assertEquals(2, accessCounter.get());
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(2, accessCounter.get()));
         JobStateEvent jobStateEventFailed = jobStateEventReference.get();
         Assertions.assertEquals(String.valueOf(jobId_failed), jobStateEventFailed.getJobId());
         Assertions.assertEquals(JobStatus.FAILED, jobStateEventFailed.getJobStatus());


### PR DESCRIPTION
### Purpose of this pull request

Fix flaky test in `testJobStateEvent`.

Since the eventHandler updates the counter asynchronously after the job status changes,
the test fails intermittently in CI.

This patch wraps the assertions with `await().untilAsserted(...)` to give the event handler
time to process the job status change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing test.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)