### PR TITLE
[Fix[Connector-V2][Hbase] Avoid duplicate split assignment on restore

### DIFF
--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
@@ -50,6 +50,9 @@ public class HbaseSourceSplitEnumerator
     /** The splits that have not assigned */
     private Set<HbaseSourceSplit> pendingSplit;
 
+    /** Whether the pending splits have been initialized */
+    private boolean initialized = false;
+
     private HbaseParameters hbaseParameters;
 
     private HbaseClient hbaseClient;
@@ -71,23 +74,40 @@ public class HbaseSourceSplitEnumerator
             Context<HbaseSourceSplit> context,
             HbaseParameters hbaseParameters,
             HbaseClient hbaseClient) {
-        this(context, hbaseParameters, new HashSet<>());
-        this.hbaseClient = hbaseClient;
+        this(context, hbaseParameters, new HashSet<>(), hbaseClient);
+    }
+
+    @VisibleForTesting
+    public HbaseSourceSplitEnumerator(
+            Context<HbaseSourceSplit> context,
+            HbaseParameters hbaseParameters,
+            HbaseSourceState sourceState,
+            HbaseClient hbaseClient) {
+        this(context, hbaseParameters, sourceState.getAssignedSplits(), hbaseClient);
     }
 
     private HbaseSourceSplitEnumerator(
             Context<HbaseSourceSplit> context,
             HbaseParameters hbaseParameters,
             Set<HbaseSourceSplit> assignedSplit) {
+        this(context, hbaseParameters, assignedSplit, HbaseClient.createInstance(hbaseParameters));
+    }
+
+    private HbaseSourceSplitEnumerator(
+            Context<HbaseSourceSplit> context,
+            HbaseParameters hbaseParameters,
+            Set<HbaseSourceSplit> assignedSplit,
+            HbaseClient hbaseClient) {
         this.context = context;
         this.hbaseParameters = hbaseParameters;
         this.assignedSplit = assignedSplit;
-        this.hbaseClient = HbaseClient.createInstance(hbaseParameters);
+        this.hbaseClient = hbaseClient;
     }
 
     @Override
     public void open() {
         this.pendingSplit = new HashSet<>();
+        this.initialized = false;
     }
 
     @Override
@@ -110,7 +130,9 @@ public class HbaseSourceSplitEnumerator
     public void addSplitsBack(List<HbaseSourceSplit> splits, int subtaskId) {
         if (!splits.isEmpty()) {
             pendingSplit.addAll(splits);
-            assignSplit(subtaskId);
+            if (context.registeredReaders().contains(subtaskId)) {
+                assignSplit(subtaskId);
+            }
         }
     }
 
@@ -121,8 +143,28 @@ public class HbaseSourceSplitEnumerator
 
     @Override
     public void registerReader(int subtaskId) {
-        pendingSplit = getTableSplits();
+        initializePendingSplits();
         assignSplit(subtaskId);
+    }
+
+    private void initializePendingSplits() {
+        if (initialized) {
+            return;
+        }
+        Set<HbaseSourceSplit> tableSplits = getTableSplits();
+        if (assignedSplit.isEmpty()) {
+            pendingSplit.addAll(tableSplits);
+        } else {
+            Set<String> assignedSplitIds =
+                    assignedSplit.stream()
+                            .map(HbaseSourceSplit::splitId)
+                            .collect(Collectors.toSet());
+            pendingSplit.addAll(
+                    tableSplits.stream()
+                            .filter(split -> !assignedSplitIds.contains(split.splitId()))
+                            .collect(Collectors.toSet()));
+        }
+        initialized = true;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
@@ -152,18 +152,18 @@ public class HbaseSourceSplitEnumerator
             return;
         }
         Set<HbaseSourceSplit> tableSplits = getTableSplits();
-        if (assignedSplit.isEmpty()) {
-            pendingSplit.addAll(tableSplits);
-        } else {
-            Set<String> assignedSplitIds =
+        Set<String> existedSplitIds =
+                pendingSplit.stream().map(HbaseSourceSplit::splitId).collect(Collectors.toSet());
+        if (!assignedSplit.isEmpty()) {
+            existedSplitIds.addAll(
                     assignedSplit.stream()
                             .map(HbaseSourceSplit::splitId)
-                            .collect(Collectors.toSet());
-            pendingSplit.addAll(
-                    tableSplits.stream()
-                            .filter(split -> !assignedSplitIds.contains(split.splitId()))
                             .collect(Collectors.toSet()));
         }
+        pendingSplit.addAll(
+                tableSplits.stream()
+                        .filter(split -> !existedSplitIds.contains(split.splitId()))
+                        .collect(Collectors.toSet()));
         initialized = true;
     }
 

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumeratorTest.java
@@ -27,16 +27,26 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HbaseSourceSplitEnumeratorTest {
@@ -375,5 +385,81 @@ public class HbaseSourceSplitEnumeratorTest {
         assertEquals("hbase_source_split_1", split.splitId());
         assertArrayEquals(Bytes.toBytes("row100"), split.getStartRow());
         assertArrayEquals(Bytes.toBytes("row200"), split.getEndRow());
+    }
+
+    @Test
+    void testRestoreOnlyAssignReturnedSplits() throws Exception {
+        when(context.currentParallelism()).thenReturn(1);
+        when(context.registeredReaders()).thenReturn(Collections.emptySet());
+
+        byte[][] startKeys = {
+            HConstants.EMPTY_BYTE_ARRAY, Bytes.toBytes("row100"), Bytes.toBytes("row200")
+        };
+        byte[][] endKeys = {
+            Bytes.toBytes("row100"), Bytes.toBytes("row200"), HConstants.EMPTY_BYTE_ARRAY
+        };
+        when(regionLocator.getStartKeys()).thenReturn(startKeys);
+        when(regionLocator.getEndKeys()).thenReturn(endKeys);
+
+        Set<HbaseSourceSplit> assignedSplits = new HashSet<>();
+        assignedSplits.add(new HbaseSourceSplit(0, startKeys[0], endKeys[0]));
+        assignedSplits.add(new HbaseSourceSplit(1, startKeys[1], endKeys[1]));
+        assignedSplits.add(new HbaseSourceSplit(2, startKeys[2], endKeys[2]));
+
+        HbaseSourceSplitEnumerator restoredEnumerator =
+                new HbaseSourceSplitEnumerator(
+                        context,
+                        hbaseParameters,
+                        new HbaseSourceState(assignedSplits),
+                        hbaseClient);
+
+        restoredEnumerator.open();
+
+        List<HbaseSourceSplit> returnedSplits =
+                Arrays.asList(
+                        new HbaseSourceSplit(1, startKeys[1], endKeys[1]),
+                        new HbaseSourceSplit(2, startKeys[2], endKeys[2]));
+        restoredEnumerator.addSplitsBack(returnedSplits, 0);
+
+        ArgumentCaptor<List<HbaseSourceSplit>> assignedCaptor = ArgumentCaptor.forClass(List.class);
+        restoredEnumerator.registerReader(0);
+
+        verify(context, times(1)).assignSplit(eq(0), assignedCaptor.capture());
+        Set<String> assignedSplitIds =
+                assignedCaptor.getValue().stream()
+                        .map(HbaseSourceSplit::splitId)
+                        .collect(Collectors.toSet());
+        assertEquals(2, assignedSplitIds.size());
+        assertTrue(assignedSplitIds.contains("hbase_source_split_1"));
+        assertTrue(assignedSplitIds.contains("hbase_source_split_2"));
+        assertFalse(assignedSplitIds.contains("hbase_source_split_0"));
+    }
+
+    @Test
+    void testRegisterReaderInitializePendingSplitOnlyOnceWhenParallelismMoreThanOne()
+            throws Exception {
+        when(context.currentParallelism()).thenReturn(2);
+
+        byte[][] startKeys = {
+            HConstants.EMPTY_BYTE_ARRAY,
+            Bytes.toBytes("row100"),
+            Bytes.toBytes("row200"),
+            Bytes.toBytes("row300")
+        };
+        byte[][] endKeys = {
+            Bytes.toBytes("row100"),
+            Bytes.toBytes("row200"),
+            Bytes.toBytes("row300"),
+            HConstants.EMPTY_BYTE_ARRAY
+        };
+        when(regionLocator.getStartKeys()).thenReturn(startKeys);
+        when(regionLocator.getEndKeys()).thenReturn(endKeys);
+
+        enumerator.open();
+        enumerator.registerReader(0);
+        enumerator.registerReader(1);
+
+        verify(hbaseClient, times(1)).getRegionLocator("test_table");
+        assertEquals(0, enumerator.currentUnassignedSplitSize());
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

When running HBase source on Flink with checkpoint/savepoint, the restore path calls addSplitsBack() and then registerReader(). The enumerator used to re-enumerate all table splits in registerReader and reassign them, so the job re-scans the table and the read count can roughly double after restore. 

<img width="1686" height="301" alt="image" src="https://github.com/user-attachments/assets/45990a27-1424-42d6-8adb-a8afcdd55599" />
There are only 10 million records in the real HBase source data

### Does this PR introduce _any_ user-facing change?

Yes. Restoring from checkpoint/savepoint now resumes from the remaining splits without re-scanning the whole table, so duplicate reads drop to the expected at-least-once behavior. Fresh runs are unchanged.

### How was this patch tested?

- Added unit tests in `HbaseSourceSplitEnumeratorTest` to cover restore assignment and multi-parallel init.
- Not run locally (skipped by request).

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)