### PR TITLE
[Feature] [connector-file] Support file_exists_mode for file sink commit

### DIFF
--- a/docs/en/connector-v2/sink/CosFile.md
+++ b/docs/en/connector-v2/sink/CosFile.md
@@ -47,6 +47,7 @@ To use this connector you need put hadoop-cos-{hadoop.version}-{version}.jar and
 |---------------------------------------|---------|----------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | path                                  | string  | yes      | -                                          |                                                                                                                                                                                 |
 | tmp_path                              | string  | no       | /tmp/seatunnel                             | The result file will write to a tmp path first and then use `mv` to submit tmp dir to target dir. Need a COS dir.                                                               |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | bucket                                | string  | yes      | -                                          |                                                                                                                                                                                 |
 | secret_id                             | string  | yes      | -                                          |                                                                                                                                                                                 |
 | secret_key                            | string  | yes      | -                                          |                                                                                                                                                                                 |
@@ -248,6 +249,16 @@ Support writing Parquet INT96 from a 12-byte field, only valid for parquet files
 
 Only used when file_format_type is json,text,csv,xml.
 The encoding of the file to write. This param will be parsed by `Charset.forName(encoding)`.
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/en/connector-v2/sink/FtpFile.md
+++ b/docs/en/connector-v2/sink/FtpFile.md
@@ -79,6 +79,7 @@ By default, we use 2PC commit to ensure `exactly-once`
 | encoding                              | string  | no       | "UTF-8"                                    | Only used when file_format_type is json,text,csv,xml.                                                                                                                  |
 | schema_save_mode                      | string  | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | Existing dir processing method                                                                                                                                         |
 | data_save_mode                        | string  | no       | APPEND_DATA                                | Existing data processing method                                                                                                                                        |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 
 ### host [string]
 
@@ -278,6 +279,16 @@ Existing data processing method.
 - DROP_DATA: preserve dir and delete data files
 - APPEND_DATA: preserve dir, preserve data files
 - ERROR_WHEN_DATA_EXISTS: when there is data files, an error is reported
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ## Example
 

--- a/docs/en/connector-v2/sink/HdfsFile.md
+++ b/docs/en/connector-v2/sink/HdfsFile.md
@@ -53,6 +53,7 @@ Output data to hdfs file
 | fs.defaultFS                          | string  | yes      | -                                          | Hadoop cluster address. Supports the following formats:<br/>- Standard HDFS: `hdfs://hadoopcluster` or `hdfs://namenode:9000`<br/>- ViewFS (Federated HDFS): `viewfs://mycluster`<br/>See ViewFS configuration example below.                                                                                                                                                                                                                                                            |
 | path                                  | string  | yes      | -                                          | The target dir path is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | tmp_path                              | string  | yes      | /tmp/seatunnel                             | The result file will write to a tmp path first and then use `mv` to submit tmp dir to target dir. Need a hdfs path.                                                                                                                                                                                                                                                                                                                                                                      |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | hdfs_site_path                        | string  | no       | -                                          | The path of `hdfs-site.xml`, used to load ha configuration of namenodes                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | custom_filename                       | boolean | no       | false                                      | Whether you need custom the filename                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | file_name_expression                  | string  | no       | "${transactionId}"                         | Only used when `custom_filename` is `true`.`file_name_expression` describes the file expression which will be created into the `path`. We can add the variable `${now}` or `${uuid}` in the `file_name_expression`, like `test_${uuid}_${now}`,`${now}` represents the current time, and its format can be defined by specifying the option `filename_time_format`.Please note that, If `is_enable_transaction` is `true`, we will auto add `${transactionId}_` in the head of the file. |
@@ -93,6 +94,16 @@ Output data to hdfs file
 ### Tips
 
 > If you use spark/flink, In order to use this connector, You must ensure your spark/flink cluster already integrated hadoop. The tested hadoop version is 2.x. If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you download and install SeaTunnel Engine. You can check the jar package under ${SEATUNNEL_HOME}/lib to confirm this.
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/en/connector-v2/sink/LocalFile.md
+++ b/docs/en/connector-v2/sink/LocalFile.md
@@ -77,6 +77,7 @@ By default, we use 2PC commit to ensure `exactly-once`
 | encoding                              | string  | no       | "UTF-8"                                    | Only used when file_format_type is json,text,csv,xml.                                                                                                                           |
 | schema_save_mode                      | string  | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | Existing dir processing method                                                                                                                                                  |
 | data_save_mode                        | string  | no       | APPEND_DATA                                | Existing data processing method                                                                                                                                                 |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | merge_update_event                    | boolean | no       | false                                      | Only used when file_format_type is canal_json,debezium_json or maxwell_json. When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data |
 
 ### path [string]
@@ -249,6 +250,16 @@ Existing data processing method.
 - DROP_DATA: preserve dir and delete data files
 - APPEND_DATA: preserve dir, preserve data files
 - ERROR_WHEN_DATA_EXISTS: when there is data files, an error is reported
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/en/connector-v2/sink/ObsFile.md
+++ b/docs/en/connector-v2/sink/ObsFile.md
@@ -62,6 +62,7 @@ It only supports hadoop version **2.9.X+**.
 | name                             | type    | required | default                                    | description                                                                                                                                                                     |
 |----------------------------------|---------|----------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | path                             | string  | yes      | -                                          | The target dir path.                                                                                                                                                            |
+| file_exists_mode                 | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. [Tips](#file_exists_mode)                           |
 | bucket                           | string  | yes      | -                                          | The bucket address of obs file system, for example: `obs://obs-bucket-name`.                                                                                                    |
 | access_key                       | string  | yes      | -                                          | The access key of obs file system.                                                                                                                                              |
 | access_secret                    | string  | yes      | -                                          | The access secret of obs file system.                                                                                                                                           |
@@ -151,6 +152,16 @@ Please note that, The final file name will end with the file_format's suffix, th
 > If `is_enable_transaction` is true, we will ensure that data will not be lost or duplicated when it is written to the target directory.
 >
 > Please note that, If `is_enable_transaction` is `true`, we will auto add `${transactionId}_` in the head of the file. Only support `true` now.
+
+#### <span id="file_exists_mode"> file_exists_mode </span>
+
+> When committing a single file, this option controls what happens if the target file already exists:
+>
+> - `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+> - `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+> - `FAIL`: throw an error and fail the job.
+>
+> This option only applies to a single file and does not operate on directories.
 
 #### <span id="batch_size"> batch_size </span>
 

--- a/docs/en/connector-v2/sink/OssFile.md
+++ b/docs/en/connector-v2/sink/OssFile.md
@@ -134,6 +134,7 @@ If write to `csv`, `text`, `json` file type, All column will be string.
 | encoding                              | string  | no       | "UTF-8"                                    | Only used when file_format_type is json,text,csv,xml.                                                                                                                           |
 | schema_save_mode                      | Enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | Before turning on the synchronous task, do different treatment of the target path                                                                                               |
 | data_save_mode                        | Enum    | no       | APPEND_DATA                                | Before opening the synchronous task, the data file in the target path is differently processed                                                                                  |
+| file_exists_mode                      | Enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | merge_update_event                    | boolean | no       | false                                      | Only used when file_format_type is canal_json,debezium_json or maxwell_json. When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data |
 
 ### path [string]
@@ -320,6 +321,16 @@ Option introduction：
 `DROP_DATA`： use the path but delete data files in the path.
 `APPEND_DATA`：use the path, and add new files in the path for write data.   
 `ERROR_WHEN_DATA_EXISTS`：When there are some data files in the path, an error will is reported.
+
+### file_exists_mode [Enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/en/connector-v2/sink/OssJindoFile.md
+++ b/docs/en/connector-v2/sink/OssJindoFile.md
@@ -51,6 +51,7 @@ It only supports hadoop version **2.9.X+**.
 |---------------------------------------|---------|----------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | path                                  | string  | yes      | -                                          |                                                                                                                                                                                 |
 | tmp_path                              | string  | no       | /tmp/seatunnel                             | The result file will write to a tmp path first and then use `mv` to submit tmp dir to target dir. Need a OSS dir.                                                               |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | bucket                                | string  | yes      | -                                          |                                                                                                                                                                                 |
 | access_key                            | string  | yes      | -                                          |                                                                                                                                                                                 |
 | access_secret                         | string  | yes      | -                                          |                                                                                                                                                                                 |
@@ -252,6 +253,16 @@ Support writing Parquet INT96 from a 12-byte field, only valid for parquet files
 
 Only used when file_format_type is json,text,csv,xml.
 The encoding of the file to write. This param will be parsed by `Charset.forName(encoding)`.
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/en/connector-v2/sink/S3File.md
+++ b/docs/en/connector-v2/sink/S3File.md
@@ -142,6 +142,7 @@ If write to `csv`, `text` file type, All column will be string.
 | hadoop_s3_properties                  | map     | no       |                                                       | If you need to add a other option, you could add it here and refer to this [link](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html)                 |
 | schema_save_mode                      | Enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST                          | Before turning on the synchronous task, do different treatment of the target path                                                                                               |
 | data_save_mode                        | Enum    | no       | APPEND_DATA                                           | Before opening the synchronous task, the data file in the target path is differently processed                                                                                  |
+| file_exists_mode                      | Enum    | no       | OVERWRITE                                             | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | enable_header_write                   | boolean | no       | false                                                 | Only used when file_format_type is text,csv.<br/> false:don't write header,true:write header.                                                                                   |
 | encoding                              | string  | no       | "UTF-8"                                               | Only used when file_format_type is json,text,csv,xml.                                                                                                                           |
 | merge_update_event                    | boolean | no       | false                                                 | Only used when file_format_type is canal_json,debezium_json or maxwell_json. When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data |
@@ -320,6 +321,16 @@ Option introduction：
 `DROP_DATA`： use the path but delete data files in the path.
 `APPEND_DATA`：use the path, and add new files in the path for write data.   
 `ERROR_WHEN_DATA_EXISTS`：When there are some data files in the path, an error will is reported.
+
+### file_exists_mode [Enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### encoding [string]
 

--- a/docs/en/connector-v2/sink/SftpFile.md
+++ b/docs/en/connector-v2/sink/SftpFile.md
@@ -80,6 +80,7 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 | encoding                              | string  | no       | "UTF-8"                                    | Only used when file_format_type is json,text,csv,xml.                                                                                                                           |
 | schema_save_mode                      | string  | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | Existing dir processing method                                                                                                                                                  |
 | data_save_mode                        | string  | no       | APPEND_DATA                                | Existing data processing method                                                                                                                                                 |
+| file_exists_mode                      | enum    | no       | OVERWRITE                                  | When committing a single file and the target file already exists, choose the behavior: SKIP / OVERWRITE / FAIL. SKIP will keep the existing target file and delete the temp file. |
 | merge_update_event                    | boolean | no       | false                                      | Only used when file_format_type is canal_json,debezium_json or maxwell_json. When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data |
 
 ### host [string]
@@ -270,6 +271,16 @@ Existing data processing method.
 - DROP_DATA: preserve dir and delete data files
 - APPEND_DATA: preserve dir, preserve data files
 - ERROR_WHEN_DATA_EXISTS: when there is data files, an error is reported
+
+### file_exists_mode [enum]
+
+When committing a single file from `tmp_path` to `path`, this option controls what happens if the target file already exists:
+
+- `OVERWRITE` (default): delete the target file then rename the temp file to the target path.
+- `SKIP`: keep the target file, delete the temp file, and treat the commit as successful.
+- `FAIL`: throw an error and fail the job.
+
+This option only applies to a single file and does not operate on directories.
 
 ### merge_update_event [boolean]
 

--- a/docs/zh/connector-v2/sink/CosFile.md
+++ b/docs/zh/connector-v2/sink/CosFile.md
@@ -47,6 +47,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 |---------------------------------------|---------|----|--------------------------------------------|-----------------------------------------------------------------|
 | path                                  | string  | 是  | -                                          |                                                                 |
 | tmp_path                              | string  | 否  | /tmp/seatunnel                             | 结果文件将首先写入tmp路径，然后使用“mv”将tmp目录提交到目标目录。需要一个COS目录.                 |
+| file_exists_mode                      | enum    | 否  | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 | bucket                                | string  | 是  | -                                          |                                                                 |
 | secret_id                             | string  | 是  | -                                          |                                                                 |
 | secret_key                            | string  | 是  | -                                          |                                                                 |
@@ -242,6 +243,16 @@ Tips: excel 类型不支持任何压缩格式
 
 仅当file_format_type为json、text、csv、xml时使用.
 要写入的文件的编码。此参数将由`Charset.forName(encoding)` 解析.
+
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### merge_update_event [boolean]
 

--- a/docs/zh/connector-v2/sink/FtpFile.md
+++ b/docs/zh/connector-v2/sink/FtpFile.md
@@ -78,6 +78,7 @@ import ChangeLog from '../changelog/connector-file-ftp.md';
 | encoding                              | string  | 否    | "UTF-8"                                    | 仅在 `file_format_type` 为 `json`、`text`、`csv`、`xml` 时使用。                    |
 | schema_save_mode                      | string  | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST               | 现有目录处理方法                                                                  |
 | data_save_mode                        | string  | 否    | APPEND_DATA                                | 现有数据处理方法                                                                  |
+| file_exists_mode                      | enum    | 否    | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 
 ### host [string]
 
@@ -281,6 +282,16 @@ Sink 插件的通用参数，请参考[Sink通用选项](../sink-common-options.
 - DROP_DATA（删除数据）：保留目录，删除数据文件。
 - APPEND_DATA（追加数据）：保留目录和数据文件。
 - ERROR_WHEN_DATA_EXISTS（数据存在时报错）：当存在数据文件时，报告错误。
+
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ## 示例
 

--- a/docs/zh/connector-v2/sink/HdfsFile.md
+++ b/docs/zh/connector-v2/sink/HdfsFile.md
@@ -51,6 +51,7 @@ import ChangeLog from '../changelog/connector-file-hadoop.md';
 | fs.defaultFS                     | string  | 是    | -                                          | Hadoop 集群地址。支持以下格式：<br/>- 标准 HDFS：`hdfs://hadoopcluster` 或 `hdfs://namenode:9000`<br/>- ViewFS（联邦 HDFS）：`viewfs://mycluster`<br/>详见下方 ViewFS 配置示例。                                                                                                                                                      |
 | path                             | string  | 是    | -                                          | 目标目录路径是必需的。                                                                                                                                                                                                                                                                                      |
 | tmp_path                         | string  | 是    | /tmp/seatunnel                             | 结果文件将首先写入临时路径，然后使用 `mv` 命令将临时目录提交到目标目录。需要一个Hdfs路径。                                                                                                                                                                                                                                               |
+| file_exists_mode                 | enum    | 否    | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。                                                                                                                                                                                                                                         |
 | hdfs_site_path                   | string  | 否    | -                                          | `hdfs-site.xml` 的路径，用于加载 namenodes 的 ha 配置。                                                                                                                                                                                                                                                      |
 | custom_filename                  | boolean | 否    | false                                      | 是否需要自定义文件名                                                                                                                                                                                                                                                                                       |
 | file_name_expression             | string  | 否    | "${transactionId}"                         | 仅在 `custom_filename` 为 `true` 时使用。`file_name_expression` 描述将创建到 `path` 中的文件表达式。我们可以在 `file_name_expression` 中添加变量 `${now}` 或 `${uuid}`，例如 `test_${uuid}_${now}`，`${now}` 表示当前时间，其格式可以通过指定选项 `filename_time_format` 来定义。请注意，如果 `is_enable_transaction` 为 `true`，我们将在文件头部自动添加 `${transactionId}_`。 |
@@ -86,6 +87,16 @@ import ChangeLog from '../changelog/connector-file-hadoop.md';
 > 如果您使用 spark/flink，为了使用此连接器，您必须确保您的 spark/flink 集群已经集成了 hadoop。测试过的 hadoop 版本是
 > 2.x。如果您使用 SeaTunnel Engine，则在下载和安装 SeaTunnel Engine 时会自动集成 hadoop
 > jar。您可以检查 `${SEATUNNEL_HOME}/lib` 下的 jar 包来确认这一点。
+
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### merge_update_event [boolean]
 

--- a/docs/zh/connector-v2/sink/LocalFile.md
+++ b/docs/zh/connector-v2/sink/LocalFile.md
@@ -45,6 +45,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
 |---------------------------------------|---------|------|--------------------------------------------|-----------------------------------------------------------------|
 | path                                  | string  | 是    | -                                          | 目标目录路径                                                          |
 | tmp_path                              | string  | 否    | /tmp/seatunnel                             | 结果文件将首先写入临时路径，然后使用 `mv` 将临时目录提交到目标目录。                           |
+| file_exists_mode                      | enum    | 否    | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 | custom_filename                       | boolean | 否    | false                                      | 是否需要自定义文件名                                                      |
 | file_name_expression                  | string  | 否    | "${transactionId}"                         | 仅在 custom_filename 为 true 时使用                                   |
 | filename_time_format                  | string  | 否    | "yyyy.MM.dd"                               | 仅在 custom_filename 为 true 时使用                                   |
@@ -225,6 +226,16 @@ _root_tag [string]
 ### encoding [string]
 
 仅在 file_format_type 为 json,text,csv,xml 时使用。文件写入的编码。该参数将通过 `Charset.forName(encoding)` 解析。
+
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### merge_update_event [boolean]
 

--- a/docs/zh/connector-v2/sink/ObsFile.md
+++ b/docs/zh/connector-v2/sink/ObsFile.md
@@ -62,6 +62,7 @@ import ChangeLog from '../changelog/connector-file-obs.md';
 | 名称                               | 类型      | 是否必填 | 默认值                                        | 描述                                                                      |
 |----------------------------------|---------|------|--------------------------------------------|-------------------------------------------------------------------------|
 | path                             | string  | 是    | -                                          | 目标目录路径。                                                                 |
+| file_exists_mode                 | enum    | 否    | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。[提示](#file_exists_mode) |
 | bucket                           | string  | 是    | -                                          | obs文件系统的bucket地址，例如：`obs://obs-bucket-name`.                            |
 | access_key                       | string  | 是    | -                                          | obs文件系统的访问密钥。                                                           |
 | access_secret                    | string  | 是    | -                                          | obs文件系统的访问私钥。                                                           |
@@ -149,6 +150,16 @@ import ChangeLog from '../changelog/connector-file-obs.md';
 >如果`is_enable_transaction`为`true`，我们将确保数据在写入目标目录时不会丢失或重复。
 >
 >请注意，如果`is_enable_transaction`为`true`，我们将自动添加`${transactionId}_`在文件的开头。现在只支持“true”。
+
+#### <span id="file_exists_mode"> file_exists_mode </span>
+
+>当提交阶段写入单个文件时，如果目标文件已存在，将按如下策略处理：
+>
+> - `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+> - `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+> - `FAIL`：直接抛错，任务失败。
+>
+>该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 #### <span id="batch_size"> batch_size </span>
 

--- a/docs/zh/connector-v2/sink/OssFile.md
+++ b/docs/zh/connector-v2/sink/OssFile.md
@@ -134,6 +134,7 @@ import ChangeLog from '../changelog/connector-file-oss.md';
 | encoding                              | string  | 否  | "UTF-8"                                    | 仅当file_format_type为json、text、csv、xml时使用。                          |
 | schema_save_mode                      | Enum    | 否  | CREATE_SCHEMA_WHEN_NOT_EXIST               | 在开启同步任务之前，对目标路径进行不同的处理                                            |
 | data_save_mode                        | Enum    | 否  | APPEND_DATA                                | 在开启同步任务之前，对目标路径中的数据文件进行不同的处理                                      |
+| file_exists_mode                      | Enum    | 否  | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 | merge_update_event                    | boolean | 否  | false                                      | 仅当file_format_type为canal_json、debezium_json、maxwell_json.         |
 
 ### path [string]
@@ -315,6 +316,16 @@ Sink插件常用参数，请参考[Sink common Options]（../Sink common Options
 `DROP_DATA`：使用路径但删除路径中的数据文件。
 `APPEND_DATA`：使用路径，并在路径中添加新文件以写入数据。   
 `ERROR_WHEN_DATA_EXISTS`：当路径中存在数据文件时，将报错。
+
+### file_exists_mode [Enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### merge_update_event [boolean]
 

--- a/docs/zh/connector-v2/sink/OssJindoFile.md
+++ b/docs/zh/connector-v2/sink/OssJindoFile.md
@@ -50,6 +50,7 @@ import ChangeLog from '../changelog/connector-file-oss-jindo.md';
 |---------------------------------------|---------|----|--------------------------------------------|-----------------------------------------------------------|
 | path                                  | string  | 是  | -                                          |                                                           |
 | tmp_path                              | string  | 否  | /tmp/seatunnel                             | 结果文件将首先写入临时路径，然后使用`mv`将tmp-dir提交到目标目录。需要一个OSS 目录。         |
+| file_exists_mode                      | enum    | 否  | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 | bucket                                | string  | 是  | -                                          |                                                           |
 | access_key                            | string  | 是  | -                                          |                                                           |
 | access_secret                         | string  | 是  | -                                          |                                                           |
@@ -245,6 +246,16 @@ Sink插件常用参数，请参考[Sink common Options]（../sink-common-options
 
 仅当file_format_type为json、text、csv、xml时使用。
 要写入的文件的编码。此参数将由`Charset.forName(encoding)`解析。
+
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 
 ### merge_update_event [boolean]

--- a/docs/zh/connector-v2/sink/S3File.md
+++ b/docs/zh/connector-v2/sink/S3File.md
@@ -139,6 +139,7 @@ import ChangeLog from '../changelog/connector-file-s3.md';
 | hadoop_s3_properties                  | map     | 否    |                                                       | 如果您需要添加其他选项，可以在此处添加，并参考此[链接](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html)                          |
 | schema_save_mode                      | Enum    | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST                          | 在开启同步任务之前，对目标路径进行不同的处理                                                                                                              |
 | data_save_mode                        | Enum    | 否    | APPEND_DATA                                           | 在开启同步任务之前，对目标路径中的数据文件进行不同的处理                                                                                                        |
+| file_exists_mode                      | Enum    | 否    | OVERWRITE                                             | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。                                                        |
 | enable_header_write                   | boolean | 否    | false                                                 | 仅当 file_format_type 为 text,csv 时使用。<br/> false: 不写入表头, true: 写入表头。                                                                  |
 | encoding                              | string  | 否    | "UTF-8"                                               | 仅当 file_format_type 为 json,text,csv,xml 时使用。                                                                                        |
 | merge_update_event                    | boolean | 否    | false                                                 | 仅当file_format_type为canal_json、debezium_json、maxwell_json.                                                                           |
@@ -313,6 +314,16 @@ Sink 插件通用参数，请参考 [Sink 通用选项](../sink-common-options.m
 `DROP_DATA`：使用路径但删除路径中的数据文件。
 `APPEND_DATA`：使用路径，并在路径中添加新文件以写入数据。   
 `ERROR_WHEN_DATA_EXISTS`：当路径中存在数据文件时，将报错。
+
+### file_exists_mode [Enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### encoding [string]
 

--- a/docs/zh/connector-v2/sink/SftpFile.md
+++ b/docs/zh/connector-v2/sink/SftpFile.md
@@ -77,6 +77,7 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 | encoding                              | string  | 否    | "UTF-8"                                    | 仅当file_format_type为json、text、csv、xml时使用。                  |
 | schema_save_mode                      | string  | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST               | 现有目录处理方式                                                  |
 | data_save_mode                        | string  | 否    | APPEND_DATA                                | 现有数据处理方式                                                  |
+| file_exists_mode                      | enum    | 否    | OVERWRITE                                  | 提交阶段（临时文件重命名到目标文件）当目标文件已存在时的处理策略：SKIP / OVERWRITE / FAIL。SKIP 会保留目标文件并删除临时文件。 |
 | merge_update_event                    | boolean | 否    | false                                      | 仅当file_format_type为canal_json、debezium_json、maxwell_json. |
 
 ### host [string]
@@ -262,6 +263,15 @@ Sink插件常用参数，请参考[Sink common Options]（../sink-common-options
 -APPEND_DATA：保留目录，保留数据文件
 -ERROR_WHEN_DATA_EXISTS：当有数据文件时，会报告错误
 
+### file_exists_mode [enum]
+
+当提交阶段将 `tmp_path` 下的临时文件移动/重命名到 `path` 时，如果目标文件已存在，将按如下策略处理：
+
+- `OVERWRITE`（默认）：删除目标文件，再将临时文件重命名到目标路径。
+- `SKIP`：保留目标文件，删除临时文件，并认为本次提交成功（避免重复写/避免 tmp 堆积）。
+- `FAIL`：直接抛错，任务失败。
+
+该参数仅针对单个文件生效，不对目录进行覆盖/删除操作。
 
 ### merge_update_event [boolean]
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/config/FileBaseSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/config/FileBaseSinkOptions.java
@@ -305,6 +305,16 @@ public class FileBaseSinkOptions extends FileBaseOptions {
                     .withDescription(
                             "Before the synchronization task begins, different processing of data files that already exist in the directory");
 
+    public static final Option<FileExistsMode> FILE_EXISTS_MODE =
+            Options.key("file_exists_mode")
+                    .enumType(FileExistsMode.class)
+                    .defaultValue(FileExistsMode.OVERWRITE)
+                    .withDescription(
+                            "When committing a single file to the target path and the target file already exists, choose how to handle it. "
+                                    + "OVERWRITE (default): overwrite the target file. "
+                                    + "SKIP: skip writing and keep the existing target file. "
+                                    + "FAIL: fail the job.");
+
     public static final Option<CsvStringQuoteMode> CSV_STRING_QUOTE_MODE =
             Options.key("csv_string_quote_mode")
                     .enumType(CsvStringQuoteMode.class)

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/config/FileExistsMode.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/config/FileExistsMode.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.file.config;
+
+/**
+ * Behavior when a target file already exists during commit (e.g. moving/renaming a temp file to the
+ * final path).
+ */
+public enum FileExistsMode {
+    /** Skip writing the file when the target already exists. */
+    SKIP,
+    /** Overwrite the target file when it already exists. */
+    OVERWRITE,
+    /** Fail the job when the target file already exists. */
+    FAIL
+}

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxy.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
 
 import org.apache.hadoop.conf.Configuration;
@@ -97,6 +98,14 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
             @NonNull String newFilePath,
             boolean removeWhenNewFilePathExist)
             throws IOException {
+        FileExistsMode fileExistsMode =
+                removeWhenNewFilePathExist ? FileExistsMode.OVERWRITE : FileExistsMode.FAIL;
+        renameFile(oldFilePath, newFilePath, fileExistsMode);
+    }
+
+    public void renameFile(
+            @NonNull String oldFilePath, @NonNull String newFilePath, @NonNull FileExistsMode mode)
+            throws IOException {
         execute(
                 () -> {
                     Path oldPath = new Path(oldFilePath);
@@ -112,10 +121,50 @@ public class HadoopFileSystemProxy implements Serializable, Closeable {
                         return Void.class;
                     }
 
-                    if (removeWhenNewFilePathExist) {
-                        if (fileExist(newFilePath)) {
-                            getFileSystem().delete(newPath, true);
-                            log.info("Delete already file: {}", newPath);
+                    if (fileExist(newFilePath)) {
+                        if (!isFile(newFilePath)) {
+                            throw CommonError.fileOperationFailed(
+                                    "SeaTunnel",
+                                    "rename",
+                                    oldFilePath
+                                            + " -> "
+                                            + newFilePath
+                                            + " failed, target path exists but is not a file");
+                        }
+                        switch (mode) {
+                            case OVERWRITE:
+                                if (!getFileSystem().delete(newPath, true)) {
+                                    throw CommonError.fileOperationFailed(
+                                            "SeaTunnel",
+                                            "delete",
+                                            newFilePath + " failed, can not overwrite target file");
+                                }
+                                log.info("Delete already file: {}", newPath);
+                                break;
+                            case SKIP:
+                                if (!getFileSystem().delete(oldPath, true)) {
+                                    throw CommonError.fileOperationFailed(
+                                            "SeaTunnel",
+                                            "delete",
+                                            oldFilePath
+                                                    + " failed, can not remove temp file when skipping");
+                                }
+                                log.info(
+                                        "Target file already exists, skip rename file :[{}] to [{}]",
+                                        oldPath,
+                                        newPath);
+                                return Void.class;
+                            case FAIL:
+                                throw CommonError.fileOperationFailed(
+                                        "SeaTunnel",
+                                        "rename",
+                                        oldFilePath
+                                                + " -> "
+                                                + newFilePath
+                                                + " failed, target file already exists");
+                            default:
+                                throw new IllegalArgumentException(
+                                        "Unknown FileExistsMode: " + mode);
                         }
                     }
                     if (!fileExist(newPath.getParent().toString())) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseFileSink.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseFileSink.java
@@ -90,7 +90,8 @@ public abstract class BaseFileSink
     @Override
     public Optional<SinkAggregatedCommitter<FileCommitInfo, FileAggregatedCommitInfo>>
             createAggregatedCommitter() {
-        return Optional.of(new FileSinkAggregatedCommitter(hadoopConf));
+        return Optional.of(
+                new FileSinkAggregatedCommitter(hadoopConf, fileSinkConfig.getFileExistsMode()));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseFileSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseFileSinkWriter.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
 import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.file.hadoop.HadoopFileSystemProxy;
@@ -75,8 +76,10 @@ public class BaseFileSinkWriter
             try {
                 List<String> transactions =
                         findTransactionList(jobId, uuidPrefix, hadoopFileSystemProxy);
+                FileExistsMode fileExistsMode =
+                        writeStrategy.getFileSinkConfig().getFileExistsMode();
                 FileSinkAggregatedCommitter fileSinkAggregatedCommitter =
-                        new FileSinkAggregatedCommitter(hadoopConf);
+                        new FileSinkAggregatedCommitter(hadoopConf, fileExistsMode);
                 fileSinkAggregatedCommitter.init();
                 LinkedHashMap<String, FileSinkState> fileStatesMap = new LinkedHashMap<>();
                 fileSinkStates.forEach(

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseMultipleTableFileSink.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/BaseMultipleTableFileSink.java
@@ -97,7 +97,8 @@ public abstract class BaseMultipleTableFileSink
     @Override
     public Optional<SinkAggregatedCommitter<FileCommitInfo, FileAggregatedCommitInfo>>
             createAggregatedCommitter() {
-        return Optional.of(new FileSinkAggregatedCommitter(hadoopConf));
+        return Optional.of(
+                new FileSinkAggregatedCommitter(hadoopConf, fileSinkConfig.getFileExistsMode()));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
@@ -55,30 +55,35 @@ public class FileSinkAggregatedCommitter
     public List<FileAggregatedCommitInfo> commit(
             List<FileAggregatedCommitInfo> aggregatedCommitInfos) throws IOException {
         List<FileAggregatedCommitInfo> errorAggregatedCommitInfoList = new ArrayList<>();
-        aggregatedCommitInfos.forEach(
-                aggregatedCommitInfo -> {
-                    try {
-                        for (Map.Entry<String, LinkedHashMap<String, String>> entry :
-                                aggregatedCommitInfo.getTransactionMap().entrySet()) {
-                            for (Map.Entry<String, String> mvFileEntry :
-                                    entry.getValue().entrySet()) {
-                                // first rename temp file
-                                hadoopFileSystemProxy.renameFile(
-                                        mvFileEntry.getKey(),
-                                        mvFileEntry.getValue(),
-                                        fileExistsMode);
-                            }
-                            // second delete transaction directory
-                            hadoopFileSystemProxy.deleteFile(entry.getKey());
-                        }
-                    } catch (Throwable e) {
-                        log.error(
-                                "commit aggregatedCommitInfo error, aggregatedCommitInfo = {} ",
-                                aggregatedCommitInfo,
-                                e);
-                        errorAggregatedCommitInfoList.add(aggregatedCommitInfo);
+        for (FileAggregatedCommitInfo aggregatedCommitInfo : aggregatedCommitInfos) {
+            try {
+                for (Map.Entry<String, LinkedHashMap<String, String>> entry :
+                        aggregatedCommitInfo.getTransactionMap().entrySet()) {
+                    for (Map.Entry<String, String> mvFileEntry : entry.getValue().entrySet()) {
+                        // first rename temp file
+                        hadoopFileSystemProxy.renameFile(
+                                mvFileEntry.getKey(), mvFileEntry.getValue(), fileExistsMode);
                     }
-                });
+                    // second delete transaction directory
+                    hadoopFileSystemProxy.deleteFile(entry.getKey());
+                }
+            } catch (Throwable e) {
+                log.error(
+                        "commit aggregatedCommitInfo error, aggregatedCommitInfo = {} ",
+                        aggregatedCommitInfo,
+                        e);
+                if (FileExistsMode.FAIL.equals(fileExistsMode)) {
+                    if (e instanceof IOException) {
+                        throw (IOException) e;
+                    }
+                    throw new IOException(
+                            "commit aggregatedCommitInfo failed, aggregatedCommitInfo = "
+                                    + aggregatedCommitInfo,
+                            e);
+                }
+                errorAggregatedCommitInfoList.add(aggregatedCommitInfo);
+            }
+        }
         return errorAggregatedCommitInfoList;
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.file.sink.commit;
 
 import org.apache.seatunnel.api.sink.SinkAggregatedCommitter;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
 import org.apache.seatunnel.connectors.seatunnel.file.hadoop.HadoopFileSystemProxy;
 
@@ -34,9 +35,15 @@ public class FileSinkAggregatedCommitter
         implements SinkAggregatedCommitter<FileCommitInfo, FileAggregatedCommitInfo> {
     protected HadoopFileSystemProxy hadoopFileSystemProxy;
     private final HadoopConf hadoopConf;
+    private final FileExistsMode fileExistsMode;
 
     public FileSinkAggregatedCommitter(HadoopConf hadoopConf) {
+        this(hadoopConf, FileExistsMode.OVERWRITE);
+    }
+
+    public FileSinkAggregatedCommitter(HadoopConf hadoopConf, FileExistsMode fileExistsMode) {
         this.hadoopConf = hadoopConf;
+        this.fileExistsMode = fileExistsMode == null ? FileExistsMode.OVERWRITE : fileExistsMode;
     }
 
     @Override
@@ -57,7 +64,9 @@ public class FileSinkAggregatedCommitter
                                     entry.getValue().entrySet()) {
                                 // first rename temp file
                                 hadoopFileSystemProxy.renameFile(
-                                        mvFileEntry.getKey(), mvFileEntry.getValue(), true);
+                                        mvFileEntry.getKey(),
+                                        mvFileEntry.getValue(),
+                                        fileExistsMode);
                             }
                             // second delete transaction directory
                             hadoopFileSystemProxy.deleteFile(entry.getKey());

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/config/FileSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/config/FileSinkConfig.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.file.config.BaseFileSinkConfig;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileFormat;
 import org.apache.seatunnel.connectors.seatunnel.file.config.PartitionConfig;
 import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -62,6 +64,8 @@ public class FileSinkConfig extends BaseFileSinkConfig implements PartitionConfi
     private String fileNameTimeFormat = FileBaseSinkOptions.FILENAME_TIME_FORMAT.defaultValue();
 
     private boolean isEnableTransaction = FileBaseSinkOptions.IS_ENABLE_TRANSACTION.defaultValue();
+
+    private FileExistsMode fileExistsMode = FileBaseSinkOptions.FILE_EXISTS_MODE.defaultValue();
 
     private String encoding = FileBaseSinkOptions.ENCODING.defaultValue();
 
@@ -144,6 +148,13 @@ public class FileSinkConfig extends BaseFileSinkConfig implements PartitionConfi
         if (config.hasPath(FileBaseSinkOptions.IS_ENABLE_TRANSACTION.key())) {
             this.isEnableTransaction =
                     config.getBoolean(FileBaseSinkOptions.IS_ENABLE_TRANSACTION.key());
+        }
+
+        if (config.hasPath(FileBaseSinkOptions.FILE_EXISTS_MODE.key())) {
+            this.fileExistsMode =
+                    FileExistsMode.valueOf(
+                            config.getString(FileBaseSinkOptions.FILE_EXISTS_MODE.key())
+                                    .toUpperCase(Locale.ROOT));
         }
 
         if (config.hasPath(FileBaseSinkOptions.ENCODING.key())) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyRenameFileTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/HadoopFileSystemProxyRenameFileTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.file.hadoop;
+
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
+import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@DisabledOnOs(OS.WINDOWS)
+class HadoopFileSystemProxyRenameFileTest {
+
+    @TempDir private Path tempDir;
+
+    @Test
+    void testRenameOverwriteWhenTargetExists() throws Exception {
+        Path oldFile = tempDir.resolve("old.txt");
+        Path newFile = tempDir.resolve("new.txt");
+        Files.write(oldFile, "old".getBytes(StandardCharsets.UTF_8));
+        Files.write(newFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        try (HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(new HadoopConf("file:///"))) {
+            proxy.renameFile(
+                    oldFile.toUri().toString(),
+                    newFile.toUri().toString(),
+                    FileExistsMode.OVERWRITE);
+        }
+
+        Assertions.assertFalse(Files.exists(oldFile));
+        Assertions.assertEquals(
+                "old", new String(Files.readAllBytes(newFile), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testRenameSkipDeletesTempFileWhenTargetExists() throws Exception {
+        Path oldFile = tempDir.resolve("old.txt");
+        Path newFile = tempDir.resolve("new.txt");
+        Files.write(oldFile, "new".getBytes(StandardCharsets.UTF_8));
+        Files.write(newFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        try (HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(new HadoopConf("file:///"))) {
+            proxy.renameFile(
+                    oldFile.toUri().toString(), newFile.toUri().toString(), FileExistsMode.SKIP);
+        }
+
+        Assertions.assertFalse(Files.exists(oldFile));
+        Assertions.assertEquals(
+                "existing", new String(Files.readAllBytes(newFile), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testRenameFailWhenTargetExists() throws Exception {
+        Path oldFile = tempDir.resolve("old.txt");
+        Path newFile = tempDir.resolve("new.txt");
+        Files.write(oldFile, "new".getBytes(StandardCharsets.UTF_8));
+        Files.write(newFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        try (HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(new HadoopConf("file:///"))) {
+            Assertions.assertThrows(
+                    SeaTunnelRuntimeException.class,
+                    () ->
+                            proxy.renameFile(
+                                    oldFile.toUri().toString(),
+                                    newFile.toUri().toString(),
+                                    FileExistsMode.FAIL));
+        }
+
+        Assertions.assertTrue(Files.exists(oldFile));
+        Assertions.assertEquals(
+                "existing", new String(Files.readAllBytes(newFile), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testRenameTargetExistsButIsDirectory() throws Exception {
+        Path oldFile = tempDir.resolve("old.txt");
+        Path targetDir = tempDir.resolve("targetDir");
+        Files.createDirectories(targetDir);
+        Files.write(oldFile, "new".getBytes(StandardCharsets.UTF_8));
+
+        try (HadoopFileSystemProxy proxy = new HadoopFileSystemProxy(new HadoopConf("file:///"))) {
+            Assertions.assertThrows(
+                    SeaTunnelRuntimeException.class,
+                    () ->
+                            proxy.renameFile(
+                                    oldFile.toUri().toString(),
+                                    targetDir.toUri().toString(),
+                                    FileExistsMode.OVERWRITE));
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitterFileExistsModeTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitterFileExistsModeTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.file.sink.commit;
+
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileExistsMode;
+import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+@DisabledOnOs(OS.WINDOWS)
+class FileSinkAggregatedCommitterFileExistsModeTest {
+
+    @TempDir private Path tempDir;
+
+    @Test
+    void testCommitOverwriteWhenTargetExists() throws Exception {
+        Path transactionDir = tempDir.resolve("txn");
+        Files.createDirectories(transactionDir);
+        Path tempFile = transactionDir.resolve("tmp.txt");
+        Files.write(tempFile, "new".getBytes(StandardCharsets.UTF_8));
+
+        Path targetDir = tempDir.resolve("target");
+        Files.createDirectories(targetDir);
+        Path targetFile = targetDir.resolve("out.txt");
+        Files.write(targetFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        FileAggregatedCommitInfo commitInfo = buildCommitInfo(transactionDir, tempFile, targetFile);
+        FileSinkAggregatedCommitter committer =
+                new FileSinkAggregatedCommitter(
+                        new HadoopConf("file:///"), FileExistsMode.OVERWRITE);
+        committer.init();
+        try {
+            List<FileAggregatedCommitInfo> errors =
+                    committer.commit(Collections.singletonList(commitInfo));
+            Assertions.assertTrue(errors.isEmpty());
+        } finally {
+            committer.close();
+        }
+
+        Assertions.assertFalse(Files.exists(tempFile));
+        Assertions.assertFalse(Files.exists(transactionDir));
+        Assertions.assertEquals(
+                "new", new String(Files.readAllBytes(targetFile), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testCommitSkipDeletesTempFileWhenTargetExists() throws Exception {
+        Path transactionDir = tempDir.resolve("txn");
+        Files.createDirectories(transactionDir);
+        Path tempFile = transactionDir.resolve("tmp.txt");
+        Files.write(tempFile, "new".getBytes(StandardCharsets.UTF_8));
+
+        Path targetDir = tempDir.resolve("target");
+        Files.createDirectories(targetDir);
+        Path targetFile = targetDir.resolve("out.txt");
+        Files.write(targetFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        FileAggregatedCommitInfo commitInfo = buildCommitInfo(transactionDir, tempFile, targetFile);
+        FileSinkAggregatedCommitter committer =
+                new FileSinkAggregatedCommitter(new HadoopConf("file:///"), FileExistsMode.SKIP);
+        committer.init();
+        try {
+            List<FileAggregatedCommitInfo> errors =
+                    committer.commit(Collections.singletonList(commitInfo));
+            Assertions.assertTrue(errors.isEmpty());
+        } finally {
+            committer.close();
+        }
+
+        Assertions.assertFalse(Files.exists(tempFile));
+        Assertions.assertFalse(Files.exists(transactionDir));
+        Assertions.assertEquals(
+                "existing", new String(Files.readAllBytes(targetFile), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testCommitFailWhenTargetExists() throws Exception {
+        Path transactionDir = tempDir.resolve("txn");
+        Files.createDirectories(transactionDir);
+        Path tempFile = transactionDir.resolve("tmp.txt");
+        Files.write(tempFile, "new".getBytes(StandardCharsets.UTF_8));
+
+        Path targetDir = tempDir.resolve("target");
+        Files.createDirectories(targetDir);
+        Path targetFile = targetDir.resolve("out.txt");
+        Files.write(targetFile, "existing".getBytes(StandardCharsets.UTF_8));
+
+        FileAggregatedCommitInfo commitInfo = buildCommitInfo(transactionDir, tempFile, targetFile);
+        FileSinkAggregatedCommitter committer =
+                new FileSinkAggregatedCommitter(new HadoopConf("file:///"), FileExistsMode.FAIL);
+        committer.init();
+        try {
+            List<FileAggregatedCommitInfo> errors =
+                    committer.commit(Collections.singletonList(commitInfo));
+            Assertions.assertEquals(1, errors.size());
+        } finally {
+            committer.close();
+        }
+
+        Assertions.assertTrue(Files.exists(tempFile));
+        Assertions.assertTrue(Files.exists(transactionDir));
+        Assertions.assertEquals(
+                "existing", new String(Files.readAllBytes(targetFile), StandardCharsets.UTF_8));
+    }
+
+    private FileAggregatedCommitInfo buildCommitInfo(
+            Path transactionDir, Path tempFile, Path targetFile) {
+        LinkedHashMap<String, String> needMoveFiles = new LinkedHashMap<>();
+        needMoveFiles.put(tempFile.toUri().toString(), targetFile.toUri().toString());
+
+        LinkedHashMap<String, LinkedHashMap<String, String>> transactionMap = new LinkedHashMap<>();
+        transactionMap.put(transactionDir.toUri().toString(), needMoveFiles);
+        return new FileAggregatedCommitInfo(transactionMap, new LinkedHashMap<>());
+    }
+}

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitterFileExistsModeTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitterFileExistsModeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -116,9 +117,9 @@ class FileSinkAggregatedCommitterFileExistsModeTest {
                 new FileSinkAggregatedCommitter(new HadoopConf("file:///"), FileExistsMode.FAIL);
         committer.init();
         try {
-            List<FileAggregatedCommitInfo> errors =
-                    committer.commit(Collections.singletonList(commitInfo));
-            Assertions.assertEquals(1, errors.size());
+            Assertions.assertThrows(
+                    IOException.class,
+                    () -> committer.commit(Collections.singletonList(commitInfo)));
         } finally {
             committer.close();
         }

--- a/seatunnel-connectors-v2/connector-file/connector-file-cos/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/cos/sink/CosFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-cos/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/cos/sink/CosFileSinkFactory.java
@@ -108,6 +108,7 @@ public class CosFileSinkFactory implements TableSinkFactory {
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/sink/FtpFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/sink/FtpFileSinkFactory.java
@@ -56,6 +56,7 @@ public class FtpFileSinkFactory extends BaseMultipleTableFileSinkFactory {
                 .required(FtpFileSinkOptions.FTP_PASSWORD)
                 .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .optional(FileBaseSinkOptions.FILE_FORMAT_TYPE)
                 .optional(FileBaseSinkOptions.SCHEMA_SAVE_MODE)
                 .optional(FileBaseSinkOptions.DATA_SAVE_MODE)

--- a/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/sink/HdfsFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/sink/HdfsFileSinkFactory.java
@@ -129,6 +129,7 @@ public class HdfsFileSinkFactory extends BaseMultipleTableFileSinkFactory {
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-jindo-oss/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/oss/jindo/sink/OssFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-jindo-oss/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/oss/jindo/sink/OssFileSinkFactory.java
@@ -108,6 +108,7 @@ public class OssFileSinkFactory implements TableSinkFactory {
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-local/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/local/sink/LocalFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-local/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/local/sink/LocalFileSinkFactory.java
@@ -114,6 +114,7 @@ public class LocalFileSinkFactory extends BaseMultipleTableFileSinkFactory {
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-obs/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/obs/sink/ObsFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-obs/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/obs/sink/ObsFileSinkFactory.java
@@ -90,6 +90,7 @@ public class ObsFileSinkFactory implements TableSinkFactory {
                 .optional(FileBaseSinkOptions.BATCH_SIZE)
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-oss/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/oss/sink/OssFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-oss/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/oss/sink/OssFileSinkFactory.java
@@ -123,6 +123,7 @@ public class OssFileSinkFactory extends BaseMultipleTableFileSinkFactory {
                 .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/sink/S3FileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/sink/S3FileSinkFactory.java
@@ -120,6 +120,7 @@ public class S3FileSinkFactory implements TableSinkFactory {
                 .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/sink/SftpFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/sink/SftpFileSinkFactory.java
@@ -119,6 +119,7 @@ public class SftpFileSinkFactory extends BaseMultipleTableFileSinkFactory {
                 .optional(FileBaseSinkOptions.CREATE_EMPTY_FILE_WHEN_NO_DATA)
                 .optional(FileBaseSinkOptions.FILENAME_EXTENSION)
                 .optional(FileBaseSinkOptions.TMP_PATH)
+                .optional(FileBaseSinkOptions.FILE_EXISTS_MODE)
                 .build();
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/hdfs/HdfsFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/hdfs/HdfsFileIT.java
@@ -128,4 +128,41 @@ public class HdfsFileIT extends TestSuiteBase implements TestResource {
                 container.executeJob("/hdfs_normal_to_assert.conf");
         Assertions.assertEquals(0, readResult.getExitCode());
     }
+
+    @TestTemplate
+    public void testHdfsWriteWithFileExistsModeSkip(TestContainer container)
+            throws IOException, InterruptedException {
+        org.testcontainers.containers.Container.ExecResult firstWriteResult =
+                container.executeJob("/fake_to_hdfs_file_exists_mode_skip_prepare.conf");
+        Assertions.assertEquals(0, firstWriteResult.getExitCode());
+
+        String targetFile = "/exists_mode/skip/output/file_exists_mode_0.txt";
+        org.testcontainers.containers.Container.ExecResult sizeBeforeResult =
+                nameNode.execInContainer("hdfs", "dfs", "-stat", "%b", targetFile);
+        Assertions.assertEquals(0, sizeBeforeResult.getExitCode());
+        String sizeBefore = sizeBeforeResult.getStdout().trim();
+
+        org.testcontainers.containers.Container.ExecResult secondWriteResult =
+                container.executeJob("/fake_to_hdfs_file_exists_mode_skip.conf");
+        Assertions.assertEquals(0, secondWriteResult.getExitCode());
+
+        org.testcontainers.containers.Container.ExecResult sizeAfterResult =
+                nameNode.execInContainer("hdfs", "dfs", "-stat", "%b", targetFile);
+        Assertions.assertEquals(0, sizeAfterResult.getExitCode());
+        String sizeAfter = sizeAfterResult.getStdout().trim();
+
+        Assertions.assertEquals(sizeBefore, sizeAfter);
+    }
+
+    @TestTemplate
+    public void testHdfsWriteWithFileExistsModeFail(TestContainer container)
+            throws IOException, InterruptedException {
+        org.testcontainers.containers.Container.ExecResult firstWriteResult =
+                container.executeJob("/fake_to_hdfs_file_exists_mode_fail_prepare.conf");
+        Assertions.assertEquals(0, firstWriteResult.getExitCode());
+
+        org.testcontainers.containers.Container.ExecResult secondWriteResult =
+                container.executeJob("/fake_to_hdfs_file_exists_mode_fail.conf");
+        Assertions.assertNotEquals(0, secondWriteResult.getExitCode());
+    }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail.conf
@@ -18,6 +18,7 @@
 env {
   parallelism = 1
   job.mode = "BATCH"
+  flink.restart-strategy = "none"
 }
 
 source {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 200
+    schema = {
+      fields {
+        c_string = string
+        c_int = int
+      }
+    }
+  }
+}
+
+sink {
+  HdfsFile {
+    fs.defaultFS = "hdfs://namenode1:9000"
+    path = "/exists_mode/fail/output"
+    tmp_path = "/exists_mode/fail/tmp"
+
+    file_format_type = "text"
+    row_delimiter = "\n"
+    field_delimiter = ","
+    compress_codec = "none"
+    enable_header_write = false
+
+    custom_filename = true
+    file_name_expression = "file_exists_mode"
+    is_enable_transaction = false
+    file_exists_mode = "FAIL"
+
+    hadoop_conf = {
+      "dfs.replication" = 1
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail_prepare.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_fail_prepare.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 100
+    schema = {
+      fields {
+        c_string = string
+        c_int = int
+      }
+    }
+  }
+}
+
+sink {
+  HdfsFile {
+    fs.defaultFS = "hdfs://namenode1:9000"
+    path = "/exists_mode/fail/output"
+    tmp_path = "/exists_mode/fail/tmp"
+
+    file_format_type = "text"
+    row_delimiter = "\n"
+    field_delimiter = ","
+    compress_codec = "none"
+    enable_header_write = false
+
+    custom_filename = true
+    file_name_expression = "file_exists_mode"
+    is_enable_transaction = false
+    file_exists_mode = "OVERWRITE"
+
+    hadoop_conf = {
+      "dfs.replication" = 1
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_skip.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_skip.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 200
+    schema = {
+      fields {
+        c_string = string
+        c_int = int
+      }
+    }
+  }
+}
+
+sink {
+  HdfsFile {
+    fs.defaultFS = "hdfs://namenode1:9000"
+    path = "/exists_mode/skip/output"
+    tmp_path = "/exists_mode/skip/tmp"
+
+    file_format_type = "text"
+    row_delimiter = "\n"
+    field_delimiter = ","
+    compress_codec = "none"
+    enable_header_write = false
+
+    custom_filename = true
+    file_name_expression = "file_exists_mode"
+    is_enable_transaction = false
+    file_exists_mode = "SKIP"
+
+    hadoop_conf = {
+      "dfs.replication" = 1
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_skip_prepare.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-hadoop-e2e/src/test/resources/fake_to_hdfs_file_exists_mode_skip_prepare.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 100
+    schema = {
+      fields {
+        c_string = string
+        c_int = int
+      }
+    }
+  }
+}
+
+sink {
+  HdfsFile {
+    fs.defaultFS = "hdfs://namenode1:9000"
+    path = "/exists_mode/skip/output"
+    tmp_path = "/exists_mode/skip/tmp"
+
+    file_format_type = "text"
+    row_delimiter = "\n"
+    field_delimiter = ","
+    compress_codec = "none"
+    enable_header_write = false
+
+    custom_filename = true
+    file_name_expression = "file_exists_mode"
+    is_enable_transaction = false
+    file_exists_mode = "OVERWRITE"
+
+    hadoop_conf = {
+      "dfs.replication" = 1
+    }
+  }
+}
+


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This PR introduces a new sink option `file_exists_mode` for File connectors to control what happens when the target file already exists during commit (rename temp -> target): `OVERWRITE` (default) / `SKIP` / `FAIL`. It also ensures `FAIL` mode fails the job on commit, updates the EN/ZH docs, and adds unit + HDFS E2E coverage

### Does this PR introduce _any_ user-facing change?
Yes. New optional config `file_exists_mode` (default `OVERWRITE`, so behavior is unchanged unless configured).
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

- Unit tests: `HadoopFileSystemProxyRenameFileTest`, `FileSinkAggregatedCommitterFileExistsModeTest`
- E2E: `HdfsFileIT` with `fake_to_hdfs_file_exists_mode_*` configs

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [*] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)