### PR TITLE
[Fix][Doc] Fix failure of st-website build caused by incorrect relative path references

### DIFF
--- a/docs/en/ecosystem/seatunnel-mcp.md
+++ b/docs/en/ecosystem/seatunnel-mcp.md
@@ -6,9 +6,9 @@ title: SeaTunnel MCP
 
 A Model Context Protocol (MCP) server for interacting with SeaTunnel through LLM interfaces like Claude.
 
-![SeaTunnel MCP Logo](../images/seatunnel-mcp-logo.png)
+![SeaTunnel MCP Logo](../../images/seatunnel-mcp-logo.png)
 
-![SeaTunnel MCP Server](../images/seatunnel-mcp-server.png)
+![SeaTunnel MCP Server](../../images/seatunnel-mcp-server.png)
 
 ## Related Links
 

--- a/docs/zh/ecosystem/seatunnel-mcp.md
+++ b/docs/zh/ecosystem/seatunnel-mcp.md
@@ -7,9 +7,9 @@ title: SeaTunnel MCP
 
 SeaTunnel MCP（Model Context Protocol）服务器，提供与大型语言模型（如 Claude）交互的能力，使其能够操作 SeaTunnel 任务。
 
-![SeaTunnel MCP Logo](../images/seatunnel-mcp-logo.png)
+![SeaTunnel MCP Logo](../../images/seatunnel-mcp-logo.png)
 
-![SeaTunnel MCP Server](../images/seatunnel-mcp-server.png)
+![SeaTunnel MCP Server](../../images/seatunnel-mcp-server.png)
 
 ## 相关链接
 


### PR DESCRIPTION
seatunnel-website repo build failed. Cause:
```
Error: Image docs/ecosystem/images/seatunnel-mcp-logo.png used in docs/ecosystem/seatunnel-mcp.md not found.
Error: Image i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/images/seatunnel-mcp-logo.png used in i18n/zh-CN/docusaurus-plugin-content-docs/current/ecosystem/seatunnel-mcp.md not found.
```

P.S. build failure stems from toolchain inconsistency: 
- st main repo uses `sync.sh` to enforce absolute paths;
- st-website's `build-docs.js` retains relative paths with limited regex logic, [build failed](https://github.com/apache/seatunnel-website/actions/runs/19918267104/job/57101682474);

this divergence in path handling causes the error and fix this relative path reference.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)