### PR TITLE
[Fix][e2e] Fix flaky Redis tests

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
@@ -346,10 +346,7 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
             Assertions.assertEquals(0, execResult.getExitCode());
 
             List<String> items = jedisCluster.lrange("cluster-list-value-check", 0, -1);
-            Set<String> unique = new HashSet<>();
-            if (items != null) {
-                unique.addAll(items);
-            }
+            Set<String> unique = new HashSet<>(items);
 
             Assertions.assertEquals(100, unique.size());
         } finally {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
@@ -290,11 +290,11 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
                     container.executeJob("/cluster-redis-to-redis-scan.conf");
             Assertions.assertEquals(0, execResult.getExitCode());
 
-            long listLength = jedisCluster.llen("key_list");
-            Assertions.assertEquals(100, listLength);
+            long amount = jedisCluster.scard("key_set");
+            Assertions.assertEquals(100, amount);
         } finally {
-            jedisCluster.del("key_list");
-            Assertions.assertEquals(0, jedisCluster.llen("key_list"));
+            jedisCluster.del("key_set");
+            Assertions.assertEquals(0, jedisCluster.llen("key_set"));
         }
     }
 
@@ -345,8 +345,13 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
                     container.executeJob("/cluster-redis-to-redis-type-list.conf");
             Assertions.assertEquals(0, execResult.getExitCode());
 
-            long amount = jedisCluster.llen("cluster-list-value-check");
-            Assertions.assertEquals(100, amount);
+            List<String> items = jedisCluster.lrange("cluster-list-value-check", 0, -1);
+            Set<String> unique = new HashSet<>();
+            if (items != null) {
+                unique.addAll(items);
+            }
+
+            Assertions.assertEquals(100, unique.size());
         } finally {
             jedisCluster.del("cluster-list-value-check");
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/cluster-redis-to-redis-scan.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/cluster-redis-to-redis-scan.conf
@@ -37,7 +37,7 @@ sink {
     mode = "CLUSTER"
     auth = "SeaTunnel"
     key = "key_list"
-    data_type = list
+    data_type = set
     batch_size = 33
   }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/cluster-redis-to-redis-scan.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/resources/cluster-redis-to-redis-scan.conf
@@ -36,7 +36,7 @@ sink {
     nodes = ["redis-cluster-0:6379", "redis-cluster-1:6379", "redis-cluster-2:6379"]
     mode = "CLUSTER"
     auth = "SeaTunnel"
-    key = "key_list"
+    key = "key_set"
     data_type = set
     batch_size = 33
   }


### PR DESCRIPTION
### Purpose of this pull request

This PR fixes flaky Redis tests.

```
2025-10-30T21:33:29.1934764Z [ERROR] Failures: 
2025-10-30T21:33:29.1935455Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1937019Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1938065Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1939086Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1940211Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1941290Z [ERROR]   RedisClusterIT.testRedisClusterCustomValueWithListType:349 expected: <100> but was: <132>
2025-10-30T21:33:29.1942187Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
2025-10-30T21:33:29.1943049Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
2025-10-30T21:33:29.1943823Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
2025-10-30T21:33:29.1944866Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
2025-10-30T21:33:29.1945655Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
2025-10-30T21:33:29.1946415Z [ERROR]   RedisClusterIT.testRedisClusterScan:294 expected: <100> but was: <132>
```

The `RedisClusterIT` test class involves multiple Redis clusters, which can lead to race conditions in the sink, resulting in duplicate writes.  
Given that the batch size is 33, a total of 33 × 4 = 132 records can occasionally appear due to this race condition.  
To address this, I modified some test cases that handle the List type.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)