### PR TITLE
[Feature][Engine][Checkpoint Storage] Add Kubernetes IRSA support for…

### DIFF
--- a/docs/en/engines/zeta/checkpoint-storage.md
+++ b/docs/en/engines/zeta/checkpoint-storage.md
@@ -162,6 +162,83 @@ seatunnel:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.InstanceProfileCredentialsProvider
 ```
 
+If you are running SeaTunnel in **Kubernetes with IRSA (IAM Roles for Service Accounts)**, you can use `WebIdentityTokenCredentialsProvider` which automatically uses the service account token to assume an IAM role. You can check [eks-iam-roles-for-service-accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+**Prerequisites for IRSA:**
+1. SeaTunnel version 2.3.13+ (which includes hadoop-aws 3.3.6+)
+2. Your Kubernetes service account must be annotated with the IAM role ARN
+3. The pod must have the AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables set (typically done automatically by EKS)
+
+You can config like this:
+
+```yaml
+
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint  # optional, omit for standard AWS S3
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
+```
+
+Alternatively, you can use `DefaultAWSCredentialsProviderChain` which is **recommended** as it automatically detects the best credential provider based on your environment (environment variables, web identity tokens for IRSA, EC2 instance profiles, etc.):
+
+```yaml
+
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint  # optional, omit for standard AWS S3
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+```
+
+The `DefaultAWSCredentialsProviderChain` checks credentials in this order:
+1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+2. Java system properties
+3. Web Identity Token (Kubernetes IRSA)
+4. EC2 instance profile credentials
+5. ECS container credentials
+
+**Example Kubernetes Service Account setup for IRSA:**
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel-sa
+  namespace: default
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_ROLE_NAME
+```
+
+Then reference this service account in your SeaTunnel pod spec:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seatunnel-pod
+spec:
+  serviceAccountName: seatunnel-sa
+  containers:
+  - name: seatunnel
+    image: your-seatunnel-image
+    # ... rest of your container config
+```
+
 If you want to use Minio that supports the S3 protocol as checkpoint storage, you should configure it this way:
 
 ```yaml

--- a/docs/zh/engines/zeta/checkpoint-storage.md
+++ b/docs/zh/engines/zeta/checkpoint-storage.md
@@ -160,6 +160,106 @@ seatunnel:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.InstanceProfileCredentialsProvider
 ```
 
+如果您在**Kubernetes中使用IRSA（IAM Roles for Service Accounts）运行SeaTunnel**，可以使用`WebIdentityTokenCredentialsProvider`，它会自动使用服务账户令牌来承担IAM角色。您可以查看[eks-iam-roles-for-service-accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)。
+
+**IRSA前提条件：**
+1. SeaTunnel版本2.3.13+（包含hadoop-aws 3.3.6+）
+2. 您的Kubernetes服务账户必须使用IAM角色ARN进行注释
+3. Pod必须设置AWS_WEB_IDENTITY_TOKEN_FILE和AWS_ROLE_ARN环境变量（通常由EKS自动完成）
+
+您可以这样配置：
+
+```yaml
+
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint  # 可选，标准AWS S3可省略
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
+```
+
+或者，您可以使用**推荐**的`DefaultAWSCredentialsProviderChain`，它会根据您的环境自动检测最佳凭证提供程序（环境变量、IRSA的Web Identity令牌、EC2实例配置文件等）：
+
+```yaml
+
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint  # 可选，标准AWS S3可省略
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+```
+
+`DefaultAWSCredentialsProviderChain`按以下顺序检查凭证：
+1. 环境变量（AWS_ACCESS_KEY_ID、AWS_SECRET_ACCESS_KEY）
+2. Java系统属性
+3. Web Identity令牌（Kubernetes IRSA）
+4. EC2实例配置文件凭证
+5. ECS容器凭证
+
+**Kubernetes服务账户IRSA设置示例：**
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel-sa
+  namespace: default
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_ROLE_NAME
+```
+
+然后在SeaTunnel Pod规范中引用此服务账户：
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seatunnel-pod
+spec:
+  serviceAccountName: seatunnel-sa
+  containers:
+  - name: seatunnel
+    image: your-seatunnel-image
+    # ... 其余容器配置
+```
+
+如果您想使用支持S3协议的MinIO作为检查点存储，您应该这样配置：
+
+```yaml
+
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 10000
+      timeout: 60000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          namespace: # 检查点存储父路径，默认值为/seatunnel/checkpoint/
+          storage.type: s3
+          fs.s3a.access.key: xxxxxxxxx # MinIO的Access Key
+          fs.s3a.secret.key: xxxxxxxxxxxxxxxxxxxxx # MinIO的Secret Key
+          fs.s3a.endpoint: http://127.0.0.1:9000 # MinIO HTTP服务访问地址
+          s3.bucket: s3a://test # test是存储检查点文件的bucket名称
+          fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+       # 重要：此密钥的用户需要对bucket具有写权限，否则将返回403异常
+```
+
 有关Hadoop Credential Provider API的更多信息，请参见: [Credential Provider API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
 
 #### HDFS

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <prometheus.simpleclient.version>0.16.0</prometheus.simpleclient.version>
         <enableSourceJarCreation>true</enableSourceJarCreation>
 
-        <hadoop-aws.version>3.1.4</hadoop-aws.version>
+        <hadoop-aws.version>3.3.6</hadoop-aws.version>
         <software.amazon.awssdk.version>2.31.30</software.amazon.awssdk.version>
         <arrow.version>15.0.1</arrow.version>
         <okhttp.version>4.12.0</okhttp.version>

--- a/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/config/S3FileBaseOptions.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/config/S3FileBaseOptions.java
@@ -65,7 +65,25 @@ public class S3FileBaseOptions extends FileBaseSourceOptions {
     public enum S3aAwsCredentialsProvider {
         SimpleAWSCredentialsProvider("org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"),
 
-        InstanceProfileCredentialsProvider("com.amazonaws.auth.InstanceProfileCredentialsProvider");
+        InstanceProfileCredentialsProvider("com.amazonaws.auth.InstanceProfileCredentialsProvider"),
+
+        /**
+         * Use WebIdentityTokenCredentialsProvider for Kubernetes IRSA (IAM Roles for Service Accounts).
+         * This provider reads the web identity token from AWS_WEB_IDENTITY_TOKEN_FILE environment variable
+         * and assumes the role specified in AWS_ROLE_ARN.
+         */
+        WebIdentityTokenCredentialsProvider("com.amazonaws.auth.WebIdentityTokenCredentialsProvider"),
+
+        /**
+         * Use DefaultAWSCredentialsProviderChain for automatic credential detection.
+         * This is the recommended option as it supports multiple credential sources in order:
+         * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+         * 2. Java system properties
+         * 3. Web Identity Token (Kubernetes IRSA)
+         * 4. EC2 instance profile credentials
+         * 5. ECS container credentials
+         */
+        DefaultAWSCredentialsProviderChain("com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
 
         private String provider;
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/config/S3FileBaseOptions.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/config/S3FileBaseOptions.java
@@ -68,20 +68,19 @@ public class S3FileBaseOptions extends FileBaseSourceOptions {
         InstanceProfileCredentialsProvider("com.amazonaws.auth.InstanceProfileCredentialsProvider"),
 
         /**
-         * Use WebIdentityTokenCredentialsProvider for Kubernetes IRSA (IAM Roles for Service Accounts).
-         * This provider reads the web identity token from AWS_WEB_IDENTITY_TOKEN_FILE environment variable
-         * and assumes the role specified in AWS_ROLE_ARN.
+         * Use WebIdentityTokenCredentialsProvider for Kubernetes IRSA (IAM Roles for Service
+         * Accounts). This provider reads the web identity token from AWS_WEB_IDENTITY_TOKEN_FILE
+         * environment variable and assumes the role specified in AWS_ROLE_ARN.
          */
-        WebIdentityTokenCredentialsProvider("com.amazonaws.auth.WebIdentityTokenCredentialsProvider"),
+        WebIdentityTokenCredentialsProvider(
+                "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"),
 
         /**
-         * Use DefaultAWSCredentialsProviderChain for automatic credential detection.
-         * This is the recommended option as it supports multiple credential sources in order:
-         * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-         * 2. Java system properties
-         * 3. Web Identity Token (Kubernetes IRSA)
-         * 4. EC2 instance profile credentials
-         * 5. ECS container credentials
+         * Use DefaultAWSCredentialsProviderChain for automatic credential detection. This is the
+         * recommended option as it supports multiple credential sources in order: 1. Environment
+         * variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) 2. Java system properties 3. Web
+         * Identity Token (Kubernetes IRSA) 4. EC2 instance profile credentials 5. ECS container
+         * credentials
          */
         DefaultAWSCredentialsProviderChain("com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
 

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/pom.xml
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/pom.xml
@@ -52,13 +52,13 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
-            <version>3.1.4</version>
+            <version>${hadoop-aws.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-bundle</artifactId>
-            <version>1.11.271</version>
+            <version>1.12.770</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/S3FileCheckpointWithIRSATest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/S3FileCheckpointWithIRSATest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.seatunnel.engine.checkpoint.storage.hdfs;
+
+import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test S3 checkpoint storage using Kubernetes IRSA (IAM Roles for Service Accounts).
+ *
+ * <p>This test uses DefaultAWSCredentialsProviderChain which supports:
+ * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+ * 2. Java system properties
+ * 3. Web Identity Token (Kubernetes IRSA) - reads from AWS_WEB_IDENTITY_TOKEN_FILE
+ * 4. EC2 instance profile credentials
+ * 5. ECS container credentials
+ *
+ * <p>To run this test in Kubernetes with IRSA:
+ * 1. Create a Kubernetes service account with IRSA annotation:
+ *    kubectl create serviceaccount seatunnel-sa
+ *    kubectl annotate serviceaccount seatunnel-sa \
+ *      eks.amazonaws.com/role-arn=arn:aws:iam::YOUR_ACCOUNT:role/YOUR_ROLE
+ *
+ * 2. Deploy the test pod with this service account
+ *
+ * 3. The AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables
+ *    will be automatically set by EKS
+ *
+ * <p>Alternatively, for local testing with environment variables:
+ * export AWS_ACCESS_KEY_ID=your-key
+ * export AWS_SECRET_ACCESS_KEY=your-secret
+ * export AWS_REGION=your-region
+ */
+@Disabled(
+        "IRSA requires Kubernetes environment with proper IAM role setup. "
+                + "Enable this test when running in EKS with IRSA configured.")
+public class S3FileCheckpointWithIRSATest extends AbstractFileCheckPointTest {
+
+    @BeforeAll
+    public static void setup() throws CheckpointStorageException {
+        Map<String, String> config = new HashMap<>();
+        config.put("storage.type", "s3");
+        config.put("disable.cache", "false");
+
+        // Set your S3 bucket - replace with your actual bucket name
+        config.put("s3.bucket", "s3a://your-test-bucket");
+
+        // Optional: set endpoint for non-AWS S3-compatible storage
+        // config.put("fs.s3a.endpoint", "https://s3.us-west-2.amazonaws.com");
+
+        // Use DefaultAWSCredentialsProviderChain for automatic credential detection
+        // This will work with IRSA, environment variables, EC2 instance profiles, etc.
+        config.put(
+                "fs.s3a.aws.credentials.provider",
+                "com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
+
+        STORAGE = new HdfsStorage(config);
+        initStorageData();
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/S3FileCheckpointWithIRSATest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/S3FileCheckpointWithIRSATest.java
@@ -31,28 +31,22 @@ import java.util.Map;
 /**
  * Test S3 checkpoint storage using Kubernetes IRSA (IAM Roles for Service Accounts).
  *
- * <p>This test uses DefaultAWSCredentialsProviderChain which supports:
- * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
- * 2. Java system properties
- * 3. Web Identity Token (Kubernetes IRSA) - reads from AWS_WEB_IDENTITY_TOKEN_FILE
- * 4. EC2 instance profile credentials
- * 5. ECS container credentials
+ * <p>This test uses DefaultAWSCredentialsProviderChain which supports: 1. Environment variables
+ * (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) 2. Java system properties 3. Web Identity Token
+ * (Kubernetes IRSA) - reads from AWS_WEB_IDENTITY_TOKEN_FILE 4. EC2 instance profile credentials 5.
+ * ECS container credentials
  *
- * <p>To run this test in Kubernetes with IRSA:
- * 1. Create a Kubernetes service account with IRSA annotation:
- *    kubectl create serviceaccount seatunnel-sa
- *    kubectl annotate serviceaccount seatunnel-sa \
- *      eks.amazonaws.com/role-arn=arn:aws:iam::YOUR_ACCOUNT:role/YOUR_ROLE
+ * <p>To run this test in Kubernetes with IRSA: 1. Create a Kubernetes service account with IRSA
+ * annotation: kubectl create serviceaccount seatunnel-sa kubectl annotate serviceaccount
+ * seatunnel-sa \ eks.amazonaws.com/role-arn=arn:aws:iam::YOUR_ACCOUNT:role/YOUR_ROLE
  *
- * 2. Deploy the test pod with this service account
+ * <p>2. Deploy the test pod with this service account
  *
- * 3. The AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables
- *    will be automatically set by EKS
+ * <p>3. The AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables will be
+ * automatically set by EKS
  *
- * <p>Alternatively, for local testing with environment variables:
- * export AWS_ACCESS_KEY_ID=your-key
- * export AWS_SECRET_ACCESS_KEY=your-secret
- * export AWS_REGION=your-region
+ * <p>Alternatively, for local testing with environment variables: export AWS_ACCESS_KEY_ID=your-key
+ * export AWS_SECRET_ACCESS_KEY=your-secret export AWS_REGION=your-region
  */
 @Disabled(
         "IRSA requires Kubernetes environment with proper IAM role setup. "

--- a/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/pom.xml
+++ b/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/pom.xml
@@ -26,7 +26,7 @@
     <name>SeaTunnel : Shade : Hadoop3</name>
 
     <properties>
-        <hadoop3.version>3.1.4</hadoop3.version>
+        <hadoop3.version>3.3.6</hadoop3.version>
         <guava.version>27.0-jre</guava.version>
     </properties>
 


### PR DESCRIPTION
… S3 checkpoint storage

This commit adds support for Kubernetes IRSA (IAM Roles for Service Accounts) authentication when using S3 as checkpoint storage in SeaTunnel Engine.

Changes:
- Upgraded hadoop-aws from 3.1.4 to 3.3.6 to support WebIdentityTokenCredentialsProvider
- Upgraded aws-java-sdk-bundle from 1.11.271 to 1.12.770 for IRSA compatibility
- Added WebIdentityTokenCredentialsProvider option for direct IRSA authentication
- Added DefaultAWSCredentialsProviderChain for automatic credential detection
- Updated documentation with IRSA configuration examples and Kubernetes setup
- Added unit test framework for IRSA authentication (requires K8s environment)

The changes are backward compatible - existing credential providers (SimpleAWSCredentialsProvider, InstanceProfileCredentialsProvider) continue to work unchanged.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)