### PR TITLE
[Fix][connector-fake] Signal no more splits to avoid FakeSourceReader wait-split hang after restore

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -439,7 +439,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 150
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceSplitEnumerator.java
@@ -44,6 +44,7 @@ public class FakeSourceSplitEnumerator
     private final Set<FakeSourceSplit> assignedSplits;
 
     private final Object lock = new Object();
+    private volatile boolean splitsDiscovered = false;
 
     public FakeSourceSplitEnumerator(
             SourceSplitEnumerator.Context<FakeSourceSplit> enumeratorContext,
@@ -61,6 +62,7 @@ public class FakeSourceSplitEnumerator
     @Override
     public void run() throws Exception {
         discoverySplits();
+        splitsDiscovered = true;
         assignPendingSplits();
     }
 
@@ -71,6 +73,9 @@ public class FakeSourceSplitEnumerator
     public void addSplitsBack(List<FakeSourceSplit> splits, int subtaskId) {
         log.debug("Fake source add splits back {}, subtaskId:{}", splits, subtaskId);
         addSplitChangeToPendingAssignments(splits);
+        if (splitsDiscovered) {
+            assignPendingSplits();
+        }
     }
 
     @Override
@@ -79,11 +84,17 @@ public class FakeSourceSplitEnumerator
     }
 
     @Override
-    public void handleSplitRequest(int subtaskId) {}
+    public void handleSplitRequest(int subtaskId) {
+        if (splitsDiscovered) {
+            assignPendingSplits(subtaskId);
+        }
+    }
 
     @Override
     public void registerReader(int subtaskId) {
-        // nothing
+        if (splitsDiscovered) {
+            assignPendingSplits(subtaskId);
+        }
     }
 
     @Override
@@ -121,39 +132,46 @@ public class FakeSourceSplitEnumerator
                     allSplit.size());
         }
 
-        assignedSplits.forEach(allSplit::remove);
+        synchronized (lock) {
+            assignedSplits.forEach(allSplit::remove);
+        }
         addSplitChangeToPendingAssignments(allSplit);
         log.info("Assigned {} to {} readers.", allSplit, numReaders);
         log.info("Calculated splits successfully, the size of splits is {}.", allSplit.size());
     }
 
     private void addSplitChangeToPendingAssignments(Collection<FakeSourceSplit> newSplits) {
-        for (FakeSourceSplit split : newSplits) {
-            int ownerReader = split.getSplitId() % enumeratorContext.currentParallelism();
-            pendingSplits.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
+        synchronized (lock) {
+            for (FakeSourceSplit split : newSplits) {
+                int ownerReader = split.getSplitId() % enumeratorContext.currentParallelism();
+                pendingSplits.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
+            }
         }
     }
 
     private void assignPendingSplits() {
-        // Check if there's any pending splits for given readers
         for (int pendingReader : enumeratorContext.registeredReaders()) {
-            // Remove pending assignment for the reader
+            assignPendingSplits(pendingReader);
+        }
+    }
+
+    private void assignPendingSplits(int pendingReader) {
+        synchronized (lock) {
             final Set<FakeSourceSplit> pendingAssignmentForReader =
                     pendingSplits.remove(pendingReader);
 
             if (pendingAssignmentForReader != null && !pendingAssignmentForReader.isEmpty()) {
-                // Mark pending splits as already assigned
-                synchronized (lock) {
-                    assignedSplits.addAll(pendingAssignmentForReader);
-                    // Assign pending splits to reader
-                    log.info(
-                            "Assigning splits to readers {} {}",
-                            pendingReader,
-                            pendingAssignmentForReader);
-                    enumeratorContext.assignSplit(
-                            pendingReader, new ArrayList<>(pendingAssignmentForReader));
-                    enumeratorContext.signalNoMoreSplits(pendingReader);
-                }
+                assignedSplits.addAll(pendingAssignmentForReader);
+                log.info(
+                        "Assigning splits to readers {} {}",
+                        pendingReader,
+                        pendingAssignmentForReader);
+                enumeratorContext.assignSplit(
+                        pendingReader, new ArrayList<>(pendingAssignmentForReader));
+            }
+            // Avoid readers waiting for split request forever after restore/restart.
+            if (splitsDiscovered) {
+                enumeratorContext.signalNoMoreSplits(pendingReader);
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceSplitEnumeratorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.fake.source;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.apache.seatunnel.api.common.metrics.AbstractMetricsContext;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.Event;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.connectors.seatunnel.fake.config.MultipleTableFakeSourceConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class FakeSourceSplitEnumeratorTest {
+
+    @Test
+    void signalNoMoreSplitsAfterRestoreWhenNoPendingSplits() throws Exception {
+        MultipleTableFakeSourceConfig sourceConfig = loadSingleTableFakeSourceConfig();
+
+        TestingEnumeratorContext firstContext =
+                new TestingEnumeratorContext(2, new HashSet<>(Arrays.asList(0, 1)));
+        FakeSourceSplitEnumerator firstRunEnumerator =
+                new FakeSourceSplitEnumerator(firstContext, sourceConfig, Collections.emptySet());
+        firstRunEnumerator.run();
+
+        Set<FakeSourceSplit> assignedSplits = new HashSet<>(firstContext.getAllAssignedSplits());
+        Assertions.assertFalse(assignedSplits.isEmpty(), "Expected assigned splits in first run");
+
+        TestingEnumeratorContext restoredContext =
+                new TestingEnumeratorContext(2, new HashSet<>(Arrays.asList(0, 1)));
+        FakeSourceSplitEnumerator restoredEnumerator =
+                new FakeSourceSplitEnumerator(restoredContext, sourceConfig, assignedSplits);
+        restoredEnumerator.run();
+
+        Assertions.assertTrue(
+                restoredContext.getAllAssignedSplits().isEmpty(),
+                "Expected no split assignments on restore when all splits were already assigned");
+        Assertions.assertEquals(
+                new HashSet<>(Arrays.asList(0, 1)),
+                restoredContext.getNoMoreSplitsReaders(),
+                "Expected signalNoMoreSplits for all registered readers");
+    }
+
+    @Test
+    void assignAndSignalOnLateRegisterReaderAfterDiscovery() throws Exception {
+        MultipleTableFakeSourceConfig sourceConfig = loadSingleTableFakeSourceConfig();
+
+        TestingEnumeratorContext context = new TestingEnumeratorContext(2, new HashSet<>());
+        FakeSourceSplitEnumerator enumerator =
+                new FakeSourceSplitEnumerator(context, sourceConfig, Collections.emptySet());
+
+        enumerator.run();
+        Assertions.assertTrue(
+                context.getAllAssignedSplits().isEmpty(),
+                "Expected no split assignments when no readers are registered during run()");
+
+        enumerator.registerReader(0);
+        enumerator.registerReader(1);
+
+        Assertions.assertFalse(
+                context.getAllAssignedSplits().isEmpty(),
+                "Expected split assignments after late reader registration");
+        Assertions.assertEquals(
+                new HashSet<>(Arrays.asList(0, 1)),
+                context.getNoMoreSplitsReaders(),
+                "Expected signalNoMoreSplits for late registered readers");
+    }
+
+    private static MultipleTableFakeSourceConfig loadSingleTableFakeSourceConfig()
+            throws URISyntaxException {
+        URL resource = FakeSourceSplitEnumeratorTest.class.getResource("/simple.schema.conf");
+        Config config = ConfigFactory.parseFile(new File(Paths.get(resource.toURI()).toString()));
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(config.getConfig("FakeSource"));
+        return new MultipleTableFakeSourceConfig(readonlyConfig);
+    }
+
+    private static final class TestingEnumeratorContext
+            implements SourceSplitEnumerator.Context<FakeSourceSplit> {
+        private final int parallelism;
+        private final Set<Integer> registeredReaders;
+        private final Map<Integer, List<FakeSourceSplit>> assignedSplitsByReader = new HashMap<>();
+        private final Set<Integer> noMoreSplitsReaders = new HashSet<>();
+        private final MetricsContext metricsContext = new AbstractMetricsContext() {};
+        private final EventListener eventListener =
+                new EventListener() {
+                    @Override
+                    public void onEvent(Event event) {
+                        // no-op
+                    }
+                };
+
+        private TestingEnumeratorContext(int parallelism, Set<Integer> registeredReaders) {
+            this.parallelism = parallelism;
+            this.registeredReaders = registeredReaders;
+        }
+
+        @Override
+        public int currentParallelism() {
+            return parallelism;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return registeredReaders;
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<FakeSourceSplit> splits) {
+            assignedSplitsByReader
+                    .computeIfAbsent(subtaskId, ignored -> new ArrayList<>())
+                    .addAll(splits);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            noMoreSplitsReaders.add(subtask);
+        }
+
+        @Override
+        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+            // no-op
+        }
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return metricsContext;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return eventListener;
+        }
+
+        private List<FakeSourceSplit> getAllAssignedSplits() {
+            return assignedSplitsByReader.values().stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+        }
+
+        private Set<Integer> getNoMoreSplitsReaders() {
+            return noMoreSplitsReaders;
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
<img width="2520" height="654" alt="image" src="https://github.com/user-attachments/assets/d65d7022-b78d-45c8-8602-526350e7d252" />
Fix a potential hang after Flink restart/restore when using FakeSource: once split discovery is finished, some readers may receive no splits (e.g. all splits were already assigned before restore). Previously, FakeSourceSplitEnumerator only called signalNoMoreSplits when it actually assigned splits, which could leave readers waiting forever.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes (bug fix). Previously jobs could hang after restart/restore; now readers can finish correctly.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
Added unit tests: FakeSourceSplitEnumeratorTest.java
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [*] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)