### PR TITLE
[Bug][kerberos]Before kerberos expires, the authentication and file clients are re-flashed

### DIFF
--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
@@ -39,36 +39,90 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.seatunnel.engine.checkpoint.storage.constants.StorageConstants.STORAGE_NAME_SPACE;
 
 @Slf4j
 public class HdfsStorage extends AbstractCheckpointStorage {
 
+
     public FileSystem fs;
     private static final String STORAGE_TMP_SUFFIX = "tmp";
     private static final String STORAGE_TYPE_KEY = "storage.type";
 
+    private final Map<String, String> initConfiguration; // 初始配置
+    private final ReentrantReadWriteLock fsLock = new ReentrantReadWriteLock(); // 读写锁保护 fs
+    private Integer ticketLifetime = 900; //kerberos票据过期时间
+
     public HdfsStorage(Map<String, String> configuration) throws CheckpointStorageException {
-        this.initStorage(configuration);
+        // 深拷贝初始配置
+        this.initConfiguration = deepCopy(configuration);
+        this.ticketLifetime=Integer.valueOf(StringUtils.defaultString(configuration.get("seatunnel.hadoop.dfs.kerberos.ticket.lifetime"),"900"));
+        // 初次初始化
+        initStorage(configuration);
+        // 启动周期刷新任务
+        startPeriodicInit();
     }
 
-    @Override
+    /**
+     * 初始化 FileSystem
+     */
     public void initStorage(Map<String, String> configuration) throws CheckpointStorageException {
-        if (StringUtils.isNotBlank(configuration.get(STORAGE_NAME_SPACE))) {
-            setStorageNameSpace(configuration.get(STORAGE_NAME_SPACE));
-            configuration.remove(STORAGE_NAME_SPACE);
+        Map<String, String> configurationCopy = deepCopy(configuration); // 深拷贝配置
+
+        if (StringUtils.isNotBlank(configurationCopy.get(STORAGE_NAME_SPACE))) {
+            setStorageNameSpace(configurationCopy.get(STORAGE_NAME_SPACE));
+            configurationCopy.remove(STORAGE_NAME_SPACE);
         }
-        Configuration hadoopConf = getConfiguration(configuration);
+
+        Configuration hadoopConf = getConfiguration(configurationCopy);
+
+        fsLock.writeLock().lock(); // 写锁：阻塞所有正在用 fs 的读线程
         try {
-            fs = FileSystem.get(hadoopConf);
+            FileSystem newFs = FileSystem.get(hadoopConf);
+            if (fs != null) {
+                try {
+                    fs.close();
+                    log.info("Old FileSystem closed.");
+                } catch (IOException e) {
+                    log.warn("Old FileSystem close failed", e);
+                }
+            }
+            fs = newFs;
+            log.info("FileSystem refreshed.");
         } catch (IOException e) {
             throw new CheckpointStorageException("Failed to get file system", e);
+        } finally {
+            fsLock.writeLock().unlock();
         }
+    }
+    /**
+     * 深拷贝 Map
+     */
+    private Map<String, String> deepCopy(Map<String, String> source) {
+        return new HashMap<>(source);
+    }
+    /**
+     * 启动周期性刷新 FileSystem
+     */
+    private void startPeriodicInit() {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        Integer delay = ticketLifetime / 2;//一个过期周期刷新2次
+        scheduler.scheduleWithFixedDelay(() -> {
+            try {
+                initStorage(initConfiguration);
+                System.out.println("[HdfsStorage] Periodic fs refresh success.");
+            } catch (Exception e) {
+                System.err.println("[HdfsStorage] Periodic fs refresh failed: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }, delay, delay, TimeUnit.SECONDS);
+        log.info("[HdfsStorage] Periodic fs refresh scheduled. refresh time delay ="+delay);
     }
 
     private Configuration getConfiguration(Map<String, String> config)
@@ -83,271 +137,334 @@ public class HdfsStorage extends AbstractCheckpointStorage {
 
     @Override
     public String storeCheckPoint(PipelineState state) throws CheckpointStorageException {
-        byte[] datas;
+        fsLock.readLock().lock();
         try {
-            datas = serializeCheckPointData(state);
-        } catch (IOException e) {
-            throw new CheckpointStorageException(
-                    String.format("Failed to serialize checkpoint data, state: %s", state), e);
-        }
-        Path filePath =
-                new Path(
-                        getStorageParentDirectory()
-                                + state.getJobId()
-                                + "/"
-                                + getCheckPointName(state));
-
-        Path tmpFilePath =
-                new Path(
-                        getStorageParentDirectory()
-                                + state.getJobId()
-                                + "/"
-                                + getCheckPointName(state)
-                                + STORAGE_TMP_SUFFIX);
-        try (FSDataOutputStream out = fs.create(tmpFilePath, false)) {
-            out.write(datas);
-        } catch (IOException e) {
-            throw new CheckpointStorageException(
-                    String.format(
-                            "Failed to write checkpoint data, file: %s, state: %s",
-                            tmpFilePath, state),
-                    e);
-        }
-        try {
-            boolean success = fs.rename(tmpFilePath, filePath);
-            if (!success) {
-                throw new CheckpointStorageException("Failed to rename tmp file to final file");
-            }
-
-        } catch (IOException e) {
-            throw new CheckpointStorageException("Failed to rename tmp file to final file");
-        } finally {
+            byte[] datas;
             try {
-                // clean up tmp file, if still lying around
-                if (fs.exists(tmpFilePath)) {
-                    fs.delete(tmpFilePath, false);
-                }
-            } catch (IOException ioe) {
-                log.error("Failed to delete tmp file", ioe);
+                datas = serializeCheckPointData(state);
+            } catch (IOException e) {
+                throw new CheckpointStorageException(
+                        String.format("Failed to serialize checkpoint data, state: %s", state), e);
             }
-        }
+            Path filePath =
+                    new Path(
+                            getStorageParentDirectory()
+                                    + state.getJobId()
+                                    + "/"
+                                    + getCheckPointName(state));
 
-        return filePath.getName();
+            Path tmpFilePath =
+                    new Path(
+                            getStorageParentDirectory()
+                                    + state.getJobId()
+                                    + "/"
+                                    + getCheckPointName(state)
+                                    + STORAGE_TMP_SUFFIX);
+            try (FSDataOutputStream out = fs.create(tmpFilePath, false)) {
+                out.write(datas);
+            } catch (IOException e) {
+                throw new CheckpointStorageException(
+                        String.format(
+                                "Failed to write checkpoint data, file: %s, state: %s",
+                                tmpFilePath, state),
+                        e);
+            }
+            try {
+                boolean success = fs.rename(tmpFilePath, filePath);
+                if (!success) {
+                    throw new CheckpointStorageException("Failed to rename tmp file to final file");
+                }
+
+            } catch (IOException e) {
+                throw new CheckpointStorageException("Failed to rename tmp file to final file");
+            } finally {
+                try {
+                    // clean up tmp file, if still lying around
+                    if (fs.exists(tmpFilePath)) {
+                        fs.delete(tmpFilePath, false);
+                    }
+                } catch (IOException ioe) {
+                    log.error("Failed to delete tmp file", ioe);
+                }
+            }
+
+            return filePath.getName();
+        } finally {
+            fsLock.readLock().unlock();
+        }
     }
 
     @Override
     public List<PipelineState> getAllCheckpoints(String jobId) throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            log.info("No checkpoint found for this job, the job id is: " + jobId);
-            return new ArrayList<>();
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                log.info("No checkpoint found for this job, the job id is: " + jobId);
+                return new ArrayList<>();
+            }
+            List<PipelineState> states = new ArrayList<>();
+            fileNames.forEach(
+                    file -> {
+                        try {
+                            states.add(readPipelineState(file, jobId));
+                        } catch (CheckpointStorageException e) {
+                            log.error("Failed to read checkpoint data from file: " + file, e);
+                        }
+                    });
+            if (states.isEmpty()) {
+                throw new CheckpointStorageException(
+                        "No checkpoint found for job, job id is: " + jobId);
+            }
+            return states;
+        } finally {
+            fsLock.readLock().unlock();
         }
-        List<PipelineState> states = new ArrayList<>();
-        fileNames.forEach(
-                file -> {
-                    try {
-                        states.add(readPipelineState(file, jobId));
-                    } catch (CheckpointStorageException e) {
-                        log.error("Failed to read checkpoint data from file: " + file, e);
-                    }
-                });
-        if (states.isEmpty()) {
-            throw new CheckpointStorageException(
-                    "No checkpoint found for job, job id is: " + jobId);
-        }
-        return states;
     }
 
     @Override
     public List<PipelineState> getLatestCheckpoint(String jobId) throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            log.info("No checkpoint found for this  job, the job id is: " + jobId);
-            return new ArrayList<>();
-        }
-        Set<String> latestPipelineNames = getLatestPipelineNames(fileNames);
-        List<PipelineState> latestPipelineStates = new ArrayList<>();
-        latestPipelineNames.forEach(
-                fileName -> {
-                    try {
-                        latestPipelineStates.add(readPipelineState(fileName, jobId));
-                    } catch (CheckpointStorageException e) {
-                        log.error("Failed to read pipeline state for file: {}", fileName, e);
-                    }
-                });
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                log.info("No checkpoint found for this  job, the job id is: " + jobId);
+                return new ArrayList<>();
+            }
+            Set<String> latestPipelineNames = getLatestPipelineNames(fileNames);
+            List<PipelineState> latestPipelineStates = new ArrayList<>();
+            latestPipelineNames.forEach(
+                    fileName -> {
+                        try {
+                            latestPipelineStates.add(readPipelineState(fileName, jobId));
+                        } catch (CheckpointStorageException e) {
+                            log.error("Failed to read pipeline state for file: {}", fileName, e);
+                        }
+                    });
 
-        if (latestPipelineStates.isEmpty()) {
-            log.info("No checkpoint found for this job, the job id:{} ", jobId);
+            if (latestPipelineStates.isEmpty()) {
+                log.info("No checkpoint found for this job, the job id:{} ", jobId);
+            }
+            return latestPipelineStates;
+        } finally {
+            fsLock.readLock().unlock();
         }
-        return latestPipelineStates;
+
     }
 
     @Override
     public PipelineState getLatestCheckpointByJobIdAndPipelineId(String jobId, String pipelineId)
             throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            log.info("No checkpoint found for job, job id is: " + jobId);
-            return null;
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                log.info("No checkpoint found for job, job id is: " + jobId);
+                return null;
+            }
+
+            String latestFileName =
+                    getLatestCheckpointFileNameByJobIdAndPipelineId(fileNames, pipelineId);
+            if (latestFileName == null) {
+                log.info(
+                        "No checkpoint found for this job, the job id is: "
+                                + jobId
+                                + ", pipeline id is: "
+                                + pipelineId);
+                return null;
+            }
+            return readPipelineState(latestFileName, jobId);
+        } finally {
+            fsLock.readLock().unlock();
         }
 
-        String latestFileName =
-                getLatestCheckpointFileNameByJobIdAndPipelineId(fileNames, pipelineId);
-        if (latestFileName == null) {
-            log.info(
-                    "No checkpoint found for this job, the job id is: "
-                            + jobId
-                            + ", pipeline id is: "
-                            + pipelineId);
-            return null;
-        }
-        return readPipelineState(latestFileName, jobId);
     }
 
     @Override
     public List<PipelineState> getCheckpointsByJobIdAndPipelineId(String jobId, String pipelineId)
             throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            log.info("No checkpoint found for this job, the job id is: " + jobId);
-            return new ArrayList<>();
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                log.info("No checkpoint found for this job, the job id is: " + jobId);
+                return new ArrayList<>();
+            }
+
+            List<PipelineState> pipelineStates = new ArrayList<>();
+            fileNames.forEach(
+                    file -> {
+                        String filePipelineId = getPipelineIdByFileName(file);
+                        if (pipelineId.equals(filePipelineId)) {
+                            try {
+                                pipelineStates.add(readPipelineState(file, jobId));
+                            } catch (Exception e) {
+                                log.error("Failed to read checkpoint data from file " + file, e);
+                            }
+                        }
+                    });
+            return pipelineStates;
+        } finally {
+            fsLock.readLock().unlock();
         }
 
-        List<PipelineState> pipelineStates = new ArrayList<>();
-        fileNames.forEach(
-                file -> {
-                    String filePipelineId = getPipelineIdByFileName(file);
-                    if (pipelineId.equals(filePipelineId)) {
-                        try {
-                            pipelineStates.add(readPipelineState(file, jobId));
-                        } catch (Exception e) {
-                            log.error("Failed to read checkpoint data from file " + file, e);
-                        }
-                    }
-                });
-        return pipelineStates;
+
     }
 
     @Override
     public void deleteCheckpoint(String jobId) {
-        String jobPath = getStorageParentDirectory() + jobId;
+        fsLock.readLock().lock();
         try {
-            fs.delete(new Path(jobPath), true);
-        } catch (IOException e) {
-            log.warn("Failed to delete checkpoint for job {}", jobId, e);
+            String jobPath = getStorageParentDirectory() + jobId;
+            try {
+                fs.delete(new Path(jobPath), true);
+            } catch (IOException e) {
+                log.warn("Failed to delete checkpoint for job {}", jobId, e);
+            }
+        } finally {
+            fsLock.readLock().unlock();
         }
+
     }
 
     @Override
     public PipelineState getCheckpoint(String jobId, String pipelineId, String checkpointId)
             throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            log.info("No checkpoint found for this job,  the job id is: " + jobId);
-            return null;
-        }
-        for (String fileName : fileNames) {
-            if (pipelineId.equals(getPipelineIdByFileName(fileName))
-                    && checkpointId.equals(getCheckpointIdByFileName(fileName))) {
-                try {
-                    return readPipelineState(fileName, jobId);
-                } catch (Exception e) {
-                    log.error(
-                            "Failed to get checkpoint {} for job {}, pipeline {}",
-                            checkpointId,
-                            jobId,
-                            pipelineId,
-                            e);
+        fsLock.readLock().lock();
+        try {
+
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                log.info("No checkpoint found for this job,  the job id is: " + jobId);
+                return null;
+            }
+            for (String fileName : fileNames) {
+                if (pipelineId.equals(getPipelineIdByFileName(fileName))
+                        && checkpointId.equals(getCheckpointIdByFileName(fileName))) {
+                    try {
+                        return readPipelineState(fileName, jobId);
+                    } catch (Exception e) {
+                        log.error(
+                                "Failed to get checkpoint {} for job {}, pipeline {}",
+                                checkpointId,
+                                jobId,
+                                pipelineId,
+                                e);
+                    }
                 }
             }
+            throw new CheckpointStorageException(
+                    String.format(
+                            "No checkpoint found, job(%s), pipeline(%s), checkpoint(%s)",
+                            jobId, pipelineId, checkpointId));
+        } finally {
+            fsLock.readLock().unlock();
         }
-        throw new CheckpointStorageException(
-                String.format(
-                        "No checkpoint found, job(%s), pipeline(%s), checkpoint(%s)",
-                        jobId, pipelineId, checkpointId));
+
     }
 
     @Override
     public synchronized void deleteCheckpoint(String jobId, String pipelineId, String checkpointId)
             throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            throw new CheckpointStorageException(
-                    "No checkpoint found for job, job id is: " + jobId);
-        }
-        fileNames.forEach(
-                fileName -> {
-                    if (pipelineId.equals(getPipelineIdByFileName(fileName))
-                            && checkpointId.equals(getCheckpointIdByFileName(fileName))) {
-                        try {
-                            fs.delete(
-                                    new Path(path + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName),
-                                    false);
-                        } catch (Exception e) {
-                            log.error(
-                                    "Failed to delete checkpoint {} for job {}, pipeline {}",
-                                    checkpointId,
-                                    jobId,
-                                    pipelineId,
-                                    e);
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                throw new CheckpointStorageException(
+                        "No checkpoint found for job, job id is: " + jobId);
+            }
+            fileNames.forEach(
+                    fileName -> {
+                        if (pipelineId.equals(getPipelineIdByFileName(fileName))
+                                && checkpointId.equals(getCheckpointIdByFileName(fileName))) {
+                            try {
+                                fs.delete(
+                                        new Path(path + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName),
+                                        false);
+                            } catch (Exception e) {
+                                log.error(
+                                        "Failed to delete checkpoint {} for job {}, pipeline {}",
+                                        checkpointId,
+                                        jobId,
+                                        pipelineId,
+                                        e);
+                            }
                         }
-                    }
-                });
+                    });
+        } finally {
+            fsLock.readLock().unlock();
+        }
+
+
     }
 
     @Override
     public void deleteCheckpoint(String jobId, String pipelineId, List<String> checkpointIdList)
             throws CheckpointStorageException {
-        String path = getStorageParentDirectory() + jobId;
-        List<String> fileNames = getFileNames(path);
-        if (fileNames.isEmpty()) {
-            throw new CheckpointStorageException(
-                    "No checkpoint found for job, job id is: " + jobId);
-        }
-        fileNames.forEach(
-                fileName -> {
-                    String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
-                    if (pipelineId.equals(getPipelineIdByFileName(fileName))
-                            && checkpointIdList.contains(checkpointIdByFileName)) {
-                        try {
-                            fs.delete(
-                                    new Path(path + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName),
-                                    false);
-                        } catch (Exception e) {
-                            log.error(
-                                    "Failed to delete checkpoint {} for job {}, pipeline {}",
-                                    checkpointIdByFileName,
-                                    jobId,
-                                    pipelineId,
-                                    e);
+        fsLock.readLock().lock();
+        try {
+            String path = getStorageParentDirectory() + jobId;
+            List<String> fileNames = getFileNames(path);
+            if (fileNames.isEmpty()) {
+                throw new CheckpointStorageException(
+                        "No checkpoint found for job, job id is: " + jobId);
+            }
+            fileNames.forEach(
+                    fileName -> {
+                        String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
+                        if (pipelineId.equals(getPipelineIdByFileName(fileName))
+                                && checkpointIdList.contains(checkpointIdByFileName)) {
+                            try {
+                                fs.delete(
+                                        new Path(path + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName),
+                                        false);
+                            } catch (Exception e) {
+                                log.error(
+                                        "Failed to delete checkpoint {} for job {}, pipeline {}",
+                                        checkpointIdByFileName,
+                                        jobId,
+                                        pipelineId,
+                                        e);
+                            }
                         }
-                    }
-                });
+                    });
+        } finally {
+            fsLock.readLock().unlock();
+        }
+
+
     }
 
     public List<String> getFileNames(String path) throws CheckpointStorageException {
+        fsLock.readLock().lock();
         try {
-            Path parentPath = new Path(path);
-            if (!fs.exists(parentPath)) {
-                log.info("Path " + path + " is not a directory");
-                return new ArrayList<>();
+            try {
+                Path parentPath = new Path(path);
+                if (!fs.exists(parentPath)) {
+                    log.info("Path " + path + " is not a directory");
+                    return new ArrayList<>();
+                }
+                FileStatus[] fileStatus =
+                        fs.listStatus(parentPath, path1 -> path1.getName().endsWith(FILE_FORMAT));
+                List<String> fileNames = new ArrayList<>();
+                for (FileStatus status : fileStatus) {
+                    fileNames.add(status.getPath().getName());
+                }
+                return fileNames;
+            } catch (IOException e) {
+                throw new CheckpointStorageException("Failed to list files from names" + path, e);
             }
-            FileStatus[] fileStatus =
-                    fs.listStatus(parentPath, path1 -> path1.getName().endsWith(FILE_FORMAT));
-            List<String> fileNames = new ArrayList<>();
-            for (FileStatus status : fileStatus) {
-                fileNames.add(status.getPath().getName());
-            }
-            return fileNames;
-        } catch (IOException e) {
-            throw new CheckpointStorageException("Failed to list files from names" + path, e);
+        } finally {
+            fsLock.readLock().unlock();
         }
+
+
     }
 
     /**
@@ -358,19 +475,26 @@ public class HdfsStorage extends AbstractCheckpointStorage {
      */
     private PipelineState readPipelineState(String fileName, String jobId)
             throws CheckpointStorageException {
-        fileName =
-                getStorageParentDirectory() + jobId + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName;
-        try (FSDataInputStream in = fs.open(new Path(fileName));
-                ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            IOUtils.copyBytes(in, stream, 1024);
-            byte[] bytes = stream.toByteArray();
-            return deserializeCheckPointData(bytes);
-        } catch (IOException e) {
-            throw new CheckpointStorageException(
-                    String.format(
-                            "Failed to read checkpoint data, file name is %s,job id is %s",
-                            fileName, jobId),
-                    e);
+        fsLock.readLock().lock();
+        try {
+            fileName =
+                    getStorageParentDirectory() + jobId + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName;
+            try (FSDataInputStream in = fs.open(new Path(fileName));
+                 ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+                IOUtils.copyBytes(in, stream, 1024);
+                byte[] bytes = stream.toByteArray();
+                return deserializeCheckPointData(bytes);
+            } catch (IOException e) {
+                throw new CheckpointStorageException(
+                        String.format(
+                                "Failed to read checkpoint data, file name is %s,job id is %s",
+                                fileName, jobId),
+                        e);
+            }
+        } finally {
+            fsLock.readLock().unlock();
         }
+
+
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
https://github.com/apache/seatunnel/pull/7995
Using the zeta engine, data was written to iceberg via mysqlcdc. The checkpoint failed to save after 24 hours, and the error was that the kerberos authentication of hdfs had expired and failed

### Does this PR introduce _any_ user-facing change?
yes

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
The seatunnel.yaml configuration file has added an expiration time for kerberos. Within one expiration period, kerberos authentication will be retweeted.

Add a new configuration “seatunnel.hadoop.dfs.kerberos.ticket.lifetime” in seatunnel.yaml  
Sample：
```
seatunnel:
  engine:
    history-job-expire-minutes: 10080
    backup-count: 1
    queue-type: blockingqueue
    print-execution-info-interval: 60000
    print-job-metrics-info-interval: 60000
    slot-service:
      dynamic-slot: false
      slot-num: 10
    checkpoint:
      interval: 600000
      timeout: 300000
      storage:
        type: hdfs
        max-retained: 1
        plugin-config:
          namespace: /tmp/seatunnel/checkpoint_snapshot
          storage.type: hdfs
          fs.defaultFS: hdfs://[NAMESERVICE]
          #fs.defaultFS: file:///
          seatunnel.hadoop.dfs.nameservices: [NAMESERVICE]
          seatunnel.hadoop.dfs.ha.namenodes.[NAMESERVICE]: [NAMENODE1],[NAMENODE2]
          seatunnel.hadoop.dfs.namenode.rpc-address.[NAMESERVICE].[NAMENODE1]: [NAMENODE1_HOST]:8020
          seatunnel.hadoop.dfs.namenode.rpc-address.[NAMESERVICE].[NAMENODE2]: [NAMENODE2_HOST]:8020
          seatunnel.hadoop.dfs.client.failover.proxy.provider.[NAMESERVICE]: org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider
          seatunnel.hadoop.dfs.namenode.kerberos.principal: ENC(加密后的字符串)
          seatunnel.hadoop.dfs.datanode.kerberos.principal: ENC(加密后的字符串)
          seatunnel.hadoop.dfs.kerberos.ticket.lifetime: 86400
          seatunnel.hadoop.rpc.protection: authentication
          kerberosPrincipal: ENC(加密后的字符串)
          kerberosKeytabFilePath: ENC(加密后的字符串)
    telemetry:
      metric:
        enabled: false
      logs:
        scheduled-deletion-enable: true
    http:
      enable-http: true
      port: 8080
      enable-dynamic-port: false
      # Uncomment the following lines to enable basic authentication for web UI
      # enable-basic-auth: true
      # basic-auth-username: admin
      # basic-auth-password: admin
```

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)