### PR TITLE
[Feature][CI] Add check to prevent .class files from being committed

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,6 +58,27 @@ jobs:
         run: ./mvnw -B -T 1 clean test -D"license.skipAddThirdParty"=true -pl seatunnel-ci-tools -am --no-snapshot-updates
         env:
           MAVEN_OPTS: -Xmx512m
+      - name: Check for .class files in git
+        run: |
+          echo "Checking for .class files tracked by git..."
+
+          # Find all .class files tracked by git
+          CLASS_FILES=$(git ls-files '*.class')
+
+          if [ -n "$CLASS_FILES" ]; then
+            echo "ERROR: The following .class files are tracked by git:"
+            echo "$CLASS_FILES"
+            echo ""
+            echo "Please remove .class files from the repository."
+            echo "These files should not be committed. You can remove them using:"
+            echo "  git rm --cached <file>.class"
+            echo "  git commit -m 'Remove .class files'"
+            echo ""
+            echo "Also, consider adding '*.class' to .gitignore if not already present."
+            exit 1
+          else
+            echo "No .class files found in git repository."
+          fi
 
   helm-chart-check:
     name: Check Helm Chart Syntax

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Package Files #
 *.jar
+*.class
 *.zip
 *.tar.gz
 


### PR DESCRIPTION
## Summary
This PR adds a CI check in the backend workflow to prevent .class files from being committed to the repository.

## Changes
- Added a new step in `.github/workflows/backend.yml` to check for .class files tracked by git
- Added `*.class` to `.gitignore` to prevent accidental commits in the future

## Motivation
Recently, some .class files from the target directory were accidentally committed to the repository. This check will prevent such issues in the future by:
1. Running as part of the code-style job in the backend CI workflow
2. Failing the CI build if any .class files are found in the git repository
3. Providing clear instructions on how to remove the files

## Test Plan
- [x] The check script has been tested and can successfully detect .class files
- [x] The check runs as part of the backend workflow (triggered by push to any branch and scheduled runs)