### PR TITLE
[Hotfix] [connector-jdbc-e2e-part-7] CI failure caused by a conflict during container deletion

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
@@ -48,7 +48,7 @@ import static org.awaitility.Awaitility.await;
 @Slf4j
 @DisabledOnContainer(
         value = {},
-        type = {EngineType.SPARK},
+        type = {EngineType.SPARK, EngineType.FLINK},
         disabledReason = "Currently SPARK do not support cdc")
 public class TiDBCDCIT extends TiDBTestBase implements TestResource {
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
@@ -48,7 +48,7 @@ import static org.awaitility.Awaitility.await;
 @Slf4j
 @DisabledOnContainer(
         value = {},
-        type = {EngineType.SPARK, EngineType.FLINK},
+        type = {EngineType.SPARK},
         disabledReason = "Currently SPARK do not support cdc")
 public class TiDBCDCIT extends TiDBTestBase implements TestResource {
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
@@ -40,8 +39,6 @@ import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.MountableFile;
-
-import com.github.dockerjava.api.DockerClient;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -74,8 +71,6 @@ public class MetalakeIT extends SeaTunnelContainer {
 
     protected Catalog catalog;
 
-    protected DockerClient dockerClient = DockerClientFactory.lazyClient();
-
     protected static final String HOST = "HOST";
 
     private static final String MYSQL_IMAGE = "mysql:8.0";
@@ -89,9 +84,6 @@ public class MetalakeIT extends SeaTunnelContainer {
     private static final String MYSQL_PASSWORD = "Abc!@#135_seatunnel";
     private static final int MYSQL_PORT = 3306;
     private static final String MYSQL_URL = "jdbc:mysql://" + HOST + ":%s/%s?useSSL=false";
-    private static final String URL = "jdbc:mysql://" + HOST + ":3306/seatunnel";
-
-    private static final String SQL = "select * from seatunnel.source";
 
     private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
 
@@ -112,7 +104,6 @@ public class MetalakeIT extends SeaTunnelContainer {
     @BeforeEach
     @Override
     public void startUp() throws Exception {
-        // super.startUp();
         server =
                 new GenericContainer<>(getDockerImage())
                         .withNetwork(NETWORK)
@@ -190,18 +181,13 @@ public class MetalakeIT extends SeaTunnelContainer {
 
         if (dbServer != null) {
             dbServer.close();
-            try {
-                dockerClient.removeImageCmd(dbServer.getDockerImageName()).exec();
-            } catch (Exception ignored) {
-                ignored.printStackTrace();
-            }
         }
 
         super.tearDown();
     }
 
     @Test
-    public void TestMetalake() throws IOException, InterruptedException {
+    public void testMetalake() throws IOException, InterruptedException {
         Container.ExecResult execResult =
                 executeJob("/jdbc_mysql_source_to_assert_sink_with_metalake.conf");
         Assertions.assertEquals(0, execResult.getExitCode());


### PR DESCRIPTION
### Purpose of this pull request

- Fix CI issues
- Delete useless code and fix method name errors

If the container is deleted, it will cause errors in other CI processes.

```java
dockerClient.removeImageCmd(dbServer.getDockerImageName()).exec();
```

Error message:
<img width="1831" height="907" alt="image" src="https://github.com/user-attachments/assets/c200f77a-6159-4755-8f4e-6acd6cb2f2f0" />

In https://github.com/apache/seatunnel/pull/9688, the CI passed also because the dbServer was not successfully deleted.
<img width="2101" height="720" alt="image" src="https://github.com/user-attachments/assets/89f6288a-7dac-4e3f-ad10-38e674912165" />


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)