### PR TITLE
[Bug] [Connector-Kudu] Fix Doris auto table from Kudu STRING being created as CHAR(16)

### DIFF
--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
@@ -156,9 +156,9 @@ public class KuduCatalog implements Catalog {
                                 && PrimaryKey.isPrimaryKeyField(
                                         primaryKeyRef, columnSchema.getName())) {
                             // Doris does not allow STRING as key column type. For primary key
-                            // string columns we provide a reasonable logical length so that
-                            // downstream sinks (e.g. Doris) can map them to a supported CHAR /
-                            // VARCHAR type instead of the invalid STRING type.
+                            // string columns we provide a reasonable logical length
+                            // so that downstream sinks (e.g. Doris) can map them to a supported
+                            // CHAR / VARCHAR type instead of the invalid STRING type.
                             columnLength = 256L;
                         } else if (!Type.STRING.equals(columnSchema.getType())) {
                             columnLength = (long) columnSchema.getTypeSize();

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
@@ -143,6 +143,7 @@ public class KuduCatalog implements Catalog {
             kuduTable.getPartitionSchema();
             List<ColumnSchema> columnSchemaList = schema.getColumns();
             Optional<PrimaryKey> primaryKey = getPrimaryKey(schema.getPrimaryKeyColumns());
+            PrimaryKey primaryKeyRef = primaryKey.orElse(null);
             buildColumnsWithErrorCheck(
                     tablePath,
                     builder,
@@ -151,7 +152,15 @@ public class KuduCatalog implements Catalog {
                         ColumnSchema columnSchema = columnSchemaList.get(i);
                         SeaTunnelDataType<?> type = KuduTypeMapper.mapping(columnSchemaList, i);
                         Long columnLength = null;
-                        if (!Type.STRING.equals(columnSchema.getType())) {
+                        if (Type.STRING.equals(columnSchema.getType())
+                                && PrimaryKey.isPrimaryKeyField(
+                                        primaryKeyRef, columnSchema.getName())) {
+                            // Doris does not allow STRING as key column type. For primary key
+                            // string columns we provide a reasonable logical length so that
+                            // downstream sinks (e.g. Doris) can map them to a supported CHAR /
+                            // VARCHAR type instead of the invalid STRING type.
+                            columnLength = 256L;
+                        } else if (!Type.STRING.equals(columnSchema.getType())) {
                             columnLength = (long) columnSchema.getTypeSize();
                         }
                         return PhysicalColumn.of(

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
@@ -39,6 +39,7 @@ import org.apache.seatunnel.connectors.seatunnel.kudu.util.KuduUtil;
 
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
 import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduTable;
@@ -147,14 +148,19 @@ public class KuduCatalog implements Catalog {
                     builder,
                     IntStream.range(0, columnSchemaList.size()).iterator(),
                     i -> {
+                        ColumnSchema columnSchema = columnSchemaList.get(i);
                         SeaTunnelDataType<?> type = KuduTypeMapper.mapping(columnSchemaList, i);
+                        Long columnLength = null;
+                        if (!Type.STRING.equals(columnSchema.getType())) {
+                            columnLength = (long) columnSchema.getTypeSize();
+                        }
                         return PhysicalColumn.of(
-                                columnSchemaList.get(i).getName(),
+                                columnSchema.getName(),
                                 type,
-                                columnSchemaList.get(i).getTypeSize(),
-                                columnSchemaList.get(i).isNullable(),
-                                columnSchemaList.get(i).getDefaultValue(),
-                                columnSchemaList.get(i).getComment());
+                                columnLength,
+                                columnSchema.isNullable(),
+                                columnSchema.getDefaultValue(),
+                                columnSchema.getComment());
                     });
 
             primaryKey.ifPresent(builder::primaryKey);

--- a/seatunnel-connectors-v2/connector-kudu/src/test/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/test/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalogTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.kudu.catalog;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.kudu.config.CommonConfig;
+
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduTable;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+class KuduCatalogTest {
+
+    @Test
+    void testStringColumnLengthShouldBeNull() throws Exception {
+        CommonConfig commonConfig = Mockito.mock(CommonConfig.class);
+        KuduCatalog kuduCatalog = new KuduCatalog("kudu", commonConfig);
+
+        KuduClient kuduClient = Mockito.mock(KuduClient.class);
+        Field clientField = KuduCatalog.class.getDeclaredField("kuduClient");
+        clientField.setAccessible(true);
+        clientField.set(kuduCatalog, kuduClient);
+
+        TablePath tablePath = TablePath.of("kudu_string_table");
+        Mockito.when(kuduClient.tableExists(tablePath.getFullName())).thenReturn(true);
+
+        ColumnSchema idColumn =
+                new ColumnSchema.ColumnSchemaBuilder("id", Type.INT32).key(true).build();
+        ColumnSchema stringColumn =
+                new ColumnSchema.ColumnSchemaBuilder("val_string", Type.STRING)
+                        .nullable(true)
+                        .build();
+        Schema schema = new Schema(Arrays.asList(idColumn, stringColumn));
+
+        KuduTable kuduTable = Mockito.mock(KuduTable.class);
+        Mockito.when(kuduClient.openTable(tablePath.getFullName())).thenReturn(kuduTable);
+        Mockito.when(kuduTable.getSchema()).thenReturn(schema);
+        Mockito.when(kuduTable.getPartitionSchema()).thenReturn(null);
+
+        CatalogTable catalogTable = kuduCatalog.getTable(tablePath);
+        Column id = catalogTable.getTableSchema().getColumns().get(0);
+        Column valString = catalogTable.getTableSchema().getColumns().get(1);
+
+        // Non-STRING types should still keep the physical length from Kudu.
+        Assertions.assertEquals("id", id.getName());
+        Assertions.assertNotNull(id.getColumnLength());
+
+        // STRING columns must not use the internal typeSize (commonly 16) as logical length.
+        Assertions.assertEquals("val_string", valString.getName());
+        Assertions.assertNull(valString.getColumnLength());
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
@@ -254,6 +254,51 @@ public class DorisCatalogIT extends AbstractDorisIT {
                 BasicType.DOUBLE_TYPE, newTable.getTableSchema().getColumns().get(4).getDataType());
     }
 
+    @Test
+    void testCreateTableWithUnboundedStringColumn() {
+        TableSchema.Builder builder = TableSchema.builder();
+        builder.column(PhysicalColumn.of("k1", BasicType.INT_TYPE, 10L, false, 0, "k1"));
+        // Simulate upstream catalog (such as KuduCatalog) where string column has no logical
+        // length, so Doris should create it as STRING instead of CHAR(16).
+        builder.column(
+                PhysicalColumn.of(
+                        "k2",
+                        BasicType.STRING_TYPE,
+                        (Long) null,
+                        false,
+                        null,
+                        "k2 without length"));
+        builder.primaryKey(PrimaryKey.of("pk_k1", Collections.singletonList("k1")));
+
+        CatalogTable upstreamTable =
+                CatalogTable.of(
+                        TableIdentifier.of("doris", TablePath.of("test.unbounded_string")),
+                        builder.build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        null);
+
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        new HashMap<String, Object>() {
+                            {
+                                put(
+                                        DorisBaseOptions.FENODES.key(),
+                                        container.getHost() + ":" + HTTP_PORT);
+                                put(DorisBaseOptions.DATABASE.key(), "test");
+                                put(DorisBaseOptions.TABLE.key(), "unbounded_string");
+                                put(DorisBaseOptions.USERNAME.key(), USERNAME);
+                                put(DorisBaseOptions.PASSWORD.key(), PASSWORD);
+                            }
+                        });
+
+        CatalogTable createdTable =
+                assertCreateTable(upstreamTable, config, "test.unbounded_string");
+        Column createdStringColumn = createdTable.getTableSchema().getColumns().get(1);
+        Assertions.assertEquals("k2", createdStringColumn.getName());
+        Assertions.assertNull(createdStringColumn.getColumnLength());
+    }
+
     private CatalogTable assertCreateTable(
             CatalogTable upstreamTable, ReadonlyConfig config, String fullName) {
         DorisSinkFactory dorisSinkFactory = new DorisSinkFactory();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
@@ -297,14 +297,10 @@ public class DorisCatalogIT extends AbstractDorisIT {
                 assertCreateTable(upstreamTable, config, "test.unbounded_string");
         Column createdStringColumn = createdTable.getTableSchema().getColumns().get(1);
         Assertions.assertEquals("k2", createdStringColumn.getName());
-        // Ensure that the target column is mapped to Doris STRING type, not CHAR(16) / VARCHAR(16)
-        // inferred from a fake length.
+        // Ensure that the target column is mapped to Doris STRING type
         Assertions.assertEquals(BasicType.STRING_TYPE, createdStringColumn.getDataType());
         Assertions.assertEquals(
                 "string", createdStringColumn.getSourceType().toLowerCase(Locale.ROOT));
-        if (createdStringColumn.getColumnLength() != null) {
-            Assertions.assertTrue(createdStringColumn.getColumnLength() > 16L);
-        }
     }
 
     private CatalogTable assertCreateTable(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -296,7 +297,14 @@ public class DorisCatalogIT extends AbstractDorisIT {
                 assertCreateTable(upstreamTable, config, "test.unbounded_string");
         Column createdStringColumn = createdTable.getTableSchema().getColumns().get(1);
         Assertions.assertEquals("k2", createdStringColumn.getName());
-        Assertions.assertNull(createdStringColumn.getColumnLength());
+        // Ensure that the target column is mapped to Doris STRING type, not CHAR(16) / VARCHAR(16)
+        // inferred from a fake length.
+        Assertions.assertEquals(BasicType.STRING_TYPE, createdStringColumn.getDataType());
+        Assertions.assertEquals(
+                "string", createdStringColumn.getSourceType().toLowerCase(Locale.ROOT));
+        if (createdStringColumn.getColumnLength() != null) {
+            Assertions.assertTrue(createdStringColumn.getColumnLength() > 16L);
+        }
     }
 
     private CatalogTable assertCreateTable(


### PR DESCRIPTION
https://github.com/apache/seatunnel/issues/10174

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

This pull request fixes an incorrect type mapping in the Kudu → Doris pipeline when Doris tables are auto-created from Kudu catalogs.

Previously, `connector-kudu` used Kudu’s internal `typeSize` for all columns as the logical `columnLength`. For `Type.STRING`, `typeSize` is typically `16`. When this value was propagated to Doris, Doris sink treated these columns as short fixed-length strings and created `CHAR(16)` columns instead of `STRING` (unbounded) columns. This breaks real-world Kudu tables where `STRING` columns often contain values much longer than 16 characters.

This PR:

1. Updates `KuduCatalog` so that Kudu `STRING` columns no longer use `typeSize` as `columnLength`. Only non-`STRING` types keep using `typeSize`.
2. Adds a unit test for `KuduCatalog` to ensure `STRING` columns are reported with `columnLength = null`.
3. Adds an e2e assertion for Doris catalog to ensure that an upstream “unbounded string” column is created as Doris `STRING` (not `CHAR(16)`), and `sourceType` is `string`.

### Does this PR introduce _any_ user-facing change?

Yes.

**Previous behavior**

- When using Kudu as source and Doris as sink with schema auto-creation (`schema_save_mode = "RECREATE_SCHEMA"` or `CREATE_SCHEMA_WHEN_NOT_EXIST`), Kudu `STRING` columns were created in Doris as `CHAR(16)`.
- This could lead to:
  - Truncation or write failures for values longer than 16 characters.
  - Mismatched schema between Kudu and Doris: developers expect `STRING` or large `VARCHAR`, but get fixed-length `CHAR(16)`.

**New behavior**

- Kudu `STRING` columns are now exposed from `KuduCatalog` with no logical length (`columnLength = null`).
- Doris sink maps these columns to Doris `STRING` type (internally using Doris’ `MAX_STRING_LENGTH`), not `CHAR(16)`.
- Existing Doris tables are not modified by this PR; the change only affects how new tables are auto-created from Kudu catalogs.


### How was this patch tested?

1. **Unit test**

   - Added `KuduCatalogTest` in `connector-kudu`:

     - Mocks `KuduClient` and `KuduTable` with:
       - One `INT32` column (`id`)
       - One `STRING` column (`val_string`)
     - Calls `KuduCatalog.getTable` and verifies:
       - Non-`STRING` column `id` keeps a non-null `columnLength`.
       - `STRING` column `val_string` has `columnLength == null`.

2. **Doris e2e test**

   - Extended `DorisCatalogIT` in `connector-doris-e2e` with `testCreateTableWithUnboundedStringColumn`:
     - Builds an upstream `CatalogTable` with:
       - `k1` as `INT` primary key.
       - `k2` as `STRING` with `columnLength = null` (simulating KuduCatalog’s behavior).
     - Uses Doris sink `schema_save_mode` to auto-create `test.unbounded_string`.
     - Reads the table via `DorisCatalog` and asserts that:
       - Column name is `k2`.
       - Logical type is `BasicType.STRING_TYPE`.
       - `sourceType` is `string` (case-insensitive).
       - If `columnLength` is present, it is greater than 16 (preventing regression to `CHAR(16)`).

3. **Existing e2e**

   - Ran existing connector Kudu/Doris e2e suites locally to ensure no regressions in other scenarios.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] This PR only touches existing connectors (Kudu, Doris) and does **not** add new connector jars:
  * No changes needed for `plugin-mapping.properties`.
  * No changes needed for `seatunnel-dist/pom.xml`.
  * No new CI label required in `.github/workflows/labeler/label-scope-conf.yml`.
  * E2E tests have been added/extended under `seatunnel-e2e/seatunnel-connector-v2-e2e/`.
