### PR TITLE
[Fix][Connector-v2][Clickhouse] Use actual table schema instead of DESC results for PhysicalColumn creation

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/Column.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/Column.java
@@ -119,6 +119,34 @@ public abstract class Column implements Serializable {
             boolean nullable,
             Object defaultValue,
             String comment,
+            String sinkType,
+            String sourceType,
+            Map<String, Object> options) {
+        this.name = name;
+        this.dataType = dataType;
+        this.columnLength = columnLength;
+        this.scale = scale;
+        this.nullable = nullable;
+        this.defaultValue = defaultValue;
+        this.comment = comment;
+        this.sourceType = sourceType;
+        this.sinkType = sinkType;
+        this.options = options;
+
+        this.bitLen = columnLength != null ? columnLength * 8 : 0;
+        this.longColumnLength = columnLength;
+        this.isUnsigned = false;
+        this.isZeroFill = false;
+    }
+
+    protected Column(
+            String name,
+            SeaTunnelDataType<?> dataType,
+            Long columnLength,
+            Integer scale,
+            boolean nullable,
+            Object defaultValue,
+            String comment,
             String sourceType,
             Map<String, Object> options) {
         this.name = name;

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/PhysicalColumn.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/PhysicalColumn.java
@@ -39,6 +39,30 @@ public class PhysicalColumn extends Column {
         super(name, dataType, columnLength, scale);
     }
 
+    public PhysicalColumn(
+            String name,
+            SeaTunnelDataType<?> dataType,
+            Long columnLength,
+            Integer scale,
+            boolean nullable,
+            Object defaultValue,
+            String comment,
+            String sinkType,
+            String sourceType,
+            Map<String, Object> options) {
+        super(
+                name,
+                dataType,
+                columnLength,
+                scale,
+                nullable,
+                defaultValue,
+                comment,
+                sinkType,
+                sourceType,
+                options);
+    }
+
     protected PhysicalColumn(
             String name,
             SeaTunnelDataType<?> dataType,
@@ -241,6 +265,29 @@ public class PhysicalColumn extends Column {
                 comment,
                 sourceType,
                 options);
+    }
+
+    public static PhysicalColumn of(
+            String name,
+            SeaTunnelDataType<?> dataType,
+            Long columnLength,
+            Integer scale,
+            boolean nullable,
+            Object defaultValue,
+            String comment,
+            String sinkType,
+            String sourceType) {
+        return new PhysicalColumn(
+                name,
+                dataType,
+                columnLength,
+                scale,
+                nullable,
+                defaultValue,
+                comment,
+                sinkType,
+                sourceType,
+                null);
     }
 
     @Deprecated

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/catalog/ClickhouseCatalog.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/catalog/ClickhouseCatalog.java
@@ -100,6 +100,9 @@ public class ClickhouseCatalog implements Catalog {
         List<ClickHouseColumn> clickHouseColumns =
                 proxy.getClickHouseColumns(tablePath.getFullNameWithQuoted());
 
+        // Get source type mapping from DESC query
+        Map<String, String> sourceTypeMap =
+                proxy.getClickhouseTableSchema(tablePath.getFullNameWithQuoted());
         try {
             Optional<PrimaryKey> primaryKey =
                     proxy.getPrimaryKey(tablePath.getDatabaseName(), tablePath.getTableName());
@@ -118,7 +121,9 @@ public class ClickhouseCatalog implements Catalog {
                                     column.getScale(),
                                     column.isNullable(),
                                     null,
-                                    null));
+                                    null,
+                                    null,
+                                    sourceTypeMap.get(column.getColumnName())));
 
             TableIdentifier tableIdentifier =
                     TableIdentifier.of(

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseProxy.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseProxy.java
@@ -178,7 +178,7 @@ public class ClickhouseProxy implements AutoCloseable {
     }
 
     public List<ClickHouseColumn> getClickHouseColumns(String table) {
-        String sql = "desc " + table;
+        String sql = "SELECT * FROM " + table + " WHERE 1 = 0";
         try (ClickHouseResponse response = this.clickhouseRequest.query(sql).executeAndWait()) {
             return response.getColumns();
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/pom.xml
@@ -26,7 +26,7 @@
     <name>SeaTunnel : E2E : Connector V2 : Clickhouse</name>
 
     <properties>
-        <clickhouse.jdbc.version>0.3.2-patch9</clickhouse.jdbc.version>
+        <clickhouse.jdbc.version>0.3.2-patch11</clickhouse.jdbc.version>
     </properties>
 
     <dependencies>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
@@ -32,9 +32,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.clickhouse.catalog.ClickhouseCatalog;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
-import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
-import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.util.ContainerUtil;
 
 import org.awaitility.Awaitility;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
@@ -83,10 +83,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@DisabledOnContainer(
-        value = {},
-        type = {EngineType.FLINK, EngineType.SPARK},
-        disabledReason = "Currently FLINK engine unsupported NULL type")
 public class ClickhouseIT extends TestSuiteBase implements TestResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClickhouseIT.class);
     private static final String CLICKHOUSE_DOCKER_IMAGE = "clickhouse/clickhouse-server:23.3.13.6";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-clickhouse-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/ClickhouseIT.java
@@ -17,6 +17,10 @@
 
 package org.apache.seatunnel.connectors.seatunnel.clickhouse;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.DecimalType;
@@ -25,9 +29,12 @@ import org.apache.seatunnel.api.table.type.MapType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.clickhouse.catalog.ClickhouseCatalog;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
+import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.util.ContainerUtil;
 
 import org.awaitility.Awaitility;
@@ -67,13 +74,19 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@DisabledOnContainer(
+        value = {},
+        type = {EngineType.FLINK, EngineType.SPARK},
+        disabledReason = "Currently FLINK engine unsupported NULL type")
 public class ClickhouseIT extends TestSuiteBase implements TestResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClickhouseIT.class);
     private static final String CLICKHOUSE_DOCKER_IMAGE = "clickhouse/clickhouse-server:23.3.13.6";
@@ -272,6 +285,161 @@ public class ClickhouseIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals(100, countData(MULTI_SOURCE_SINK_TABLES.get(0)));
         Assertions.assertEquals(47, countData(MULTI_SOURCE_SINK_TABLES.get(1)));
         MULTI_SOURCE_SINK_TABLES.forEach(this::clearTable);
+    }
+
+    @TestTemplate
+    public void testClickhouseCatalogGetTableColumnsCorrectly(TestContainer testContainer)
+            throws Exception {
+        String testTableName = "test_column_names_table";
+        String createTableSql =
+                String.format(
+                        "CREATE TABLE IF NOT EXISTS %s.%s ("
+                                + "user_id UInt64, "
+                                + "user_name String, "
+                                + "user_age UInt32, "
+                                + "created_at DateTime, "
+                                + "balance Decimal(10, 2)"
+                                + ") ENGINE = MergeTree() ORDER BY user_id",
+                        DATABASE, testTableName);
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(createTableSql);
+
+            String insertSql =
+                    String.format(
+                            "INSERT INTO %s.%s VALUES (1, 'Alice', 25, '2024-01-01 10:00:00', 100.50)",
+                            DATABASE, testTableName);
+            statement.execute(insertSql);
+        }
+
+        Map<String, Object> catalogConfig = new HashMap<>();
+        catalogConfig.put("host", container.getHost() + ":" + container.getMappedPort(8123));
+        catalogConfig.put("database", DATABASE);
+        catalogConfig.put("username", container.getUsername());
+        catalogConfig.put("password", container.getPassword());
+
+        ClickhouseCatalog catalog =
+                new ClickhouseCatalog(ReadonlyConfig.fromMap(catalogConfig), "test_catalog");
+
+        try {
+            catalog.open();
+
+            TablePath tablePath = TablePath.of(DATABASE, testTableName);
+            CatalogTable catalogTable = catalog.getTable(tablePath);
+
+            List<String> actualColumnNames = new ArrayList<>();
+            for (Column column : catalogTable.getTableSchema().getColumns()) {
+                actualColumnNames.add(column.getName());
+            }
+
+            List<String> expectedColumnNames =
+                    Arrays.asList("user_id", "user_name", "user_age", "created_at", "balance");
+
+            Assertions.assertEquals(
+                    expectedColumnNames.size(),
+                    actualColumnNames.size(),
+                    "Column count should match");
+
+            for (int i = 0; i < expectedColumnNames.size(); i++) {
+                Assertions.assertEquals(
+                        expectedColumnNames.get(i),
+                        actualColumnNames.get(i),
+                        String.format(
+                                "Column %d name should be '%s' but got '%s'",
+                                i, expectedColumnNames.get(i), actualColumnNames.get(i)));
+            }
+
+            // Verify we don't have DESC result column names like 'name', 'type', 'default_type'
+            Assertions.assertFalse(
+                    actualColumnNames.contains("name"),
+                    "Should not contain DESC result column 'name'");
+            Assertions.assertFalse(
+                    actualColumnNames.contains("type"),
+                    "Should not contain DESC result column 'type'");
+            Assertions.assertFalse(
+                    actualColumnNames.contains("default_type"),
+                    "Should not contain DESC result column 'default_type'");
+
+        } finally {
+            catalog.close();
+            dropTable(DATABASE + "." + testTableName);
+        }
+    }
+
+    @TestTemplate
+    public void testClickhouseCatalogSourceTypeNotNull(TestContainer testContainer)
+            throws Exception {
+        String testTableName = "test_source_type_table";
+        String createTableSql =
+                String.format(
+                        "CREATE TABLE IF NOT EXISTS %s.%s ("
+                                + "id UInt64, "
+                                + "name String, "
+                                + "age UInt32, "
+                                + "score Int32, "
+                                + "balance Decimal(18, 4), "
+                                + "created_at DateTime, "
+                                + "is_active UInt8, "
+                                + "description Nullable(String), "
+                                + "tags Array(String)"
+                                + ") ENGINE = MergeTree() ORDER BY id",
+                        DATABASE, testTableName);
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(createTableSql);
+
+            String insertSql =
+                    String.format(
+                            "INSERT INTO %s.%s VALUES "
+                                    + "(1, 'Alice', 25, 95, 1000.5000, '2024-01-01 10:00:00', 1, 'Test user', ['tag1', 'tag2'])",
+                            DATABASE, testTableName);
+            statement.execute(insertSql);
+        }
+
+        Map<String, Object> catalogConfig = new HashMap<>();
+        catalogConfig.put("host", container.getHost() + ":" + container.getMappedPort(8123));
+        catalogConfig.put("database", DATABASE);
+        catalogConfig.put("username", container.getUsername());
+        catalogConfig.put("password", container.getPassword());
+
+        ClickhouseCatalog catalog =
+                new ClickhouseCatalog(ReadonlyConfig.fromMap(catalogConfig), "test_catalog");
+
+        try {
+            catalog.open();
+
+            TablePath tablePath = TablePath.of(DATABASE, testTableName);
+            CatalogTable catalogTable = catalog.getTable(tablePath);
+
+            Map<String, String> expectedSourceTypes = new HashMap<>();
+            expectedSourceTypes.put("id", "UInt64");
+            expectedSourceTypes.put("name", "String");
+            expectedSourceTypes.put("age", "UInt32");
+            expectedSourceTypes.put("score", "Int32");
+            expectedSourceTypes.put("balance", "Decimal(18, 4)");
+            expectedSourceTypes.put("created_at", "DateTime");
+            expectedSourceTypes.put("is_active", "UInt8");
+            expectedSourceTypes.put("description", "Nullable(String)");
+            expectedSourceTypes.put("tags", "Array(String)");
+
+            for (Column column : catalogTable.getTableSchema().getColumns()) {
+                String columnName = column.getName();
+                String sourceType = column.getSourceType();
+
+                Assertions.assertNotNull(
+                        sourceType,
+                        String.format("Column '%s' sourceType should not be null", columnName));
+
+                String expectedSourceType = expectedSourceTypes.get(columnName);
+                Assertions.assertNotNull(expectedSourceType);
+
+                Assertions.assertEquals(expectedSourceType, sourceType);
+            }
+
+        } finally {
+            catalog.close();
+            dropTable(DATABASE + "." + testTableName);
+        }
     }
 
     @BeforeAll


### PR DESCRIPTION


### Purpose of this pull request

• e2e dependency version modification is consistent with connector
• getClickHouseColumns uses the DESC command and calls response. getColumns(), which returns the column definitions (name, type, default_date, etc.) of the DESC query result set, rather than the actual fields of the table.
• when creating a PhysicalColumn in the ClickhouseCatalog. getTable() method, the sourceType parameter is passed as null

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)