### PR TITLE
[Fix][Zeta] Fix memory leak when cancelling pending job

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -771,13 +771,6 @@ public class CoordinatorService {
                     CompletableFuture.supplyAsync(
                             () -> {
                                 runningJobMaster.cancelJob();
-                                // The pending task "JobMaster.init" has not been executed, so the
-                                // job status (JobStatus) will not be stored in the
-                                // jobHistoryService. Here, storeJobEndState is called to store the
-                                // `CANCELED` status in the jobHistoryService.
-                                if (isPendingJob) {
-                                    runningJobMaster.storeJobEndState();
-                                }
                                 return null;
                             },
                             executorService));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -204,6 +204,7 @@ public class PhysicalPlan {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running
             updateJobState(JobStatus.CANCELED);
+            jobEndFuture.complete(new JobResult(JobStatus.CANCELED));
         } else {
             updateJobState(JobStatus.CANCELING);
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
@@ -132,15 +132,16 @@ public class CoordinatorServiceWithCancelPendingJobTest extends AbstractSeaTunne
 
         // Verify if the task has been deleted in pending
         Assertions.assertFalse(server.getCoordinatorService().getPendingJobQueue().contains(jobId));
-
         // Verify if the final status of the task is cancelled
         await().pollDelay(3, TimeUnit.SECONDS)
                 .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        JobStatus.CANCELED,
-                                        server.getCoordinatorService().getJobStatus(jobId)));
+                        () -> {
+                            Assertions.assertEquals(
+                                    JobStatus.CANCELED,
+                                    server.getCoordinatorService().getJobStatus(jobId));
+                            Assertions.assertTrue(jobMaster.getRunningJobStateIMap().isEmpty());
+                        });
     }
 
     private JobMaster newJobInstanceWithRunningState(long jobId) throws InterruptedException {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server;
 
+import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.ScheduleStrategy;
@@ -132,6 +133,14 @@ public class CoordinatorServiceWithCancelPendingJobTest extends AbstractSeaTunne
 
         // Verify if the task has been deleted in pending
         Assertions.assertFalse(server.getCoordinatorService().getPendingJobQueue().contains(jobId));
+
+        IMap<Object, Object> runningJobInfoImap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Object, Object> runningJobStateImap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_STATE);
+        IMap<Object, Object> runningStateTimestampsImap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_STATE_TIMESTAMPS);
+
         // Verify if the final status of the task is cancelled
         await().pollDelay(3, TimeUnit.SECONDS)
                 .atMost(120, TimeUnit.SECONDS)
@@ -140,7 +149,10 @@ public class CoordinatorServiceWithCancelPendingJobTest extends AbstractSeaTunne
                             Assertions.assertEquals(
                                     JobStatus.CANCELED,
                                     server.getCoordinatorService().getJobStatus(jobId));
-                            Assertions.assertTrue(jobMaster.getRunningJobStateIMap().isEmpty());
+
+                            Assertions.assertTrue(runningJobInfoImap.isEmpty());
+                            Assertions.assertTrue(runningJobStateImap.isEmpty());
+                            Assertions.assertTrue(runningStateTimestampsImap.isEmpty());
                         });
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceWithCancelPendingJobTest.java
@@ -139,7 +139,8 @@ public class CoordinatorServiceWithCancelPendingJobTest extends AbstractSeaTunne
                 .untilAsserted(
                         () ->
                                 Assertions.assertEquals(
-                                        JobStatus.CANCELED, jobMaster.getJobStatus()));
+                                        JobStatus.CANCELED,
+                                        server.getCoordinatorService().getJobStatus(jobId)));
     }
 
     private JobMaster newJobInstanceWithRunningState(long jobId) throws InterruptedException {


### PR DESCRIPTION
### Purpose of this pull request

With the existing logic, when a job in the pending state is cancelled, it is not removed from the `runningJobStateIMap`, `runningJobInfoIMap`, `runningJobStateTimestampsIMap`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`CoordinatorServiceWithCancelPendingJobTest.testCancelPendingJob()`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)