### PR TITLE
[Improve][Fink] NO_CDC source support checkpoint

### DIFF
--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/execution/RuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/execution/RuntimeEnvironment.java
@@ -61,13 +61,13 @@ public interface RuntimeEnvironment {
     }
 
     static boolean getEnableCheckpoint(Config config) {
-        boolean enableCheckpoint;
         Config envConfig = config.getConfig("env");
+        long checkpointInterval = -1;
         if (envConfig.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
-            enableCheckpoint = envConfig.getInt(EnvCommonOptions.CHECKPOINT_INTERVAL.key()) > 0;
-        } else {
-            enableCheckpoint = false;
+            checkpointInterval = envConfig.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key());
+        } else if (envConfig.hasPath("execution.checkpoint.interval")) {
+            checkpointInterval = envConfig.getLong("execution.checkpoint.interval");
         }
-        return enableCheckpoint || getJobMode(config) == JobMode.STREAMING;
+        return checkpointInterval > 0 || getJobMode(config) == JobMode.STREAMING;
     }
 }

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/execution/RuntimeEnvironmentTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/execution/RuntimeEnvironmentTest.java
@@ -45,5 +45,23 @@ public class RuntimeEnvironmentTest {
                                 + "  checkpoint.interval = 10\n"
                                 + "}");
         Assertions.assertTrue(RuntimeEnvironment.getEnableCheckpoint(config));
+
+        config =
+                ConfigFactory.parseString(
+                        "env {\n"
+                                + "  parallelism = 1\n"
+                                + "  job.mode = \"BATCH\"\n"
+                                + "  execution.checkpoint.interval = 10\n"
+                                + "}");
+        Assertions.assertTrue(RuntimeEnvironment.getEnableCheckpoint(config));
+
+        config =
+                ConfigFactory.parseString(
+                        "env {\n"
+                                + "  parallelism = 1\n"
+                                + "  job.mode = \"BATCH\"\n"
+                                + "  checkpoint.interval = 0\n"
+                                + "}");
+        Assertions.assertFalse(RuntimeEnvironment.getEnableCheckpoint(config));
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
@@ -212,7 +212,10 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
             boolean enableCheckpointForBatch =
                     config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
                             && config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key()) > 0;
-            if (!enableCheckpointForBatch) {
+            if (enableCheckpointForBatch) {
+                log.info(
+                        "Flink batch runtime does not support checkpoint-based restore; 'checkpoint.interval' > 0 will make this batch job run in streaming runtime.");
+            } else {
                 environment.setRuntimeMode(RuntimeExecutionMode.BATCH);
             }
         }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
@@ -77,19 +77,33 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
     }
 
     protected void setCheckpoint() {
-        if (jobMode == JobMode.BATCH) {
-            log.warn(
-                    "Disabled Checkpointing. In flink execution environment, checkpointing is not supported and not needed when executing jobs in BATCH mode");
-        }
-        long interval;
+        long interval = 10000L;
+        boolean hasExplicitInterval = false;
         if (config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
             interval = config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key());
+            hasExplicitInterval = true;
         } else if (config.hasPath(ConfigKeyName.CHECKPOINT_INTERVAL)) {
             log.warn(
                     "the parameter 'execution.checkpoint.interval' will be deprecated, please use common parameter 'checkpoint.interval' to set it");
             interval = config.getLong(ConfigKeyName.CHECKPOINT_INTERVAL);
-        } else {
+        }
+
+        if (hasExplicitInterval && interval <= 0) {
+            log.warn(
+                    "checkpoint.interval is set to {} which is not positive, checkpoint will be disabled for batch job and default interval will be used for streaming job.",
+                    interval);
             interval = 10000L;
+        }
+
+        boolean enableCheckpoint =
+                JobMode.STREAMING.equals(jobMode) || (hasExplicitInterval && interval > 0);
+
+        if (!enableCheckpoint) {
+            if (jobMode == JobMode.BATCH) {
+                log.info(
+                        "Checkpoint is disabled for batch job because 'checkpoint.interval' is not set or <= 0.");
+            }
+            return;
         }
 
         CheckpointConfig checkpointConfig = environment.getCheckpointConfig();
@@ -195,7 +209,12 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
         }
 
         if (this.jobMode.equals(JobMode.BATCH)) {
-            environment.setRuntimeMode(RuntimeExecutionMode.BATCH);
+            boolean enableCheckpointForBatch =
+                    config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
+                            && config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key()) > 0;
+            if (!enableCheckpointForBatch) {
+                environment.setRuntimeMode(RuntimeExecutionMode.BATCH);
+            }
         }
     }
 

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
@@ -46,6 +46,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -55,6 +56,8 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
     protected StreamExecutionEnvironment environment;
     protected JobMode jobMode;
     protected String jobName = Constants.LOGO;
+
+    private static final long DEFAULT_CHECKPOINT_INTERVAL_MS = 10000L;
 
     protected AbstractFlinkRuntimeEnvironment(Config config) {
         this.initialize(config);
@@ -77,33 +80,23 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
     }
 
     protected void setCheckpoint() {
-        long interval = 10000L;
-        boolean hasExplicitInterval = false;
-        if (config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
-            interval = config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key());
-            hasExplicitInterval = true;
-        } else if (config.hasPath(ConfigKeyName.CHECKPOINT_INTERVAL)) {
-            log.warn(
-                    "the parameter 'execution.checkpoint.interval' will be deprecated, please use common parameter 'checkpoint.interval' to set it");
-            interval = config.getLong(ConfigKeyName.CHECKPOINT_INTERVAL);
-        }
+        OptionalLong intervalOpt = resolveCheckpointInterval(true);
+        boolean hasExplicitInterval = intervalOpt.isPresent();
+        boolean positiveInterval = intervalOpt.isPresent() && intervalOpt.getAsLong() > 0;
+        long interval = intervalOpt.orElse(DEFAULT_CHECKPOINT_INTERVAL_MS);
 
-        if (hasExplicitInterval && interval <= 0) {
-            log.warn(
-                    "checkpoint.interval is set to {} which is not positive, checkpoint will be disabled for batch job and default interval will be used for streaming job.",
-                    interval);
-            interval = 10000L;
-        }
-
-        boolean enableCheckpoint =
-                JobMode.STREAMING.equals(jobMode) || (hasExplicitInterval && interval > 0);
-
-        if (!enableCheckpoint) {
-            if (jobMode == JobMode.BATCH) {
-                log.info(
-                        "Checkpoint is disabled for batch job because 'checkpoint.interval' is not set or <= 0.");
-            }
+        if (jobMode == JobMode.BATCH && !positiveInterval) {
+            log.info(
+                    "Checkpoint is disabled for batch job because 'checkpoint.interval' is not set or <= 0.");
             return;
+        }
+
+        if (hasExplicitInterval && !positiveInterval) {
+            log.warn(
+                    "checkpoint.interval is set to {} which is not positive, fallback to default {} ms for streaming job.",
+                    interval,
+                    DEFAULT_CHECKPOINT_INTERVAL_MS);
+            interval = DEFAULT_CHECKPOINT_INTERVAL_MS;
         }
 
         CheckpointConfig checkpointConfig = environment.getCheckpointConfig();
@@ -209,16 +202,28 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
         }
 
         if (this.jobMode.equals(JobMode.BATCH)) {
-            boolean enableCheckpointForBatch =
-                    config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
-                            && config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key()) > 0;
-            if (enableCheckpointForBatch) {
+            OptionalLong intervalOpt = resolveCheckpointInterval(false);
+            if (intervalOpt.isPresent() && intervalOpt.getAsLong() > 0) {
                 log.info(
                         "Flink batch runtime does not support checkpoint-based restore; 'checkpoint.interval' > 0 will make this batch job run in streaming runtime.");
             } else {
                 environment.setRuntimeMode(RuntimeExecutionMode.BATCH);
             }
         }
+    }
+
+    protected OptionalLong resolveCheckpointInterval(boolean warnLegacy) {
+        if (config.hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())) {
+            return OptionalLong.of(config.getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key()));
+        }
+        if (config.hasPath(ConfigKeyName.CHECKPOINT_INTERVAL)) {
+            if (warnLegacy) {
+                log.warn(
+                        "the parameter 'execution.checkpoint.interval' will be deprecated, please use common parameter 'checkpoint.interval' to set it");
+            }
+            return OptionalLong.of(config.getLong(ConfigKeyName.CHECKPOINT_INTERVAL));
+        }
+        return OptionalLong.empty();
     }
 
     private void setTimeCharacteristic() {

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -136,14 +137,10 @@ public class FlinkExecution implements TaskExecution {
                 flinkRuntimeEnvironment.getStreamExecutionEnvironment().getExecutionPlan());
         LOGGER.info("Flink job name: {}", flinkRuntimeEnvironment.getJobName());
         if (flinkRuntimeEnvironment.getJobMode() == JobMode.BATCH) {
+            OptionalLong checkpointInterval =
+                    flinkRuntimeEnvironment.resolveCheckpointInterval(false);
             boolean enableCheckpointForBatch =
-                    flinkRuntimeEnvironment
-                                    .getConfig()
-                                    .hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
-                            && flinkRuntimeEnvironment
-                                            .getConfig()
-                                            .getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
-                                    > 0;
+                    checkpointInterval.isPresent() && checkpointInterval.getAsLong() > 0;
             if (!enableCheckpointForBatch) {
                 flinkRuntimeEnvironment
                         .getStreamExecutionEnvironment()

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
@@ -135,11 +135,21 @@ public class FlinkExecution implements TaskExecution {
                 "Flink Execution Plan: {}",
                 flinkRuntimeEnvironment.getStreamExecutionEnvironment().getExecutionPlan());
         LOGGER.info("Flink job name: {}", flinkRuntimeEnvironment.getJobName());
-        if (!flinkRuntimeEnvironment.isStreaming()) {
-            flinkRuntimeEnvironment
-                    .getStreamExecutionEnvironment()
-                    .setRuntimeMode(RuntimeExecutionMode.BATCH);
-            LOGGER.info("Flink job Mode: {}", JobMode.BATCH);
+        if (flinkRuntimeEnvironment.getJobMode() == JobMode.BATCH) {
+            boolean enableCheckpointForBatch =
+                    flinkRuntimeEnvironment
+                                    .getConfig()
+                                    .hasPath(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
+                            && flinkRuntimeEnvironment
+                                            .getConfig()
+                                            .getLong(EnvCommonOptions.CHECKPOINT_INTERVAL.key())
+                                    > 0;
+            if (!enableCheckpointForBatch) {
+                flinkRuntimeEnvironment
+                        .getStreamExecutionEnvironment()
+                        .setRuntimeMode(RuntimeExecutionMode.BATCH);
+                LOGGER.info("Flink job Mode: {}", JobMode.BATCH);
+            }
         }
         try {
             final long jobStartTime = System.currentTimeMillis();

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointEnableIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointEnableIT.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
-import org.apache.seatunnel.e2e.common.container.TestContainerId;
 import org.apache.seatunnel.e2e.common.container.flink.AbstractTestFlinkContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
@@ -208,9 +207,10 @@ public class CheckpointEnableIT extends TestSuiteBase {
     public void testFlinkCheckpointEnable(AbstractTestFlinkContainer container)
             throws IOException, InterruptedException {
         /**
-         * In flink execution environment, checkpoint is not supported and not needed when executing
-         * jobs in BATCH mode. So it is only necessary to determine whether flink has enabled
-         * checkpoint by configuring tasks with 'checkpoint.interval'.
+         * In Flink execution environment, batch jobs normally do not enable checkpointing. When
+         * 'checkpoint.interval' is configured for a batch job, SeaTunnel will submit it in
+         * streaming runtime with the same checkpoint interval. This test verifies that Flink has
+         * enabled checkpointing and uses the configured interval.
          */
         Container.ExecResult enableExecResult =
                 container.executeJob(
@@ -228,19 +228,12 @@ public class CheckpointEnableIT extends TestSuiteBase {
                                         jobId)),
                         String.class,
                         Object.class);
-        /**
-         * when the checkpoint interval is 0x7fffffffffffffff, indicates that checkpoint is
-         * disabled. reference {@link
-         * org.apache.flink.runtime.jobgraph.JobGraph#isCheckpointingEnabled()}
-         */
-        if (container.identifier().equals(TestContainerId.FLINK_1_13)
-                || container.identifier().equals(TestContainerId.FLINK_1_14)
-                || container.identifier().equals(TestContainerId.FLINK_1_15)
-                || container.identifier().equals(TestContainerId.FLINK_1_16)) {
-            Assertions.assertEquals(Long.MAX_VALUE, jobConfig.getOrDefault("interval", 0L));
-        } else {
-            Assertions.assertEquals(0, jobConfig.getOrDefault("interval", 0));
-        }
+        Object intervalObject = jobConfig.get("interval");
+        Assertions.assertNotNull(intervalObject);
+        long interval = ((Number) intervalObject).longValue();
+        // the value here should be consistent with `checkpoint.interval` in
+        // batch_fakesource_to_localfile_checkpoint_enable.conf
+        Assertions.assertEquals(1000L, interval);
     }
 
     @TestTemplate


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

https://github.com/apache/seatunnel/issues/10077
## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

- Clarify Flink checkpoint semantics for non‑CDC jobs: pure batch mode cannot use checkpoint‑based restore, while streaming mode can.

- Align the actual behaviour of the Flink engine (batch vs. streaming with checkpoint.interval) with the way we describe it in the documentation and connector feature matrix.

- Avoid confusing new users: the current JDBC connector docs show “batch” checked and “streaming” unchecked for Spark/Flink engines, which suggests that streaming is not supported, and does not explain the checkpoint limitation in batch mode.

- Keep the feature description consistent between the SeaTunnel Zeta engine and Flink engine so that users can choose the engine with a clear understanding of checkpoint support.

- Address the discussion and requirements raised in issue #10077 and make sure tests and docs cover the new behaviour.



### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

- For Flink engine, when job.mode = BATCH and checkpoint.interval > 0, submit the job in streaming runtime and enable Flink checkpointing with the configured interval.

- Keep batch jobs without checkpoint.interval (or <= 0) running in pure batch runtime with checkpointing disabled.
- Adjust the e2e tests so that they verify the actual checkpoint interval configured on the Flink job instead of treating batch jobs as always “checkpoint disabled”.

- Align JDBC connector documentation so that the “Batch / Streaming” capability description is consistent between SeaTunnel Zeta and Flink engines, and make it explicit that checkpoint‑based restore is only supported in streaming mode for Flink (non‑CDC) jobs.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

1. Updated existing e2e test 
- org.apache.seatunnel.engine.e2e.CheckpointEnableIT#testFlinkCheckpointEnable to assert the configured checkpoint interval.

2. Existing unit tests such as
- org.apache.seatunnel.core.starter.execution.RuntimeEnvironmentTest
- org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.utils.CatalogUtilsTest continue to pass locally.

### Check list

* [ * ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ * ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)