### PR TITLE
[Feature][Hive] Kerberos renew for >24h Hive and HDFS writes

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
@@ -340,10 +340,28 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
         }
 
         try {
+            // Ensure Kerberos ticket is valid for long-running jobs
+            maybeRelogin();
             return userGroupInformation.doAs(action);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
+        }
+    }
+
+    private void maybeRelogin() {
+        if (!isAuthTypeKerberos) {
+            return;
+        }
+        if (userGroupInformation == null) {
+            return;
+        }
+        try {
+            if (userGroupInformation.isFromKeytab()) {
+                userGroupInformation.checkTGTAndReloginFromKeytab();
+            }
+        } catch (IOException e) {
+            log.warn("Kerberos re-login from keytab failed: {}", e.getMessage());
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
@@ -1,0 +1,87 @@
+package org.apache.seatunnel.connectors.seatunnel.file.hadoop;
+
+import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+static class HadoopFileSystemProxyKerberosRenewTest {
+
+    private static void set(Object target, String field, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static Object invoke(Object target, String method) throws Exception {
+        Method m = target.getClass().getDeclaredMethod(method);
+        m.setAccessible(true);
+        return m.invoke(target);
+    }
+
+    @Test
+    void testMaybeRelogin_fromKeytab_callsCheck() throws Exception {
+        HadoopConf conf = new HadoopConf("file:///");
+        HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
+
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(true);
+
+        set(proxy, "isAuthTypeKerberos", true);
+        set(proxy, "userGroupInformation", ugi);
+
+        // invoke private maybeRelogin()
+        invoke(proxy, "maybeRelogin");
+
+        verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
+    }
+
+    @Test
+    void testMaybeRelogin_notFromKeytab_noCheck() throws Exception {
+        HadoopConf conf = new HadoopConf("file:///");
+        HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
+
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(false);
+
+        set(proxy, "isAuthTypeKerberos", true);
+        set(proxy, "userGroupInformation", ugi);
+
+        invoke(proxy, "maybeRelogin");
+
+        verify(ugi, never()).checkTGTAndReloginFromKeytab();
+    }
+
+    @Test
+    void testMaybeRelogin_checkThrows_swallowed() throws Exception {
+        HadoopConf conf = new HadoopConf("file:///");
+        HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
+
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(true);
+        doThrow(new IOException("test")).when(ugi).checkTGTAndReloginFromKeytab();
+
+        set(proxy, "isAuthTypeKerberos", true);
+        set(proxy, "userGroupInformation", ugi);
+
+        // should not throw out
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    try {
+                        invoke(proxy, "maybeRelogin");
+                    } catch (Exception e) {
+                        // unwrap reflection InvocationTargetException if any
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
+    }
+}

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seatunnel.connectors.seatunnel.file.hadoop;
 
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
@@ -12,7 +28,13 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-static class HadoopFileSystemProxyKerberosRenewTest {
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HadoopFileSystemProxyKerberosRenewTest {
 
     private static void set(Object target, String field, Object value) throws Exception {
         Field f = target.getClass().getDeclaredField(field);

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
@@ -66,7 +66,7 @@ class HadoopFileSystemProxyKerberosRenewTest {
     }
 
     @Test
-    void testMaybeRelogin_notFromKeytab_noCheck() throws Exception {
+    void testMaybeReloginNotFromKeytabNoCheck() throws Exception {
         HadoopConf conf = new HadoopConf("file:///");
         HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
 
@@ -82,7 +82,7 @@ class HadoopFileSystemProxyKerberosRenewTest {
     }
 
     @Test
-    void testMaybeRelogin_checkThrows_swallowed() throws Exception {
+    void testMaybeReloginCheckThrowsSwallowed() throws Exception {
         HadoopConf conf = new HadoopConf("file:///");
         HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyKerberosRenewTest.java
@@ -49,7 +49,7 @@ class HadoopFileSystemProxyKerberosRenewTest {
     }
 
     @Test
-    void testMaybeRelogin_fromKeytab_callsCheck() throws Exception {
+    void testMaybeReloginFromKeytabCallsCheck() throws Exception {
         HadoopConf conf = new HadoopConf("file:///");
         HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(conf);
 

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxy.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxy.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.thrift.TException;
 
 import lombok.NonNull;
@@ -65,6 +66,7 @@ public class HiveMetaStoreProxy implements Closeable, Serializable {
     private final String remoteUser;
 
     private transient HiveMetaStoreClient hiveClient;
+    private transient UserGroupInformation userGroupInformation;
 
     public HiveMetaStoreProxy(ReadonlyConfig config) {
         this.metastoreUri = config.get(HiveOptions.METASTORE_URI);
@@ -81,6 +83,9 @@ public class HiveMetaStoreProxy implements Closeable, Serializable {
     private synchronized HiveMetaStoreClient getClient() {
         if (hiveClient == null) {
             hiveClient = initializeClient();
+        }
+        if (kerberosEnabled) {
+            maybeRelogin();
         }
         return hiveClient;
     }
@@ -140,7 +145,10 @@ public class HiveMetaStoreProxy implements Closeable, Serializable {
                 krb5Path,
                 principal,
                 keytabPath,
-                (conf, ugi) -> new HiveMetaStoreClient(hiveConf));
+                (conf, ugi) -> {
+                    this.userGroupInformation = ugi;
+                    return new HiveMetaStoreClient(hiveConf);
+                });
     }
 
     private HiveMetaStoreClient loginWithRemoteUser(HiveConf hiveConf) throws Exception {
@@ -182,6 +190,19 @@ public class HiveMetaStoreProxy implements Closeable, Serializable {
     public synchronized void close() {
         if (Objects.nonNull(hiveClient)) {
             hiveClient.close();
+        }
+    }
+
+    private void maybeRelogin() {
+        if (userGroupInformation == null) {
+            return;
+        }
+        try {
+            if (userGroupInformation.isFromKeytab()) {
+                userGroupInformation.checkTGTAndReloginFromKeytab();
+            }
+        } catch (Exception e) {
+            log.warn("Kerberos re-login for HiveMetaStore failed: {}", e.getMessage());
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
@@ -50,7 +50,7 @@ class HiveMetaStoreProxyKerberosRenewTest {
     }
 
     @Test
-    void testGetClient_triggersMaybeRelogin_fromKeytab() throws Exception {
+    void testGetClientTriggersMaybeReloginFromKeytab() throws Exception {
         ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
         HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
 
@@ -68,7 +68,7 @@ class HiveMetaStoreProxyKerberosRenewTest {
     }
 
     @Test
-    void testGetClient_triggersMaybeRelogin_notFromKeytab() throws Exception {
+    void testGetClientTriggersMaybeReloginNotFromKeytab() throws Exception {
         ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
         HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
 
@@ -86,7 +86,7 @@ class HiveMetaStoreProxyKerberosRenewTest {
     }
 
     @Test
-    void testGetClient_reloginThrows_swallowed() throws Exception {
+    void testGetClientReloginThrowsSwallowed() throws Exception {
         ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
         HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
 

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.seatunnel.connectors.seatunnel.hive.utils;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
@@ -10,13 +27,26 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
-static class HiveMetaStoreProxyKerberosRenewTest {
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HiveMetaStoreProxyKerberosRenewTest {
 
     private static void set(Object target, String field, Object value) throws Exception {
         Field f = target.getClass().getDeclaredField(field);
         f.setAccessible(true);
         f.set(target, value);
+    }
+
+    private static Object invoke(Object target, String method) throws Exception {
+        Method m = target.getClass().getDeclaredMethod(method);
+        m.setAccessible(true);
+        return m.invoke(target);
     }
 
     @Test
@@ -32,7 +62,7 @@ static class HiveMetaStoreProxyKerberosRenewTest {
         set(proxy, "userGroupInformation", ugi);
         set(proxy, "kerberosEnabled", true);
 
-        HiveMetaStoreClient out = proxy.getClient();
+        HiveMetaStoreClient out = (HiveMetaStoreClient) invoke(proxy, "getClient");
         Assertions.assertNotNull(out);
         verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
     }
@@ -50,7 +80,7 @@ static class HiveMetaStoreProxyKerberosRenewTest {
         set(proxy, "userGroupInformation", ugi);
         set(proxy, "kerberosEnabled", true);
 
-        HiveMetaStoreClient out = proxy.getClient();
+        HiveMetaStoreClient out = (HiveMetaStoreClient) invoke(proxy, "getClient");
         Assertions.assertNotNull(out);
         verify(ugi, never()).checkTGTAndReloginFromKeytab();
     }
@@ -69,7 +99,14 @@ static class HiveMetaStoreProxyKerberosRenewTest {
         set(proxy, "userGroupInformation", ugi);
         set(proxy, "kerberosEnabled", true);
 
-        Assertions.assertDoesNotThrow(proxy::getClient);
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    try {
+                        invoke(proxy, "getClient");
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
         verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
     }
 }

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreProxyKerberosRenewTest.java
@@ -1,0 +1,75 @@
+package org.apache.seatunnel.connectors.seatunnel.hive.utils;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+static class HiveMetaStoreProxyKerberosRenewTest {
+
+    private static void set(Object target, String field, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    @Test
+    void testGetClient_triggersMaybeRelogin_fromKeytab() throws Exception {
+        ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
+        HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
+
+        HiveMetaStoreClient client = Mockito.mock(HiveMetaStoreClient.class);
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(true);
+
+        set(proxy, "hiveClient", client);
+        set(proxy, "userGroupInformation", ugi);
+        set(proxy, "kerberosEnabled", true);
+
+        HiveMetaStoreClient out = proxy.getClient();
+        Assertions.assertNotNull(out);
+        verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
+    }
+
+    @Test
+    void testGetClient_triggersMaybeRelogin_notFromKeytab() throws Exception {
+        ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
+        HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
+
+        HiveMetaStoreClient client = Mockito.mock(HiveMetaStoreClient.class);
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(false);
+
+        set(proxy, "hiveClient", client);
+        set(proxy, "userGroupInformation", ugi);
+        set(proxy, "kerberosEnabled", true);
+
+        HiveMetaStoreClient out = proxy.getClient();
+        Assertions.assertNotNull(out);
+        verify(ugi, never()).checkTGTAndReloginFromKeytab();
+    }
+
+    @Test
+    void testGetClient_reloginThrows_swallowed() throws Exception {
+        ReadonlyConfig cfg = Mockito.mock(ReadonlyConfig.class);
+        HiveMetaStoreProxy proxy = new HiveMetaStoreProxy(cfg);
+
+        HiveMetaStoreClient client = Mockito.mock(HiveMetaStoreClient.class);
+        UserGroupInformation ugi = Mockito.mock(UserGroupInformation.class);
+        when(ugi.isFromKeytab()).thenReturn(true);
+        doThrow(new RuntimeException("test")).when(ugi).checkTGTAndReloginFromKeytab();
+
+        set(proxy, "hiveClient", client);
+        set(proxy, "userGroupInformation", ugi);
+        set(proxy, "kerberosEnabled", true);
+
+        Assertions.assertDoesNotThrow(proxy::getClient);
+        verify(ugi, times(1)).checkTGTAndReloginFromKeytab();
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
Long‑running Seatunnel Kafka→Hive streaming jobs on Flink(or zeta) fail after ~24h due to expired Kerberos credentials (TGT/Delegation Tokens).
Keep jobs healthy well past 24h by ensuring credentials are refreshed and actually used by connectors.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
yes,
Job ran >48h with renewals at ~18h intervals and no Hive write failures.
log:
<img width="2618" height="1000" alt="image" src="https://github.com/user-attachments/assets/078c9c75-8547-49da-9aef-0e3eefd0847e" />


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)