### PR TITLE
[Improve][seatunnel-dist] delete opengauss jdbc driver

### DIFF
--- a/seatunnel-dist/src/main/assembly/assembly-bin-ci.xml
+++ b/seatunnel-dist/src/main/assembly/assembly-bin-ci.xml
@@ -186,7 +186,6 @@
                 <include>net.snowflake.snowflake-jdbc:jar</include>
                 <include>com.xugudb:xugu-jdbc:jar</include>
                 <include>org.tikv:tikv-client-java:jar</include>
-                <include>org.opengauss:opengauss-jdbc:jar</include>
                 <include>com.amazonaws:aws-java-sdk-bundle:jar</include>
                 <include>org.apache.seatunnel:seatunnel-hadoop3-3.1.4-uber:jar:*:optional</include>
                 <include>org.apache.seatunnel:seatunnel-hadoop-aws:jar:*:optional</include>


### PR DESCRIPTION
### Why delete the driver
There is a class conflict between the jdbc driver of opengauss-jdbc and the jdbc driver of postgresql, because both driver packages have the class `org.postgresql.Driver`. If both exist at the same time, an exception will be thrown when I run postgresql related synchronization tasks.