### PR TITLE
[docs][connector-hbase] Add Kerberos configuration notes/examples and fix hbase_extra_config type

### DIFF
--- a/docs/en/connector-v2/sink/Hbase.md
+++ b/docs/en/connector-v2/sink/Hbase.md
@@ -26,7 +26,7 @@ Output data to Hbase
 | wal_write          | boolean | yes      | false           |
 | write_buffer_size  | string  | no       | 8 * 1024 * 1024 |
 | encoding           | string  | no       | utf8            |
-| hbase_extra_config | string  | no       | -               |
+| hbase_extra_config | config  | no       | -               |
 | common-options     |         | no       | -               |
 | ttl                | long    | no       | -               |
 
@@ -119,6 +119,36 @@ Hbase {
   }
 }
 
+```
+
+## Kerberos Example
+
+Note:
+
+- `connector-hbase` does not parse `krb5_path`, `kerberos_principal`, or `kerberos_keytab_path`.
+- Prepare Kerberos credentials and `krb5.conf` in the runtime environment (for example, `kinit -kt ...` or JVM `-Djava.security.krb5.conf=...`), and put HBase/Hadoop security settings into `hbase_extra_config`.
+
+```hocon
+sink {
+  Hbase {
+    zookeeper_quorum = "zk1:2181,zk2:2181,zk3:2181"
+    table = "target_table"
+    rowkey_column = ["rowkey"]
+    family_name {
+      all_columns = "info"
+    }
+
+    # HBase security config
+    hbase_extra_config = {
+      "hbase.security.authentication" = "kerberos"
+      "hadoop.security.authentication" = "kerberos"
+      "hbase.master.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.regionserver.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.rpc.protection" = "authentication"
+      "hbase.zookeeper.useSasl" = "false"
+    }
+  }
+}
 ```
 
 ### Multiple Table

--- a/docs/en/connector-v2/source/Hbase.md
+++ b/docs/en/connector-v2/source/Hbase.md
@@ -24,7 +24,7 @@ Reads data from Apache Hbase.
 | zookeeper_quorum     | string    | Yes       | -       |
 | table                | string    | Yes       | -       |
 | schema               | config    | Yes       | -       |
-| hbase_extra_config   | string    | No        | -       |
+| hbase_extra_config   | config    | No        | -       |
 | caching              | int       | No        | -1      |
 | batch                | int       | No        | -1      |
 | cache_blocks         | boolean   | No        | false   |
@@ -127,6 +127,44 @@ source {
           name = "columnFamily2:column1"
           type = bigint
         }
+      ]
+    }
+  }
+}
+```
+
+## Kerberos Example
+
+Note:
+
+- `connector-hbase` does not parse `krb5_path`, `kerberos_principal`, or `kerberos_keytab_path`.
+- Prepare Kerberos credentials and `krb5.conf` in the runtime environment (for example, `kinit -kt ...` or JVM `-Djava.security.krb5.conf=...`), and put HBase/Hadoop security settings into `hbase_extra_config`.
+
+```hocon
+source {
+  Hbase {
+    zookeeper_quorum = "zk1:2181,zk2:2181,zk3:2181"
+    table = "source_table"
+    caching = 1000
+    batch = 200
+    cache_blocks = false
+    is_binary_rowkey = false
+
+    # HBase security config
+    hbase_extra_config = {
+      "hbase.security.authentication" = "kerberos"
+      "hadoop.security.authentication" = "kerberos"
+      "hbase.master.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.regionserver.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.rpc.protection" = "authentication"
+      "hbase.zookeeper.useSasl" = "false"
+    }
+
+    schema = {
+      columns = [
+        { name = "rowkey", type = string },
+        { name = "info:name", type = string },
+        { name = "info:score", type = string }
       ]
     }
   }

--- a/docs/zh/connector-v2/sink/Hbase.md
+++ b/docs/zh/connector-v2/sink/Hbase.md
@@ -26,7 +26,7 @@ import ChangeLog from '../changelog/connector-hbase.md';
 | wal_write          | boolean | yes  | false           |
 | write_buffer_size  | string  | no   | 8 * 1024 * 1024 |
 | encoding           | string  | no   | utf8            |
-| hbase_extra_config | string  | no   | -               |
+| hbase_extra_config | config  | no   | -               |
 | common-options     |         | no   | -               |
 | ttl                | long    | no   | -               |
 
@@ -119,6 +119,36 @@ Hbase {
   }
 }
 
+```
+
+## Kerberos 示例
+
+备注：
+
+- `connector-hbase` 不会解析 `krb5_path` / `kerberos_principal` / `kerberos_keytab_path`。
+- 需要在运行环境中提前完成 Kerberos 登录并保证 `krb5.conf` 可被 JVM 访问（例如 `kinit -kt ...` 或 JVM `-Djava.security.krb5.conf=...`），同时将 HBase/Hadoop 的安全配置写入 `hbase_extra_config`。
+
+```hocon
+sink {
+  Hbase {
+    zookeeper_quorum = "zk1:2181,zk2:2181,zk3:2181"
+    table = "target_table"
+    rowkey_column = ["rowkey"]
+    family_name {
+      all_columns = "info"
+    }
+
+    # HBase安全配置
+    hbase_extra_config = {
+      "hbase.security.authentication" = "kerberos"
+      "hadoop.security.authentication" = "kerberos"
+      "hbase.master.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.regionserver.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.rpc.protection" = "authentication"
+      "hbase.zookeeper.useSasl" = "false"
+    }
+  }
+}
 ```
 
 ### 写入多表

--- a/docs/zh/connector-v2/source/Hbase.md
+++ b/docs/zh/connector-v2/source/Hbase.md
@@ -24,7 +24,7 @@ import ChangeLog from '../changelog/connector-hbase.md';
 | zookeeper_quorum     | string   | 是  | -     |
 | table                | string   | 是  | -     |
 | schema               | config   | 是  | -     |
-| hbase_extra_config   | string   | 否  | -     |
+| hbase_extra_config   | config   | 否  | -     |
 | caching              | int      | 否  | -1    |
 | batch                | int      | 否  | -1    |
 | cache_blocks         | boolean  | 否  | false |
@@ -127,6 +127,44 @@ source {
           name = "columnFamily2:column1"
           type = bigint
         }
+      ]
+    }
+  }
+}
+```
+
+## Kerberos 示例
+
+备注：
+
+- `connector-hbase` 不会解析 `krb5_path` / `kerberos_principal` / `kerberos_keytab_path`。
+- 需要在运行环境中提前完成 Kerberos 登录并保证 `krb5.conf` 可被 JVM 访问（例如 `kinit -kt ...` 或 JVM `-Djava.security.krb5.conf=...`），同时将 HBase/Hadoop 的安全配置写入 `hbase_extra_config`。
+
+```hocon
+source {
+  Hbase {
+    zookeeper_quorum = "zk1:2181,zk2:2181,zk3:2181"
+    table = "source_table"
+    caching = 1000
+    batch = 200
+    cache_blocks = false
+    is_binary_rowkey = false
+
+    # HBase安全配置
+    hbase_extra_config = {
+      "hbase.security.authentication" = "kerberos"
+      "hadoop.security.authentication" = "kerberos"
+      "hbase.master.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.regionserver.kerberos.principal" = "hbase/_HOST@REALM"
+      "hbase.rpc.protection" = "authentication"
+      "hbase.zookeeper.useSasl" = "false"
+    }
+
+    schema = {
+      columns = [
+        { name = "rowkey", type = string },
+        { name = "info:name", type = string },
+        { name = "info:score", type = string }
       ]
     }
   }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
This PR improve the HBase connector documentation for Kerberos authentication scenarios:

1. Add Kerberos configuration examples for HBase Source/Sink docs (EN/ZH)

2. Fix hbase_extra_config option type in tables (string -> config)

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes. Documentation changes only:

- Updates Hbase.md
- Updates Hbase.md
- Updates Hbase.md
- Updates Hbase.md

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [*] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)