### PR TITLE
[Feature][connector-kudu] Support regex and whole-database table_name for source

### DIFF
--- a/docs/en/connector-v2/source/Kudu.md
+++ b/docs/en/connector-v2/source/Kudu.md
@@ -57,9 +57,10 @@ The tested kudu version is 1.11.1.
 | kerberos_krb5conf                         | String | No       | -                                              | Kerberos krb5 conf. Note that all zeta nodes require have this file.                                                                                                                             |
 | scan_token_query_timeout                  | Long   | No       | 30000                                          | The timeout for connecting scan token. If not set, it will be the same as operationTimeout.                                                                                                      |
 | scan_token_batch_size_bytes               | Int    | No       | 1024 * 1024                                    | Kudu scan bytes. The maximum number of bytes read at a time, the default is 1MB.                                                                                                                 |
+| use_regex                                 | Bool   | No       | false                                          | Control regular expression matching for `table_name`. When set to `true`, the `table_name` will be treated as a regular expression pattern and can match multiple tables. When set to `false` or not specified, the `table_name` will be treated as an exact table name (no regex matching). |
 | filter                                    | String | No       | -                                              | Kudu scan filter expressions,example id > 100 AND id < 200.                                                                                                                                      |
 | schema                                    | Map    | No       | 1024 * 1024                                    | SeaTunnel Schema.                                                                                                                                                                                |
-| table_list                                | Array  | No       | -                                              | The list of tables to be read. you can use this configuration instead of `table_path` example: ```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ``` |
+| table_list                                | Array  | No       | -                                              | The list of tables to be read. you can use this configuration instead of `table_name`, for example: ```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ```. You can also configure `use_regex = true` inside each entry to enable regex matching for `table_name`. |
 | common-options                            |        | No       | -                                              | Source plugin common parameters, please refer to [Source Common Options](../source-common-options.md) for details.                                                                               |
 
 ## Task Example
@@ -139,6 +140,62 @@ sink {
     rules {
       table-names = ["kudu_source_table_1", "kudu_source_table_2"]
     }
+  }
+}
+```
+
+### Table Matching With Regex
+
+The Kudu Source supports using regular expressions on `table_name` to match multiple tables (including whole-database style synchronization, since Kudu tables are in a single logical database).
+
+#### Exact Table Name
+
+Use `table_name` to specify a single Kudu table with an exact name:
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    table_name = "kudu_source_table_1"
+  }
+}
+```
+
+#### Regex Matching
+
+Use `table_name` as a regex pattern and enable `use_regex` to read multiple tables with one configuration:
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    # Match tables like kudu_source_table_1, kudu_source_table_2, etc.
+    table_name = "kudu_source_table_\\d+"
+    use_regex = true
+  }
+}
+```
+
+You can also combine regex entries in `table_list`:
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    table_list = [
+      {
+        table_name = "kudu_source_table_1"
+      },
+      {
+        table_name = "kudu_source_table_2"
+      },
+      {
+        # Regex matching - any table whose name starts with prefix_ and ends with digits
+        table_name = "prefix_\\d+"
+        use_regex = true
+        filter = "id > 100"
+      }
+    ]
   }
 }
 ```

--- a/docs/en/connector-v2/source/Kudu.md
+++ b/docs/en/connector-v2/source/Kudu.md
@@ -193,9 +193,23 @@ source {
         # Regex matching - any table whose name starts with prefix_ and ends with digits
         table_name = "prefix_\\d+"
         use_regex = true
-        filter = "id > 100"
       }
     ]
+  }
+}
+```
+
+#### Whole-Database Matching
+
+You can also synchronize all tables in the current Kudu cluster (or all business tables in the current instance, if there are no system tables) by using a catch-all regex:
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    # Match all tables in the current Kudu cluster
+    table_name = ".*"
+    use_regex = true
   }
 }
 ```

--- a/docs/zh/connector-v2/source/Kudu.md
+++ b/docs/zh/connector-v2/source/Kudu.md
@@ -57,9 +57,10 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | kerberos_krb5conf | String | 否 | - | Kerberos krb5 conf。注意所有 zeta 节点都需要有此文件。 |
 | scan_token_query_timeout | Long | 否 | 30000 | 连接扫描令牌的超时时间。如果未设置，将与 operationTimeout 相同。 |
 | scan_token_batch_size_bytes | Int | 否 | 1024 * 1024 | Kudu 扫描字节数。一次读取的最大字节数，默认为 1MB。 |
+| use_regex | Bool | 否 | false | 控制 `table_name` 的正则匹配。当设置为 `true` 时，`table_name` 将被视为正则表达式模式，可以匹配多张表。当设置为 `false` 或未指定时，`table_name` 将被视为精确表名（不进行正则匹配）。 |
 | filter | String | 否 | - | Kudu 扫描过滤表达式，例如 id > 100 AND id < 200。 |
 | schema | Map | 否 | 1024 * 1024 | SeaTunnel Schema。 |
-| table_list | Array | 否 | - | 要读取的表列表。您可以使用此配置代替 `table_path`，例如：```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ``` |
+| table_list | Array | 否 | - | 要读取的表列表。您可以使用此配置代替 `table_name`，例如：```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ```。也可以在每个 entry 中配置 `use_regex = true` 来对 `table_name` 启用正则匹配。 |
 | common-options | | 否 | - | 源插件通用参数，请参考 [源通用选项](../source-common-options.md) 详见。 |
 
 ## 任务示例
@@ -139,6 +140,62 @@ sink {
     rules {
       table-names = ["kudu_source_table_1", "kudu_source_table_2"]
     }
+  }
+}
+```
+
+### 使用正则表达式匹配表
+
+Kudu Source 支持在 `table_name` 上使用正则表达式来匹配多张表（由于 Kudu 逻辑上只有一个 database，因此也可以用来实现“整库表”同步）。
+
+#### 精确表名
+
+使用 `table_name` 指定单个 Kudu 表的精确名称：
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    table_name = "kudu_source_table_1"
+  }
+}
+```
+
+#### 正则匹配
+
+将 `table_name` 视为正则表达式，并开启 `use_regex`，即可用一条配置匹配多张表：
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    # 匹配 kudu_source_table_1、kudu_source_table_2 等
+    table_name = "kudu_source_table_\\d+"
+    use_regex = true
+  }
+}
+```
+
+也可以在 `table_list` 中组合精确表和正则表：
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    table_list = [
+      {
+        table_name = "kudu_source_table_1"
+      },
+      {
+        table_name = "kudu_source_table_2"
+      },
+      {
+        # 使用正则匹配，以 prefix_ 开头、以数字结尾的所有表
+        table_name = "prefix_\\d+"
+        use_regex = true
+        filter = "id > 100"
+      }
+    ]
   }
 }
 ```

--- a/docs/zh/connector-v2/source/Kudu.md
+++ b/docs/zh/connector-v2/source/Kudu.md
@@ -193,9 +193,23 @@ source {
         # 使用正则匹配，以 prefix_ 开头、以数字结尾的所有表
         table_name = "prefix_\\d+"
         use_regex = true
-        filter = "id > 100"
       }
     ]
+  }
+}
+```
+
+#### 整库匹配
+
+如果当前 Kudu 实例中只有业务表，或者你希望“一次性同步所有表”，可以使用一个全匹配的正则：
+
+```hocon
+source {
+  kudu {
+    kudu_masters = "kudu-master:7051"
+    # 匹配当前 Kudu 实例中的所有表
+    table_name = ".*"
+    use_regex = true
   }
 }
 ```

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceOptions.java
@@ -38,6 +38,16 @@ public class KuduSourceOptions extends KuduBaseOptions {
                     .withDescription(
                             "Kudu scan bytes. The maximum number of bytes read at a time, the default is 1MB");
 
+    public static final Option<Boolean> USE_REGEX =
+            Options.key("use_regex")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Control regular expression matching for table_name. When set to true, "
+                                    + "the table_name will be treated as a regular expression pattern. "
+                                    + "When set to false or not specified, the table_name will be treated "
+                                    + "as an exact table name (no regex matching).");
+
     public static final Option<String> FILTER =
             Options.key("filter")
                     .stringType()

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceTableConfig.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.kudu.config;
 
-import org.apache.seatunnel.shade.com.google.common.collect.Lists;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.Catalog;
@@ -32,8 +30,10 @@ import org.apache.seatunnel.connectors.seatunnel.kudu.catalog.KuduCatalogFactory
 import lombok.Getter;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Getter
@@ -61,15 +61,28 @@ public class KuduSourceTableConfig implements Serializable {
 
         try (KuduCatalog kuduCatalog = (KuduCatalog) optionalCatalog.get()) {
             kuduCatalog.open();
+
+            List<ReadonlyConfig> tableConfigs = new ArrayList<>();
             if (config.getOptional(ConnectorCommonOptions.TABLE_LIST).isPresent()) {
-                return config.get(ConnectorCommonOptions.TABLE_LIST).stream()
-                        .map(ReadonlyConfig::fromMap)
-                        .map(readonlyConfig -> parseKuduSourceConfig(readonlyConfig, kuduCatalog))
-                        .collect(Collectors.toList());
+                tableConfigs =
+                        config.get(ConnectorCommonOptions.TABLE_LIST).stream()
+                                .map(ReadonlyConfig::fromMap)
+                                .collect(Collectors.toList());
+            } else {
+                tableConfigs.add(config);
             }
-            KuduSourceTableConfig kuduSourceTableConfig =
-                    parseKuduSourceConfig(config, kuduCatalog);
-            return Lists.newArrayList(kuduSourceTableConfig);
+
+            List<KuduSourceTableConfig> result = new ArrayList<>();
+            for (ReadonlyConfig tableConfig : tableConfigs) {
+                Boolean useRegex = tableConfig.get(KuduSourceOptions.USE_REGEX);
+                if (useRegex != null && useRegex) {
+                    result.addAll(parseKuduSourceConfigWithRegex(tableConfig, kuduCatalog));
+                } else {
+                    result.add(parseKuduSourceConfig(tableConfig, kuduCatalog));
+                }
+            }
+
+            return result;
         }
     }
 
@@ -85,5 +98,31 @@ public class KuduSourceTableConfig implements Serializable {
         }
         return new KuduSourceTableConfig(
                 tableName, catalogTable, config.get(KuduSourceOptions.FILTER));
+    }
+
+    static List<KuduSourceTableConfig> parseKuduSourceConfigWithRegex(
+            ReadonlyConfig config, KuduCatalog kuduCatalog) {
+        String patternString = config.get(KuduBaseOptions.TABLE_NAME);
+        if (patternString == null) {
+            throw new IllegalArgumentException(
+                    "When `use_regex` is enabled, `table_name` must be configured");
+        }
+
+        Pattern pattern = Pattern.compile(patternString);
+
+        List<String> allTables =
+                kuduCatalog.listTables(kuduCatalog.getDefaultDatabase()).stream()
+                        .filter(tableName -> pattern.matcher(tableName).matches())
+                        .collect(Collectors.toList());
+
+        List<KuduSourceTableConfig> result = new ArrayList<>();
+        for (String tableName : allTables) {
+            CatalogTable catalogTable = kuduCatalog.getTable(TablePath.of(tableName));
+            result.add(
+                    new KuduSourceTableConfig(
+                            tableName, catalogTable, config.get(KuduSourceOptions.FILTER)));
+        }
+
+        return result;
     }
 }

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/source/KuduSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/source/KuduSourceFactory.java
@@ -46,14 +46,16 @@ public class KuduSourceFactory implements TableSourceFactory {
         return OptionRule.builder()
                 .required(KuduSourceOptions.MASTER)
                 .optional(KuduSourceOptions.SCHEMA)
-                .optional(KuduSourceOptions.WORKER_COUNT)
-                .optional(KuduSourceOptions.OPERATION_TIMEOUT)
-                .optional(KuduSourceOptions.ADMIN_OPERATION_TIMEOUT)
-                .optional(KuduSourceOptions.QUERY_TIMEOUT)
-                .optional(KuduSourceOptions.SCAN_BATCH_SIZE_BYTES)
-                .optional(KuduSourceOptions.FILTER)
-                .optional(KuduSourceOptions.ENABLE_KERBEROS)
-                .optional(KuduSourceOptions.KERBEROS_KRB5_CONF)
+                .optional(
+                        KuduSourceOptions.WORKER_COUNT,
+                        KuduSourceOptions.OPERATION_TIMEOUT,
+                        KuduSourceOptions.ADMIN_OPERATION_TIMEOUT,
+                        KuduSourceOptions.QUERY_TIMEOUT,
+                        KuduSourceOptions.SCAN_BATCH_SIZE_BYTES,
+                        KuduSourceOptions.FILTER,
+                        KuduSourceOptions.USE_REGEX,
+                        KuduSourceOptions.ENABLE_KERBEROS,
+                        KuduSourceOptions.KERBEROS_KRB5_CONF)
                 .exclusive(KuduSourceOptions.TABLE_NAME, ConnectorCommonOptions.TABLE_LIST)
                 .conditional(
                         KuduSourceOptions.ENABLE_KERBEROS,

--- a/seatunnel-connectors-v2/connector-kudu/src/test/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceTableConfigTest.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/test/java/org/apache/seatunnel/connectors/seatunnel/kudu/config/KuduSourceTableConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.kudu.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.connectors.seatunnel.kudu.catalog.KuduCatalog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class KuduSourceTableConfigTest {
+
+    @Test
+    void testParseKuduSourceConfigWithRegex() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(KuduBaseOptions.TABLE_NAME.key(), "kudu_source_table_\\d+");
+        configMap.put(KuduSourceOptions.FILTER.key(), "id > 10");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        List<String> tables =
+                Arrays.asList("kudu_source_table_1", "kudu_source_table_2", "other_table");
+        KuduCatalog kuduCatalog = new FakeKuduCatalog(tables);
+
+        List<KuduSourceTableConfig> result =
+                KuduSourceTableConfig.parseKuduSourceConfigWithRegex(config, kuduCatalog);
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals("kudu_source_table_1", result.get(0).getTablePath().getTableName());
+        Assertions.assertEquals("kudu_source_table_2", result.get(1).getTablePath().getTableName());
+        Assertions.assertEquals("id > 10", result.get(0).getFilter());
+        Assertions.assertEquals("id > 10", result.get(1).getFilter());
+    }
+
+    private static class FakeKuduCatalog extends KuduCatalog {
+
+        private final List<String> tables;
+
+        FakeKuduCatalog(List<String> tables) {
+            super("test_catalog", createCommonConfig());
+            this.tables = tables;
+        }
+
+        @Override
+        public String getDefaultDatabase() {
+            return "default_database";
+        }
+
+        @Override
+        public List<String> listTables(String databaseName) {
+            return tables;
+        }
+
+        @Override
+        public CatalogTable getTable(TablePath tablePath) {
+            TableIdentifier identifier = TableIdentifier.of(name(), tablePath);
+            TableSchema schema = TableSchema.builder().build();
+            return CatalogTable.of(
+                    identifier, schema, Collections.emptyMap(), Collections.emptyList(), null);
+        }
+
+        private static CommonConfig createCommonConfig() {
+            Map<String, Object> map = new HashMap<>();
+            map.put(KuduBaseOptions.MASTER.key(), "dummy:7051");
+            ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
+            return new CommonConfig(readonlyConfig);
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kudu/KuduIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kudu/KuduIT.java
@@ -414,6 +414,34 @@ public class KuduIT extends TestSuiteBase implements TestResource {
         kuduClient.deleteTable("kudu_source_table_2");
     }
 
+    @TestTemplate
+    public void testKuduMultipleReadWithRegex(TestContainer container)
+            throws IOException, InterruptedException {
+        initializeKuduTable("kudu_source_table_1");
+        initializeKuduTable("kudu_source_table_2");
+        batchInsertData("kudu_source_table_1");
+        batchInsertData("kudu_source_table_2");
+        Container.ExecResult execResult =
+                container.executeJob("/kudu_to_assert_with_pattern_tables.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+        kuduClient.deleteTable("kudu_source_table_1");
+        kuduClient.deleteTable("kudu_source_table_2");
+    }
+
+    @TestTemplate
+    public void testKuduWholeDatabaseRead(TestContainer container)
+            throws IOException, InterruptedException {
+        initializeKuduTable("kudu_source_table_1");
+        initializeKuduTable("kudu_source_table_2");
+        batchInsertData("kudu_source_table_1");
+        batchInsertData("kudu_source_table_2");
+        Container.ExecResult execResult =
+                container.executeJob("/kudu_to_assert_with_all_tables.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+        kuduClient.deleteTable("kudu_source_table_1");
+        kuduClient.deleteTable("kudu_source_table_2");
+    }
+
     @DisabledOnContainer(
             value = {},
             type = {EngineType.FLINK},

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kudu/KuduIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kudu/KuduIT.java
@@ -442,6 +442,23 @@ public class KuduIT extends TestSuiteBase implements TestResource {
         kuduClient.deleteTable("kudu_source_table_2");
     }
 
+    @TestTemplate
+    public void testKuduTableListWithRegex(TestContainer container)
+            throws IOException, InterruptedException {
+        initializeKuduTable("kudu_source_table_1");
+        initializeKuduTable("kudu_source_table_2");
+        initializeKuduTable("kudu_extra_1");
+        batchInsertData("kudu_source_table_1");
+        batchInsertData("kudu_source_table_2");
+        batchInsertData("kudu_extra_1");
+        Container.ExecResult execResult =
+                container.executeJob("/kudu_to_assert_with_table_list_pattern.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+        kuduClient.deleteTable("kudu_source_table_1");
+        kuduClient.deleteTable("kudu_source_table_2");
+        kuduClient.deleteTable("kudu_extra_1");
+    }
+
     @DisabledOnContainer(
             value = {},
             type = {EngineType.FLINK},

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_all_tables.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_all_tables.conf
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of batch processing with whole-database style table matching in Kudu source
+######
+
+env {
+  # You can set engine configuration here
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  # Kudu source with full-database regex table_name
+  kudu{
+    kudu_masters = "kudu-master:7051"
+    # Match all user tables in the current Kudu cluster.
+    table_name = ".*"
+    use_regex = true
+    plugin_output = "kudu"
+  }
+}
+
+transform {
+}
+
+sink {
+  Assert {
+    rules {
+      # Only the two tables created in the test case should appear
+      table-names = ["kudu_source_table_1", "kudu_source_table_2"]
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_pattern_tables.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_pattern_tables.conf
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of batch processing with regex table matching in Kudu source
+######
+
+env {
+  # You can set engine configuration here
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  # Kudu source with regex table_name
+  kudu{
+    kudu_masters = "kudu-master:7051"
+    table_name = "kudu_source_table_\\d+"
+    use_regex = true
+    plugin_output = "kudu"
+  }
+}
+
+transform {
+}
+
+sink {
+  Assert {
+    rules {
+      table-names = ["kudu_source_table_1", "kudu_source_table_2"]
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_table_list_pattern.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e/src/test/resources/kudu_to_assert_with_table_list_pattern.conf
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of batch processing with mixed table_list and regex entries in Kudu source
+######
+
+env {
+  # You can set engine configuration here
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  # Kudu source with table_list that combines exact and regex table_name entries
+  kudu{
+    kudu_masters = "kudu-master:7051"
+    table_list = [
+      {
+        table_name = "kudu_source_table_1"
+      },
+      {
+        table_name = "kudu_source_table_2"
+      },
+      {
+        # Regex entry - matches additional tables, e.g. kudu_extra_1
+        table_name = "kudu_extra_.*"
+        use_regex = true
+      }
+    ]
+    plugin_output = "kudu"
+  }
+}
+
+transform {
+}
+
+sink {
+  Assert {
+    rules {
+      table-names = ["kudu_source_table_1", "kudu_source_table_2", "kudu_extra_1"]
+    }
+  }
+}
+


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
This pull request adds regex-based table matching support for the Kudu source
connector, including:
- A new optional option `use_regex` for Kudu source.
- Regex matching on `table_name` to read multiple tables with a single configuration (including whole-database style matching).


It addresses the requirement that Kudu should support multi-table / whole-database reading similar to the JDBC connector's `use_regex` behavior.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

Yes.

**Previous behavior**

- Kudu source only supported:
  - Single table via `table_name`.
  - Multiple tables via `table_list` with exact `table_name` entries.
- There was no official way to:
  - Use regex to expand `table_name` into multiple tables.
  - Implement whole-database style synchronization via a single pattern.

**New behavior**

- New option `use_regex` is added to Kudu source options:

  - When `use_regex = true`, `table_name` is treated as a regex pattern and all Kudu tables whose names match this pattern are read.
  - When `use_regex = false` or not set, `table_name` is treated as an exact table name (backward compatible with existing jobs).


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

1. Unit tests

Added KuduSourceTableConfigTest to verify:

- parseKuduSourceConfigWithRegex correctly expands a regex table_name = "kudu_source_table_\\d+" into multiple KuduSourceTableConfig instances.

2. E2E tests

Updated Kudu e2e module(seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e):

- kudu_to_assert_with_pattern_tables.conf + testKuduMultipleReadWithRegex:

   Uses table_name = "kudu_source_table_\\d+" and use_regex = true to read multiple tables via a single pattern.

- kudu_to_assert_with_all_tables.conf +testKuduWholeDatabaseRead:

   Uses table_name = ".*" and use_regex = true to simulate whole-database style synchronization.

- kudu_to_assert_with_table_list_pattern.conf + testKuduTableListWithRegex:

   Uses table_list combining exact entries (kudu_source_table_1, kudu_source_table_2) and a regex entry (kudu_extra_.* with use_regex = true), and validates that all three logical tables are seen.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [*] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [*] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)