### PR TITLE
[Fix][Flink] Cache writer states during commit preparation to fix streaming mode lost data.

### DIFF
--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
@@ -71,6 +71,19 @@ public class FlinkSinkWriter<InputT, CommT, WriterStateT>
 
     private MultiTableResourceManager resourceManager;
 
+    /**
+     * Cached writer states produced together with {@link #prepareCommit(boolean)}.
+     *
+     * <p>Flink 1.13+ calls {@code prepareCommit(..)} in {@code prepareSnapshotPreBarrier} and
+     * {@code snapshotState(..)} afterwards. To guarantee that SeaTunnel {@link
+     * org.apache.seatunnel.api.sink.SinkWriter} always sees {@code prepareCommit(checkpointId)}
+     * followed immediately by {@code snapshotState(checkpointId)} without any further writes to the
+     * same transaction, we invoke {@code snapshotState(checkpointId)} inside {@link
+     * #prepareCommit(boolean)} and cache the result here. The subsequent Flink {@code
+     * snapshotState(..)} call simply consumes this cached state.
+     */
+    private List<FlinkWriterState<WriterStateT>> pendingStates;
+
     FlinkSinkWriter(
             org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT> sinkWriter,
             long checkpointId,
@@ -161,7 +174,22 @@ public class FlinkSinkWriter<InputT, CommT, WriterStateT>
 
     @Override
     public List<CommitWrapper<CommT>> prepareCommit(boolean flush) throws IOException {
+        // 1. Let SeaTunnel SinkWriter prepare the commit for the current checkpointId
         Optional<CommT> commTOptional = sinkWriter.prepareCommit(checkpointId);
+
+        // 2. Immediately snapshot state for the same checkpointId, so from SeaTunnel's
+        //    perspective prepareCommit(checkpointId) and snapshotState(checkpointId) are
+        //    executed back-to-back with no further writes to the same transaction.
+        List<FlinkWriterState<WriterStateT>> states =
+                sinkWriter.snapshotState(this.checkpointId).stream()
+                        .map(state -> new FlinkWriterState<>(this.checkpointId, state))
+                        .collect(Collectors.toList());
+        this.pendingStates = states;
+
+        // 3. Advance internal checkpointId for the next round.
+        this.checkpointId++;
+
+        // 4. Wrap commit info as before.
         return commTOptional
                 .map(CommitWrapper::new)
                 .map(Collections::singletonList)
@@ -170,6 +198,17 @@ public class FlinkSinkWriter<InputT, CommT, WriterStateT>
 
     @Override
     public List<FlinkWriterState<WriterStateT>> snapshotState() throws IOException {
+        // If we have already snapshotted state in prepareCommit for this checkpoint,
+        // just return the cached value to Flink and avoid calling the underlying
+        // SeaTunnel SinkWriter.snapshotState(..) a second time.
+        if (pendingStates != null) {
+            List<FlinkWriterState<WriterStateT>> states = pendingStates;
+            pendingStates = null;
+            return states;
+        }
+
+        // Fallback: in some edge cases (e.g., sinks without 2PC) Flink might call snapshotState
+        // without a preceding prepareCommit. Preserve the original behaviour then.
         List<FlinkWriterState<WriterStateT>> states =
                 sinkWriter.snapshotState(this.checkpointId).stream()
                         .map(state -> new FlinkWriterState<>(this.checkpointId, state))

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/test/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterTest.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/test/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.translation.flink.sink;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+class FlinkSinkWriterTest {
+
+    @Test
+    void testPrepareCommitSnapshotsStateAndAdvancesCheckpoint() throws Exception {
+        RecordingSinkWriter delegate = new RecordingSinkWriter();
+        RecordingContext context = new RecordingContext();
+
+        FlinkSinkWriter<SeaTunnelRow, String, String> flinkSinkWriter =
+                new FlinkSinkWriter<>(delegate, 1L, context);
+
+        // first checkpoint
+        List<CommitWrapper<String>> commits = flinkSinkWriter.prepareCommit(false);
+        List<FlinkWriterState<String>> states = flinkSinkWriter.snapshotState();
+
+        // prepareCommit should call delegate.prepareCommit with checkpointId 1
+        Assertions.assertEquals(Collections.singletonList(1L), delegate.prepareCommitCalls);
+        Assertions.assertEquals("commit-1", commits.get(0).getCommit());
+
+        // snapshotState should have been called exactly once for checkpointId 1
+        Assertions.assertEquals(Collections.singletonList(1L), delegate.snapshotCalls);
+        Assertions.assertEquals(1, states.size());
+        Assertions.assertEquals(1L, states.get(0).getCheckpointId());
+        Assertions.assertEquals("state-1", states.get(0).getState());
+
+        // internal checkpointId should have advanced to 2 for next round
+        commits = flinkSinkWriter.prepareCommit(false);
+        states = flinkSinkWriter.snapshotState();
+
+        Assertions.assertEquals(2, delegate.prepareCommitCalls.size());
+        Assertions.assertEquals(2, delegate.snapshotCalls.size());
+        Assertions.assertEquals("commit-2", commits.get(0).getCommit());
+        Assertions.assertEquals(2L, states.get(0).getCheckpointId());
+        Assertions.assertEquals("state-2", states.get(0).getState());
+    }
+
+    @Test
+    void testSnapshotStateWithoutPrepareCommitFallsBack() throws Exception {
+        RecordingSinkWriter delegate = new RecordingSinkWriter();
+        RecordingContext context = new RecordingContext();
+
+        FlinkSinkWriter<SeaTunnelRow, String, String> flinkSinkWriter =
+                new FlinkSinkWriter<>(delegate, 3L, context);
+
+        // Direct snapshotState should call delegate.snapshotState with checkpointId 3
+        List<FlinkWriterState<String>> states = flinkSinkWriter.snapshotState();
+
+        Assertions.assertEquals(Collections.singletonList(3L), delegate.snapshotCalls);
+        Assertions.assertEquals(1, states.size());
+        Assertions.assertEquals(3L, states.get(0).getCheckpointId());
+        Assertions.assertEquals("state-3", states.get(0).getState());
+    }
+
+    private static class RecordingSinkWriter implements SinkWriter<SeaTunnelRow, String, String> {
+
+        private final List<Long> prepareCommitCalls = new ArrayList<>();
+        private final List<Long> snapshotCalls = new ArrayList<>();
+
+        @Override
+        public void write(SeaTunnelRow element) throws IOException {}
+
+        @Override
+        public Optional<String> prepareCommit() {
+            // not used in these tests
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> prepareCommit(long checkpointId) {
+            prepareCommitCalls.add(checkpointId);
+            return Optional.of("commit-" + checkpointId);
+        }
+
+        @Override
+        public List<String> snapshotState(long checkpointId) {
+            snapshotCalls.add(checkpointId);
+            return Collections.singletonList("state-" + checkpointId);
+        }
+
+        @Override
+        public void abortPrepare() {}
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    private static class RecordingContext implements SinkWriter.Context {
+
+        @Override
+        public int getIndexOfSubtask() {
+            return 0;
+        }
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return new NoopMetricsContext();
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return event -> {};
+        }
+    }
+
+    private static class NoopMetricsContext implements MetricsContext {
+
+        @Override
+        public org.apache.seatunnel.api.common.metrics.Counter counter(String name) {
+            return new org.apache.seatunnel.api.common.metrics.Counter() {
+                @Override
+                public void inc() {}
+
+                @Override
+                public void inc(long n) {}
+
+                @Override
+                public void dec() {}
+
+                @Override
+                public void dec(long n) {}
+
+                @Override
+                public void set(long n) {}
+
+                @Override
+                public long getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String name() {
+                    return name;
+                }
+
+                @Override
+                public org.apache.seatunnel.api.common.metrics.Unit unit() {
+                    return org.apache.seatunnel.api.common.metrics.Unit.COUNT;
+                }
+            };
+        }
+
+        @Override
+        public <C extends org.apache.seatunnel.api.common.metrics.Counter> C counter(
+                String name, C counter) {
+            return counter;
+        }
+
+        @Override
+        public org.apache.seatunnel.api.common.metrics.Meter meter(String name) {
+            return new org.apache.seatunnel.api.common.metrics.Meter() {
+                @Override
+                public void markEvent() {}
+
+                @Override
+                public void markEvent(long n) {}
+
+                @Override
+                public double getRate() {
+                    return 0;
+                }
+
+                @Override
+                public long getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String name() {
+                    return name;
+                }
+
+                @Override
+                public org.apache.seatunnel.api.common.metrics.Unit unit() {
+                    return org.apache.seatunnel.api.common.metrics.Unit.COUNT;
+                }
+            };
+        }
+
+        @Override
+        public <M extends org.apache.seatunnel.api.common.metrics.Meter> M meter(
+                String name, M meter) {
+            return meter;
+        }
+    }
+}


### PR DESCRIPTION
… 

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
https://github.com/apache/seatunnel/issues/9826
- Fix the Flink translation semantics for SeaTunnel v1 sinks when running on Flink 1.15/1.16 Streaming, where File/Hive sinks could lose data or fail with source missing during commit.
- Ensure that, from the SeaTunnel sink’s perspective, prepareCommit(checkpointId) and snapshotState(checkpointId) are executed back‑to‑back for the same checkpoint inside FlinkSinkWriter, removing the race where data is still written into the old transaction directory after prepareCommit.
- Keep the change local to seatunnel-translation-flink-common (FlinkSinkWriter), preserving existing behavior for Flink 1.13/1.14 and the dedicated Flink 1.20 translation module, and add unit tests to lock in the new semantics.

### Does this PR introduce _any_ user-facing change?
no
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
UT
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)