### PR TITLE
[Fix][Transforms-V2] fix exclude filter mode logic

### DIFF
--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/java/org/apache/seatunnel/e2e/transform/TestTableFilterIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/java/org/apache/seatunnel/e2e/transform/TestTableFilterIT.java
@@ -38,4 +38,16 @@ public class TestTableFilterIT extends TestSuiteBase {
         Container.ExecResult execResult = container.executeJob("/table_filter_multi_table.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
     }
+
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK, EngineType.FLINK},
+            disabledReason = "Only support for seatunnel")
+    @TestTemplate
+    public void testFilterMultiTableWithExcludeMode(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult execResult =
+                container.executeJob("/table_filter_multi_table_with_exclude_mode.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+    }
 }

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/table_filter_multi_table_with_exclude_mode.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/table_filter_multi_table_with_exclude_mode.conf
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "source1"
+
+    tables_configs = [
+      {
+        row.num = 3
+        schema = {
+          table = "test.user_1"
+          columns = [
+            {
+              name = "id"
+              type = "bigint"
+            },
+            {
+              name = "name"
+              type = "string"
+            }
+          ]
+        }
+      },
+      {
+        row.num = 3
+        schema = {
+          table = "test.user_2"
+          columns = [
+            {
+              name = "id"
+              type = "bigint"
+            },
+            {
+              name = "name"
+              type = "string"
+            }
+          ]
+        }
+      },
+      {
+        row.num = 5
+        schema = {
+          table = "test.xyz"
+          columns = [
+            {
+              name = "id"
+              type = "bigint"
+            },
+            {
+              name = "age"
+              type = "int"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+transform {
+  TableFilter {
+    plugin_input = "source1"
+    plugin_output = "transform_a_1"
+
+    database_pattern = "test"
+    table_pattern = "user_\\d+"
+  }
+  TableRename {
+      plugin_input = "transform_a_1"
+      plugin_output = "transform_a_2"
+
+      prefix = "table_a_"
+    }
+
+
+
+  TableFilter {
+    plugin_input = "source1"
+    plugin_output = "transform_b_1"
+
+    database_pattern = "test"
+    table_pattern = "user_\\d+"
+    pattern_mode = "EXCLUDE"
+  }
+    TableRename {
+        plugin_input = "transform_b_1"
+        plugin_output = "transform_b_2"
+
+        prefix = "table_b_"
+      }
+}
+sink {
+  Assert {
+    plugin_input = "transform_a_2"
+
+    rules =
+      {
+        tables_configs = [
+          {
+            table_path = "test.table_a_user_1"
+            row_rules = [
+              {
+                rule_type = MAX_ROW
+                rule_value = 3
+              },
+              {
+                rule_type = MIN_ROW
+                rule_value = 3
+              }
+            ]
+          },
+          {
+              table_path = "test.table_a_user_2"
+              row_rules = [
+                {
+                  rule_type = MAX_ROW
+                  rule_value = 3
+                },
+                {
+                  rule_type = MIN_ROW
+                  rule_value = 3
+                }
+              ]
+          },
+        {
+          table_path = "test.table_a_xyz"
+          row_rules = [
+            {
+              rule_type = MAX_ROW
+              rule_value = 0
+            },
+            {
+              rule_type = MIN_ROW
+              rule_value = 0
+            }
+          ]
+        }
+        ]
+      }
+  }
+
+  Assert {
+      plugin_input = "transform_b_2"
+
+      rules =
+        {
+          tables_configs = [
+            {
+              table_path = "test.table_b_user_1"
+              row_rules = [
+                {
+                  rule_type = MAX_ROW
+                  rule_value = 0
+                },
+                {
+                  rule_type = MIN_ROW
+                  rule_value = 0
+                }
+              ]
+            },
+            {
+                table_path = "test.table_b_user_2"
+                row_rules = [
+                  {
+                    rule_type = MAX_ROW
+                    rule_value = 0
+                  },
+                  {
+                    rule_type = MIN_ROW
+                    rule_value = 0
+                  }
+                ]
+            },
+          {
+            table_path = "test.table_b_xyz"
+            row_rules = [
+              {
+                rule_type = MAX_ROW
+                rule_value = 5
+              },
+              {
+                rule_type = MIN_ROW
+                rule_value = 5
+              }
+            ]
+          }
+          ]
+        }
+    }
+}

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
@@ -88,30 +88,17 @@ public class TableFilterConfig implements Serializable {
     @JsonAlias("pattern_mode")
     private PatternMode patternMode;
 
-    public boolean isMatch(TablePath tablePath) {
+    public boolean isIncluded(TablePath tablePath) {
         if (PatternMode.INCLUDE.equals(patternMode)) {
-            if (databasePattern != null && !tablePath.getDatabaseName().matches(databasePattern)) {
-                return false;
-            }
-            if (schemaPattern != null && !tablePath.getSchemaName().matches(schemaPattern)) {
-                return false;
-            }
-            if (tablePattern != null && !tablePath.getTableName().matches(tablePattern)) {
-                return false;
-            }
-            return true;
+            return isMatch(tablePath);
         }
+        return !isMatch(tablePath);
+    }
 
-        if (databasePattern != null && tablePath.getDatabaseName().matches(databasePattern)) {
-            return false;
-        }
-        if (schemaPattern != null && tablePath.getSchemaName().matches(schemaPattern)) {
-            return false;
-        }
-        if (tablePattern != null && tablePath.getTableName().matches(tablePattern)) {
-            return false;
-        }
-        return true;
+    private boolean isMatch(TablePath tablePath) {
+        return (databasePattern == null || tablePath.getDatabaseName().matches(databasePattern))
+                && (schemaPattern == null || tablePath.getSchemaName().matches(schemaPattern))
+                && (tablePattern == null || tablePath.getTableName().matches(tablePattern));
     }
 
     public static TableFilterConfig of(ReadonlyConfig config) {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterMultiCatalogTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterMultiCatalogTransform.java
@@ -56,7 +56,7 @@ public class TableFilterMultiCatalogTransform extends AbstractMultiCatalogMapTra
                     TableFilterConfig.PatternMode.INCLUDE.equals(
                             tableFilterConfig.getPatternMode());
         } else {
-            include = tableFilterConfig.isMatch(table.getTablePath());
+            include = tableFilterConfig.isIncluded(table.getTablePath());
         }
         return new TableFilterTransform(include, table);
     }


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/9934
### Purpose of this pull request

When using exclude mode, the conditional logic should be the exact opposite of include mode. However, the current code does not implement this correctly. This PR fixes that issue.

### Does this PR introduce _any_ user-facing change?

Yes.
Users can now use the exclude filter mode as intended.

### How was this patch tested?

Added e2e test case for exclude mode.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)