### PR TITLE
[Improve][Zeta] Improve waiting mechanism in CheckpointCoordinator

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -607,7 +607,7 @@ public class CheckpointCoordinator {
         synchronized (lock) {
             while (pendingCounter.get() > 0 && !shutdown) {
                 try {
-                    lock.wait();
+                    lock.wait(30_000);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return completableFutureWithError(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -607,7 +607,7 @@ public class CheckpointCoordinator {
         synchronized (lock) {
             while (pendingCounter.get() > 0 && !shutdown) {
                 try {
-                    lock.wait(500);
+                    lock.wait();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return completableFutureWithError(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -610,8 +610,10 @@ public class CheckpointCoordinator {
                     lock.wait(500);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    return completableFutureWithError(
-                            CheckpointCloseReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
+                    handleCoordinatorError(
+                            "start checkpoint failed",
+                            e,
+                            CheckpointCloseReason.CHECKPOINT_INSIDE_ERROR);
                 }
             }
             if (shutdown || isCompleted()) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -862,10 +862,10 @@ public class CheckpointCoordinator {
             readyToCloseStartingTask.clear();
             readyToCloseIdleTask.clear();
             closedIdleTask.clear();
-            synchronized (lock) {
-                pendingCounter.set(0);
-                lock.notifyAll();
-            }
+
+            pendingCounter.set(0);
+            lock.notifyAll();
+
             schemaChanging.set(false);
             scheduler.shutdownNow();
             scheduler =
@@ -961,6 +961,7 @@ public class CheckpointCoordinator {
         latestCompletedCheckpoint = completedCheckpoint;
         notifyCompleted(completedCheckpoint);
         pendingCheckpoints.remove(checkpointId).abortCheckpointTimeoutFutureWhenIsCompleted();
+
         synchronized (lock) {
             pendingCounter.decrementAndGet();
             lock.notifyAll();

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -610,9 +610,7 @@ public class CheckpointCoordinator {
                     lock.wait(500);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    handleCoordinatorError(
-                            "start checkpoint failed",
-                            e,
+                    return completableFutureWithError(
                             CheckpointCloseReason.CHECKPOINT_INSIDE_ERROR);
                 }
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -606,7 +606,13 @@ public class CheckpointCoordinator {
         CompletableFuture<PendingCheckpoint> savepoint;
         synchronized (lock) {
             while (pendingCounter.get() > 0 && !shutdown) {
-                Thread.sleep(500);
+                try {
+                    lock.wait(500);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return completableFutureWithError(
+                            CheckpointCloseReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
+                }
             }
             if (shutdown || isCompleted()) {
                 return completableFutureWithError(
@@ -714,7 +720,9 @@ public class CheckpointCoordinator {
                                         TimeUnit.MILLISECONDS));
                     }
                 });
-        pendingCounter.incrementAndGet();
+        synchronized (lock) {
+            pendingCounter.incrementAndGet();
+        }
     }
 
     private CompletableFuture<PendingCheckpoint> createPendingCheckpoint(
@@ -854,7 +862,10 @@ public class CheckpointCoordinator {
             readyToCloseStartingTask.clear();
             readyToCloseIdleTask.clear();
             closedIdleTask.clear();
-            pendingCounter.set(0);
+            synchronized (lock) {
+                pendingCounter.set(0);
+                lock.notifyAll();
+            }
             schemaChanging.set(false);
             scheduler.shutdownNow();
             scheduler =
@@ -950,7 +961,10 @@ public class CheckpointCoordinator {
         latestCompletedCheckpoint = completedCheckpoint;
         notifyCompleted(completedCheckpoint);
         pendingCheckpoints.remove(checkpointId).abortCheckpointTimeoutFutureWhenIsCompleted();
-        pendingCounter.decrementAndGet();
+        synchronized (lock) {
+            pendingCounter.decrementAndGet();
+            lock.notifyAll();
+        }
 
         if (isCompleted()) {
             cleanPendingCheckpoint(CheckpointCloseReason.CHECKPOINT_COORDINATOR_COMPLETED);


### PR DESCRIPTION
### Purpose of this pull request

This PR improves the waiting mechanism in CheckpointCoordinator by replacing the busy-loop check with a wait/notifyAll–based synchronization model.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not applicable.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)