### PR TITLE
[Fix][Zeta] Handle null log file name response

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
@@ -313,7 +313,7 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
 
         if (StringUtils.isBlank(logName)) {
             // Get Current Node Log List
-            this.prepareResponse(httpGetCommand, getRestValue(logService.currentNodeLog(uri)));
+            this.prepareResponse(httpGetCommand, getRestValue(logService.currentNodeLog()));
         } else {
             // Get Current Node Log Content
             prepareLogResponse(httpGetCommand, logPath, logName);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -49,7 +49,7 @@ public class LogService extends BaseLogService {
         String logPath = getLogPath();
         List<File> logFileList = FileUtils.listFile(logPath);
         if (logFileList == null) {
-            return null;
+            return new ArrayList<>();
         }
         return logFileList.stream().map(File::getName).collect(Collectors.toList());
     }
@@ -71,7 +71,13 @@ public class LogService extends BaseLogService {
                     String host = systemMonitoringInformation.asObject().get("host").asString();
                     String url = "http://" + host + ":" + port + contextPath;
                     String allName = sendGet(url + REST_URL_GET_ALL_LOG_NAME);
-                    log.debug(String.format("Request: %s , Result: %s", url, allName));
+                    if (StringUtils.isBlank(allName)) {
+                        log.warn(
+                                "Get log file name failed, url: {}",
+                                url + REST_URL_GET_ALL_LOG_NAME);
+                        return;
+                    }
+                    log.debug("Request: {} , Result: {}", url, allName);
                     ArrayNode jsonNodes = JsonUtils.parseArray(allName);
 
                     jsonNodes.forEach(
@@ -113,7 +119,7 @@ public class LogService extends BaseLogService {
         return buildWebSiteContent(logLink);
     }
 
-    public String currentNodeLog(String uri) {
+    public String currentNodeLog() {
         List<File> logFileList = FileUtils.listFile(getLogPath());
         StringBuffer logLink = new StringBuffer();
         if (logFileList != null) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -73,8 +73,9 @@ public class LogService extends BaseLogService {
                     String allName = sendGet(url + REST_URL_GET_ALL_LOG_NAME);
                     if (StringUtils.isBlank(allName)) {
                         log.warn(
-                                "Get log file name failed, url: {}",
-                                url + REST_URL_GET_ALL_LOG_NAME);
+                                "Get log file name failed: response logName is blank. url: {}, response: {}",
+                                url + REST_URL_GET_ALL_LOG_NAME,
+                                allName);
                         return;
                     }
                     log.debug("Request: {} , Result: {}", url, allName);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/CurrentNodeLogServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/CurrentNodeLogServlet.java
@@ -55,7 +55,7 @@ public class CurrentNodeLogServlet extends LogBaseServlet {
         String logPath = logService.getLogPath();
 
         if (StringUtils.isBlank(logName)) {
-            writeHtml(resp, logService.currentNodeLog(uri));
+            writeHtml(resp, logService.currentNodeLog());
         } else {
             // Get Current Node Log Content
             prepareLogResponse(resp, logPath, logName);


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/9423

### Purpose of this pull request

Fix occasional IllegalArgumentException when log file list is null, which caused unstable log view in Web UI/API.
In addition, some minor refactoring was performed.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No additional tests were added for this change.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)