### PR TITLE
[Fix][Connector-V2][HBase] Ensure fully qualified table name is used in tableExists method and add unit tests

### DIFF
--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/catalog/HbaseCatalog.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/catalog/HbaseCatalog.java
@@ -104,7 +104,13 @@ public class HbaseCatalog implements Catalog {
     @Override
     public boolean tableExists(TablePath tablePath) throws CatalogException {
         checkNotNull(tablePath);
-        return hbaseClient.tableExists(tablePath.getTableName());
+        String databaseName = tablePath.getDatabaseName();
+        String tableName = tablePath.getTableName();
+        String fullTableName =
+                (databaseName == null || databaseName.isEmpty())
+                        ? tableName
+                        : databaseName + ":" + tableName;
+        return hbaseClient.tableExists(fullTableName);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseCatalogTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hbase;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.hbase.catalog.HbaseCatalog;
+import org.apache.seatunnel.connectors.seatunnel.hbase.client.HbaseClient;
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+public class HbaseCatalogTest {
+
+    @Test
+    public void testTableExistsWithNamespace() throws Exception {
+        HbaseParameters parameters =
+                HbaseParameters.builder()
+                        .zookeeperQuorum("localhost")
+                        .namespace("ns1")
+                        .table("tbl")
+                        .build();
+        HbaseCatalog catalog = new HbaseCatalog("hbase", "ns1", parameters);
+
+        HbaseClient hbaseClient = Mockito.mock(HbaseClient.class);
+        Mockito.when(hbaseClient.tableExists("ns1:tbl")).thenReturn(true);
+
+        injectHbaseClient(catalog, hbaseClient);
+
+        TablePath tablePath = TablePath.of("ns1", "tbl");
+        Assertions.assertTrue(catalog.tableExists(tablePath));
+        Mockito.verify(hbaseClient, Mockito.times(1)).tableExists("ns1:tbl");
+    }
+
+    @Test
+    public void testTableExistsWithoutNamespace() throws Exception {
+        HbaseParameters parameters =
+                HbaseParameters.builder()
+                        .zookeeperQuorum("localhost")
+                        .namespace("default")
+                        .table("tbl")
+                        .build();
+        HbaseCatalog catalog = new HbaseCatalog("hbase", "default", parameters);
+
+        HbaseClient hbaseClient = Mockito.mock(HbaseClient.class);
+        Mockito.when(hbaseClient.tableExists("tbl")).thenReturn(true);
+
+        injectHbaseClient(catalog, hbaseClient);
+
+        TablePath tablePath = TablePath.of("tbl");
+        Assertions.assertTrue(catalog.tableExists(tablePath));
+        Mockito.verify(hbaseClient, Mockito.times(1)).tableExists("tbl");
+    }
+
+    private void injectHbaseClient(HbaseCatalog catalog, HbaseClient hbaseClient) throws Exception {
+        Field clientField = HbaseCatalog.class.getDeclaredField("hbaseClient");
+        clientField.setAccessible(true);
+        clientField.set(catalog, hbaseClient);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

There is a bug in the tableExists method when the namespace is not the default.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)