### PR TITLE
Fix URI configuration inconsistency and support passive queue declaration

### DIFF
--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/client/RabbitmqClient.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/client/RabbitmqClient.java
@@ -84,9 +84,9 @@ public class RabbitmqClient {
 
     public ConnectionFactory getConnectionFactory() {
         ConnectionFactory factory = new ConnectionFactory();
-        if (!StringUtils.isEmpty(config.getUri())) {
+        if (!StringUtils.isEmpty(config.getUrl())) {
             try {
-                factory.setUri(config.getUri());
+                factory.setUri(config.getUrl());
             } catch (URISyntaxException e) {
                 throw new RabbitmqConnectorException(PARSE_URI_FAILED, e);
             } catch (KeyManagementException e) {
@@ -194,11 +194,17 @@ public class RabbitmqClient {
     }
 
     private void declareQueueDefaults(Channel channel, RabbitmqConfig config) throws IOException {
-        channel.queueDeclare(
-                config.getQueueName(),
-                config.getDurable(),
-                config.getExclusive(),
-                config.getAutoDelete(),
-                null);
+        if (config.isPassive()) {
+            channel.queueDeclarePassive(config.getQueueName());
+            log.info("Queue' {}' declared passively.", config.getQueueName());
+        } else {
+            channel.queueDeclare(
+                    config.getQueueName(),
+                    config.getDurable(),
+                    config.getExclusive(),
+                    config.getAutoDelete(),
+                    null);
+            log.info("Queue '{}' declared actively.", config.getQueueName());
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqConfig.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqConfig.java
@@ -38,7 +38,7 @@ public class RabbitmqConfig implements Serializable {
     private String virtualHost;
     private String username;
     private String password;
-    private String uri;
+    private String url;
     private Integer networkRecoveryInterval;
     private Boolean automaticRecovery;
     private Boolean topologyRecovery;
@@ -58,6 +58,7 @@ public class RabbitmqConfig implements Serializable {
 
     private boolean forE2ETesting = false;
     private boolean usesCorrelationId = false;
+    private boolean passive = true;
 
     private Map<String, String> sinkOptionProps = new HashMap<>();
 
@@ -113,6 +114,12 @@ public class RabbitmqConfig implements Serializable {
         }
         if (config.getOptional(RabbitmqSourceOptions.USE_CORRELATION_ID).isPresent()) {
             this.usesCorrelationId = config.get(RabbitmqSourceOptions.USE_CORRELATION_ID);
+        }
+        if (config.getOptional(RabbitmqBaseOptions.URL).isPresent()) {
+            this.url = config.get(RabbitmqBaseOptions.URL);
+        }
+        if (config.getOptional(RabbitmqSourceOptions.PASSIVE).isPresent()) {
+            this.passive = config.get(RabbitmqSourceOptions.PASSIVE);
         }
         this.durable = config.get(RabbitmqBaseOptions.DURABLE);
         this.exclusive = config.get(RabbitmqBaseOptions.EXCLUSIVE);

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSourceOptions.java
@@ -60,4 +60,13 @@ public class RabbitmqSourceOptions extends RabbitmqBaseOptions {
                     .withDescription(
                             "Whether the messages received are supplied with a unique"
                                     + "id to deduplicate messages (in case of failed acknowledgments).");
+    public static final Option<Boolean> PASSIVE =
+            Options.key("passive")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Whether to declare the RabbitMQ queue in passive mode. If true, the connector " +
+                                    "uses AMQP passive declaration (queueDeclarePassive) to verify the queue exists " +
+                                    "and is accessible; it will not create or modify the queue. If false, the connector " +
+                                    "may actively declare the queue using the provided durable/exclusive/autoDelete settings.");
 }


### PR DESCRIPTION
Fix url / uri configuration bug
 Unify parameter naming and internal usage to support both standard and URL-style configurations correctly.

Add passive option
 Introduce a new Boolean option passive to control queue declaration mode:
  true: use channel.queueDeclarePassive() to only verify that the queue exists.
  false: use channel.queueDeclare() for active creation (default behavior).

Improve connection handling for AMQPS
 Ensure that both URL and parameter-based configurations can establish SSL connections when amqps is required.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)