### PR TITLE
[Fix][Connector-V2] [Doris] Fix DECIMAL scale=0 conversion to avoid unintended MAX_SCALE

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
@@ -91,7 +91,7 @@ public class DorisTypeConverterV2 extends AbstractDorisTypeConverter {
                     p = typeDefine.getPrecision();
                 }
 
-                if (typeDefine.getScale() != null && typeDefine.getScale() > 0) {
+                if (typeDefine.getScale() != null && typeDefine.getScale() >= 0) {
                     scale = typeDefine.getScale();
                 }
                 DecimalType decimalType;

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
@@ -236,6 +236,21 @@ public class DorisTypeConvertorV2Test {
         Assertions.assertEquals(38L, column.getColumnLength());
         Assertions.assertEquals(2, column.getScale());
         Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("decimalv3(8,0)")
+                        .dataType("decimal")
+                        .precision(8L)
+                        .scale(0)
+                        .build();
+        column = DorisTypeConverterV2.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(new DecimalType(8, 0), column.getDataType());
+        Assertions.assertEquals(8L, column.getColumnLength());
+        Assertions.assertEquals(0, column.getScale());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
     }
 
     @Test


### PR DESCRIPTION
### Purpose of this pull request

Fixes #9641 

This PR fixes an issue in the Doris connector’s field type conversion:
when converting `DECIMAL(p, s)` types, a scale of `0` was not respected.
Previously, the converter only overrode the default scale when `scale > 0`.
Because Doris allows `scale` in the `range [0, 10]`, `DECIMAL(p, 0)` fell through and the converter used the default `MAX_SCALE` (`10`), producing an incorrect column definition.

This change updates the condition to treat 0 as a valid scale and correctly propagate it to the target schema.

- Before: `scale` is applied only if `scale > 0`; `DECIMAL(p, 0)` becomes `DECIMAL(p, 10)`.

- After: `scale` is applied if `scale >= 0`; `DECIMAL(p, 0)` remains `DECIMAL(p, 0)` as Doris intends.


### Does this PR introduce _any_ user-facing change?

**Yes (bug fix).**
Users with Doris columns defined as `DECIMAL(p, 0)` will now see the correct scale (`0`) after conversion. Previously, these columns were incorrectly converted with `scale = 10`.

This aligns SeaTunnel’s conversion behavior with Doris’ documented range for `DECIMAL`  (`0 <= scale <= 10`) and fixes wrong mappings and potential downstream data formatting issues.


### How was this patch tested?

#### 1. Unit tests:

  - Extended the existing decimal conversion test to cover the `DECIMAL(8, 0)` case.

  - Verified three scenarios:

    - Only precision provided (uses defaults, still correct).

    - Explicit precision/scale like `DECIMAL(36, 2)` (unchanged, still correct).

    - New: `DECIMAL(8, 0)` now results in precision = 8, scale = 0 (previously `scale` incorrectly became `10`).

#### 2. Assertions covered:

  - Data type equals expected `DecimalType(precision, scale)`.

  - `columnLength` equals the provided precision.

  - `column.scale` equals the provided scale, including `0`.

  - Source type remains the original Doris column type.

#### 3. No changes to unrelated type mappings; existing tests continue to pass.

### Implementation details

- In `DorisTypeConverterV2.convert(...)`, for the `DORIS_DECIMALV3` branch:

Keep defaults: `p = MAX_PRECISION`, `scale = MAX_SCALE`.

**Change**: apply provided scale when it is not null and `>= 0`, instead of `> 0`.

Precision handling (`> 0`) remains unchanged.

This ensures Doris’ valid scale `range [0, 10]` is honored; `0` is no longer treated as “unset”.

### Check list

* [x] No new binary dependencies introduced.
* [x] No documentation changes required (behavior now matches Doris semantics).
* [x] Unit tests updated to cover `DECIMAL(8, 0)` and to prevent regressions.
* [x] No changes to plugin mapping or distribution POMs.
* [x] No CI labeling or E2E additions required for this bug fix.