### PR TITLE
[Improve][e2e] Increase timeout for DatabendCDCSinkIT to reduce test flakiness

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
@@ -63,7 +63,6 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
     private static final int PORT = 8000;
     private static final int LOCAL_PORT = 8000;
     private static final String DATABASE = "default";
-    private static final String SINK_TABLE = "sink_table";
     private DatabendContainer container;
     private GenericContainer<?> minioContainer;
     private Connection connection;
@@ -76,7 +75,7 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
 
         Awaitility.await()
-                .atMost(120, TimeUnit.SECONDS)
+                .atMost(150, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(
@@ -287,9 +286,7 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
         }
     }
 
-    private void initConnection()
-            throws SQLException, ClassNotFoundException, InstantiationException,
-                    IllegalAccessException {
+    private void initConnection() throws SQLException {
         final Properties info = new Properties();
         info.put("user", "root"); // Default Databend user
         info.put("password", ""); // Default Databend password is empty

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
@@ -75,7 +75,7 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
 
         Awaitility.await()
-                .atMost(150, TimeUnit.SECONDS)
+                .atMost(180, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(


### PR DESCRIPTION
### Purpose of this pull request

```
[ERROR]   DatabendCDCSinkIT.testDatabendSinkCDC:82 » ConditionTimeout Assertion conditio...
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)