### PR TITLE
[Fix][Iceberg] Fix IllegalMonitorStateException in streaming enumerator

### DIFF
--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
@@ -79,9 +79,9 @@ public class IcebergStreamSplitEnumerator extends AbstractSplitEnumerator {
         Set<Integer> readers = context.registeredReaders();
         while (true) {
             for (TablePath tablePath : pendingTables) {
-                checkThrowInterruptedException();
-
                 synchronized (stateLock) {
+                    checkThrowInterruptedException();
+
                     log.info("Scan table {}.", tablePath);
 
                     Collection<IcebergFileScanTaskSplit> splits = loadSplits(tablePath);
@@ -95,7 +95,9 @@ public class IcebergStreamSplitEnumerator extends AbstractSplitEnumerator {
                 initialized = true;
             }
 
-            stateLock.wait(sourceConfig.getIncrementScanInterval());
+            synchronized (stateLock) {
+                stateLock.wait(sourceConfig.getIncrementScanInterval());
+            }
         }
     }
 
@@ -111,8 +113,10 @@ public class IcebergStreamSplitEnumerator extends AbstractSplitEnumerator {
 
     @Override
     public void handleSplitRequest(int subtaskId) {
-        if (initialized) {
-            stateLock.notifyAll();
+        synchronized (stateLock) {
+            if (initialized) {
+                stateLock.notifyAll();
+            }
         }
     }
 

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
@@ -115,8 +115,8 @@ public class IcebergStreamSplitEnumerator extends AbstractSplitEnumerator {
 
     @Override
     public void handleSplitRequest(int subtaskId) {
-        synchronized (stateLock) {
-            if (initialized) {
+        if (initialized) {
+            synchronized (stateLock) {
                 stateLock.notifyAll();
             }
         }

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumerator.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.iceberg.source.enumerator;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -46,7 +47,8 @@ import java.util.concurrent.ConcurrentMap;
 public class IcebergStreamSplitEnumerator extends AbstractSplitEnumerator {
 
     private final ConcurrentMap<TablePath, IcebergEnumeratorPosition> tableOffsets;
-    private volatile boolean initialized = false;
+
+    @VisibleForTesting volatile boolean initialized = false;
 
     public IcebergStreamSplitEnumerator(
             Context<IcebergFileScanTaskSplit> context,

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumeratorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.iceberg.source.enumerator;
+
+import org.apache.seatunnel.api.common.metrics.AbstractMetricsContext;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.Event;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.connectors.seatunnel.iceberg.config.IcebergCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.iceberg.config.IcebergSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.iceberg.source.split.IcebergFileScanTaskSplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Minimal test for {@link IcebergStreamSplitEnumerator} wait / notify fix. */
+class IcebergStreamSplitEnumeratorTest {
+
+    @Test
+    void testHandleSplitRequestDoesNotThrowIllegalMonitorStateException() throws Exception {
+        SourceSplitEnumerator.Context<IcebergFileScanTaskSplit> context =
+                new DummyEnumeratorContext();
+
+        IcebergSourceConfig sourceConfig = createSourceConfig();
+
+        // Catalog tables must be non-empty because AbstractSplitEnumerator uses the size as the
+        // capacity of an ArrayBlockingQueue.
+        TablePath tablePath = TablePath.of("default", "source");
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("seatunnel", "default", "source"),
+                        TableSchema.builder().build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        "test table");
+        Map<TablePath, CatalogTable> catalogTables =
+                Collections.singletonMap(tablePath, catalogTable);
+
+        IcebergStreamSplitEnumerator enumerator =
+                new IcebergStreamSplitEnumerator(
+                        context, sourceConfig, catalogTables, Collections.emptyMap());
+
+        // Force initialized = true so handleSplitRequest executes the notify logic.
+        Field initializedField = IcebergStreamSplitEnumerator.class.getDeclaredField("initialized");
+        initializedField.setAccessible(true);
+        initializedField.set(enumerator, true);
+
+        // Before the fix, this would throw IllegalMonitorStateException because notifyAll was
+        // called without holding the monitor.
+        Assertions.assertDoesNotThrow(() -> enumerator.handleSplitRequest(0));
+    }
+
+    private IcebergSourceConfig createSourceConfig() {
+        Map<String, Object> configs = new HashMap<>();
+        Map<String, Object> catalogProps = new HashMap<>();
+        catalogProps.put("type", "hadoop");
+        catalogProps.put("warehouse", Paths.get("target", "iceberg", "hadoop").toUri().toString());
+
+        configs.put(IcebergCommonOptions.KEY_CATALOG_NAME.key(), "seatunnel");
+        configs.put(IcebergCommonOptions.KEY_NAMESPACE.key(), "default");
+        configs.put(IcebergCommonOptions.KEY_TABLE.key(), "source");
+        configs.put(IcebergCommonOptions.CATALOG_PROPS.key(), catalogProps);
+
+        return new IcebergSourceConfig(ReadonlyConfig.fromMap(configs));
+    }
+
+    private static class DummyEnumeratorContext
+            implements SourceSplitEnumerator.Context<IcebergFileScanTaskSplit> {
+
+        private final MetricsContext metricsContext = new AbstractMetricsContext() {};
+        private final EventListener eventListener =
+                new EventListener() {
+                    @Override
+                    public void onEvent(Event event) {
+                        // no-op
+                    }
+                };
+
+        @Override
+        public int currentParallelism() {
+            return 1;
+        }
+
+        @Override
+        public java.util.Set<Integer> registeredReaders() {
+            return Collections.singleton(0);
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, java.util.List<IcebergFileScanTaskSplit> splits) {
+            // no-op
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            // no-op
+        }
+
+        @Override
+        public void sendEventToSourceReader(
+                int subtaskId, org.apache.seatunnel.api.source.SourceEvent event) {
+            // no-op
+        }
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return metricsContext;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return eventListener;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/IcebergStreamSplitEnumeratorTest.java
@@ -34,7 +34,6 @@ import org.apache.seatunnel.connectors.seatunnel.iceberg.source.split.IcebergFil
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,9 +67,7 @@ class IcebergStreamSplitEnumeratorTest {
                         context, sourceConfig, catalogTables, Collections.emptyMap());
 
         // Force initialized = true so handleSplitRequest executes the notify logic.
-        Field initializedField = IcebergStreamSplitEnumerator.class.getDeclaredField("initialized");
-        initializedField.setAccessible(true);
-        initializedField.set(enumerator, true);
+        enumerator.initialized = true;
 
         // Before the fix, this would throw IllegalMonitorStateException because notifyAll was
         // called without holding the monitor.


### PR DESCRIPTION
https://github.com/apache/seatunnel/issues/10098
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

-->

### Purpose of this pull request
Fix a bug(https://github.com/apache/seatunnel/issues/10098) where the Iceberg streaming source enumerator crashes with
`IllegalMonitorStateException: current thread is not owner` when running
in STREAMING job mode (e.g. with `stream_scan_strategy = TABLE_SCAN_THEN_INCREMENTAL`).

The root cause is that `wait()` / `notifyAll()` on `stateLock` were called
without holding the monitor in `IcebergStreamSplitEnumerator.run` /
`handleSplitRequest`. This PR:

- Wraps `stateLock.wait(...)` and `stateLock.notifyAll()` in `synchronized (stateLock)` blocks.
- Adds a minimal unit test `IcebergStreamSplitEnumeratorTest` to guard the fix.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, Iceberg source jobs in streaming mode could fail with
`IllegalMonitorStateException` from `IcebergStreamSplitEnumerator`, causing the
SeaTunnel job to terminate unexpectedly. After this fix, the streaming enumerator
no longer throws this exception and the job can run normally without config changes.

### How was this patch tested?

- Added unit test `IcebergStreamSplitEnumeratorTest` to verify that
  `handleSplitRequest` no longer throws `IllegalMonitorStateException` when
  triggering the notify logic.
- (Optional) Run connector-iceberg module tests locally:
  - `mvn -pl seatunnel-connectors-v2/connector-iceberg test`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update `plugin-mapping.properties` and add new connector information in it
  2. Update the pom file of `seatunnel-dist`
  3. Add ci label in `.github/workflows/labeler/label-scope-conf.yml`
  4. Add e2e testcase in `seatunnel-e2e/seatunnel-connector-v2-e2e/`
  5. Update connector `config/plugin_config` if needed
