### PR TITLE
[Bugfix][Connector-V2] Doris sink check load error before stopLoad to interrupt blocking poll() in RecordBuffer

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -200,6 +200,7 @@ public class DorisSinkWriter
     private RespContent flush() throws IOException {
         // disable exception checker before stop load.
         checkState(dorisStreamLoad != null);
+        checkDone();
         RespContent respContent = dorisStreamLoad.stopLoad();
         if (respContent != null && !DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
             String errMsg =


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

#### Problem

The `stopBufferData()` method in `RecordBuffer` can block indefinitely in a `while` loop waiting for a buffer from `writeQueue.poll(100ms)` to send an EOF marker. The `checkErrorMessageByStreamLoad()` check inside the loop never receives an error signal to interrupt the wait, even when Doris FE has already returned an error response.

flink jstack
<img width="2105" height="816" alt="image" src="https://github.com/user-attachments/assets/aabb9b87-6ab9-4282-a11d-40897ed4ec45" />


#### Root Cause

1. **Buffer pool exhaustion**: All buffers are moved from `writeQueue` to `readQueue` by the write thread, but the read thread (HTTP upload) doesn't consume them (e.g., due to Doris node restart or network issues). Without consumption, no buffers are recycled back to `writeQueue`.

2. **Error message not propagated**: In `DorisStreamLoad.stopLoad()`, `loading = false` is set immediately, which prevents `getLoadFailedMsg()` from checking `pendingLoadFuture` and setting the error message. The `endInput()` call blocks before `pendingLoadFuture.get()` can be reached to parse the error response.

3. **Circular dependency**: Need EOF to finish → need buffer for EOF → buffer unavailable → need error to interrupt → error not propagated → infinite wait.

#### Solution

`checkDone()` **before** calling `stopLoad()`

### Does this PR introduce _any_ user-facing change?
no

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)