### PR TITLE
[Fix][Connector-V2][ClickHouse] Fix ThreadLocal memory leak in ClickhouseCatalogUtil

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtil.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtil.java
@@ -55,6 +55,7 @@ public class ClickhouseCatalogUtil extends CatalogUtil {
                     template, database, table, tableSchema, comment, optionsKey);
         } finally {
             pkColumns.clear();
+            PRIMARY_KEY_COLUMNS.remove();
         }
     }
 

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtil.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtil.java
@@ -54,7 +54,6 @@ public class ClickhouseCatalogUtil extends CatalogUtil {
             return super.getCreateTableSql(
                     template, database, table, tableSchema, comment, optionsKey);
         } finally {
-            pkColumns.clear();
             PRIMARY_KEY_COLUMNS.remove();
         }
     }

--- a/seatunnel-connectors-v2/connector-clickhouse/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtilTest.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/util/ClickhouseCatalogUtilTest.java
@@ -18,10 +18,19 @@
 package org.apache.seatunnel.connectors.seatunnel.clickhouse.util;
 
 import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.seatunnel.clickhouse.config.ClickhouseSinkOptions;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -100,5 +109,75 @@ public class ClickhouseCatalogUtilTest {
         assertThrows(
                 NullPointerException.class,
                 () -> ClickhouseCatalogUtil.INSTANCE.columnToConnectorType(null));
+    }
+
+    @Test
+    void testPrimaryKeyColumnShouldNotBeNullable() {
+        // Test that ThreadLocal is properly cleared after getCreateTableSql call
+        Column column = mock(Column.class);
+        when(column.getName()).thenReturn("pk_column");
+        when(column.getSinkType()).thenReturn("String");
+        when(column.isNullable()).thenReturn(true);
+        when(column.getComment()).thenReturn("");
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(column);
+
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .primaryKey(PrimaryKey.of("", Collections.singletonList("pk_column")))
+                        .columns(columns)
+                        .build();
+
+        ClickhouseCatalogUtil.INSTANCE.getCreateTableSql(
+                "CREATE TABLE `${database}`.`${table}` (${rowtype_fields})",
+                "test_db",
+                "test_table",
+                tableSchema,
+                null,
+                ClickhouseSinkOptions.SAVE_MODE_CREATE_TEMPLATE.key());
+
+        // After getCreateTableSql call, ThreadLocal should be cleared
+        // so columnToConnectorType should treat it as NOT a primary key
+        String result = ClickhouseCatalogUtil.INSTANCE.columnToConnectorType(column);
+        assertEquals("`pk_column` Nullable(String) ", result);
+    }
+
+    @Test
+    void testPrimaryKeyColumnWithNullableShouldNotWrapInNullable() {
+        // Test the actual scenario: primary key columns should NOT be wrapped in Nullable
+        // because ClickHouse doesn't allow nullable columns in ORDER BY / PRIMARY KEY
+        String template =
+                "CREATE TABLE `${database}`.`${table}` (\n"
+                        + "    ${rowtype_primary_key},\n"
+                        + "    ${rowtype_fields}\n"
+                        + ") ENGINE = MergeTree()\n"
+                        + "ORDER BY (${rowtype_primary_key})";
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(PhysicalColumn.of("id", BasicType.LONG_TYPE, (Long) null, true, null, ""));
+        columns.add(PhysicalColumn.of("name", BasicType.STRING_TYPE, (Long) null, true, null, ""));
+        columns.add(PhysicalColumn.of("age", BasicType.INT_TYPE, (Long) null, true, null, ""));
+
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .primaryKey(PrimaryKey.of("", Arrays.asList("id", "age")))
+                        .columns(columns)
+                        .build();
+
+        String sql =
+                ClickhouseCatalogUtil.INSTANCE.getCreateTableSql(
+                        template,
+                        "test_db",
+                        "test_table",
+                        tableSchema,
+                        null,
+                        ClickhouseSinkOptions.SAVE_MODE_CREATE_TEMPLATE.key());
+
+        // Primary key columns (id, age) should NOT be wrapped in Nullable
+        assertEquals(true, sql.contains("`id` Int64 "));
+        assertEquals(true, sql.contains("`age` Int32 "));
+        // Non-primary key column (name) should be wrapped in Nullable
+        assertEquals(true, sql.contains("`name` Nullable(String) "));
     }
 }


### PR DESCRIPTION
…

Add PRIMARY_KEY_COLUMNS.remove() in finally block to properly clean up ThreadLocal and prevent memory leak when thread pool reuses threads.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)