### PR TITLE
[Fix] Fix CVE-2025-48924 for commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <elasticsearch6.client.version>6.3.1</elasticsearch6.client.version>
         <elasticsearch7.client.version>7.5.1</elasticsearch7.client.version>
         <flink-shaded-hadoop-2.version>2.7.5-7.0</flink-shaded-hadoop-2.version>
-        <commons-lang3.version>3.8</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-csv.version>1.10.0</commons-csv.version>

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/pom.xml
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <orc.version>1.5.6</orc.version>
         <commons.collecton4.version>4.4</commons.collecton4.version>
-        <commons.lang3.version>3.4</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <parquet-avro.version>1.12.3</parquet-avro.version>
         <poi.version>4.1.2</poi.version>
         <poi-ooxml.version>4.1.2</poi-ooxml.version>

--- a/seatunnel-connectors-v2/connector-hudi/pom.xml
+++ b/seatunnel-connectors-v2/connector-hudi/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <hudi.version>0.15.0</hudi.version>
-        <commons.lang3.version>3.4</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <parquet.version>1.12.2</parquet.version>
         <snappy.version>1.1.10.4</snappy.version>
         <kryo.shaded.version>4.0.2</kryo.shaded.version>

--- a/seatunnel-connectors-v2/connector-kudu/pom.xml
+++ b/seatunnel-connectors-v2/connector-kudu/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <kudu.version>1.11.1</kudu.version>
-        <commons.lang3.version>3.4</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
     </properties>
 
     <dependencies>

--- a/seatunnel-connectors-v2/connector-maxcompute/pom.xml
+++ b/seatunnel-connectors-v2/connector-maxcompute/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <maxcompute.version>0.51.0</maxcompute.version>
-        <commons.lang3.version>3.4</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
     </properties>
 
     <dependencies>

--- a/seatunnel-connectors-v2/connector-pulsar/pom.xml
+++ b/seatunnel-connectors-v2/connector-pulsar/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <pulsar.version>2.11.0</pulsar.version>
-        <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>
 
     <dependencies>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -2,7 +2,7 @@ commons-codec-1.13.jar
 commons-collections4-4.4.jar
 commons-compress-1.20.jar
 commons-io-2.11.0.jar
-commons-lang3-3.8.jar
+commons-lang3-3.18.0.jar
 commons-csv-1.10.0.jar
 config-1.3.3.jar
 disruptor-3.4.4.jar


### PR DESCRIPTION
https://app.opencve.io/cve/CVE-2025-48924 

```
Uncontrolled Recursion vulnerability in Apache Commons Lang.

This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.

The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a
StackOverflowError could cause an application to stop.

Users are recommended to upgrade to version 3.18.0, which fixes the issue.
```