### PR TITLE
 [Improve][Engine] Enhance logging and exception handling for resource allocation failures

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -105,6 +105,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -426,15 +427,32 @@ public class JobMaster {
             preApplyResourcesForAll(preApplyResourceFutures);
         }
 
+        AtomicLong successCount = new AtomicLong(0);
+        AtomicLong failedCount = new AtomicLong(0);
+
         boolean enoughResource =
                 preApplyResourceFutures.values().stream()
                                 .filter(
                                         value -> {
                                             try {
-                                                return value != null && value.join() != null;
+                                                if (value != null && value.join() != null) {
+                                                    successCount.incrementAndGet();
+                                                    return true;
+                                                }
+                                                failedCount.incrementAndGet();
+                                                return false;
                                             } catch (CompletionException e) {
+                                                long failed = failedCount.incrementAndGet();
                                                 LOGGER.warning(
-                                                        "Pre resource application failed, resources may be not enough");
+                                                        String.format(
+                                                                "Pre resource application failed for job: %s, success: %d, failed: %d/%d, error: %s",
+                                                                jobImmutableInformation.getJobId(),
+                                                                successCount.get(),
+                                                                failed,
+                                                                preApplyResourceFutures.size(),
+                                                                e.getCause() != null
+                                                                        ? e.getCause().getMessage()
+                                                                        : e.getMessage()));
                                                 return false;
                                             }
                                         })
@@ -477,7 +495,16 @@ public class JobMaster {
                                                                             && value.join() != null;
                                                                 } catch (CompletionException e) {
                                                                     LOGGER.warning(
-                                                                            "Pre resource application failed, resources may be not enough");
+                                                                            String.format(
+                                                                                    "Filtering failed resource for job %s during release: %s",
+                                                                                    jobImmutableInformation
+                                                                                            .getJobId(),
+                                                                                    e.getCause()
+                                                                                                    != null
+                                                                                            ? e.getCause()
+                                                                                                    .getMessage()
+                                                                                            : e
+                                                                                                    .getMessage()));
                                                                     return false;
                                                                 }
                                                             })

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/NoEnoughResourceException.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/NoEnoughResourceException.java
@@ -24,4 +24,12 @@ public class NoEnoughResourceException extends RuntimeException {
     public NoEnoughResourceException(String message) {
         super(message);
     }
+
+    public NoEnoughResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoEnoughResourceException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -134,8 +135,20 @@ public class ResourceRequestHandler {
                                                 if (resourceManager.supportDynamicWorker()) {
                                                     applyByDynamicWorker(tags);
                                                 } else {
+                                                    int failedIndex =
+                                                            findNullIndexInResultSlotProfiles();
                                                     completeRequestWithException(
-                                                            requestSlotWithRetryError);
+                                                            new NoEnoughResourceException(
+                                                                    String.format(
+                                                                            "Can't apply enough resources for job %d, required: %d slots, obtained: %d slots, "
+                                                                                    + "first unassigned resource at index %d: %s",
+                                                                            jobId,
+                                                                            resourceProfile.size(),
+                                                                            resultSlotProfiles
+                                                                                    .size(),
+                                                                            failedIndex,
+                                                                            resourceProfile.get(
+                                                                                    failedIndex))));
                                                 }
                                             }
                                         }
@@ -151,6 +164,15 @@ public class ResourceRequestHandler {
             }
         }
         return needRequestResource;
+    }
+
+    private int findNullIndexInResultSlotProfiles() {
+        for (int i = 0; i < resourceProfile.size(); i++) {
+            if (!resultSlotProfiles.containsKey(i)) {
+                return i;
+            }
+        }
+        return 0;
     }
 
     private List<CompletableFuture<SlotAndWorkerProfile>> requestSlots(
@@ -285,14 +307,32 @@ public class ResourceRequestHandler {
     }
 
     private void releaseAllResourceInternal() {
-        LOGGER.warning("apply resource not success, release all already applied resource");
-        new ArrayList<>(resultSlotProfiles.keySet())
+        int appliedCount = resultSlotProfiles.size();
+        int requiredCount = resourceProfile.size();
+
+        String slotIds =
+                resultSlotProfiles.values().stream()
+                        .map(
+                                slot ->
+                                        String.format(
+                                                "Slot-%d@%s", slot.getSlotID(), slot.getWorker()))
+                        .collect(Collectors.joining(", "));
+
+        LOGGER.warning(
+                String.format(
+                        "Apply resource not success for job: %d, required: %d slots, applied: %d slots, "
+                                + "releasing slots: [%s], remaining: %d slots not assigned",
+                        jobId, requiredCount, appliedCount, slotIds, requiredCount - appliedCount));
+
+        resultSlotProfiles.values().stream()
+                .filter(Objects::nonNull)
                 .forEach(
-                        index -> {
-                            SlotProfile profile = resultSlotProfiles.remove(index);
-                            if (profile != null) {
-                                resourceManager.releaseResource(jobId, profile);
-                            }
+                        profile -> {
+                            LOGGER.fine(
+                                    String.format(
+                                            "Releasing slot %d for job %d from worker %s",
+                                            profile.getSlotID(), jobId, profile.getWorker()));
+                            resourceManager.releaseResource(jobId, profile);
                         });
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
@@ -137,18 +137,18 @@ public class ResourceRequestHandler {
                                                 } else {
                                                     int failedIndex =
                                                             findNullIndexInResultSlotProfiles();
+                                                    LOGGER.warning(
+                                                            String.format(
+                                                                    "Apply resource not success for job: %d, required: %d slots, obtained: %d slots, "
+                                                                            + "first unassigned resource at index %d: %s",
+                                                                    jobId,
+                                                                    resourceProfile.size(),
+                                                                    resultSlotProfiles.size(),
+                                                                    failedIndex,
+                                                                    resourceProfile.get(
+                                                                            failedIndex)));
                                                     completeRequestWithException(
-                                                            new NoEnoughResourceException(
-                                                                    String.format(
-                                                                            "Can't apply enough resources for job %d, required: %d slots, obtained: %d slots, "
-                                                                                    + "first unassigned resource at index %d: %s",
-                                                                            jobId,
-                                                                            resourceProfile.size(),
-                                                                            resultSlotProfiles
-                                                                                    .size(),
-                                                                            failedIndex,
-                                                                            resourceProfile.get(
-                                                                                    failedIndex))));
+                                                            requestSlotWithRetryError);
                                                 }
                                             }
                                         }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
@@ -40,8 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -112,7 +114,7 @@ public class ResourceRequestHandler {
                                 LOGGER,
                                 (unused, error) -> {
                                     if (error != null) {
-                                        completeRequestWithException(error);
+                                        completeRequestWithException(toExternalException(error));
                                     } else {
                                         List<ResourceProfile> needRequestResource =
                                                 stillNeedRequestResource();
@@ -137,7 +139,7 @@ public class ResourceRequestHandler {
                                                 } else {
                                                     int failedIndex =
                                                             findNullIndexInResultSlotProfiles();
-                                                    LOGGER.warning(
+                                                    String failureMessage =
                                                             String.format(
                                                                     "Apply resource not success for job: %d, required: %d slots, obtained: %d slots, "
                                                                             + "first unassigned resource at index %d: %s",
@@ -146,9 +148,12 @@ public class ResourceRequestHandler {
                                                                     resultSlotProfiles.size(),
                                                                     failedIndex,
                                                                     resourceProfile.get(
-                                                                            failedIndex)));
+                                                                            failedIndex));
+                                                    LOGGER.warning(failureMessage);
                                                     completeRequestWithException(
-                                                            requestSlotWithRetryError);
+                                                            toExternalException(
+                                                                    failureMessage,
+                                                                    requestSlotWithRetryError));
                                                 }
                                             }
                                         }
@@ -202,8 +207,9 @@ public class ResourceRequestHandler {
     }
 
     private void completeRequestWithException(Throwable e) {
-        releaseAllResourceInternal();
-        completableFuture.completeExceptionally(e);
+        if (completableFuture.completeExceptionally(e)) {
+            releaseAllResourceInternal();
+        }
     }
 
     private void addSlotToCacheMap(int index, SlotProfile slotProfile) {
@@ -312,6 +318,7 @@ public class ResourceRequestHandler {
 
         String slotIds =
                 resultSlotProfiles.values().stream()
+                        .filter(Objects::nonNull)
                         .map(
                                 slot ->
                                         String.format(
@@ -324,16 +331,58 @@ public class ResourceRequestHandler {
                                 + "releasing slots: [%s], remaining: %d slots not assigned",
                         jobId, requiredCount, appliedCount, slotIds, requiredCount - appliedCount));
 
-        resultSlotProfiles.values().stream()
-                .filter(Objects::nonNull)
+        new ArrayList<>(resultSlotProfiles.keySet())
                 .forEach(
-                        profile -> {
+                        index -> {
+                            SlotProfile profile = resultSlotProfiles.remove(index);
+                            if (profile == null) {
+                                return;
+                            }
                             LOGGER.fine(
                                     String.format(
                                             "Releasing slot %d for job %d from worker %s",
                                             profile.getSlotID(), jobId, profile.getWorker()));
                             resourceManager.releaseResource(jobId, profile);
                         });
+    }
+
+    private NoEnoughResourceException toExternalException(Throwable error) {
+        return toExternalException(buildFailureMessage(), error);
+    }
+
+    private NoEnoughResourceException toExternalException(String message, Throwable error) {
+        Throwable root = unwrapCompletionException(error);
+        if (root instanceof NoEnoughResourceException) {
+            return (NoEnoughResourceException) root;
+        }
+        return new NoEnoughResourceException(message, root);
+    }
+
+    private String buildFailureMessage() {
+        int failedIndex = findNullIndexInResultSlotProfiles();
+        String failedResource =
+                failedIndex >= 0 && failedIndex < resourceProfile.size()
+                        ? String.valueOf(resourceProfile.get(failedIndex))
+                        : "unknown";
+        return String.format(
+                "Apply resource not success for job: %d, required: %d slots, obtained: %d slots, "
+                        + "first unassigned resource at index %d: %s",
+                jobId,
+                resourceProfile.size(),
+                resultSlotProfiles.size(),
+                failedIndex,
+                failedResource);
+    }
+
+    private static Throwable unwrapCompletionException(Throwable error) {
+        Throwable current = error;
+        while (current instanceof ExecutionException || current instanceof CompletionException) {
+            if (current.getCause() == null) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return current;
     }
 
     private <T> CompletableFuture<T> getAllOfFuture(List<CompletableFuture<T>> allRequestFuture) {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/FakeResourceManagerForExternalExceptionTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/FakeResourceManagerForExternalExceptionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.resourcemanager;
+
+import org.apache.seatunnel.engine.common.config.EngineConfig;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.RequestSlotOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+
+public class FakeResourceManagerForExternalExceptionTest extends AbstractResourceManager {
+    public FakeResourceManagerForExternalExceptionTest(NodeEngine nodeEngine) {
+        super(nodeEngine, new EngineConfig());
+        init();
+    }
+
+    @Override
+    public void init() {
+        try {
+            generateWorker(5801);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void generateWorker(int port) throws UnknownHostException {
+        Address address = new Address("localhost", port);
+        WorkerProfile workerProfile =
+                new WorkerProfile(
+                        address,
+                        new ResourceProfile(),
+                        new ResourceProfile(),
+                        true,
+                        new SlotProfile[] {},
+                        new SlotProfile[] {},
+                        Collections.emptyMap());
+        this.registerWorker.put(address, workerProfile);
+    }
+
+    @Override
+    protected <E> CompletableFuture<E> sendToMember(Operation operation, Address address) {
+        if (operation instanceof RequestSlotOperation) {
+            return (CompletableFuture<E>)
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                throw new IllegalStateException("boom");
+                            });
+        }
+        return super.sendToMember(operation, address);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceManagerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceManagerTest.java
@@ -161,11 +161,27 @@ public class ResourceManagerTest extends AbstractSeaTunnelServerTest<ResourceMan
                                 finalResourceManager2
                                         .applyResources(1L, finalResourceProfiles2, null)
                                         .get());
-        Assertions.assertInstanceOf(
-                NoEnoughResourceException.class, exception2.getCause().getCause());
+        Assertions.assertInstanceOf(NoEnoughResourceException.class, exception2.getCause());
         Assertions.assertEquals(
                 "can't apply resource request with retry times: 3",
-                exception2.getCause().getCause().getMessage());
+                exception2.getCause().getMessage());
+    }
+
+    @Test
+    public void testApplyResourcesPreserveCauseForExternalException()
+            throws ExecutionException, InterruptedException {
+        FakeResourceManagerForExternalExceptionTest resourceManager =
+                new FakeResourceManagerForExternalExceptionTest(nodeEngine);
+        List<ResourceProfile> resourceProfiles = new ArrayList<>();
+        resourceProfiles.add(new ResourceProfile());
+        ExecutionException exception =
+                Assertions.assertThrows(
+                        ExecutionException.class,
+                        () -> resourceManager.applyResources(1L, resourceProfiles, null).get());
+        Assertions.assertInstanceOf(NoEnoughResourceException.class, exception.getCause());
+        Assertions.assertInstanceOf(
+                IllegalStateException.class,
+                ((NoEnoughResourceException) exception.getCause()).getCause());
     }
 
     @Test


### PR DESCRIPTION

### Purpose of this pull request

<img width="2702" height="1124" alt="image" src="https://github.com/user-attachments/assets/72e33027-1fc2-474c-8a0e-f2fcc4340a44" />


  Before:
```
  WARN  [o.a.s.e.s.m.JobMaster] - Pre resource application failed, resources may be not enough
```
  After:
```
  WARN  [o.a.s.e.s.m.JobMaster] - Pre resource application failed for job: 123456789, success: 3, failed: 5/8, error: NoEnoughResourceException: Can't apply enough resources
  WARN  [o.a.s.e.s.m.JobMaster] - Filtering failed resource for job 123456789 during release: NoEnoughResourceException: Can't apply enough resources
```
  ResourceRequestHandler Log Improvements

  Before:
```
  WARN  [s.e.s.r.ResourceRequestHandler] - apply resource not success, release all already applied resource
```
  After:
```
  WARN  [s.e.s.r.ResourceRequestHandler] - Apply resource not success for job: 123456789, required: 8 slots, applied: 3 slots, releasing slots: [Slot-1@192.168.1.10:5801, Slot-2@192.168.1.11:5801, Slot-3@192.168.1.12:5801], remaining: 5 slots not assigned
  FINE  [s.e.s.r.ResourceRequestHandler] - Releasing slot 1 for job 123456789 from worker 192.168.1.10:5801
  FINE  [s.e.s.r.ResourceRequestHandler] - Releasing slot 2 for job 123456789 from worker 192.168.1.11:5801
  FINE  [s.e.s.r.ResourceRequestHandler] - Releasing slot 3 for job 123456789 from worker 192.168.1.12:5801
```
### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)