### PR TITLE
[Feature][Zeta] Support the tolerable-failed configuration for checkpoints

### DIFF
--- a/docs/en/seatunnel-engine/hybrid-cluster-deployment.md
+++ b/docs/en/seatunnel-engine/hybrid-cluster-deployment.md
@@ -93,6 +93,10 @@ The timeout for checkpoints. If the checkpoint cannot be completed within the ti
 
 The minimum pause (in milliseconds) between consecutive checkpoints. This ensures that checkpoints are not triggered too frequently.
 
+**tolerable-failed**
+
+The number of consecutive checkpoint failures that can be tolerated before the job fails.
+
 Example
 
 ```yaml
@@ -106,6 +110,7 @@ seatunnel:
             interval: 300000
             timeout: 10000
             min-pause: 5000
+            tolerable-failed: 3
 
 ```
 

--- a/docs/en/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/en/seatunnel-engine/separated-cluster-deployment.md
@@ -134,6 +134,10 @@ The timeout time of the checkpoint. If the checkpoint cannot be completed within
 
 The minimum pause (in milliseconds) between consecutive checkpoints. This ensures that checkpoints are not triggered too frequently.
 
+**tolerable-failed**
+
+The number of consecutive checkpoint failures that can be tolerated before the job fails.
+
 Example
 
 ```yaml
@@ -147,6 +151,7 @@ seatunnel:
             interval: 300000
             timeout: 10000
             min-pause: 5000
+            tolerable-failed: 3
 ```
 
 **checkpoint storage**

--- a/docs/zh/seatunnel-engine/hybrid-cluster-deployment.md
+++ b/docs/zh/seatunnel-engine/hybrid-cluster-deployment.md
@@ -93,6 +93,10 @@ seatunnel:
 
 连续检查点之间的最小暂停时间(以毫秒为单位)，确保检查点不会频繁触发。
 
+**tolerable-failed**
+
+可容忍的连续检查点失败次数，超过该次数后作业将失败。
+
 示例
 
 ```yaml
@@ -106,6 +110,7 @@ seatunnel:
             interval: 300000
             timeout: 10000
             min-pause: 5000
+            tolerable-failed: 3
 ```
 
 **checkpoint storage**

--- a/docs/zh/seatunnel-engine/separated-cluster-deployment.md
+++ b/docs/zh/seatunnel-engine/separated-cluster-deployment.md
@@ -137,6 +137,11 @@ seatunnel:
 
 连续检查点之间的最小暂停时间(以毫秒为单位)，确保检查点不会频繁触发。
 
+
+**tolerable-failed**
+
+可容忍的连续检查点失败次数，超过该次数后作业将失败。
+
 示例
 
 ```yaml
@@ -150,6 +155,7 @@ seatunnel:
             interval: 300000
             timeout: 10000
             min-pause: 5000
+            tolerable-failed: 3
 ```
 
 **checkpoint storage**

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -92,6 +92,14 @@ public class EnvCommonOptions {
                             "The minimum pause (in milliseconds) between consecutive checkpoints. "
                                     + "This ensures that checkpoints are not triggered too frequently and provides.");
 
+    public static final Option<Integer> CHECKPOINT_TOLERABLE_FAILED =
+            Options.key("tolerable-failed")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "The number of consecutive checkpoint failures that can be tolerated before the job fails. "
+                                    + "Default is 0, which means any checkpoint failure will cause the job to fail.");
+
     public static Option<SaveModeExecuteLocation> SAVEMODE_EXECUTE_LOCATION =
             Options.key("savemode.execute.location")
                     .enumType(SaveModeExecuteLocation.class)

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
@@ -43,6 +43,7 @@ public class EnvOptionRule implements Factory {
                         EnvCommonOptions.CHECKPOINT_INTERVAL,
                         EnvCommonOptions.CHECKPOINT_TIMEOUT,
                         EnvCommonOptions.CHECKPOINT_MIN_PAUSE,
+                        EnvCommonOptions.CHECKPOINT_TOLERABLE_FAILED,
                         EnvCommonOptions.READ_LIMIT_ROW_PER_SECOND,
                         EnvCommonOptions.READ_LIMIT_BYTES_PER_SECOND,
                         EnvCommonOptions.SAVEMODE_EXECUTE_LOCATION,

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractFlinkRuntimeEnvironment.java
@@ -114,6 +114,10 @@ public abstract class AbstractFlinkRuntimeEnvironment implements RuntimeEnvironm
         } else if (config.hasPath(EnvCommonOptions.CHECKPOINT_MIN_PAUSE.key())) {
             long minPause = config.getLong(EnvCommonOptions.CHECKPOINT_MIN_PAUSE.key());
             checkpointConfig.setMinPauseBetweenCheckpoints(minPause);
+        } else if (config.hasPath(EnvCommonOptions.CHECKPOINT_TOLERABLE_FAILED.key())) {
+            int tolerableFailedCheckpointsNums =
+                    config.getInt(EnvCommonOptions.CHECKPOINT_TOLERABLE_FAILED.key());
+            checkpointConfig.setTolerableCheckpointFailureNumber(tolerableFailedCheckpointsNums);
         }
 
         if (EnvironmentUtil.hasPathAndWaring(config, ConfigKeyName.CHECKPOINT_MODE)) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -299,6 +299,15 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                                 ServerConfigOptions.MasterServerConfigOptions.CHECKPOINT_MIN_PAUSE
                                         .key(),
                                 getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.CHECKPOINT_TOLERABLE_FAILED
+                    .key()
+                    .equals(name)) {
+                checkpointConfig.setCheckpointTolerableFailed(
+                        getIntegerValue(
+                                ServerConfigOptions.MasterServerConfigOptions
+                                        .CHECKPOINT_TOLERABLE_FAILED
+                                        .key(),
+                                getTextContent(node)));
             } else if (ServerConfigOptions.MasterServerConfigOptions
                     .SCHEMA_CHANGE_CHECKPOINT_TIMEOUT
                     .key()

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/CheckpointConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/CheckpointConfig.java
@@ -34,6 +34,9 @@ public class CheckpointConfig implements Serializable {
             ServerConfigOptions.MasterServerConfigOptions.CHECKPOINT_TIMEOUT.defaultValue();
     private long checkpointMinPause =
             ServerConfigOptions.MasterServerConfigOptions.CHECKPOINT_MIN_PAUSE.defaultValue();
+    private int checkpointTolerableFailed =
+            ServerConfigOptions.MasterServerConfigOptions.CHECKPOINT_TOLERABLE_FAILED
+                    .defaultValue();
     private long schemaChangeCheckpointTimeout =
             ServerConfigOptions.MasterServerConfigOptions.SCHEMA_CHANGE_CHECKPOINT_TIMEOUT
                     .defaultValue();
@@ -66,5 +69,12 @@ public class CheckpointConfig implements Serializable {
                 checkpointTimeout >= MINIMAL_CHECKPOINT_TIME,
                 "The minimum checkpoint timeout is 10 ms.");
         this.schemaChangeCheckpointTimeout = checkpointTimeout;
+    }
+
+    public void setCheckpointTolerableFailed(int tolerableFailedCheckpoints) {
+        checkArgument(
+                tolerableFailedCheckpoints >= 0,
+                "The tolerable failed checkpoints must be non-negative.");
+        this.checkpointTolerableFailed = tolerableFailedCheckpoints;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -135,6 +135,14 @@ public class ServerConfigOptions {
                                 "The minimum pause (in milliseconds) between consecutive checkpoints. "
                                         + "This ensures that checkpoints are not triggered too frequently and provides.");
 
+        public static final Option<Integer> CHECKPOINT_TOLERABLE_FAILED =
+                Options.key("tolerable-failed")
+                        .intType()
+                        .defaultValue(0)
+                        .withDescription(
+                                "The number of consecutive checkpoint failures that can be tolerated before the job fails. "
+                                        + "Default is 0, which means any checkpoint failure will cause the job to fail.");
+
         public static final Option<String> CHECKPOINT_STORAGE_TYPE =
                 Options.key("type")
                         .stringType()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -98,7 +98,7 @@ public class CheckpointCoordinator {
 
     private final CheckpointManager checkpointManager;
 
-    private final CheckpointStorage checkpointStorage;
+    @Getter private CheckpointStorage checkpointStorage;
 
     @Getter private final CheckpointIDCounter checkpointIdCounter;
 
@@ -132,6 +132,8 @@ public class CheckpointCoordinator {
 
     private final AtomicInteger pendingCounter = new AtomicInteger(0);
 
+    private final AtomicInteger consecutiveFailedCounter = new AtomicInteger(0);
+
     private final AtomicBoolean schemaChanging = new AtomicBoolean(false);
 
     private final Object lock = new Object();
@@ -153,7 +155,7 @@ public class CheckpointCoordinator {
     // processed with one savepoint operation in the same time.
     private PendingCheckpoint savepointPendingCheckpoint;
 
-    private final String checkpointStateImapKey;
+    @Getter private final String checkpointStateImapKey;
 
     @SneakyThrows
     public CheckpointCoordinator(
@@ -287,6 +289,25 @@ public class CheckpointCoordinator {
         if (checkpointCoordinatorFuture.isDone()) {
             return;
         }
+
+        int failedCount = consecutiveFailedCounter.incrementAndGet();
+        int tolerableFailures = coordinatorConfig.getCheckpointTolerableFailed();
+
+        if (tolerableFailures > 0 && failedCount <= tolerableFailures) {
+            LOG.warn(
+                    "Checkpoint failed (consecutive failures: {}/{}): {}",
+                    failedCount,
+                    tolerableFailures,
+                    ExceptionUtils.getMessage(checkpointException));
+            cleanFailedCheckpoint(reason);
+            return;
+        }
+
+        LOG.error(
+                "Checkpoint failures exceeded tolerable limit ({}/{}), failing the job",
+                failedCount,
+                tolerableFailures);
+
         updateStatus(CheckpointCoordinatorStatus.FAILED);
         checkpointCoordinatorFuture.complete(
                 new CheckpointCoordinatorState(
@@ -630,7 +651,8 @@ public class CheckpointCoordinator {
         return new PassiveCompletableFuture<>(future);
     }
 
-    private void startTriggerPendingCheckpoint(
+    @VisibleForTesting
+    protected void startTriggerPendingCheckpoint(
             CompletableFuture<PendingCheckpoint> pendingCompletableFuture) {
         pendingCompletableFuture.thenAccept(
                 pendingCheckpoint -> {
@@ -717,7 +739,8 @@ public class CheckpointCoordinator {
         pendingCounter.incrementAndGet();
     }
 
-    private CompletableFuture<PendingCheckpoint> createPendingCheckpoint(
+    @VisibleForTesting
+    protected CompletableFuture<PendingCheckpoint> createPendingCheckpoint(
             long triggerTimestamp, CheckpointType checkpointType) {
         synchronized (lock) {
             CompletableFuture<Long> idFuture;
@@ -951,6 +974,13 @@ public class CheckpointCoordinator {
         notifyCompleted(completedCheckpoint);
         pendingCheckpoints.remove(checkpointId).abortCheckpointTimeoutFutureWhenIsCompleted();
         pendingCounter.decrementAndGet();
+        int lastestFailedCount = consecutiveFailedCounter.getAndSet(0);
+        if (lastestFailedCount > 0) {
+            LOG.info(
+                    "Reset consecutive failed counter from {} to 0 after checkpoint {} completed",
+                    lastestFailedCount,
+                    completedCheckpoint.getCheckpointId());
+        }
 
         if (isCompleted()) {
             cleanPendingCheckpoint(CheckpointCloseReason.CHECKPOINT_COORDINATOR_COMPLETED);
@@ -1112,8 +1142,32 @@ public class CheckpointCoordinator {
         }
     }
 
-    public String getCheckpointStateImapKey() {
-        return checkpointStateImapKey;
+    /**
+     * Clean only the failed checkpoint(s) without shutting down the coordinator. This is used for
+     * tolerable checkpoint failures to allow subsequent checkpoints to continue.
+     */
+    protected void cleanFailedCheckpoint(CheckpointCloseReason closedReason) {
+        synchronized (lock) {
+            LOG.info("start clean failed checkpoint cause {}", closedReason.message());
+            if (!pendingCheckpoints.isEmpty()) {
+                pendingCheckpoints
+                        .values()
+                        .forEach(
+                                pendingCheckpoint ->
+                                        pendingCheckpoint.abortCheckpoint(closedReason, null));
+                pendingCheckpoints.clear();
+            }
+            pendingCounter.set(0);
+        }
+    }
+
+    public int getConsecutiveFailedCounter() {
+        return consecutiveFailedCounter.get();
+    }
+
+    @VisibleForTesting
+    public void setCheckpointStorage(CheckpointStorage checkpointStorage) {
+        this.checkpointStorage = checkpointStorage;
     }
 
     /** Only for test */

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.engine.server.checkpoint;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
 import org.apache.seatunnel.api.tracing.MDCTracer;
 import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
@@ -181,6 +183,11 @@ public class CheckpointManager {
                     String.format("The checkpoint coordinator(%s) don't exist", pipelineId));
         }
         return coordinator;
+    }
+
+    @VisibleForTesting
+    protected void setCheckpointCoordinator(int pipelineId, CheckpointCoordinator coordinator) {
+        coordinatorMap.put(pipelineId, coordinator);
     }
 
     /**

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/PendingCheckpoint.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/PendingCheckpoint.java
@@ -170,7 +170,8 @@ public class PendingCheckpoint implements Checkpoint {
 
     public void abortCheckpoint(CheckpointCloseReason closedReason, @Nullable Throwable cause) {
         if (closedReason.equals(CheckpointCloseReason.CHECKPOINT_COORDINATOR_RESET)
-                || closedReason.equals(CheckpointCloseReason.PIPELINE_END)) {
+                || closedReason.equals(CheckpointCloseReason.PIPELINE_END)
+                || closedReason.equals(CheckpointCloseReason.CHECKPOINT_EXPIRED)) {
             completableFuture.complete(null);
         } else {
             this.failureCause = new CheckpointException(closedReason, cause);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -334,6 +334,8 @@ public class JobMaster {
         jobCheckpointConfig.setCheckpointTimeout(defaultCheckpointConfig.getCheckpointTimeout());
         jobCheckpointConfig.setCheckpointInterval(defaultCheckpointConfig.getCheckpointInterval());
         jobCheckpointConfig.setCheckpointMinPause(defaultCheckpointConfig.getCheckpointMinPause());
+        jobCheckpointConfig.setCheckpointTolerableFailed(
+                defaultCheckpointConfig.getCheckpointTolerableFailed());
 
         CheckpointStorageConfig jobCheckpointStorageConfig = new CheckpointStorageConfig();
         jobCheckpointStorageConfig.setStorage(defaultCheckpointConfig.getStorage().getStorage());
@@ -362,6 +364,12 @@ public class JobMaster {
             jobCheckpointConfig.setCheckpointMinPause(
                     Long.parseLong(
                             jobEnv.get(EnvCommonOptions.CHECKPOINT_MIN_PAUSE.key()).toString()));
+        }
+        if (jobEnv.containsKey(EnvCommonOptions.CHECKPOINT_TOLERABLE_FAILED.key())) {
+            jobCheckpointConfig.setCheckpointTolerableFailed(
+                    Integer.parseInt(
+                            jobEnv.get(EnvCommonOptions.CHECKPOINT_TOLERABLE_FAILED.key())
+                                    .toString()));
         }
         return jobCheckpointConfig;
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -18,13 +18,16 @@
 package org.apache.seatunnel.engine.server.checkpoint;
 
 import org.apache.seatunnel.common.utils.ReflectionUtils;
+import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
+import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointStorageConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
 import org.apache.seatunnel.engine.server.checkpoint.operation.TaskAcknowledgeOperation;
+import org.apache.seatunnel.engine.server.checkpoint.operation.TaskReportStatusOperation;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
@@ -287,6 +290,118 @@ public class CheckpointCoordinatorTest
     }
 
     @Test
+    void testTolerableFailedCheckpoints() throws Exception {
+        CheckpointConfig checkpointConfig = new CheckpointConfig();
+        checkpointConfig.setStorage(new CheckpointStorageConfig());
+        checkpointConfig.setCheckpointTimeout(500);
+        checkpointConfig.setCheckpointTolerableFailed(3);
+        checkpointConfig.setCheckpointEnable(true);
+
+        Map<Integer, CheckpointPlan> planMap = new HashMap<>();
+        TaskLocation task1 = new TaskLocation(new TaskGroupLocation(1L, 1, 1), 1, 1);
+
+        Map<TaskLocation, Set<Tuple2<ActionStateKey, Integer>>> subtaskActions = new HashMap<>();
+        subtaskActions.put(
+                task1, Collections.singleton(Tuple2.tuple2(new ActionStateKey("action1"), 0)));
+
+        Map<ActionStateKey, Integer> pipelineActions = new HashMap<>();
+        pipelineActions.put(new ActionStateKey("action1"), 1);
+        planMap.put(
+                1,
+                CheckpointPlan.builder()
+                        .pipelineId(1)
+                        .pipelineSubtasks(Collections.singleton(task1))
+                        .startingSubtasks(Collections.singleton(task1))
+                        .subtaskActions(subtaskActions)
+                        .pipelineActions(pipelineActions)
+                        .build());
+
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            TestCheckpointManager checkpointManager =
+                    new TestCheckpointManager(
+                            1L,
+                            nodeEngine,
+                            planMap,
+                            checkpointConfig,
+                            server.getCheckpointService().getCheckpointStorage(),
+                            executorService,
+                            nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE));
+
+            CheckpointCoordinator coordinator = checkpointManager.getCheckpointCoordinator(1);
+            checkpointManager.reportedPipelineRunning(1, false);
+            coordinator.reportedTask(
+                    new TaskReportStatusOperation(task1, SeaTunnelTaskState.RUNNING));
+
+            CompletableFuture<PendingCheckpoint> pendingCheckpoint1 =
+                    coordinator.createPendingCheckpoint(
+                            System.currentTimeMillis(), CheckpointType.CHECKPOINT_TYPE);
+            pendingCheckpoint1.join();
+            coordinator.startTriggerPendingCheckpoint(pendingCheckpoint1);
+            Thread.sleep(1000);
+            int failedCount1 = coordinator.getConsecutiveFailedCounter();
+            Assertions.assertEquals(
+                    1, failedCount1, "Failed counter should be 1 after first checkpoint timeout");
+            CompletableFuture<PendingCheckpoint> pendingCheckpoint2 =
+                    coordinator.createPendingCheckpoint(
+                            System.currentTimeMillis(), CheckpointType.CHECKPOINT_TYPE);
+            pendingCheckpoint2.join();
+            coordinator.startTriggerPendingCheckpoint(pendingCheckpoint2);
+
+            // Wait for second checkpoint to timeout and fail
+            Thread.sleep(1000);
+            int failedCount2 = coordinator.getConsecutiveFailedCounter();
+            Assertions.assertEquals(
+                    2, failedCount2, "Failed counter should be 2 after second checkpoint timeout");
+
+            // Simulate a successful checkpoint
+            CompletableFuture<PendingCheckpoint> pendingCheckpoint3 =
+                    coordinator.createPendingCheckpoint(
+                            System.currentTimeMillis(), CheckpointType.CHECKPOINT_TYPE);
+            PendingCheckpoint checkpoint3 = pendingCheckpoint3.join();
+            CheckpointBarrier barrier3 =
+                    new CheckpointBarrier(
+                            checkpoint3.getCheckpointId(),
+                            System.currentTimeMillis(),
+                            CheckpointType.CHECKPOINT_TYPE);
+            checkpointManager.acknowledgeTask(
+                    new TaskAcknowledgeOperation(
+                            task1,
+                            barrier3,
+                            Collections.singletonList(
+                                    new ActionSubtaskState(
+                                            new ActionStateKey("action1"),
+                                            0,
+                                            Collections.emptyList()))));
+
+            CompletedCheckpoint completedCheckpoint3 = checkpoint3.getCompletableFuture().join();
+            coordinator.completePendingCheckpoint(completedCheckpoint3);
+
+            // Verify counter is reset to 0 after successful checkpoint
+            int failedCountAfterSuccess = coordinator.getConsecutiveFailedCounter();
+            Assertions.assertEquals(
+                    0,
+                    failedCountAfterSuccess,
+                    "Failed counter should be reset to 0 after successful checkpoint");
+
+            // Trigger another checkpoint that will fail to verify counter starts from 0 again
+            CompletableFuture<PendingCheckpoint> pendingCheckpoint4 =
+                    coordinator.createPendingCheckpoint(
+                            System.currentTimeMillis(), CheckpointType.CHECKPOINT_TYPE);
+            coordinator.startTriggerPendingCheckpoint(pendingCheckpoint4);
+            Thread.sleep(1000);
+            int failedCountAfterReset = coordinator.getConsecutiveFailedCounter();
+            Assertions.assertEquals(
+                    1,
+                    failedCountAfterReset,
+                    "Failed counter should be 1 after failure following a successful checkpoint");
+
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
     void testFilteringClosedTasksAndActions() {
         CheckpointConfig checkpointConfig = new CheckpointConfig();
         checkpointConfig.setStorage(new CheckpointStorageConfig());
@@ -368,6 +483,7 @@ public class CheckpointCoordinatorTest
 
 class TestCheckpointManager extends CheckpointManager {
     public List<TaskOperation> operations = new ArrayList<>();
+    public CheckpointCoordinator spyCoordinator;
 
     public TestCheckpointManager(
             long jobId,
@@ -393,5 +509,77 @@ class TestCheckpointManager extends CheckpointManager {
     protected InvocationFuture<?> sendOperationToMemberNode(TaskOperation operation) {
         this.operations.add(operation);
         return null;
+    }
+
+    public CheckpointCoordinator getCheckpointCoordinator(int pipelineId) {
+        CheckpointCoordinator coordinator = super.getCheckpointCoordinator(pipelineId);
+        if (coordinator == null) {
+            throw new RuntimeException(
+                    String.format("The checkpoint coordinator(%s) don't exist", pipelineId));
+        }
+
+        if (this.spyCoordinator == null) {
+            spyCoordinator = Mockito.spy(coordinator);
+            Mockito.doNothing()
+                    .when(spyCoordinator)
+                    .notifyCompleted(Mockito.any(CompletedCheckpoint.class));
+
+            CheckpointStorage testCheckpointStorage =
+                    new CheckpointStorage() {
+                        @Override
+                        public String storeCheckPoint(PipelineState pipelineState)
+                                throws CheckpointStorageException {
+                            return "";
+                        }
+
+                        @Override
+                        public void asyncStoreCheckPoint(PipelineState pipelineState)
+                                throws CheckpointStorageException {}
+
+                        @Override
+                        public List<PipelineState> getAllCheckpoints(String s)
+                                throws CheckpointStorageException {
+                            return Collections.emptyList();
+                        }
+
+                        @Override
+                        public List<PipelineState> getLatestCheckpoint(String s)
+                                throws CheckpointStorageException {
+                            return Collections.emptyList();
+                        }
+
+                        @Override
+                        public PipelineState getLatestCheckpointByJobIdAndPipelineId(
+                                String s, String s1) throws CheckpointStorageException {
+                            return null;
+                        }
+
+                        @Override
+                        public List<PipelineState> getCheckpointsByJobIdAndPipelineId(
+                                String s, String s1) throws CheckpointStorageException {
+                            return Collections.emptyList();
+                        }
+
+                        @Override
+                        public void deleteCheckpoint(String s) {}
+
+                        @Override
+                        public PipelineState getCheckpoint(String s, String s1, String s2)
+                                throws CheckpointStorageException {
+                            return null;
+                        }
+
+                        @Override
+                        public void deleteCheckpoint(String s, String s1, String s2)
+                                throws CheckpointStorageException {}
+
+                        @Override
+                        public void deleteCheckpoint(String s, String s1, List<String> list)
+                                throws CheckpointStorageException {}
+                    };
+            spyCoordinator.setCheckpointStorage(testCheckpointStorage);
+            setCheckpointCoordinator(1, spyCoordinator);
+        }
+        return spyCoordinator;
     }
 }


### PR DESCRIPTION

### Purpose of this pull request

Support defines how many consecutive checkpoint failures will be tolerated, before the whole job is failed over. The default value is `0`, which means no checkpoint failures will be tolerated, and the job will fail on first reported checkpoint failure.

### Does this PR introduce _any_ user-facing change?

Yes


### How was this patch tested?

Add test: `CheckpointCoordinatorTest#testTolerableFailedCheckpoints()`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)