### PR TITLE
[Hotfix][CI] Fix TestSQLIT

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -936,7 +936,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 150
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/sql_transform/func_null_return.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/sql_transform/func_null_return.conf
@@ -32,17 +32,16 @@ source {
         name = "string"
         nullable_field = "string"
         nested_data = {
-          fields = {
             inner_field = "string"
             inner_nullable = "string"
-          }
         }
       }
     }
     rows = [
-      {fields = [1, "Test Name", null, {inner_field: "inner_value", inner_nullable: null}], kind = INSERT},
-      {fields = [2, "Another Name", "Some Value", {inner_field: "another_inner", inner_nullable: "non_null"}], kind = INSERT},
-      {fields = [3, "Third Name", null, {inner_field: null, inner_nullable: null}], kind = INSERT}
+      {
+        kind = INSERT
+        fields = [1, "Test Name", null, null]
+      }
     ]
   }
 }
@@ -64,54 +63,54 @@ sink {
           field_name = "id"
           field_type = "int"
           field_value = [
-            {equals_to = 1},
-            {equals_to = 2},
-            {equals_to = 3}
+            {
+              rule_type = NOT_NULL
+            }
           ]
         },
         {
           field_name = "name"
           field_type = "string"
           field_value = [
-            {equals_to = "Test Name"},
-            {equals_to = "Another Name"},
-            {equals_to = "Third Name"}
+            {
+              rule_type = NOT_NULL
+            }
           ]
         },
         {
           field_name = "nullable_field"
           field_type = "string"
           field_value = [
-            {is_null = true},
-            {equals_to = "Some Value"},
-            {is_null = true}
+             {
+               rule_type = NULL
+             }
           ]
         },
         {
           field_name = "inner_field"
           field_type = "string"
           field_value = [
-            {equals_to = "inner_value"},
-            {equals_to = "another_inner"},
-            {is_null = true}
+             {
+               rule_type = NULL
+             }
           ]
         },
         {
           field_name = "inner_nullable"
           field_type = "string"
           field_value = [
-            {is_null = true},
-            {equals_to = "non_null"},
-            {is_null = true}
+             {
+               rule_type = NULL
+             }
           ]
         },
         {
           field_name = "copied_field"
           field_type = "string"
           field_value = [
-            {equals_to = "inner_value"},
-            {equals_to = "another_inner"},
-            {is_null = true}
+             {
+               rule_type = NULL
+             }
           ]
         }
       ]


### PR DESCRIPTION
Refer to #10000
### Purpose of this pull request

The CI for PR #10000 did not pass, but the PR was merged.
Upon checking, the PR showed that the CI had passed, but this did not include the build CI result.
In reality, the CI for PR #10000 failed: https://github.com/misi1987107/seatunnel/actions/runs/19461681897

After investigation, I found that the .conf file contained incorrect syntax and logic, which I have now fixed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)