### PR TITLE
[Improve][Iceberg] Fix withDescription format in IcebergSourceOptions

### DIFF
--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/config/IcebergSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/config/IcebergSourceOptions.java
@@ -33,50 +33,50 @@ public class IcebergSourceOptions extends IcebergCommonOptions {
             Options.key("start_snapshot_timestamp")
                     .longType()
                     .noDefaultValue()
-                    .withDescription(" the iceberg timestamp of starting snapshot ");
+                    .withDescription("The iceberg timestamp of starting snapshot.");
 
     public static final Option<Long> KEY_START_SNAPSHOT_ID =
             Options.key("start_snapshot_id")
                     .longType()
                     .noDefaultValue()
-                    .withDescription(" the iceberg id of starting snapshot ");
+                    .withDescription("The iceberg id of starting snapshot.");
 
     public static final Option<Long> KEY_END_SNAPSHOT_ID =
             Options.key("end_snapshot_id")
                     .longType()
                     .noDefaultValue()
-                    .withDescription(" the iceberg id of ending snapshot ");
+                    .withDescription("The iceberg id of ending snapshot.");
 
     public static final Option<Long> KEY_USE_SNAPSHOT_ID =
             Options.key("use_snapshot_id")
                     .longType()
                     .noDefaultValue()
-                    .withDescription(" the iceberg used snapshot id");
+                    .withDescription("The iceberg used snapshot id.");
 
     public static final Option<Long> KEY_USE_SNAPSHOT_TIMESTAMP =
             Options.key("use_snapshot_timestamp")
                     .longType()
                     .noDefaultValue()
-                    .withDescription(" the iceberg used snapshot timestamp");
+                    .withDescription("The iceberg used snapshot timestamp.");
 
     public static final Option<IcebergStreamScanStrategy> KEY_STREAM_SCAN_STRATEGY =
             Options.key("stream_scan_strategy")
                     .enumType(IcebergStreamScanStrategy.class)
                     .defaultValue(FROM_LATEST_SNAPSHOT)
-                    .withDescription(" the iceberg strategy of stream scanning");
+                    .withDescription("The iceberg strategy of stream scanning.");
 
     public static final Option<List<SourceTableConfig>> KEY_TABLE_LIST =
             Options.key("table_list")
                     .listType(SourceTableConfig.class)
                     .noDefaultValue()
-                    .withDescription(" the iceberg tables");
+                    .withDescription("The iceberg tables.");
 
     public static final Option<Long> KEY_INCREMENT_SCAN_INTERVAL =
             Options.key("increment.scan-interval")
                     .longType()
                     .defaultValue(2000L)
-                    .withDescription(" the interval of increment scan(mills)");
+                    .withDescription("The interval of increment scan (mills).");
 
     public static final Option<String> QUERY =
-            Options.key("query").stringType().noDefaultValue().withDescription("the select sql");
+            Options.key("query").stringType().noDefaultValue().withDescription("The select sql.");
 }


### PR DESCRIPTION
### What is the purpose of the pull request

Fix the `withDescription` format in `IcebergSourceOptions.java` to follow the standard format used by other connectors.

### Changes made:

1. **Removed leading and trailing spaces** from description text
   - e.g., `" the iceberg timestamp of starting snapshot "` → `"The iceberg timestamp of starting snapshot."`

2. **Standardized description format**:
   - Capitalized the first letter of each description
   - Added period at the end of each description
   - Consistent with other connectors like `KafkaSourceOptions`, `JdbcSourceOptions`, `MongodbSourceOptions`, etc.

### Brief change log

- Fixed 9 `withDescription` calls in `IcebergSourceOptions.java`

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the API: no
- The schema, i.e., is there new DDL syntax: no
- The connector options, i.e., is there new options for connector: no

### How to reproduce

N/A - This is a code style improvement only.

### Check list

- [x] I have reviewed the [contribution guidelines](https://seatunnel.apache.org/community/submit_guide/contribute)
- [x] I have created an issue on the [SeaTunnel ISSUE](https://github.com/apache/seatunnel/issues)
- [x] I have documented any new features or changes in behavior

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author