### PR TITLE
[Bugfix][seatunnel-connectors-v2][connector-elasticsearch] ElasticsearchSink encounters a writing error and the task does not exit

### DIFF
--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/sink/ElasticsearchSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/sink/ElasticsearchSinkWriter.java
@@ -208,8 +208,11 @@ public class ElasticsearchSinkWriter
     }
 
     @Override
-    public void close() throws IOException {
-        bulkEsWithRetry(this.esRestClient, this.requestEsList);
-        esRestClient.close();
+    public void close() {
+        try {
+            bulkEsWithRetry(this.esRestClient, this.requestEsList);
+        } finally {
+            esRestClient.close();
+        }
     }
 }


### PR DESCRIPTION
When ElasticsearchSinkWriter executes the close method, it executes the bulkEsWithRetry line of code. Once an error is reported, esRestClient cannot be closed, causing the task to never exit.