### PR TITLE
[Fix][Connector-V2][Hbase] Fix HBase sink binary rowkey handling

### DIFF
--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/sink/HbaseSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/sink/HbaseSinkWriter.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.hbase.client.HbaseClient;
 import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -144,11 +146,48 @@ public class HbaseSinkWriter
     }
 
     private byte[] getRowkeyFromRow(SeaTunnelRow row) {
-        String[] rowkeyValues = new String[rowkeyColumnIndexes.size()];
-        for (int i = 0; i < rowkeyColumnIndexes.size(); i++) {
-            rowkeyValues[i] = row.getField(rowkeyColumnIndexes.get(i)).toString();
+        int rowkeySize = rowkeyColumnIndexes.size();
+        int firstRowkeyIndex = rowkeyColumnIndexes.get(0);
+        if (rowkeySize == 1 && isBinaryRowkeyColumn(firstRowkeyIndex)) {
+            return (byte[]) row.getField(firstRowkeyIndex);
         }
-        return Bytes.toBytes(String.join(hbaseParameters.getRowkeyDelimiter(), rowkeyValues));
+        if (!hasBinaryRowkeyColumn()) {
+            String[] rowkeyValues = new String[rowkeySize];
+            for (int i = 0; i < rowkeySize; i++) {
+                rowkeyValues[i] = row.getField(rowkeyColumnIndexes.get(i)).toString();
+            }
+            return Bytes.toBytes(String.join(hbaseParameters.getRowkeyDelimiter(), rowkeyValues));
+        }
+        byte[] delimiter = Bytes.toBytes(hbaseParameters.getRowkeyDelimiter());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        for (int i = 0; i < rowkeySize; i++) {
+            if (i > 0 && delimiter.length > 0) {
+                output.write(delimiter, 0, delimiter.length);
+            }
+            byte[] bytes = rowkeyFieldToBytes(rowkeyColumnIndexes.get(i), row);
+            output.write(bytes, 0, bytes.length);
+        }
+        return output.toByteArray();
+    }
+
+    private boolean hasBinaryRowkeyColumn() {
+        for (Integer index : rowkeyColumnIndexes) {
+            if (isBinaryRowkeyColumn(index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isBinaryRowkeyColumn(int index) {
+        return seaTunnelRowType.getFieldType(index).getSqlType() == SqlType.BYTES;
+    }
+
+    private byte[] rowkeyFieldToBytes(int index, SeaTunnelRow row) {
+        if (isBinaryRowkeyColumn(index)) {
+            return (byte[]) row.getField(index);
+        }
+        return Bytes.toBytes(row.getField(index).toString());
     }
 
     private byte[] convertColumnToBytes(SeaTunnelRow row, int index) {

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/sink/HbaseSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/sink/HbaseSinkWriterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hbase.sink;
+
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.hbase.client.HbaseClient;
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
+
+import org.apache.hadoop.hbase.client.Put;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class HbaseSinkWriterTest {
+
+    @Test
+    void testBinaryRowkeyUsesRawBytes() throws Exception {
+        HbaseParameters hbaseParameters =
+                HbaseParameters.builder()
+                        .familyNames(Collections.singletonMap("all_columns", "info"))
+                        .build();
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"rowkey"},
+                        new SeaTunnelDataType[] {PrimitiveByteArrayType.INSTANCE});
+        byte[] rowkey = new byte[] {0x00, 0x01, 0x02, 0x03};
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {rowkey});
+        HbaseClient hbaseClient = Mockito.mock(HbaseClient.class);
+
+        try (MockedStatic<HbaseClient> mockedStatic = Mockito.mockStatic(HbaseClient.class)) {
+            mockedStatic
+                    .when(() -> HbaseClient.createInstance(Mockito.any(HbaseParameters.class)))
+                    .thenReturn(hbaseClient);
+
+            HbaseSinkWriter writer =
+                    new HbaseSinkWriter(rowType, hbaseParameters, Arrays.asList(0), -1);
+            writer.write(row);
+        }
+
+        ArgumentCaptor<Put> putCaptor = ArgumentCaptor.forClass(Put.class);
+        Mockito.verify(hbaseClient).mutate(putCaptor.capture());
+        assertArrayEquals(rowkey, putCaptor.getValue().getRow());
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hbase/HbaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hbase/HbaseIT.java
@@ -59,8 +59,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -78,6 +80,8 @@ public class HbaseIT extends TestSuiteBase implements TestResource {
 
     private static final String MULTI_TABLE_TWO_NAME = "hbase_sink_2";
 
+    private static final String BINARY_ROWKEY_TABLE_NAME = "seatunnel_test_binary_rowkey";
+
     private static final String FAMILY_NAME = "info";
 
     private Connection hbaseConnection;
@@ -86,6 +90,7 @@ public class HbaseIT extends TestSuiteBase implements TestResource {
 
     private TableName table;
     private TableName tableAssign;
+    private TableName binaryRowkeyTable;
 
     private HbaseCluster hbaseCluster;
 
@@ -104,6 +109,9 @@ public class HbaseIT extends TestSuiteBase implements TestResource {
         hbaseCluster.createTable(ASSIGN_CF_TABLE_NAME, Arrays.asList("cf1", "cf2"));
         table = TableName.valueOf(TABLE_NAME);
         tableAssign = TableName.valueOf(ASSIGN_CF_TABLE_NAME);
+        // Create table for hbase binary rowkey sink test
+        hbaseCluster.createTable(BINARY_ROWKEY_TABLE_NAME, Arrays.asList(FAMILY_NAME));
+        binaryRowkeyTable = TableName.valueOf(BINARY_ROWKEY_TABLE_NAME);
 
         // Create table for hbase multi-table sink test
         hbaseCluster.createTable(MULTI_TABLE_ONE_NAME, Arrays.asList(FAMILY_NAME));
@@ -254,6 +262,28 @@ public class HbaseIT extends TestSuiteBase implements TestResource {
         }
         Assertions.assertEquals(results.size(), 3);
         scanner.close();
+    }
+
+    @TestTemplate
+    public void testHbaseSinkWithBinaryRowkey(TestContainer container)
+            throws IOException, InterruptedException {
+        deleteData(binaryRowkeyTable);
+        Container.ExecResult execResult = container.executeJob("/fake-to-hbase-binary-rowkey.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+        ArrayList<Result> results = readData(binaryRowkeyTable);
+        Assertions.assertEquals(3, results.size());
+        Set<String> actualRowKeys = new HashSet<>();
+        for (Result result : results) {
+            actualRowKeys.add(Bytes.toStringBinary(result.getRow()));
+        }
+        Set<String> expectedRowKeys =
+                new HashSet<>(
+                        Arrays.asList(
+                                Bytes.toStringBinary(new byte[] {0x00, 0x01, 0x02, 0x03}),
+                                Bytes.toStringBinary(
+                                        new byte[] {(byte) 0xFF, (byte) 0xFE, 0x0A, 0x0B}),
+                                Bytes.toStringBinary(new byte[] {0x10, 0x20, 0x30, 0x40, 0x50})));
+        Assertions.assertEquals(expectedRowKeys, actualRowKeys);
     }
 
     @TestTemplate

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/resources/fake-to-hbase-binary-rowkey.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/resources/fake-to-hbase-binary-rowkey.conf
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        rowkey = bytes
+        data = string
+      }
+    }
+    rows = [
+      {fields = ["AAECAw==", "binary_value_1"], kind = INSERT},
+      {fields = ["//4KCw==", "binary_value_2"], kind = INSERT},
+      {fields = ["ECAwQFA=", "binary_value_3"], kind = INSERT}
+    ]
+  }
+}
+
+sink {
+  Hbase {
+    zookeeper_quorum = "hbase_e2e:2181"
+    table = "seatunnel_test_binary_rowkey"
+    rowkey_column = ["rowkey"]
+    family_name {
+      all_columns = info
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/seatunnel/issues/10299

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
HBase sink currently builds rowkey via `field.toString()` and then `Bytes.toBytes(...)`.  
When the rowkey field is actually a `byte[]` (SeaTunnel `BYTES` type), `toString()` produces a Java object identity string like `[B@591a15de`, so the written rowkey is corrupted and binary rowkeys cannot be migrated correctly.

### Does this PR introduce _any_ user-facing change?
Yes.
- Before: If `rowkey_column` refers to a `BYTES` field, the sink writes rowkeys like `[B@...` (corrupted).
- After: The sink preserves the original binary rowkey bytes and writes correct rowkeys.  
  Behavior for non-`BYTES` rowkeys remains unchanged.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

- Unit test added: `HbaseSinkWriterTest` verifies that `Put#getRow()` equals the input `byte[]` rowkey.

- E2E test added:
  - Config: `fake-to-hbase-binary-rowkey.conf`
  - IT: `HbaseIT#testHbaseSinkWithBinaryRowkey` writes 3 known binary rowkeys and verifies them via `Bytes.toStringBinary`.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ * ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)