### PR TITLE
[Feature][Zeta] Support Parallelism Inference

### DIFF
--- a/config/seatunnel.yaml
+++ b/config/seatunnel.yaml
@@ -44,6 +44,9 @@ seatunnel:
       enable-http: true
       port: 8080
       enable-dynamic-port: false
+    parallelism-inference:
+      enabled: false
+      max-parallelism: 64
       # Uncomment the following lines to enable basic authentication for web UI
       # enable-basic-auth: true
       # basic-auth-username: admin

--- a/docs/en/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/en/seatunnel-engine/separated-cluster-deployment.md
@@ -238,7 +238,21 @@ source {
 }
 ```
 
-For more details about parallelism inference, see [Parallelism Inference](../concept/parallelism-inference.md).
+Note:
+
+Parallelism configuration follows this priority order (from highest to lowest):
+
+1. **`env.parallelism` at Job Level**: If set in the job's `env` block, this value will be used
+2. **Parallelism Inference**: If parallelism inference is enabled and the source supports inference, the inferred parallelism will be used (limited by `max-parallelism`)
+
+   - **Job-level (env configuration) has higher priority**:
+     - `env.parallelism.inference.enabled` overrides `parallelism-inference.enabled` in `seatunnel.yaml`
+     - `env.parallelism.inference.max-parallelism` overrides `parallelism-inference.max-parallelism` in `seatunnel.yaml`
+   - **Server-level (seatunnel.yaml) serves as default configuration**:
+     - Used when not specified in job configuration
+     - Suitable for setting unified default behavior for all jobs
+
+3. **Default Parallelism**: If none of the above are configured, the default value of `1` is used
 
 ### 4.7 Persistence Configuration of IMap (This parameter is invalid on the Worker node)
 

--- a/docs/en/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/en/seatunnel-engine/separated-cluster-deployment.md
@@ -189,7 +189,58 @@ seatunnel:
     classloader-cache-mode: true
 ```
 
-### 4.6 Persistence Configuration of IMap (This parameter is invalid on the Worker node)
+### 4.6 Parallelism Inference Configuration (This parameter is invalid on the Worker node)
+
+SeaTunnel Engine supports automatic parallelism inference for sources that implement the `SupportParallelismInference` interface (e.g., Paimon connector). When enabled, the engine will automatically determine the optimal parallelism based on data characteristics instead of using a fixed parallelism value.
+
+**enabled**
+
+Whether to enable automatic parallelism inference. When enabled, sources that support parallelism inference will automatically calculate the optimal parallelism based on their data characteristics.
+
+Default: `false`
+
+**max-parallelism**
+
+The maximum limit for inferred parallelism. 
+
+Default: `64`
+
+**Server-Level Configuration Example**
+
+Configure in `seatunnel.yaml`:
+
+```yaml
+seatunnel:
+  engine:
+    parallelism-inference:
+      enabled: true
+      max-parallelism: 100
+```
+
+**Job-Level Configuration Example**
+
+Configure in the job config `env` block:
+
+```hocon
+env {
+  # Enable parallelism inference
+  parallelism.inference.enabled = true
+  # Set maximum parallelism
+  parallelism.inference.max-parallelism = 50
+}
+
+source {
+  Paimon {
+    warehouse = "hdfs://localhost:9000/paimon"
+    database = "default"
+    table = "users"
+  }
+}
+```
+
+For more details about parallelism inference, see [Parallelism Inference](../concept/parallelism-inference.md).
+
+### 4.7 Persistence Configuration of IMap (This parameter is invalid on the Worker node)
 
 :::tip
 

--- a/docs/zh/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/zh/seatunnel-engine/separated-cluster-deployment.md
@@ -192,7 +192,58 @@ seatunnel:
     classloader-cache-mode: true
 ```
 
-### 4.6 IMap持久化配置(该参数在Worker节点无效)
+### 4.6 并行度推断配置(该参数在Worker节点无效)
+
+SeaTunnel Engine 支持对实现了 `SupportParallelismInference` 接口的数据源（例如 Paimon 连接器）进行自动并行度推断。启用后，引擎将根据数据特征自动确定最佳并行度，而不是使用固定的并行度值。
+
+**enabled**
+
+是否启用自动并行度推断。启用后，支持并行度推断的数据源将根据其数据特征自动计算最佳并行度。
+
+默认值：`false`
+
+**max-parallelism**
+
+并行度推断的最大限制。即使推断出的并行度更高，也会被限制在此值以内。这有助于防止资源过度使用。
+
+默认值：`64`
+
+**服务器级别配置示例**
+
+在 `seatunnel.yaml` 中配置：
+
+```yaml
+seatunnel:
+  engine:
+    parallelism-inference:
+      enabled: true
+      max-parallelism: 100
+```
+
+**作业级别配置示例**
+
+在作业配置文件的 `env` 块中配置：
+
+```hocon
+env {
+  # 启用并行度推断
+  parallelism.inference.enabled = true
+  # 设置最大并行度
+  parallelism.inference.max-parallelism = 50
+}
+
+source {
+  Paimon {
+    warehouse = "hdfs://localhost:9000/paimon"
+    database = "default"
+    table = "users"
+  }
+}
+```
+
+有关并行度推断的更多详细信息，请参阅[并行度推断](../concept/parallelism-inference.md)。
+
+### 4.7 IMap持久化配置(该参数在Worker节点无效)
 
 :::tip
 

--- a/docs/zh/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/zh/seatunnel-engine/separated-cluster-deployment.md
@@ -241,7 +241,22 @@ source {
 }
 ```
 
-有关并行度推断的更多详细信息，请参阅[并行度推断](../concept/parallelism-inference.md)。
+注意：
+
+并行度配置遵循以下优先级顺序（从高到低）：
+
+1. **作业级别的 `env.parallelism`**：如果在作业配置的 `env` 块中设置了 `parallelism`，将使用该值
+2. **并行度推断**：如果启用了并行度推断且数据源支持推断，将使用推断出的并行度（受 `max-parallelism` 限制）
+
+   - **作业级别（env 配置）优先级更高**：
+     - `env.parallelism.inference.enabled` 会覆盖 `seatunnel.yaml` 中的 `parallelism-inference.enabled`
+     - `env.parallelism.inference.max-parallelism` 会覆盖 `seatunnel.yaml` 中的 `parallelism-inference.max-parallelism`
+   - **服务器级别（seatunnel.yaml）作为默认配置**：
+     - 当作业配置中未指定时，使用服务器级别的配置
+     - 适合为所有作业设置统一的默认行为
+
+3. **默认并行度**：如果以上都未配置，使用默认值 `1`
+
 
 ### 4.7 IMap持久化配置(该参数在Worker节点无效)
 

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -122,16 +122,12 @@ public class EnvCommonOptions {
             Options.key("parallelism.inference.enabled")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription(
-                            "Enable automatic parallelism inference based on data volume. "
-                                    + "When enabled, operators with parallelism=-1 will have their parallelism "
-                                    + "automatically determined based on the size of consumed data.");
+                    .withDescription("Enable automatic parallelism inference.");
 
     public static Option<Integer> PARALLELISM_INFERENCE_MAX_PARALLELISM =
             Options.key("parallelism.inference.max-parallelism")
                     .intType()
-                    .defaultValue(128)
+                    .defaultValue(64)
                     .withDescription(
-                            "The maximum parallelism for operators when using automatic inference. "
-                                    + "Must be a power of 2 to ensure even distribution of subpartitions.");
+                            "The maximum parallelism for operators when using automatic inference.");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -115,4 +115,23 @@ public class EnvCommonOptions {
                     .mapType()
                     .noDefaultValue()
                     .withDescription("Define the worker where the job runs by tag");
+
+    // ==================== Parallelism Inference Options ====================
+
+    public static Option<Boolean> PARALLELISM_INFERENCE_ENABLED =
+            Options.key("parallelism.inference.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable automatic parallelism inference based on data volume. "
+                                    + "When enabled, operators with parallelism=-1 will have their parallelism "
+                                    + "automatically determined based on the size of consumed data.");
+
+    public static Option<Integer> PARALLELISM_INFERENCE_MAX_PARALLELISM =
+            Options.key("parallelism.inference.max-parallelism")
+                    .intType()
+                    .defaultValue(128)
+                    .withDescription(
+                            "The maximum parallelism for operators when using automatic inference. "
+                                    + "Must be a power of 2 to ensure even distribution of subpartitions.");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
@@ -47,7 +47,9 @@ public class EnvOptionRule implements Factory {
                         EnvCommonOptions.READ_LIMIT_BYTES_PER_SECOND,
                         EnvCommonOptions.SAVEMODE_EXECUTE_LOCATION,
                         EnvCommonOptions.CUSTOM_PARAMETERS,
-                        EnvCommonOptions.NODE_TAG_FILTER)
+                        EnvCommonOptions.NODE_TAG_FILTER,
+                        EnvCommonOptions.PARALLELISM_INFERENCE_ENABLED,
+                        EnvCommonOptions.PARALLELISM_INFERENCE_MAX_PARALLELISM)
                 .build();
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SupportParallelismInference.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SupportParallelismInference.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.source;
+
+/**
+ * The Source Connectors which support automatic parallelism inference should implement this
+ * interface.
+ */
+public interface SupportParallelismInference {
+
+    /** Infer the recommended parallelism for this source. */
+    int inferParallelism();
+}

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSource.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSource.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.source.SupportColumnProjection;
 import org.apache.seatunnel.api.source.SupportParallelism;
+import org.apache.seatunnel.api.source.SupportParallelismInference;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.constants.JobMode;
@@ -42,7 +43,8 @@ import java.util.stream.Collectors;
 public class FakeSource
         implements SeaTunnelSource<SeaTunnelRow, FakeSourceSplit, FakeSourceState>,
                 SupportParallelism,
-                SupportColumnProjection {
+                SupportColumnProjection,
+                SupportParallelismInference {
 
     private JobContext jobContext;
     private final MultipleTableFakeSourceConfig multipleTableFakeSourceConfig;
@@ -97,5 +99,17 @@ public class FakeSource
     @Override
     public void setJobContext(JobContext jobContext) {
         this.jobContext = jobContext;
+    }
+
+    @Override
+    public int inferParallelism() {
+        // For testing purposes, infer parallelism based on the number of tables
+        int tableCount = multipleTableFakeSourceConfig.getFakeConfigs().size();
+        int inferredParallelism = Math.max(1, tableCount * 2);
+        log.info(
+                "FakeSource inferred parallelism: {} (based on {} tables)",
+                inferredParallelism,
+                tableCount);
+        return inferredParallelism;
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSource.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSource.java
@@ -186,6 +186,7 @@ public class PaimonSource
     /** Infer parallelism based on Paimon data partition count. */
     @Override
     public int inferParallelism() {
+        int inferParallelism = 0;
         try {
             for (Map.Entry<String, ReadBuilder> entry : readBuilders.entrySet()) {
                 String tableKey = entry.getKey();
@@ -193,7 +194,7 @@ public class PaimonSource
                 try {
                     List<PartitionEntry> partitionEntries =
                             readBuilder.newScan().listPartitionEntries();
-                    return !partitionEntries.isEmpty() ? partitionEntries.size() : 1;
+                    inferParallelism += partitionEntries.size();
                 } catch (Exception e) {
                     log.warn(
                             "Failed to get partition info for table {}, skipping parallelism inference",
@@ -207,6 +208,6 @@ public class PaimonSource
             log.warn("Failed to infer parallelism for Paimon source", e);
             return -1;
         }
-        return 1;
+        return inferParallelism <= 0 ? 1 : inferParallelism;
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSource.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSource.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.source.SupportParallelismInference;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -38,6 +39,7 @@ import org.apache.seatunnel.connectors.seatunnel.paimon.source.enumerator.Paimon
 import org.apache.seatunnel.connectors.seatunnel.paimon.source.enumerator.PaimonStreamSourceSplitEnumerator;
 import org.apache.seatunnel.connectors.seatunnel.paimon.utils.RowTypeConverter;
 
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ReadBuilder;
@@ -57,7 +59,8 @@ import static org.apache.seatunnel.connectors.seatunnel.paimon.source.converter.
 /** Paimon connector source class. */
 @Slf4j
 public class PaimonSource
-        implements SeaTunnelSource<SeaTunnelRow, PaimonSourceSplit, PaimonSourceState> {
+        implements SeaTunnelSource<SeaTunnelRow, PaimonSourceSplit, PaimonSourceState>,
+                SupportParallelismInference {
 
     private static final long serialVersionUID = 1L;
 
@@ -178,5 +181,32 @@ public class PaimonSource
                 checkpointState.getCurrentSnapshotId(),
                 readBuilders,
                 1);
+    }
+
+    /** Infer parallelism based on Paimon data partition count. */
+    @Override
+    public int inferParallelism() {
+        try {
+            for (Map.Entry<String, ReadBuilder> entry : readBuilders.entrySet()) {
+                String tableKey = entry.getKey();
+                ReadBuilder readBuilder = entry.getValue();
+                try {
+                    List<PartitionEntry> partitionEntries =
+                            readBuilder.newScan().listPartitionEntries();
+                    return !partitionEntries.isEmpty() ? partitionEntries.size() : 1;
+                } catch (Exception e) {
+                    log.warn(
+                            "Failed to get partition info for table {}, skipping parallelism inference",
+                            tableKey,
+                            e);
+                    return -1;
+                }
+            }
+
+        } catch (Exception e) {
+            log.warn("Failed to infer parallelism for Paimon source", e);
+            return -1;
+        }
+        return 1;
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
@@ -131,7 +131,7 @@ public class PaimonParallelismInferenceTest {
         PaimonSource source = createPaimonSourceWithMultipleTables(table1, table2, table3);
         int parallelism = source.inferParallelism();
 
-        // Expected: 2 (table1) + 3 (table2) + 1 (table3) = 7
+        // Expected: 2 (table1) + 3 (table2) + 1 (table3) = 6
         Assertions.assertEquals(6, parallelism);
     }
 

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
@@ -105,6 +105,36 @@ public class PaimonParallelismInferenceTest {
         Assertions.assertEquals(1, parallelism);
     }
 
+    @Test
+    public void testInferParallelismWithMultipleTables() throws Exception {
+        // Create first table with 2 partitions
+        String table1 = "multi_table_1";
+        int bucketCount1 = 2;
+        createPaimonTable(table1, bucketCount1, "dt");
+        writeTestDataToPartition(table1, bucketCount1, "2024-01-01", 50);
+        writeTestDataToPartition(table1, bucketCount1, "2024-01-02", 50);
+
+        // Create second table with 3 partitions
+        String table2 = "multi_table_2";
+        int bucketCount2 = 2;
+        createPaimonTable(table2, bucketCount2, "dt");
+        writeTestDataToPartition(table2, bucketCount2, "2024-02-01", 50);
+        writeTestDataToPartition(table2, bucketCount2, "2024-02-02", 50);
+        writeTestDataToPartition(table2, bucketCount2, "2024-02-03", 50);
+
+        // Create third table with 1 partition
+        String table3 = "multi_table_3";
+        int bucketCount3 = 2;
+        createPaimonTable(table3, bucketCount3, "dt");
+        writeTestDataToPartition(table3, bucketCount3, "2024-03-01", 50);
+
+        PaimonSource source = createPaimonSourceWithMultipleTables(table1, table2, table3);
+        int parallelism = source.inferParallelism();
+
+        // Expected: 2 (table1) + 3 (table2) + 1 (table3) = 7
+        Assertions.assertEquals(6, parallelism);
+    }
+
     private PaimonCatalog createPaimonCatalog() {
         Map<String, Object> properties = new HashMap<>();
         properties.put(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
@@ -212,6 +242,24 @@ public class PaimonParallelismInferenceTest {
         configMap.put(PaimonBaseOptions.DATABASE.key(), DATABASE);
         configMap.put(PaimonBaseOptions.TABLE.key(), table);
         configMap.put(PaimonBaseOptions.CATALOG_NAME.key(), CATALOG_NAME);
+
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        return new PaimonSource(config, paimonCatalog);
+    }
+
+    private PaimonSource createPaimonSourceWithMultipleTables(String... tables) {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        configMap.put(PaimonBaseOptions.CATALOG_NAME.key(), CATALOG_NAME);
+
+        List<Map<String, Object>> tableList = new ArrayList<>();
+        for (String table : tables) {
+            Map<String, Object> tableConfig = new HashMap<>();
+            tableConfig.put(PaimonBaseOptions.DATABASE.key(), DATABASE);
+            tableConfig.put(PaimonBaseOptions.TABLE.key(), table);
+            tableList.add(tableConfig);
+        }
+        configMap.put("table_list", tableList);
 
         ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
         return new PaimonSource(config, paimonCatalog);

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonParallelismInferenceTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.common.utils.ReflectionUtils;
+import org.apache.seatunnel.connectors.seatunnel.paimon.catalog.PaimonCatalog;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class PaimonParallelismInferenceTest {
+
+    @TempDir private Path tempDir;
+
+    private PaimonCatalog paimonCatalog;
+    private String warehouse;
+    private static final String CATALOG_NAME = "test_catalog";
+    private static final String DATABASE = "test_db";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        warehouse = new File(tempDir.toFile(), UUID.randomUUID().toString()).toString();
+        paimonCatalog = createPaimonCatalog();
+        paimonCatalog.open();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (paimonCatalog != null) {
+            paimonCatalog.close();
+        }
+    }
+
+    @Test
+    public void testInferParallelismWithNonPartitionedTable() throws Exception {
+        String table = "non_partitioned_table";
+        int bucketCount = 4;
+        createPaimonTable(table, bucketCount, null);
+        writeTestDataToBuckets(table, bucketCount, 100);
+        PaimonSource source = createPaimonSource(table);
+        int parallelism = source.inferParallelism();
+        Assertions.assertEquals(1, parallelism);
+    }
+
+    @Test
+    public void testInferParallelismWithPartitionedTable() throws Exception {
+        String table = "partitioned_table";
+        int bucketCount = 2;
+        createPaimonTable(table, bucketCount, "dt");
+        writeTestDataToPartition(table, bucketCount, "2024-01-01", 50);
+        writeTestDataToPartition(table, bucketCount, "2024-01-02", 50);
+        writeTestDataToPartition(table, bucketCount, "2024-01-03", 50);
+
+        PaimonSource source = createPaimonSource(table);
+        int parallelism = source.inferParallelism();
+        Assertions.assertEquals(3, parallelism);
+    }
+
+    @Test
+    public void testInferParallelismWithEmptyTable() throws Exception {
+        String table = "empty_table";
+        createPaimonTable(table, 4, "dt");
+        PaimonSource source = createPaimonSource(table);
+        int parallelism = source.inferParallelism();
+        Assertions.assertEquals(1, parallelism);
+    }
+
+    private PaimonCatalog createPaimonCatalog() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        properties.put(PaimonBaseOptions.DATABASE.key(), DATABASE);
+        properties.put(PaimonBaseOptions.CATALOG_NAME.key(), CATALOG_NAME);
+        return new PaimonCatalog(CATALOG_NAME, ReadonlyConfig.fromMap(properties));
+    }
+
+    private void createPaimonTable(String table, int bucketCount, String partitionKey)
+            throws Exception {
+        Identifier identifier = Identifier.create(DATABASE, table);
+        Catalog catalog = (Catalog) ReflectionUtils.getField(paimonCatalog, "catalog").get();
+
+        // Use Paimon native API to create table with partition
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("id", DataTypes.INT().notNull());
+        schemaBuilder.column("name", DataTypes.STRING());
+        schemaBuilder.column("age", DataTypes.INT());
+
+        if (partitionKey != null) {
+            schemaBuilder.column(partitionKey, DataTypes.STRING());
+            schemaBuilder.partitionKeys(partitionKey);
+            schemaBuilder.primaryKey("id", partitionKey);
+        } else {
+            schemaBuilder.primaryKey("id");
+        }
+
+        schemaBuilder.option("bucket", String.valueOf(bucketCount));
+        schemaBuilder.option("bucket-key", "id");
+
+        catalog.createDatabase(DATABASE, true);
+        catalog.createTable(identifier, schemaBuilder.build(), false);
+    }
+
+    private void writeTestDataToBuckets(String table, int bucketCount, int rowCount)
+            throws Exception {
+        Identifier identifier = Identifier.create(DATABASE, table);
+        Catalog catalog = (Catalog) ReflectionUtils.getField(paimonCatalog, "catalog").get();
+        Table paimonTable = catalog.getTable(identifier);
+
+        BatchWriteBuilder writeBuilder = paimonTable.newBatchWriteBuilder();
+        BatchTableWrite writer = writeBuilder.newWrite();
+        BatchTableCommit commit = writeBuilder.newCommit();
+
+        List<CommitMessage> messages = new ArrayList<>();
+
+        try {
+            int rowsPerBucket = Math.max(1, rowCount / bucketCount);
+            for (int bucket = 0; bucket < bucketCount; bucket++) {
+                for (int i = 0; i < rowsPerBucket; i++) {
+                    int id = bucket * rowsPerBucket + i;
+                    GenericRow row =
+                            GenericRow.of(
+                                    id, BinaryString.fromString("user_" + id), 20 + (id % 50));
+                    writer.write(row, bucket);
+                }
+            }
+            messages.addAll(writer.prepareCommit());
+            commit.commit(messages);
+        } finally {
+            writer.close();
+            commit.close();
+        }
+    }
+
+    private void writeTestDataToPartition(
+            String table, int bucketCount, String partitionValue, int rowCount) throws Exception {
+        Identifier identifier = Identifier.create(DATABASE, table);
+        Catalog catalog = (Catalog) ReflectionUtils.getField(paimonCatalog, "catalog").get();
+        Table paimonTable = catalog.getTable(identifier);
+
+        // Create a new write session for each partition
+        BatchWriteBuilder writeBuilder = paimonTable.newBatchWriteBuilder();
+        BatchTableWrite writer = writeBuilder.newWrite();
+        BatchTableCommit commit = writeBuilder.newCommit();
+
+        try {
+            int rowsPerBucket = Math.max(1, rowCount / bucketCount);
+            for (int bucket = 0; bucket < bucketCount; bucket++) {
+                for (int i = 0; i < rowsPerBucket; i++) {
+                    int id =
+                            bucket * rowsPerBucket
+                                    + i
+                                    + Math.abs(partitionValue.hashCode() % 10000);
+                    GenericRow row =
+                            GenericRow.of(
+                                    id,
+                                    BinaryString.fromString("user_" + id),
+                                    20 + (id % 50),
+                                    BinaryString.fromString(partitionValue));
+                    writer.write(row, bucket);
+                }
+            }
+            List<CommitMessage> messages = writer.prepareCommit();
+            commit.commit(messages);
+        } finally {
+            writer.close();
+            commit.close();
+        }
+    }
+
+    private PaimonSource createPaimonSource(String table) {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        configMap.put(PaimonBaseOptions.DATABASE.key(), DATABASE);
+        configMap.put(PaimonBaseOptions.TABLE.key(), table);
+        configMap.put(PaimonBaseOptions.CATALOG_NAME.key(), CATALOG_NAME);
+
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        return new PaimonSource(config, paimonCatalog);
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
@@ -204,4 +204,12 @@ public class PaimonIT extends TestSuiteBase implements TestResource {
         List<File> files = FileUtils.listFile(tmpDir);
         Assertions.assertTrue(CollectionUtils.isEmpty(files));
     }
+
+    @TestTemplate
+    public void inferParallelism(TestContainer container) throws Exception {
+        // fake to paimon
+        Container.ExecResult execResult =
+                container.executeJob("/fake_to_paimon_parallelism_inference.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+    }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/java/org/apache/seatunnel/e2e/connector/paimon/PaimonIT.java
@@ -207,7 +207,6 @@ public class PaimonIT extends TestSuiteBase implements TestResource {
 
     @TestTemplate
     public void inferParallelism(TestContainer container) throws Exception {
-        // fake to paimon
         Container.ExecResult execResult =
                 container.executeJob("/fake_to_paimon_parallelism_inference.conf");
         Assertions.assertEquals(0, execResult.getExitCode());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_parallelism_inference.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/src/test/resources/fake_to_paimon_parallelism_inference.conf
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  job.mode = "BATCH"
+  parallelism.inference.enabled = true
+  parallelism.inference.max-parallelism = 64
+}
+
+source {
+  FakeSource {
+    auto.increment.enabled = true
+    auto.increment.start = 1
+    row.num = 100000
+    schema = {
+      fields {
+        pk_id = bigint
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+        c_time = time
+      }
+      primaryKey {
+        name = "pk_id"
+        columnNames = [pk_id]
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Paimon {
+    warehouse = "/tmp/seatunnel_mnt/paimon"
+    database = "default"
+    table = "st_test"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/ClientJobExecutionEnvironment.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/ClientJobExecutionEnvironment.java
@@ -113,7 +113,8 @@ public class ClientJobExecutionEnvironment extends AbstractJobEnvironment {
                 jobConfig,
                 commonPluginJars,
                 isStartWithSavePoint,
-                pipelineCheckpoints);
+                pipelineCheckpoints,
+                seaTunnelConfig.getEngineConfig());
     }
 
     @VisibleForTesting

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/MultipleTableJobConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/MultipleTableJobConfigParserTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.common.config.Common;
 import org.apache.seatunnel.common.config.DeployMode;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.JobConfig;
 import org.apache.seatunnel.engine.common.loader.SeaTunnelChildFirstClassLoader;
 import org.apache.seatunnel.engine.common.utils.IdGenerator;
@@ -240,5 +241,161 @@ public class MultipleTableJobConfigParserTest {
             checkExp = e;
         }
         Assertions.assertInstanceOf(IllegalArgumentException.class, checkExp);
+    }
+
+    @Test
+    public void testParallelismInferenceDisabled() {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath =
+                ContentFormatUtilTest.getResource("/parallelism_inference_disabled_test.conf");
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext());
+        EngineConfig engineConfig = new EngineConfig();
+        MultipleTableJobConfigParser jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse(null);
+        List<Action> actions = parse.getLeft();
+
+        // Should use env parallelism since inference is disabled
+        Assertions.assertEquals(1, actions.get(0).getUpstream().get(0).getParallelism());
+    }
+
+    @Test
+    public void testParallelismInferenceWithEnvConfig() {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath =
+                ContentFormatUtilTest.getResource("/parallelism_inference_enabled_test.conf");
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext());
+        EngineConfig engineConfig = new EngineConfig();
+        MultipleTableJobConfigParser jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse(null);
+        List<Action> actions = parse.getLeft();
+
+        // FakeSource has 2 tables, infers parallelism = 2 * 2 = 4
+        // max-parallelism = 10, so final parallelism should be min(4, 10) = 4
+        Assertions.assertEquals(4, actions.get(0).getUpstream().get(0).getParallelism());
+    }
+
+    @Test
+    public void testParallelismConfigPriority() {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath =
+                ContentFormatUtilTest.getResource("/parallelism_inference_disabled_test.conf");
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext());
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.getParallelismInferenceConfig().setEnabled(true);
+        engineConfig.getParallelismInferenceConfig().setMaxParallelism(50);
+
+        MultipleTableJobConfigParser jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse(null);
+        List<Action> actions = parse.getLeft();
+        Assertions.assertEquals(4, actions.get(0).getUpstream().get(0).getParallelism());
+
+        filePath = ContentFormatUtilTest.getResource("/parallelism_inference_enabled_test.conf");
+        engineConfig.getParallelismInferenceConfig().setEnabled(false);
+        engineConfig.getParallelismInferenceConfig().setMaxParallelism(50);
+
+        jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        parse = jobConfigParser.parse(null);
+        actions = parse.getLeft();
+
+        // Env config should override engine config
+        // parallelism.inference.enabled = true in env, so it should be enabled
+        // FakeSource has 2 tables, infers parallelism = 2 * 2 = 4, max = 10, so final = 4
+        Assertions.assertEquals(4, actions.get(0).getUpstream().get(0).getParallelism());
+    }
+
+    @Test
+    public void testParallelismInferenceWithMaxLimit() {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath =
+                ContentFormatUtilTest.getResource("/parallelism_inference_with_limit_test.conf");
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext());
+
+        EngineConfig engineConfig = new EngineConfig();
+        MultipleTableJobConfigParser jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse(null);
+        List<Action> actions = parse.getLeft();
+
+        // FakeSource has 3 tables, infers parallelism = 3 * 2 = 6
+        // But max-parallelism = 3, so final parallelism should be min(6, 3) = 3
+        Assertions.assertEquals(3, actions.get(0).getUpstream().get(0).getParallelism());
+    }
+
+    @Test
+    public void testParallelismInferenceServerConfigFallback() {
+        Common.setDeployMode(DeployMode.CLIENT);
+        String filePath =
+                ContentFormatUtilTest.getResource("/parallelism_inference_no_env_config_test.conf");
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext());
+
+        // Engine config with inference enabled
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.getParallelismInferenceConfig().setEnabled(true);
+        engineConfig.getParallelismInferenceConfig().setMaxParallelism(5);
+
+        MultipleTableJobConfigParser jobConfigParser =
+                new MultipleTableJobConfigParser(
+                        filePath,
+                        null,
+                        new IdGenerator(),
+                        jobConfig,
+                        null,
+                        false,
+                        null,
+                        engineConfig);
+        ImmutablePair<List<Action>, Set<URL>> parse = jobConfigParser.parse(null);
+        List<Action> actions = parse.getLeft();
+
+        // should use engine config
+        Assertions.assertEquals(2, actions.get(0).getUpstream().get(0).getParallelism());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_disabled_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_disabled_test.conf
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
 env {
 }
 

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_disabled_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_disabled_test.conf
@@ -1,0 +1,40 @@
+env {
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 1000
+    tables_configs = [
+      {
+        schema = {
+          table = "test.users"
+          fields {
+            id = "int"
+            name = "string"
+            age = "int"
+            email = "string"
+          }
+        }
+      },
+      {
+        schema = {
+          table = "test.orders"
+          fields {
+            order_id = "int"
+            user_id = "int"
+            amount = "double"
+            status = "string"
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_enabled_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_enabled_test.conf
@@ -1,0 +1,42 @@
+env {
+  parallelism.inference.enabled = true
+  parallelism.inference.max-parallelism = 10
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 1000
+    tables_configs = [
+      {
+        schema = {
+          table = "test.users"
+          fields {
+            id = "int"
+            name = "string"
+            age = "int"
+            email = "string"
+          }
+        }
+      },
+      {
+        schema = {
+          table = "test.orders"
+          fields {
+            order_id = "int"
+            user_id = "int"
+            amount = "double"
+            status = "string"
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_enabled_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_enabled_test.conf
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
 env {
   parallelism.inference.enabled = true
   parallelism.inference.max-parallelism = 10

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_no_env_config_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_no_env_config_test.conf
@@ -1,0 +1,23 @@
+env {
+  parallelism = 2
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 1000
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_no_env_config_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_no_env_config_test.conf
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
 env {
   parallelism = 2
 }

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_test.conf
@@ -1,0 +1,25 @@
+env {
+  parallelism = 2
+  parallelism.inference.enabled = true
+  parallelism.inference.max-parallelism = 100
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 1000
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_test.conf
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
 env {
   parallelism = 2
   parallelism.inference.enabled = true

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_with_limit_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_with_limit_test.conf
@@ -1,0 +1,50 @@
+env {
+  parallelism.inference.enabled = true
+  parallelism.inference.max-parallelism = 3
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 1000
+    tables_configs = [
+      {
+        schema = {
+          table = "test.table1"
+          fields {
+            id = "int"
+            name = "string"
+            age = "int"
+          }
+        }
+      },
+      {
+        schema = {
+          table = "test.table2"
+          fields {
+            id = "int"
+            email = "string"
+            phone = "string"
+          }
+        }
+      },
+      {
+        schema = {
+          table = "test.table3"
+          fields {
+            id = "int"
+            address = "string"
+            city = "string"
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}
+

--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_with_limit_test.conf
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/parallelism_inference_with_limit_test.conf
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
 env {
   parallelism.inference.enabled = true
   parallelism.inference.max-parallelism = 3

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
@@ -99,6 +99,9 @@ public class EngineConfig {
     private HttpConfig httpConfig =
             ServerConfigOptions.MasterServerConfigOptions.HTTP.defaultValue();
 
+    private ParallelismInferenceConfig parallelismInferenceConfig =
+            ServerConfigOptions.MasterServerConfigOptions.PARALLELISM_INFERENCE.defaultValue();
+
     public void setBackupCount(int newBackupCount) {
         checkBackupCount(newBackupCount, 0);
         this.backupCount = newBackupCount;
@@ -173,5 +176,16 @@ public class EngineConfig {
     public EngineConfig setEventReportHttpHeaders(Map<String, String> eventReportHttpHeaders) {
         this.eventReportHttpHeaders = eventReportHttpHeaders;
         return this;
+    }
+
+    public ParallelismInferenceConfig getParallelismInferenceConfig() {
+        return parallelismInferenceConfig;
+    }
+
+    public void setParallelismInferenceConfig(
+            ParallelismInferenceConfig parallelismInferenceConfig) {
+        checkNotNull(parallelismInferenceConfig);
+        parallelismInferenceConfig.validate();
+        this.parallelismInferenceConfig = parallelismInferenceConfig;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 public class ParallelismInferenceConfig implements Serializable {
     private static final long serialVersionUID = 1L;
     private boolean enabled = false;
-    private int maxParallelism = 128;
+    private int maxParallelism = 64;
 
     public void validate() {
         if (maxParallelism <= 0) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
@@ -29,8 +29,8 @@ public class ParallelismInferenceConfig implements Serializable {
     private int maxParallelism = 128;
 
     public void validate() {
-        if (maxParallelism > 0) {
-            throw new IllegalArgumentException("maxParallelism must be a power of 2");
+        if (maxParallelism <= 0) {
+            throw new IllegalArgumentException("max-parallelism must be greater than 0");
         }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/ParallelismInferenceConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.config;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+/** Configuration for automatic parallelism inference feature. */
+@Data
+public class ParallelismInferenceConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private boolean enabled = false;
+    private int maxParallelism = 128;
+
+    public void validate() {
+        if (maxParallelism > 0) {
+            throw new IllegalArgumentException("maxParallelism must be a power of 2");
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -138,6 +138,32 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
         return coordinatorServiceConfig;
     }
 
+    private ParallelismInferenceConfig parseParallelismInferenceConfig(
+            Node parallelismInferenceNode) {
+        ParallelismInferenceConfig config = new ParallelismInferenceConfig();
+        for (Node node : childElements(parallelismInferenceNode)) {
+            String name = cleanNodeName(node);
+            if (ServerConfigOptions.MasterServerConfigOptions.PARALLELISM_INFERENCE_ENABLED
+                    .key()
+                    .equals(name)) {
+                config.setEnabled(getBooleanValue(getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions
+                    .PARALLELISM_INFERENCE_MAX_PARALLELISM
+                    .key()
+                    .equals(name)) {
+                config.setMaxParallelism(
+                        getIntegerValue(
+                                ServerConfigOptions.MasterServerConfigOptions
+                                        .PARALLELISM_INFERENCE_MAX_PARALLELISM
+                                        .key(),
+                                getTextContent(node)));
+            } else {
+                LOGGER.warning("Unrecognized element: " + name);
+            }
+        }
+        return config;
+    }
+
     private void parseEngineConfig(Node engineNode, SeaTunnelConfig config) {
         final EngineConfig engineConfig = config.getEngineConfig();
         for (Node node : childElements(engineNode)) {
@@ -259,6 +285,10 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                     .key()
                     .equals(name)) {
                 engineConfig.setCoordinatorServiceConfig(parseCoordinatorServiceConfig(node));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.PARALLELISM_INFERENCE
+                    .key()
+                    .equals(name)) {
+                engineConfig.setParallelismInferenceConfig(parseParallelismInferenceConfig(node));
             } else {
                 LOGGER.warning("Unrecognized element: " + name);
             }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
 
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.engine.common.config.ParallelismInferenceConfig;
 
 import java.util.Map;
 
@@ -382,6 +383,28 @@ public class ServerConfigOptions {
                         .defaultValue(new CoordinatorServiceConfig())
                         .withDescription("The coordinator service configuration.");
         // The options for coordinator service end
+        /////////////////////////////////////////////////
+
+        /////////////////////////////////////////////////
+        // The options for parallelism inference start
+        public static final Option<Boolean> PARALLELISM_INFERENCE_ENABLED =
+                Options.key("enabled")
+                        .booleanType()
+                        .defaultValue(false)
+                        .withDescription("Whether to enable automatic parallelism inference.");
+
+        public static final Option<Integer> PARALLELISM_INFERENCE_MAX_PARALLELISM =
+                Options.key("max-parallelism")
+                        .intType()
+                        .defaultValue(64)
+                        .withDescription("The maximum parallelism for operators.");
+
+        public static final Option<ParallelismInferenceConfig> PARALLELISM_INFERENCE =
+                Options.key("parallelism-inference")
+                        .type(new TypeReference<ParallelismInferenceConfig>() {})
+                        .defaultValue(new ParallelismInferenceConfig())
+                        .withDescription("The parallelism inference configuration.");
+        // The options for parallelism inference end
         /////////////////////////////////////////////////
 
     }

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
@@ -148,4 +148,20 @@ public class YamlSeaTunnelConfigParserTest {
         Assertions.assertEquals(
                 "123456", config.getEngineConfig().getHttpConfig().getKeyStorePassword());
     }
+
+    @Test
+    public void testParallelismInferenceConfig() throws IOException {
+        YamlSeaTunnelConfigLocator yamlConfigLocator = new YamlSeaTunnelConfigLocator();
+        ReflectionUtils.invoke(
+                yamlConfigLocator,
+                "loadDefaultConfigurationFromClasspath",
+                "seatunnel-parallelism-inference.yaml");
+        SeaTunnelConfig config =
+                new YamlSeaTunnelConfigBuilder(yamlConfigLocator).setProperties(null).build();
+        ParallelismInferenceConfig parallelismInferenceConfig =
+                config.getEngineConfig().getParallelismInferenceConfig();
+        Assertions.assertNotNull(parallelismInferenceConfig);
+        Assertions.assertTrue(parallelismInferenceConfig.isEnabled());
+        Assertions.assertEquals(256, parallelismInferenceConfig.getMaxParallelism());
+    }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel-parallelism-inference.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel-parallelism-inference.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+seatunnel:
+    engine:
+        backup-count: 1
+        print-execution-info-interval: 2
+        slot-service:
+            dynamic-slot: false
+            slot-num: 5
+        coordinator-service:
+            core-thread-num: 30
+            max-thread-num: 1000
+        checkpoint:
+            interval: 6000
+            timeout: 7000
+            storage:
+                type: hdfs
+                max-retained: 3
+                plugin-config:
+                    namespace: /tmp/seatunnel/checkpoint_snapshot
+                    storage.type: hdfs
+                    fs.defaultFS: file:/// # Ensure that the directory has written permission
+        telemetry:
+            metric:
+                enabled: false
+        http:
+             enable-http: true
+             port: 8080
+             enable-dynamic-port: true
+             port-range: 200
+        parallelism-inference:
+            enabled: true
+            max-parallelism: 256
+

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.core.parse;
 import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.org.apache.arrow.util.VisibleForTesting;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -38,6 +39,7 @@ import org.apache.seatunnel.api.sink.SupportMultiTableSink;
 import org.apache.seatunnel.api.sink.SupportSaveMode;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.source.SupportParallelismInference;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.factory.ChangeStreamTableSourceCheckpoint;
@@ -52,7 +54,9 @@ import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.common.config.ParallelismInferenceConfig;
 import org.apache.seatunnel.engine.common.exception.JobDefineCheckException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.loader.SeaTunnelChildFirstClassLoader;
@@ -129,9 +133,11 @@ public class MultipleTableJobConfigParser {
     private final boolean isStartWithSavePoint;
     private final List<JobPipelineCheckpointData> pipelineCheckpoints;
 
+    private final EngineConfig engineConfig;
+
     public MultipleTableJobConfigParser(
             String jobDefineFilePath, IdGenerator idGenerator, JobConfig jobConfig) {
-        this(jobDefineFilePath, idGenerator, jobConfig, Collections.emptyList(), false);
+        this(jobDefineFilePath, idGenerator, jobConfig, Collections.emptyList(), false, null);
     }
 
     public MultipleTableJobConfigParser(
@@ -142,7 +148,8 @@ public class MultipleTableJobConfigParser {
                 jobConfig,
                 Collections.emptyList(),
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                null);
     }
 
     public MultipleTableJobConfigParser(
@@ -158,7 +165,26 @@ public class MultipleTableJobConfigParser {
                 jobConfig,
                 commonPluginJars,
                 isStartWithSavePoint,
-                Collections.emptyList());
+                Collections.emptyList(),
+                null);
+    }
+
+    public MultipleTableJobConfigParser(
+            String jobDefineFilePath,
+            IdGenerator idGenerator,
+            JobConfig jobConfig,
+            List<URL> commonPluginJars,
+            boolean isStartWithSavePoint,
+            EngineConfig engineConfig) {
+        this(
+                jobDefineFilePath,
+                null,
+                idGenerator,
+                jobConfig,
+                commonPluginJars,
+                isStartWithSavePoint,
+                Collections.emptyList(),
+                engineConfig);
     }
 
     public MultipleTableJobConfigParser(
@@ -169,15 +195,36 @@ public class MultipleTableJobConfigParser {
             List<URL> commonPluginJars,
             boolean isStartWithSavePoint,
             List<JobPipelineCheckpointData> pipelineCheckpoints) {
+        this(
+                jobDefineFilePath,
+                variables,
+                idGenerator,
+                jobConfig,
+                commonPluginJars,
+                isStartWithSavePoint,
+                pipelineCheckpoints,
+                null);
+    }
+
+    public MultipleTableJobConfigParser(
+            String jobDefineFilePath,
+            List<String> variables,
+            IdGenerator idGenerator,
+            JobConfig jobConfig,
+            List<URL> commonPluginJars,
+            boolean isStartWithSavePoint,
+            List<JobPipelineCheckpointData> pipelineCheckpoints,
+            EngineConfig engineConfig) {
         this.idGenerator = idGenerator;
         this.jobConfig = jobConfig;
-        this.commonPluginJars = commonPluginJars;
+        this.commonPluginJars = commonPluginJars != null ? commonPluginJars : new ArrayList<>();
         this.isStartWithSavePoint = isStartWithSavePoint;
         this.seaTunnelJobConfig =
                 MetalakeConfigUtils.getMetalakeConfig(
                         ConfigBuilder.of(Paths.get(jobDefineFilePath), variables));
         this.envOptions = ReadonlyConfig.fromConfig(seaTunnelJobConfig.getConfig("env"));
         this.pipelineCheckpoints = pipelineCheckpoints;
+        this.engineConfig = engineConfig != null ? engineConfig : new EngineConfig();
         ConfigValidator.of(this.envOptions).validate(new EnvOptionRule().optionRule());
     }
 
@@ -188,13 +235,32 @@ public class MultipleTableJobConfigParser {
             List<URL> commonPluginJars,
             boolean isStartWithSavePoint,
             List<JobPipelineCheckpointData> pipelineCheckpoints) {
+        this(
+                seaTunnelJobConfig,
+                idGenerator,
+                jobConfig,
+                commonPluginJars,
+                isStartWithSavePoint,
+                pipelineCheckpoints,
+                null);
+    }
+
+    public MultipleTableJobConfigParser(
+            Config seaTunnelJobConfig,
+            IdGenerator idGenerator,
+            JobConfig jobConfig,
+            List<URL> commonPluginJars,
+            boolean isStartWithSavePoint,
+            List<JobPipelineCheckpointData> pipelineCheckpoints,
+            EngineConfig engineConfig) {
         this.idGenerator = idGenerator;
         this.jobConfig = jobConfig;
-        this.commonPluginJars = commonPluginJars;
+        this.commonPluginJars = commonPluginJars != null ? commonPluginJars : new ArrayList<>();
         this.isStartWithSavePoint = isStartWithSavePoint;
         this.seaTunnelJobConfig = seaTunnelJobConfig;
         this.envOptions = ReadonlyConfig.fromConfig(seaTunnelJobConfig.getConfig("env"));
         this.pipelineCheckpoints = pipelineCheckpoints;
+        this.engineConfig = engineConfig != null ? engineConfig : new EngineConfig();
         ConfigValidator.of(this.envOptions).validate(new EnvOptionRule().optionRule());
     }
 
@@ -364,14 +430,54 @@ public class MultipleTableJobConfigParser {
                         .orElse(envOptions.get(EnvCommonOptions.PARALLELISM)));
     }
 
+    @VisibleForTesting
+    public int getParallelism(ReadonlyConfig config, SeaTunnelSource<?, ?, ?> source) {
+
+        if (config.getOptional(EnvCommonOptions.PARALLELISM).isPresent()) {
+            return Math.max(1, config.get(EnvCommonOptions.PARALLELISM));
+        }
+        if (envOptions.getOptional(EnvCommonOptions.PARALLELISM).isPresent()) {
+            return Math.max(1, envOptions.get(EnvCommonOptions.PARALLELISM));
+        }
+
+        ParallelismInferenceConfig parallelismInferenceConfig =
+                engineConfig.getParallelismInferenceConfig();
+        boolean inferenceEnabled =
+                envOptions
+                        .getOptional(EnvCommonOptions.PARALLELISM_INFERENCE_ENABLED)
+                        .orElse(parallelismInferenceConfig.isEnabled());
+
+        if (inferenceEnabled && source instanceof SupportParallelismInference) {
+            int inferredParallelism = ((SupportParallelismInference) source).inferParallelism();
+            if (inferredParallelism > 0) {
+                int maxParallelism =
+                        envOptions
+                                .getOptional(EnvCommonOptions.PARALLELISM_INFERENCE_MAX_PARALLELISM)
+                                .orElse(parallelismInferenceConfig.getMaxParallelism());
+                int finalParallelism = Math.min(inferredParallelism, maxParallelism);
+                log.info(
+                        "Using inferred parallelism {} for source {} (inferred={}, max={})",
+                        finalParallelism,
+                        source.getPluginName(),
+                        inferredParallelism,
+                        maxParallelism);
+                return finalParallelism;
+            } else {
+                log.debug(
+                        "Source {} returned invalid inferred parallelism {}, using default",
+                        source.getPluginName(),
+                        inferredParallelism);
+            }
+        }
+        return EnvCommonOptions.PARALLELISM.defaultValue();
+    }
+
     public Tuple2<String, List<Tuple2<CatalogTable, Action>>> parseSource(
             int configIndex, Config sourceConfig, ClassLoader classLoader) {
         final ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(sourceConfig);
         final String factoryId = getFactoryId(readonlyConfig);
         final String tableId =
                 readonlyConfig.getOptional(ConnectorCommonOptions.PLUGIN_OUTPUT).orElse(DEFAULT_ID);
-
-        final int parallelism = getParallelism(readonlyConfig);
 
         Function<PluginIdentifier, SeaTunnelSource> fallbackCreateSource =
                 pluginIdentifier -> {
@@ -409,6 +515,7 @@ public class MultipleTableJobConfigParser {
         FactoryUtil.ensureJobModeMatch(jobConfig.getJobContext(), source);
         SourceAction<Object, SourceSplit, Serializable> action =
                 new SourceAction<>(id, actionName, tuple2._1(), factoryUrls, new HashSet<>());
+        final int parallelism = getParallelism(readonlyConfig, source);
         action.setParallelism(parallelism);
         for (CatalogTable catalogTable : tuple2._2()) {
             actions.add(new Tuple2<>(catalogTable, action));

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -448,25 +448,34 @@ public class MultipleTableJobConfigParser {
                         .orElse(parallelismInferenceConfig.isEnabled());
 
         if (inferenceEnabled && source instanceof SupportParallelismInference) {
-            int inferredParallelism = ((SupportParallelismInference) source).inferParallelism();
-            if (inferredParallelism > 0) {
-                int maxParallelism =
-                        envOptions
-                                .getOptional(EnvCommonOptions.PARALLELISM_INFERENCE_MAX_PARALLELISM)
-                                .orElse(parallelismInferenceConfig.getMaxParallelism());
-                int finalParallelism = Math.min(inferredParallelism, maxParallelism);
-                log.info(
-                        "Using inferred parallelism {} for source {} (inferred={}, max={})",
-                        finalParallelism,
+            try {
+                int inferredParallelism = ((SupportParallelismInference) source).inferParallelism();
+                if (inferredParallelism > 0) {
+                    int maxParallelism =
+                            envOptions
+                                    .getOptional(
+                                            EnvCommonOptions.PARALLELISM_INFERENCE_MAX_PARALLELISM)
+                                    .orElse(parallelismInferenceConfig.getMaxParallelism());
+                    int finalParallelism = Math.min(inferredParallelism, maxParallelism);
+                    log.info(
+                            "Using inferred parallelism {} for source {} (inferred={}, max={})",
+                            finalParallelism,
+                            source.getPluginName(),
+                            inferredParallelism,
+                            maxParallelism);
+                    return finalParallelism;
+                } else {
+                    log.warn(
+                            "Source {} returned invalid inferred parallelism {}, using default",
+                            source.getPluginName(),
+                            inferredParallelism);
+                }
+            } catch (Exception e) {
+                log.warn(
+                        "Failed to infer parallelism for source {}, using default: {}",
                         source.getPluginName(),
-                        inferredParallelism,
-                        maxParallelism);
-                return finalParallelism;
-            } else {
-                log.debug(
-                        "Source {} returned invalid inferred parallelism {}, using default",
-                        source.getPluginName(),
-                        inferredParallelism);
+                        EnvCommonOptions.PARALLELISM.defaultValue(),
+                        e);
             }
         }
         return EnvCommonOptions.PARALLELISM.defaultValue();

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestJobExecutionEnvironment.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestJobExecutionEnvironment.java
@@ -110,7 +110,8 @@ public class RestJobExecutionEnvironment extends AbstractJobEnvironment {
                 jobConfig,
                 commonPluginJars,
                 isStartWithSavePoint,
-                pipelineCheckpoints);
+                pipelineCheckpoints,
+                seaTunnelServer.getSeaTunnelConfig().getEngineConfig());
     }
 
     public JobImmutableInformation build() {


### PR DESCRIPTION
### Purpose of this pull request

Supports automatic parallelism inference for sources that implement the `SupportParallelismInference` interface (e.g., Paimon connector). When enabled, the engine will automatically determine the optimal parallelism based on data characteristics instead of using default parallelism value: 1 

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Add new tests


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)