### PR TITLE
[Fix][Connector-V2][Hbase] Fix source reader only scanning first split

### DIFF
--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReader.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReader.java
@@ -63,7 +63,6 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
 
     private HBaseDeserializationFormat hbaseDeserializationFormat =
             new HBaseDeserializationFormat();
-    private ResultScanner currentScanner;
 
     public HbaseSourceReader(
             HbaseParameters hbaseParameters, Context context, SeaTunnelRowType seaTunnelRowType) {
@@ -106,13 +105,6 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
 
     @Override
     public void close() throws IOException {
-        if (this.currentScanner != null) {
-            try {
-                this.currentScanner.close();
-            } catch (Exception e) {
-                throw new IOException("Failed to close HBase Scanner.", e);
-            }
-        }
         if (this.hbaseClient != null) {
             try {
                 this.hbaseClient.close();
@@ -131,15 +123,12 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
                 // read logic
                 try (ResultScanner scanner =
                         hbaseClient.scan(split, hbaseParameters, this.columnNames)) {
-                    currentScanner = scanner;
                     for (Result result : scanner) {
                         SeaTunnelRow seaTunnelRow =
                                 hbaseDeserializationFormat.deserialize(
                                         convertRawRow(result), seaTunnelRowType);
                         output.collect(seaTunnelRow);
                     }
-                } finally {
-                    currentScanner = null;
                 }
             } else if (noMoreSplit && sourceSplits.isEmpty()) {
                 // signal to the source that we have reached the end of the data.

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReader.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.hbase.source;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 import org.apache.seatunnel.shade.com.google.common.collect.Maps;
 
@@ -66,6 +67,19 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
 
     public HbaseSourceReader(
             HbaseParameters hbaseParameters, Context context, SeaTunnelRowType seaTunnelRowType) {
+        this(
+                hbaseParameters,
+                context,
+                seaTunnelRowType,
+                HbaseClient.createInstance(hbaseParameters));
+    }
+
+    @VisibleForTesting
+    HbaseSourceReader(
+            HbaseParameters hbaseParameters,
+            Context context,
+            SeaTunnelRowType seaTunnelRowType,
+            HbaseClient hbaseClient) {
         this.hbaseParameters = hbaseParameters;
         this.context = context;
         this.seaTunnelRowType = seaTunnelRowType;
@@ -82,7 +96,7 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
                                 Preconditions.checkArgument(
                                         column.contains(":") && column.split(":").length == 2,
                                         "Invalid column names, it should be [ColumnFamily:Column] format"));
-        hbaseClient = HbaseClient.createInstance(hbaseParameters);
+        this.hbaseClient = hbaseClient;
     }
 
     @Override
@@ -115,14 +129,17 @@ public class HbaseSourceReader implements SourceReader<SeaTunnelRow, HbaseSource
             final HbaseSourceSplit split = sourceSplits.poll();
             if (Objects.nonNull(split)) {
                 // read logic
-                if (currentScanner == null) {
-                    currentScanner = hbaseClient.scan(split, hbaseParameters, this.columnNames);
-                }
-                for (Result result : currentScanner) {
-                    SeaTunnelRow seaTunnelRow =
-                            hbaseDeserializationFormat.deserialize(
-                                    convertRawRow(result), seaTunnelRowType);
-                    output.collect(seaTunnelRow);
+                try (ResultScanner scanner =
+                        hbaseClient.scan(split, hbaseParameters, this.columnNames)) {
+                    currentScanner = scanner;
+                    for (Result result : scanner) {
+                        SeaTunnelRow seaTunnelRow =
+                                hbaseDeserializationFormat.deserialize(
+                                        convertRawRow(result), seaTunnelRowType);
+                        output.collect(seaTunnelRow);
+                    }
+                } finally {
+                    currentScanner = null;
                 }
             } else if (noMoreSplit && sourceSplits.isEmpty()) {
                 // signal to the source that we have reached the end of the data.

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceReaderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hbase.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.hbase.client.HbaseClient;
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
+
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HbaseSourceReaderTest {
+
+    private static class CountingCollector implements Collector<SeaTunnelRow> {
+        private final Object checkpointLock = new Object();
+        private int count;
+
+        @Override
+        public void collect(SeaTunnelRow record) {
+            count++;
+        }
+
+        @Override
+        public Object getCheckpointLock() {
+            return checkpointLock;
+        }
+
+        public int getCount() {
+            return count;
+        }
+    }
+
+    @Test
+    void testPollNextReadsAllSplits() throws Exception {
+        HbaseParameters hbaseParameters = mock(HbaseParameters.class);
+        when(hbaseParameters.getTable()).thenReturn("test_table");
+
+        SourceReader.Context readerContext = mock(SourceReader.Context.class);
+        HbaseClient hbaseClient = mock(HbaseClient.class);
+
+        SeaTunnelRowType seaTunnelRowType =
+                new SeaTunnelRowType(
+                        new String[] {"rowkey", "cf1:id", "cf1:name"},
+                        new SeaTunnelDataType[] {
+                            BasicType.STRING_TYPE, BasicType.STRING_TYPE, BasicType.STRING_TYPE
+                        });
+
+        HbaseSourceReader reader =
+                new HbaseSourceReader(
+                        hbaseParameters, readerContext, seaTunnelRowType, hbaseClient);
+
+        HbaseSourceSplit split0 = new HbaseSourceSplit(0, Bytes.toBytes("a"), Bytes.toBytes("b"));
+        HbaseSourceSplit split1 = new HbaseSourceSplit(1, Bytes.toBytes("b"), Bytes.toBytes("c"));
+
+        Result result0 = mock(Result.class);
+        when(result0.getRow()).thenReturn(Bytes.toBytes("row0"));
+        when(result0.getValue(any(byte[].class), any(byte[].class)))
+                .thenReturn(Bytes.toBytes("v0"));
+
+        Result result1 = mock(Result.class);
+        when(result1.getRow()).thenReturn(Bytes.toBytes("row1"));
+        when(result1.getValue(any(byte[].class), any(byte[].class)))
+                .thenReturn(Bytes.toBytes("v1"));
+
+        ResultScanner scanner0 = mock(ResultScanner.class);
+        when(scanner0.iterator()).thenReturn(Arrays.asList(result0).iterator());
+        ResultScanner scanner1 = mock(ResultScanner.class);
+        when(scanner1.iterator()).thenReturn(Arrays.asList(result1).iterator());
+
+        when(hbaseClient.scan(eq(split0), eq(hbaseParameters), anyList())).thenReturn(scanner0);
+        when(hbaseClient.scan(eq(split1), eq(hbaseParameters), anyList())).thenReturn(scanner1);
+
+        reader.addSplits(Arrays.asList(split0, split1));
+        reader.handleNoMoreSplits();
+
+        CountingCollector collector = new CountingCollector();
+        reader.pollNext(collector);
+        reader.pollNext(collector);
+        reader.pollNext(collector);
+
+        assertEquals(2, collector.getCount());
+        verify(hbaseClient, times(1)).scan(eq(split0), eq(hbaseParameters), anyList());
+        verify(hbaseClient, times(1)).scan(eq(split1), eq(hbaseParameters), anyList());
+        verify(scanner0, times(1)).close();
+        verify(scanner1, times(1)).close();
+        verify(readerContext, times(1)).signalNoMoreElement();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/seatunnel/issues/10286
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
Fix a correctness issue in `connector-hbase` source: when multiple splits (regions) are assigned, `HbaseSourceReader` could effectively scan only the first split because an exhausted `ResultScanner` was reused for subsequent splits.  
This PR creates a new `ResultScanner` per split, closes it after scanning, and adds a unit test to prevent regression.  
A `@VisibleForTesting` constructor is added only to allow injecting a mocked `HbaseClient` in tests; the production behavior is unchanged.
<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes. For HBase source, the read count can now correctly include all assigned splits/regions. Previously, the job could finish successfully but read only a fraction of rows.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
Added unit test: `HbaseSourceReaderTest`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)