### PR TITLE
[Fix][Connector-V2] Fix partitioning column selection logic

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -67,7 +67,10 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
             long start = System.currentTimeMillis();
 
             Column splitColumn = getSplitColumn(jdbc, dialect, tableId);
-            log.info("Chosen split column {} for table {}", splitColumn.name(), tableId);
+            log.info(
+                    "Chosen split column {} for table {}",
+                    splitColumn != null ? splitColumn.name() : "null",
+                    tableId);
             List<SnapshotSplit> splits = new ArrayList<>();
             if (splitColumn == null) {
                 if (sourceConfig.isExactlyOnce()) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -67,6 +67,7 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
             long start = System.currentTimeMillis();
 
             Column splitColumn = getSplitColumn(jdbc, dialect, tableId);
+            log.info("Chosen split column {} for table {}", splitColumn.name(), tableId);
             List<SnapshotSplit> splits = new ArrayList<>();
             if (splitColumn == null) {
                 if (sourceConfig.isExactlyOnce()) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -429,15 +429,11 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
 
         Optional<PrimaryKey> primaryKey = dialect.getPrimaryKey(jdbc, tableId);
         if (primaryKey.isPresent()) {
-            List<String> pkColumns = primaryKey.get().getColumnNames();
-
-            for (String pkColumn : pkColumns) {
-                Column column = table.columnWithName(pkColumn);
-                if (isEvenlySplitColumn(column)) {
-                    splitColumn = columnComparable(splitColumn, column);
-                    if (sqlTypePriority(splitColumn) == 1) {
-                        return splitColumn;
-                    }
+            Column firstColumn = table.columnWithName(primaryKey.get().getColumnNames().get(0));
+            if (isEvenlySplitColumn(firstColumn)) {
+                splitColumn = columnComparable(splitColumn, firstColumn);
+                if (sqlTypePriority(splitColumn) == 1) {
+                    return splitColumn;
                 }
             }
         } else {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -447,15 +447,12 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
         List<ConstraintKey> uniqueKeys = dialect.getUniqueKeys(jdbc, tableId);
         if (!uniqueKeys.isEmpty()) {
             for (ConstraintKey uniqueKey : uniqueKeys) {
-                List<ConstraintKey.ConstraintKeyColumn> uniqueKeyColumns =
-                        uniqueKey.getColumnNames();
-                for (ConstraintKey.ConstraintKeyColumn uniqueKeyColumn : uniqueKeyColumns) {
-                    Column column = table.columnWithName(uniqueKeyColumn.getColumnName());
-                    if (isEvenlySplitColumn(column)) {
-                        splitColumn = columnComparable(splitColumn, column);
-                        if (sqlTypePriority(splitColumn) == 1) {
-                            return splitColumn;
-                        }
+                Column firstColumn =
+                        table.columnWithName(uniqueKey.getColumnNames().get(0).getColumnName());
+                if (isEvenlySplitColumn(firstColumn)) {
+                    splitColumn = columnComparable(splitColumn, firstColumn);
+                    if (sqlTypePriority(splitColumn) == 1) {
+                        return splitColumn;
                     }
                 }
             }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -353,7 +353,6 @@ class JdbcSourceChunkSplitterTest {
                 throws SQLException {
             List<ConstraintKey> keys = new ArrayList<>();
 
-            // UK 1: (address, coin_type)
             keys.add(
                     ConstraintKey.of(
                             ConstraintKey.ConstraintType.UNIQUE_KEY,

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -48,16 +48,26 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-public class JdbcSourceChunkSplitterTest {
+class JdbcSourceChunkSplitterTest {
 
     @Test
-    public void splitColumnTest() throws SQLException {
+    void splitColumnTest() throws SQLException {
         TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
                 new TestJdbcSourceChunkSplitter(null, new TestSourceDialect());
         Column splitColumn =
                 testJdbcSourceChunkSplitter.getSplitColumn(
                         null, new TestSourceDialect(), new TableId("", "", ""));
-        Assertions.assertEquals(splitColumn.typeName(), "tinyint");
+        Assertions.assertEquals("tinyint", splitColumn.typeName());
+    }
+
+    @Test
+    void splitColumnTestWithUniqueKey() throws SQLException {
+        TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
+                new TestJdbcSourceChunkSplitter(null, new TestSourceDialectWithUniqueKey());
+        Column splitColumn =
+                testJdbcSourceChunkSplitter.getSplitColumn(
+                        null, new TestSourceDialectWithUniqueKey(), new TableId("", "", ""));
+        Assertions.assertEquals("int", splitColumn.typeName());
     }
 
     private class TestJdbcSourceChunkSplitter extends AbstractJdbcSourceChunkSplitter {
@@ -245,6 +255,116 @@ public class JdbcSourceChunkSplitterTest {
         public List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
                 throws SQLException {
             return new ArrayList<ConstraintKey>();
+        }
+    }
+
+    private class TestSourceDialectWithUniqueKey implements JdbcDataSourceDialect {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+            return false;
+        }
+
+        @Override
+        public ChunkSplitter createChunkSplitter(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
+            return null;
+        }
+
+        @Override
+        public JdbcConnectionPoolFactory getPooledDataSourceFactory() {
+            return null;
+        }
+
+        @Override
+        public TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
+
+            Table table =
+                    Table.editor()
+                            .tableId(tableId)
+                            .addColumns(
+                                    Column.editor()
+                                            .name("string_col")
+                                            .jdbcType(Types.VARCHAR)
+                                            .type("varchar")
+                                            .create(),
+                                    Column.editor()
+                                            .name("smallint")
+                                            .jdbcType(Types.SMALLINT)
+                                            .type("smallint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("int")
+                                            .jdbcType(Types.INTEGER)
+                                            .type("int")
+                                            .create(),
+                                    Column.editor()
+                                            .name("decimal")
+                                            .jdbcType(Types.DECIMAL)
+                                            .type("decimal")
+                                            .create(),
+                                    Column.editor()
+                                            .name("tinyint_col")
+                                            .jdbcType(Types.TINYINT)
+                                            .type("tinyint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("bigint_col")
+                                            .jdbcType(Types.BIGINT)
+                                            .type("bigint")
+                                            .create())
+                            .create();
+            return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+        }
+
+        @Override
+        public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
+            return null;
+        }
+
+        @Override
+        public JdbcSourceFetchTaskContext createFetchTaskContext(
+                SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
+            return null;
+        }
+
+        @Override
+        public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            return Optional.of(PrimaryKey.of("pkName", Arrays.asList("bigint_col")));
+        }
+
+        @Override
+        public List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            List<ConstraintKey> keys = new ArrayList<>();
+
+            // UK 1: (address, coin_type)
+            keys.add(
+                    ConstraintKey.of(
+                            ConstraintKey.ConstraintType.UNIQUE_KEY,
+                            "uk_1",
+                            Arrays.asList(
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "int", ConstraintKey.ColumnSortType.ASC),
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "smallint", ConstraintKey.ColumnSortType.ASC))));
+
+            return keys;
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -67,6 +67,16 @@ class JdbcSourceChunkSplitterTest {
         Column splitColumn =
                 testJdbcSourceChunkSplitter.getSplitColumn(
                         null, new TestSourceDialectWithUniqueKey(), new TableId("", "", ""));
+        Assertions.assertEquals("bigint", splitColumn.typeName());
+    }
+
+    @Test
+    void splitColumnTestWithUniqueKey_2() throws SQLException {
+        TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
+                new TestJdbcSourceChunkSplitter(null, new TestSourceDialectWithUniqueKey_2());
+        Column splitColumn =
+                testJdbcSourceChunkSplitter.getSplitColumn(
+                        null, new TestSourceDialectWithUniqueKey_2(), new TableId("", "", ""));
         Assertions.assertEquals("int", splitColumn.typeName());
     }
 
@@ -258,89 +268,34 @@ class JdbcSourceChunkSplitterTest {
         }
     }
 
-    private class TestSourceDialectWithUniqueKey implements JdbcDataSourceDialect {
+    private class TestSourceDialectWithUniqueKey extends TestSourceDialect {
 
         @Override
-        public String getName() {
-            return null;
+        public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            return Optional.of(PrimaryKey.of("pkName", Arrays.asList("bigint_col")));
         }
 
         @Override
-        public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
-            return false;
-        }
+        public List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            List<ConstraintKey> keys = new ArrayList<>();
 
-        @Override
-        public ChunkSplitter createChunkSplitter(JdbcSourceConfig sourceConfig) {
-            return null;
-        }
+            keys.add(
+                    ConstraintKey.of(
+                            ConstraintKey.ConstraintType.UNIQUE_KEY,
+                            "uk_1",
+                            Arrays.asList(
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "string_col", ConstraintKey.ColumnSortType.ASC),
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "int", ConstraintKey.ColumnSortType.ASC))));
 
-        @Override
-        public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
-            return null;
+            return keys;
         }
+    }
 
-        @Override
-        public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
-            return null;
-        }
-
-        @Override
-        public JdbcConnectionPoolFactory getPooledDataSourceFactory() {
-            return null;
-        }
-
-        @Override
-        public TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
-
-            Table table =
-                    Table.editor()
-                            .tableId(tableId)
-                            .addColumns(
-                                    Column.editor()
-                                            .name("string_col")
-                                            .jdbcType(Types.VARCHAR)
-                                            .type("varchar")
-                                            .create(),
-                                    Column.editor()
-                                            .name("smallint")
-                                            .jdbcType(Types.SMALLINT)
-                                            .type("smallint")
-                                            .create(),
-                                    Column.editor()
-                                            .name("int")
-                                            .jdbcType(Types.INTEGER)
-                                            .type("int")
-                                            .create(),
-                                    Column.editor()
-                                            .name("decimal")
-                                            .jdbcType(Types.DECIMAL)
-                                            .type("decimal")
-                                            .create(),
-                                    Column.editor()
-                                            .name("tinyint_col")
-                                            .jdbcType(Types.TINYINT)
-                                            .type("tinyint")
-                                            .create(),
-                                    Column.editor()
-                                            .name("bigint_col")
-                                            .jdbcType(Types.BIGINT)
-                                            .type("bigint")
-                                            .create())
-                            .create();
-            return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
-        }
-
-        @Override
-        public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
-            return null;
-        }
-
-        @Override
-        public JdbcSourceFetchTaskContext createFetchTaskContext(
-                SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
-            return null;
-        }
+    private class TestSourceDialectWithUniqueKey_2 extends TestSourceDialect {
 
         @Override
         public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -57,7 +57,7 @@ class JdbcSourceChunkSplitterTest {
         Column splitColumn =
                 testJdbcSourceChunkSplitter.getSplitColumn(
                         null, new TestSourceDialect(), new TableId("", "", ""));
-        Assertions.assertEquals("tinyint", splitColumn.typeName());
+        Assertions.assertEquals("varchar", splitColumn.typeName());
     }
 
     @Test
@@ -357,6 +357,14 @@ class JdbcSourceChunkSplitterTest {
                     ConstraintKey.of(
                             ConstraintKey.ConstraintType.UNIQUE_KEY,
                             "uk_1",
+                            Arrays.asList(
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "string_col", ConstraintKey.ColumnSortType.ASC))));
+
+            keys.add(
+                    ConstraintKey.of(
+                            ConstraintKey.ConstraintType.UNIQUE_KEY,
+                            "uk_2",
                             Arrays.asList(
                                     ConstraintKey.ConstraintKeyColumn.of(
                                             "int", ConstraintKey.ColumnSortType.ASC),


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/9949

I accidentally included unrelated commits in the [previous PR](https://github.com/apache/seatunnel/pull/10236), so I opened this new PR with only the intended changes.

### Purpose of this pull request

This PR fixes the partitioning column selection logic.
It ensures that when a primary/unique key is present, the first column of that key is correctly selected and used as the partitioning column.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `JdbcSourceChunkSplitterTest.splitColumnTestWithUniqueKey()`.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)