### PR TITLE
[Fix][Spark] Ensure order-independent schema merging by sorting catalog tables

### DIFF
--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/execution/MultiTableManager.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/execution/MultiTableManager.java
@@ -37,6 +37,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,6 +131,7 @@ public class MultiTableManager implements Serializable {
     }
 
     public List<ColumnWithIndex> mergeSchema(CatalogTable[] catalogTables) {
+        Arrays.sort(catalogTables, Comparator.comparing(t -> t.getTablePath().toString()));
         List<ColumnWithIndex> columnWithIndexes = new ArrayList<>();
         if (catalogTables.length == 1) {
             CatalogTable catalogTable = catalogTables[0];

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
@@ -127,7 +127,7 @@ public class MultiTableManagerTest {
     }
 
     @Test
-    public void testMergeSchemaWithDifferentOrder() {
+    void testMergeSchemaWithDifferentOrder() {
         initSchema();
         MultiTableManager multiTableManager1 =
                 new MultiTableManager(new CatalogTable[] {catalogTable1, catalogTable3});

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
@@ -127,6 +127,20 @@ public class MultiTableManagerTest {
     }
 
     @Test
+    public void testMergeSchemaWithDifferentOrder() {
+        initSchema();
+        MultiTableManager multiTableManager1 =
+                new MultiTableManager(new CatalogTable[] {catalogTable1, catalogTable3});
+        StructType tableSchema1 = multiTableManager1.getTableSchema();
+        MultiTableManager multiTableManager2 =
+                new MultiTableManager(new CatalogTable[] {catalogTable3, catalogTable1});
+        StructType tableSchema2 = multiTableManager2.getTableSchema();
+        System.out.println(tableSchema1);
+        System.out.println(tableSchema2);
+        Assertions.assertEquals(tableSchema1, tableSchema2);
+    }
+
+    @Test
     public void testWriteConverter() throws IOException {
         initSchema();
         initData();

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
@@ -135,8 +135,6 @@ public class MultiTableManagerTest {
         MultiTableManager multiTableManager2 =
                 new MultiTableManager(new CatalogTable[] {catalogTable3, catalogTable1});
         StructType tableSchema2 = multiTableManager2.getTableSchema();
-        System.out.println(tableSchema1);
-        System.out.println(tableSchema2);
         Assertions.assertEquals(tableSchema1, tableSchema2);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/9877
### Purpose of this pull request

This PR ensures order-independent schema merging by sorting catalog tables before schema generation. This prevents silent data corruption caused by non-deterministic field ordering.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added test to verify that merging schemas with different table orderings produces consistent results.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)