### PR TITLE
[Bugfix][connectors-v2]JdbcSink's subscript out-of-bounds exception repaired in createWriter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -163,7 +163,7 @@ public class JdbcSinkFactory implements TableSinkFactory {
         }
         map.put(JdbcSinkOptions.DATABASE.key(), catalogTable.getTableId().getDatabaseName());
         PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
-        if (!config.getOptional(JdbcSinkOptions.PRIMARY_KEYS).isPresent()) {
+        if (CollectionUtils.isEmpty(config.get(JdbcSinkOptions.PRIMARY_KEYS))) {
             if (primaryKey != null && !CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
                 map.put(
                         JdbcSinkOptions.PRIMARY_KEYS.key(),

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcFactoryTest.java
@@ -17,13 +17,26 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SupportParallelism;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.sink.JdbcSink;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.sink.JdbcSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.source.JdbcSourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 class JdbcFactoryTest {
 
@@ -35,5 +48,45 @@ class JdbcFactoryTest {
 
         Class<? extends SeaTunnelSource> sourceClass = jdbcSourceFactory.getSourceClass();
         Assertions.assertTrue(SupportParallelism.class.isAssignableFrom(sourceClass));
+    }
+
+    @Test
+    void testSinkCatalogTable() {
+        TableSinkFactoryContext tableSinkFactoryContext =
+                new TableSinkFactoryContext(
+                        getSimpleCatalogTable(),
+                        getSimpleReadonlyConfig(),
+                        Thread.currentThread().getContextClassLoader());
+        JdbcSinkFactory jdbcSinkFactory = new JdbcSinkFactory();
+        final SeaTunnelSink sink = jdbcSinkFactory.createSink(tableSinkFactoryContext).createSink();
+        JdbcSink jdbcSink = (JdbcSink) sink;
+        Assertions.assertTrue(jdbcSink.getWriteCatalogTable().isPresent());
+        Assertions.assertNull(
+                jdbcSink.getWriteCatalogTable().get().getTableSchema().getPrimaryKey());
+    }
+
+    private ReadonlyConfig getSimpleReadonlyConfig() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("url", "jdbc:mysql://127.0.0.1:3306/test?rewriteBatchedStatements=true");
+        map.put("driver", "com.mysql.cj.jdbc.Driver");
+        map.put("user", "root");
+        map.put("password", "12345");
+        map.put("database", "test");
+        map.put("table", "test_table");
+        map.put("primary_keys", "[]");
+        return ReadonlyConfig.fromMap(map);
+    }
+
+    private CatalogTable getSimpleCatalogTable() {
+        return CatalogTable.of(
+                TableIdentifier.of("catalog", "database", "table"),
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "test", BasicType.STRING_TYPE, 1L, true, null, ""))
+                        .build(),
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                "comment");
     }
 }


### PR DESCRIPTION
### Cause of bug
When I configure the parameter `"primary_keys" = []`, jdbcsink.createWriter() will report an error. The error is as follows
<img width="1413" height="309" alt="image" src="https://github.com/user-attachments/assets/f42ca6d5-f1e9-4f4f-ab26-d9ddef54a213" />
