### PR TITLE
[Fix][Jdbc]Add support for signaling NoMoreSplitsEvent in JdbcSourceSplitEnumerator

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,12 +50,12 @@ public class JdbcSourceSplitEnumerator
     private final Object stateLock = new Object();
 
     /**
-     * Indicates whether the enumerator has already notified all registered readers that there will
-     * be no more splits. This is used to avoid missing {@code NoMoreSplitsEvent} in failover
-     * scenarios where splits are added back via {@link #addSplitsBack(List, int)} instead of being
-     * produced via {@link #run()} again.
+     * Tracks which readers have already been notified that there will be no more splits. This is
+     * used to avoid missing {@code NoMoreSplitsEvent} in failover scenarios where splits are added
+     * back via {@link #addSplitsBack(List, int)} instead of being produced via {@link #run()}
+     * again, and to ensure late-registered readers can still receive the event.
      */
-    private boolean noMoreSplitsSignalSent;
+    private final Set<Integer> noMoreSplitsSignaledReaders;
 
     public JdbcSourceSplitEnumerator(
             Context<JdbcSourceSplit> context,
@@ -64,7 +65,7 @@ public class JdbcSourceSplitEnumerator
         this.context = context;
         this.tables = tables;
         this.splitter = ChunkSplitter.create(jdbcSourceConfig);
-        this.noMoreSplitsSignalSent = false;
+        this.noMoreSplitsSignaledReaders = new HashSet<>();
         if (sourceState == null) {
             this.pendingTables = new ConcurrentLinkedQueue<>(tables.keySet());
             this.pendingSplits = new HashMap<>();
@@ -203,10 +204,6 @@ public class JdbcSourceSplitEnumerator
      */
     private void maybeSignalNoMoreSplits() {
         synchronized (stateLock) {
-            if (noMoreSplitsSignalSent) {
-                return;
-            }
-
             if (!pendingTables.isEmpty()) {
                 return;
             }
@@ -232,9 +229,17 @@ public class JdbcSourceSplitEnumerator
                 return;
             }
 
-            LOG.info("No more splits to assign. Sending NoMoreSplitsEvent to reader {}.", readers);
-            readers.forEach(context::signalNoMoreSplits);
-            noMoreSplitsSignalSent = true;
+            Set<Integer> readersToSignal = new HashSet<>(readers);
+            readersToSignal.removeAll(noMoreSplitsSignaledReaders);
+            if (readersToSignal.isEmpty()) {
+                return;
+            }
+
+            LOG.info(
+                    "No more splits to assign. Sending NoMoreSplitsEvent to reader {}.",
+                    readersToSignal);
+            readersToSignal.forEach(context::signalNoMoreSplits);
+            noMoreSplitsSignaledReaders.addAll(readersToSignal);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -48,6 +48,14 @@ public class JdbcSourceSplitEnumerator
     private final Context<JdbcSourceSplit> context;
     private final Object stateLock = new Object();
 
+    /**
+     * Indicates whether the enumerator has already notified all registered readers that there will
+     * be no more splits. This is used to avoid missing {@code NoMoreSplitsEvent} in failover
+     * scenarios where splits are added back via {@link #addSplitsBack(List, int)} instead of being
+     * produced via {@link #run()} again.
+     */
+    private boolean noMoreSplitsSignalSent;
+
     public JdbcSourceSplitEnumerator(
             Context<JdbcSourceSplit> context,
             JdbcSourceConfig jdbcSourceConfig,
@@ -56,6 +64,7 @@ public class JdbcSourceSplitEnumerator
         this.context = context;
         this.tables = tables;
         this.splitter = ChunkSplitter.create(jdbcSourceConfig);
+        this.noMoreSplitsSignalSent = false;
         if (sourceState == null) {
             this.pendingTables = new ConcurrentLinkedQueue<>(tables.keySet());
             this.pendingSplits = new HashMap<>();
@@ -90,9 +99,7 @@ public class JdbcSourceSplitEnumerator
         }
 
         splitter.close();
-
-        LOG.info("No more splits to assign." + " Sending NoMoreSplitsEvent to reader {}.", readers);
-        readers.forEach(context::signalNoMoreSplits);
+        maybeSignalNoMoreSplits();
     }
 
     @Override
@@ -113,6 +120,7 @@ public class JdbcSourceSplitEnumerator
                         splits);
             }
         }
+        maybeSignalNoMoreSplits();
         LOG.info("Add back splits {} to JdbcSourceSplitEnumerator.", splits.size());
     }
 
@@ -134,6 +142,7 @@ public class JdbcSourceSplitEnumerator
         if (!pendingSplits.isEmpty()) {
             assignSplit(Collections.singletonList(subtaskId));
         }
+        maybeSignalNoMoreSplits();
     }
 
     @Override
@@ -174,5 +183,45 @@ public class JdbcSourceSplitEnumerator
 
     private static int getSplitOwner(String tp, int numReaders) {
         return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+    }
+
+    /**
+     * Signal {@code NoMoreSplitsEvent} to all currently registered readers if the enumerator has
+     * finished enumerating all tables and there are no more pending splits to assign.
+     *
+     * <p>This method is intentionally invoked from multiple code paths:
+     *
+     * <ul>
+     *   <li>At the end of {@link #run()} for the initial enumeration.
+     *   <li>After {@link #addSplitsBack(List, int)} and {@link #registerReader(int)} in failover
+     *       scenarios, where splits are recovered from task state instead of being re-enumerated.
+     * </ul>
+     *
+     * <p>In the latter case, we must still notify the new readers that there will be no more
+     * splits, otherwise a bounded source may never finish after a failover and the job would stay
+     * RUNNING indefinitely.
+     */
+    private void maybeSignalNoMoreSplits() {
+        synchronized (stateLock) {
+            if (noMoreSplitsSignalSent) {
+                return;
+            }
+
+            if (pendingTables.isEmpty() && pendingSplits.isEmpty()) {
+                Set<Integer> readers = context.registeredReaders();
+                if (readers.isEmpty()) {
+                    LOG.info(
+                            "No more splits to assign, but no readers are currently registered. "
+                                    + "Will signal NoMoreSplitsEvent when readers register.");
+                    return;
+                }
+
+                LOG.info(
+                        "No more splits to assign. Sending NoMoreSplitsEvent to reader {}.",
+                        readers);
+                readers.forEach(context::signalNoMoreSplits);
+                noMoreSplitsSignalSent = true;
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -207,21 +207,34 @@ public class JdbcSourceSplitEnumerator
                 return;
             }
 
-            if (pendingTables.isEmpty() && pendingSplits.isEmpty()) {
-                Set<Integer> readers = context.registeredReaders();
-                if (readers.isEmpty()) {
-                    LOG.info(
-                            "No more splits to assign, but no readers are currently registered. "
-                                    + "Will signal NoMoreSplitsEvent when readers register.");
-                    return;
-                }
-
-                LOG.info(
-                        "No more splits to assign. Sending NoMoreSplitsEvent to reader {}.",
-                        readers);
-                readers.forEach(context::signalNoMoreSplits);
-                noMoreSplitsSignalSent = true;
+            if (!pendingTables.isEmpty()) {
+                return;
             }
+
+            Set<Integer> readers = context.registeredReaders();
+            if (readers.isEmpty()) {
+                LOG.info(
+                        "No more splits to assign, but no readers are currently registered. "
+                                + "Will signal NoMoreSplitsEvent when readers register.");
+                return;
+            }
+
+            boolean hasPendingSplitsForRegisteredReaders =
+                    readers.stream()
+                            .anyMatch(
+                                    readerId -> {
+                                        List<JdbcSourceSplit> splitsForReader =
+                                                pendingSplits.get(readerId);
+                                        return splitsForReader != null
+                                                && !splitsForReader.isEmpty();
+                                    });
+            if (hasPendingSplitsForRegisteredReaders) {
+                return;
+            }
+
+            LOG.info("No more splits to assign. Sending NoMoreSplitsEvent to reader {}.", readers);
+            readers.forEach(context::signalNoMoreSplits);
+            noMoreSplitsSignalSent = true;
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
@@ -282,6 +282,81 @@ class JdbcSourceSplitEnumeratorTest {
     }
 
     @Test
+    void testLateRegisteredReaderReceivesNoMoreSplits() throws Exception {
+        int parallelism = 2;
+        TablePath tablePath = TablePath.of("db", "schema", "table");
+
+        Map<TablePath, JdbcSourceTable> tables = new HashMap<>();
+        tables.put(tablePath, createJdbcSourceTable(tablePath));
+
+        Set<Integer> registeredReaders = new HashSet<>(Collections.singleton(0));
+        Set<Integer> noMoreSplitsReaders = new HashSet<>();
+
+        SourceSplitEnumerator.Context<JdbcSourceSplit> context =
+                new SourceSplitEnumerator.Context<JdbcSourceSplit>() {
+                    @Override
+                    public int currentParallelism() {
+                        return parallelism;
+                    }
+
+                    @Override
+                    public Set<Integer> registeredReaders() {
+                        return new HashSet<>(registeredReaders);
+                    }
+
+                    @Override
+                    public void assignSplit(int subtaskId, List<JdbcSourceSplit> splits) {}
+
+                    @Override
+                    public void signalNoMoreSplits(int subtask) {
+                        noMoreSplitsReaders.add(subtask);
+                    }
+
+                    @Override
+                    public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        JdbcSourceConfig sourceConfig =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:mysql://localhost:3306/test")
+                                        .driverName("com.mysql.cj.jdbc.Driver")
+                                        .build())
+                        .build();
+
+        JdbcSourceState state =
+                new JdbcSourceState(
+                        new ArrayList<>(), new HashMap<Integer, List<JdbcSourceSplit>>());
+
+        JdbcSourceSplitEnumerator enumerator =
+                new JdbcSourceSplitEnumerator(context, sourceConfig, tables, state);
+
+        enumerator.open();
+        enumerator.run();
+
+        Assertions.assertEquals(Collections.singleton(0), noMoreSplitsReaders);
+
+        registeredReaders.add(1);
+        enumerator.registerReader(1);
+
+        Set<Integer> expected = new HashSet<>();
+        expected.add(0);
+        expected.add(1);
+        Assertions.assertEquals(expected, noMoreSplitsReaders);
+    }
+
+    @Test
     void testNoMoreSplitsSignalIsSentAtMostOnce() throws Exception {
         int parallelism = 1;
         TablePath tablePath = TablePath.of("db", "schema", "table");

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
@@ -202,6 +202,86 @@ class JdbcSourceSplitEnumeratorTest {
     }
 
     @Test
+    void testNoMoreSplitsWhenOnlyUnregisteredReadersHavePendingSplits() throws Exception {
+        int parallelism = 3;
+        TablePath tablePath = TablePath.of("db", "schema", "table");
+
+        Map<TablePath, JdbcSourceTable> tables = new HashMap<>();
+        tables.put(tablePath, createJdbcSourceTable(tablePath));
+
+        // Only subtask 0 is considered registered from the enumerator's perspective.
+        Set<Integer> registeredReaders = new HashSet<>(Collections.singleton(0));
+        Set<Integer> noMoreSplitsReaders = new HashSet<>();
+
+        SourceSplitEnumerator.Context<JdbcSourceSplit> context =
+                new SourceSplitEnumerator.Context<JdbcSourceSplit>() {
+                    @Override
+                    public int currentParallelism() {
+                        return parallelism;
+                    }
+
+                    @Override
+                    public Set<Integer> registeredReaders() {
+                        return new HashSet<>(registeredReaders);
+                    }
+
+                    @Override
+                    public void assignSplit(int subtaskId, List<JdbcSourceSplit> splits) {}
+
+                    @Override
+                    public void signalNoMoreSplits(int subtask) {
+                        noMoreSplitsReaders.add(subtask);
+                    }
+
+                    @Override
+                    public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        JdbcSourceConfig sourceConfig =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:mysql://localhost:3306/test")
+                                        .driverName("com.mysql.cj.jdbc.Driver")
+                                        .build())
+                        .build();
+
+        // Simulate a failover-recovery-like state where there are no pending tables
+        // and a split needs to be re-added for an unregistered reader (subtask 1).
+        JdbcSourceState state =
+                new JdbcSourceState(
+                        new ArrayList<>(), new HashMap<Integer, List<JdbcSourceSplit>>());
+
+        JdbcSourceSplitEnumerator enumerator =
+                new JdbcSourceSplitEnumerator(context, sourceConfig, tables, state);
+
+        enumerator.open();
+
+        JdbcSourceSplit split =
+                new JdbcSourceSplit(tablePath, "split-1", null, null, null, null, null);
+
+        // Add a split back for subtask 1, which is not in registeredReaders.
+        enumerator.addSplitsBack(Collections.singletonList(split), 1);
+
+        // Since there are no pending splits for the only registered reader (0),
+        // the enumerator should still signal NoMoreSplitsEvent to reader 0.
+        Assertions.assertEquals(Collections.singleton(0), noMoreSplitsReaders);
+        // currentUnassignedSplitSize still reflects that there are unassigned splits
+        // in the enumerator (for unregistered readers), so it is expected to be 1.
+        Assertions.assertEquals(1, enumerator.currentUnassignedSplitSize());
+    }
+
+    @Test
     void testNoMoreSplitsSignalIsSentAtMostOnce() throws Exception {
         int parallelism = 1;
         TablePath tablePath = TablePath.of("db", "schema", "table");

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.source;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.state.JdbcSourceState;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class JdbcSourceSplitEnumeratorTest {
+
+    @Test
+    void testRunSignalsNoMoreSplitsOnce() throws Exception {
+        int parallelism = 1;
+        TablePath tablePath = TablePath.of("db", "schema", "table");
+
+        Map<TablePath, JdbcSourceTable> tables = new HashMap<>();
+        tables.put(tablePath, createJdbcSourceTable(tablePath));
+
+        List<Integer> assignTargets = new ArrayList<>();
+        Set<Integer> noMoreSplitsReaders = new HashSet<>();
+
+        SourceSplitEnumerator.Context<JdbcSourceSplit> context =
+                new SourceSplitEnumerator.Context<JdbcSourceSplit>() {
+                    @Override
+                    public int currentParallelism() {
+                        return parallelism;
+                    }
+
+                    @Override
+                    public Set<Integer> registeredReaders() {
+                        return Collections.singleton(0);
+                    }
+
+                    @Override
+                    public void assignSplit(int subtaskId, List<JdbcSourceSplit> splits) {
+                        if (!splits.isEmpty()) {
+                            assignTargets.add(subtaskId);
+                        }
+                    }
+
+                    @Override
+                    public void signalNoMoreSplits(int subtask) {
+                        noMoreSplitsReaders.add(subtask);
+                    }
+
+                    @Override
+                    public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        JdbcSourceConfig sourceConfig =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:mysql://localhost:3306/test")
+                                        .driverName("com.mysql.cj.jdbc.Driver")
+                                        .build())
+                        .build();
+
+        JdbcSourceSplitEnumerator enumerator =
+                new JdbcSourceSplitEnumerator(context, sourceConfig, tables, null);
+
+        enumerator.open();
+        enumerator.run();
+
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
+        Assertions.assertEquals(Collections.singleton(0), noMoreSplitsReaders);
+        Assertions.assertEquals(Collections.singleton(0), new HashSet<>(assignTargets));
+    }
+
+    @Test
+    void testAddSplitsBackAndRegisterReaderSignalNoMoreSplits() throws Exception {
+        int parallelism = 1;
+        TablePath tablePath = TablePath.of("db", "schema", "table");
+
+        Map<TablePath, JdbcSourceTable> tables = new HashMap<>();
+        tables.put(tablePath, createJdbcSourceTable(tablePath));
+
+        Set<Integer> registeredReaders = new HashSet<>();
+        List<JdbcSourceSplit> assignedSplits = new ArrayList<>();
+        Set<Integer> noMoreSplitsReaders = new HashSet<>();
+
+        SourceSplitEnumerator.Context<JdbcSourceSplit> context =
+                new SourceSplitEnumerator.Context<JdbcSourceSplit>() {
+                    @Override
+                    public int currentParallelism() {
+                        return parallelism;
+                    }
+
+                    @Override
+                    public Set<Integer> registeredReaders() {
+                        return new HashSet<>(registeredReaders);
+                    }
+
+                    @Override
+                    public void assignSplit(int subtaskId, List<JdbcSourceSplit> splits) {
+                        assignedSplits.addAll(splits);
+                    }
+
+                    @Override
+                    public void signalNoMoreSplits(int subtask) {
+                        noMoreSplitsReaders.add(subtask);
+                    }
+
+                    @Override
+                    public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        JdbcSourceConfig sourceConfig =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:mysql://localhost:3306/test")
+                                        .driverName("com.mysql.cj.jdbc.Driver")
+                                        .build())
+                        .build();
+
+        // Simulate that initial enumeration has been completed in a previous attempt and there are
+        // no remaining pending tables or splits in the enumerator state. The split to be
+        // reprocessed will be added via addSplitsBack, as happens in a real failover.
+        List<TablePath> pendingTables = new ArrayList<>();
+        Map<Integer, List<JdbcSourceSplit>> pendingSplits = new HashMap<>();
+        JdbcSourceSplit split =
+                new JdbcSourceSplit(tablePath, "split-0", null, null, null, null, null);
+        JdbcSourceState state = new JdbcSourceState(pendingTables, pendingSplits);
+
+        JdbcSourceSplitEnumerator enumerator =
+                new JdbcSourceSplitEnumerator(context, sourceConfig, tables, state);
+
+        enumerator.open();
+
+        // Simulate failover recovery: add splits back from a failed reader before any reader
+        // registers.
+        List<JdbcSourceSplit> splitsBack = new ArrayList<>();
+        splitsBack.add(split);
+        enumerator.addSplitsBack(splitsBack, 0);
+
+        Assertions.assertTrue(assignedSplits.isEmpty());
+        Assertions.assertTrue(noMoreSplitsReaders.isEmpty());
+
+        // Now a new reader 0 registers, it should receive the split and then NoMoreSplitsEvent
+        registeredReaders.add(0);
+        enumerator.registerReader(0);
+
+        Assertions.assertEquals(Collections.singletonList(split), assignedSplits);
+        Assertions.assertEquals(Collections.singleton(0), noMoreSplitsReaders);
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
+    }
+
+    @Test
+    void testNoMoreSplitsSignalIsSentAtMostOnce() throws Exception {
+        int parallelism = 1;
+        TablePath tablePath = TablePath.of("db", "schema", "table");
+
+        Map<TablePath, JdbcSourceTable> tables = new HashMap<>();
+        tables.put(tablePath, createJdbcSourceTable(tablePath));
+
+        Set<Integer> registeredReaders = new HashSet<>(Collections.singleton(0));
+        AtomicBoolean noMoreSplitsCalled = new AtomicBoolean(false);
+
+        SourceSplitEnumerator.Context<JdbcSourceSplit> context =
+                new SourceSplitEnumerator.Context<JdbcSourceSplit>() {
+                    @Override
+                    public int currentParallelism() {
+                        return parallelism;
+                    }
+
+                    @Override
+                    public Set<Integer> registeredReaders() {
+                        return new HashSet<>(registeredReaders);
+                    }
+
+                    @Override
+                    public void assignSplit(int subtaskId, List<JdbcSourceSplit> splits) {}
+
+                    @Override
+                    public void signalNoMoreSplits(int subtask) {
+                        if (!noMoreSplitsCalled.compareAndSet(false, true)) {
+                            Assertions.fail("NoMoreSplitsEvent should be sent at most once.");
+                        }
+                    }
+
+                    @Override
+                    public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+                    @Override
+                    public MetricsContext getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        JdbcSourceConfig sourceConfig =
+                JdbcSourceConfig.builder()
+                        .jdbcConnectionConfig(
+                                JdbcConnectionConfig.builder()
+                                        .url("jdbc:mysql://localhost:3306/test")
+                                        .driverName("com.mysql.cj.jdbc.Driver")
+                                        .build())
+                        .build();
+
+        JdbcSourceSplitEnumerator enumerator =
+                new JdbcSourceSplitEnumerator(context, sourceConfig, tables, null);
+
+        enumerator.open();
+        enumerator.run();
+
+        // maybeSignalNoMoreSplits is invoked from run(), addSplitsBack and registerReader.
+        // Here we call addSplitsBack / registerReader again, and ensure that noMoreSplits
+        // is not sent multiple times.
+        enumerator.addSplitsBack(Collections.emptyList(), 0);
+        enumerator.registerReader(0);
+
+        Assertions.assertTrue(noMoreSplitsCalled.get());
+    }
+
+    private JdbcSourceTable createJdbcSourceTable(TablePath tablePath) {
+        TableIdentifier tableId = TableIdentifier.of("default", tablePath);
+        TableSchema tableSchema = TableSchema.builder().columns(Collections.emptyList()).build();
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        tableId, tableSchema, Collections.emptyMap(), Collections.emptyList(), "");
+        return JdbcSourceTable.builder().tablePath(tablePath).catalogTable(catalogTable).build();
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
 JdbcSource bounded job never finishes after TaskManager failover (NoMoreSplitsEvent missing for recovered readers)

**Description of error reporting scenarios**

1. The job started normally on the TaskManager container `container_e13_..._000002` for the first time:
   - `JdbcSourceSplitEnumerator` split the table into 1 split:
     - `Splitting table xxx.xxxx.`
     - `Split table xxx.xxxx into 1 splits.`
   - Then sent `NoMoreSplitsEvent`:
     - `No more splits to assign. Sending NoMoreSplitsEvent to reader [0].`
2. After running for about 7 minutes, the heartbeat of this TaskManager timed out:
   - `Heartbeat of TaskManager ... timed out.`
   - The corresponding operator changed from `RUNNING` to `FAILED`, and the job changed from `RUNNING` to `RESTARTING`.
3. Flink automatically recovered the job on the new container `container_e13_..._000003`:
   - `Recovering subtask 0 to checkpoint -1 for source Source: Jdbc-Source to checkpoint.`
   - `Adding splits back from subtask: 0, splits count: 1`
   - `Add back splits 1 to JdbcSourceSplitEnumerator.`
   - The new reader registered and obtained the split:
     - `Register reader 0 to JdbcSourceSplitEnumerator.`
     - `Assigning 1 splits to subtask: 0`
4. From the second start until it was manually canceled, the following **never appeared** in the logs:
   - `No more splits to assign. Sending NoMoreSplitsEvent ...`
   - There were no exception stacks for any operators either.
5. It was finally ended by an external cancel:
   - Job status: `RUNNING` → `CANCELLING` → `CANCELED`.
   - Final YARN status: `KILLED`, with the diagnosis being `null`.
   - SeaTunnel reported an error: `Reason:Flink job executed failed` (because the Flink Job was CANCELED).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Yes

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)