### PR TITLE
[Bug][Connector-V2][Hive] Fix init failure when Hive table/partition directory is empty

### DIFF
--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
@@ -58,6 +59,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,8 @@ import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSink
 import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSinkOptions.FILE_FORMAT_TYPE;
 import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSinkOptions.ROW_DELIMITER;
 import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions.NULL_FORMAT;
+import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions.PARSE_PARTITION_FROM_PATH;
+import static org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions.READ_COLUMNS;
 
 @Getter
 public class HiveSourceConfig implements Serializable {
@@ -261,6 +265,10 @@ public class HiveSourceConfig implements Serializable {
             HadoopConf hadoopConf,
             List<String> filePaths,
             Table table) {
+        if (CollectionUtils.isEmpty(filePaths)) {
+            // Keep a stable schema even when directory is empty.
+            return buildCatalogTableFromHiveMeta(readonlyConfig, table);
+        }
         switch (fileFormat) {
             case PARQUET:
             case ORC:
@@ -280,10 +288,6 @@ public class HiveSourceConfig implements Serializable {
             HadoopConf hadoopConf,
             List<String> filePaths,
             Table table) {
-        if (CollectionUtils.isEmpty(filePaths)) {
-            // When the directory is empty, distribute default behavior schema
-            return buildEmptyCatalogTable(readonlyConfig, table);
-        }
         CatalogTable catalogTable = buildEmptyCatalogTable(readonlyConfig, table);
         try {
             SeaTunnelRowType seaTunnelRowTypeInfo =
@@ -299,17 +303,7 @@ public class HiveSourceConfig implements Serializable {
 
     private CatalogTable parseCatalogTableFromTable(
             ReadonlyConfig readonlyConfig, ReadStrategy readStrategy, Table table) {
-        List<FieldSchema> cols = table.getSd().getCols();
-        String[] fieldNames = new String[cols.size()];
-        SeaTunnelDataType<?>[] fieldTypes = new SeaTunnelDataType[cols.size()];
-        for (int i = 0; i < cols.size(); i++) {
-            FieldSchema col = cols.get(i);
-            fieldNames[i] = col.getName();
-            fieldTypes[i] =
-                    HiveTypeConvertor.covertHiveTypeToSeaTunnelType(col.getName(), col.getType());
-        }
-
-        SeaTunnelRowType seaTunnelRowType = new SeaTunnelRowType(fieldNames, fieldTypes);
+        SeaTunnelRowType seaTunnelRowType = buildRowTypeFromHiveMeta(table);
         readStrategy.setCatalogTable(
                 CatalogTableUtil.getCatalogTable(
                         "hive", table.getDbName(), null, table.getTableName(), seaTunnelRowType));
@@ -319,13 +313,103 @@ public class HiveSourceConfig implements Serializable {
         return CatalogTableUtil.newCatalogTable(catalogTable, finalSeatunnelRowType);
     }
 
-    private CatalogTable buildEmptyCatalogTable(ReadonlyConfig readonlyConfig, Table table) {
+    /**
+     * Build a {@link CatalogTable} based on Hive metastore schema (table columns + optional
+     * partition columns). This is used as a fallback when there are no data files to infer schema
+     * from.
+     */
+    static CatalogTable buildCatalogTableFromHiveMeta(ReadonlyConfig readonlyConfig, Table table) {
+        SeaTunnelRowType rowType = buildRowTypeFromHiveMeta(table);
+        rowType = applyColumnProjectionIfPresent(readonlyConfig, rowType);
+        if (shouldParsePartitionFromPath(readonlyConfig)) {
+            rowType = appendPartitionColumnsAsString(table, rowType);
+        }
+        return CatalogTableUtil.newCatalogTable(
+                buildEmptyCatalogTable(readonlyConfig, table), rowType);
+    }
+
+    private static SeaTunnelRowType buildRowTypeFromHiveMeta(Table table) {
+        List<FieldSchema> cols = table.getSd().getCols();
+        String[] fieldNames = new String[cols.size()];
+        SeaTunnelDataType<?>[] fieldTypes = new SeaTunnelDataType[cols.size()];
+        for (int i = 0; i < cols.size(); i++) {
+            FieldSchema col = cols.get(i);
+            fieldNames[i] = col.getName();
+            fieldTypes[i] =
+                    HiveTypeConvertor.covertHiveTypeToSeaTunnelType(col.getName(), col.getType());
+        }
+        return new SeaTunnelRowType(fieldNames, fieldTypes);
+    }
+
+    private static SeaTunnelRowType applyColumnProjectionIfPresent(
+            ReadonlyConfig readonlyConfig, SeaTunnelRowType rowType) {
+        List<String> readColumns = readonlyConfig.getOptional(READ_COLUMNS).orElse(null);
+        if (CollectionUtils.isEmpty(readColumns)) {
+            return rowType;
+        }
+        String[] fieldNames = new String[readColumns.size()];
+        SeaTunnelDataType<?>[] fieldTypes = new SeaTunnelDataType[readColumns.size()];
+        for (int i = 0; i < readColumns.size(); i++) {
+            String colName = readColumns.get(i);
+            int index = rowType.indexOf(colName, false);
+            if (index < 0) {
+                throw new HiveConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format("read_columns contains non-existent column '%s'", colName));
+            }
+            fieldNames[i] = rowType.getFieldName(index);
+            fieldTypes[i] = rowType.getFieldType(index);
+        }
+        return new SeaTunnelRowType(fieldNames, fieldTypes);
+    }
+
+    private static boolean shouldParsePartitionFromPath(ReadonlyConfig readonlyConfig) {
+        return readonlyConfig
+                .getOptional(PARSE_PARTITION_FROM_PATH)
+                .orElse(PARSE_PARTITION_FROM_PATH.defaultValue());
+    }
+
+    private static SeaTunnelRowType appendPartitionColumnsAsString(
+            Table table, SeaTunnelRowType rowType) {
+        List<String> partitionKeys = extractPartitionKeyNames(table);
+        if (CollectionUtils.isEmpty(partitionKeys)) {
+            return rowType;
+        }
+        String[] baseFieldNames = rowType.getFieldNames();
+        SeaTunnelDataType<?>[] baseFieldTypes = rowType.getFieldTypes();
+        String[] newFieldNames =
+                Arrays.copyOf(baseFieldNames, baseFieldNames.length + partitionKeys.size());
+        SeaTunnelDataType<?>[] newFieldTypes =
+                Arrays.copyOf(baseFieldTypes, baseFieldTypes.length + partitionKeys.size());
+        int offset = baseFieldNames.length;
+        for (int i = 0; i < partitionKeys.size(); i++) {
+            newFieldNames[offset + i] = partitionKeys.get(i);
+            newFieldTypes[offset + i] = BasicType.STRING_TYPE;
+        }
+        return new SeaTunnelRowType(newFieldNames, newFieldTypes);
+    }
+
+    private static List<String> extractPartitionKeyNames(Table table) {
+        List<FieldSchema> partitionKeys = table.getPartitionKeys();
+        if (CollectionUtils.isEmpty(partitionKeys)) {
+            return new ArrayList<>();
+        }
+        List<String> names = new ArrayList<>(partitionKeys.size());
+        for (FieldSchema key : partitionKeys) {
+            if (key != null && StringUtils.isNotBlank(key.getName())) {
+                names.add(key.getName());
+            }
+        }
+        return names;
+    }
+
+    private static CatalogTable buildEmptyCatalogTable(ReadonlyConfig readonlyConfig, Table table) {
         TablePath tablePath = TablePath.of(table.getDbName(), table.getTableName());
         return CatalogTable.of(
                 TableIdentifier.of(HiveConstants.CONNECTOR_NAME, tablePath),
                 TableSchema.builder().build(),
                 new HashMap<>(),
-                new ArrayList<>(),
+                extractPartitionKeyNames(table),
                 readonlyConfig.get(ConnectorCommonOptions.TABLE_COMMENT));
     }
 }

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -299,8 +299,7 @@ public class HiveSourceConfig implements Serializable {
             List<String> filePaths,
             Table table) {
         if (CollectionUtils.isEmpty(filePaths)) {
-            // Keep a stable schema even when directory is empty.
-            return buildCatalogTableFromHiveMeta(readonlyConfig, table);
+            return handleEmptyFilesFallback(readonlyConfig, table);
         }
         switch (fileFormat) {
             case PARQUET:
@@ -314,6 +313,12 @@ public class HiveSourceConfig implements Serializable {
                         CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
                         "Hive connector only support [text parquet orc] table now");
         }
+    }
+
+    private static CatalogTable handleEmptyFilesFallback(
+            ReadonlyConfig readonlyConfig, Table table) {
+        // Keep a stable schema even when directory is empty.
+        return buildCatalogTableFromHiveMeta(readonlyConfig, table);
     }
 
     private CatalogTable parseCatalogTableFromRemotePath(

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -233,8 +233,12 @@ public class HiveSourceConfig implements Serializable {
     private static boolean isFileNotFound(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {
-            if (current instanceof FileNotFoundException
-                    || current instanceof org.apache.hadoop.fs.FileNotFoundException) {
+            if (current instanceof FileNotFoundException) {
+                return true;
+            }
+            String exceptionClass = current.getClass().getName();
+            if ("org.apache.hadoop.fs.FileNotFoundException".equals(exceptionClass)
+                    || "org.apache.hadoop.fs.PathNotFoundException".equals(exceptionClass)) {
                 return true;
             }
             current = current.getCause();

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -56,6 +56,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -220,14 +221,25 @@ public class HiveSourceConfig implements Serializable {
         String hdfsPath = parseHdfsPath(table);
         try {
             return readStrategy.getFileNamesByPath(hdfsPath);
-        } catch (Exception e) {
+        } catch (IOException e) {
             if (isFileNotFound(e)) {
                 return Collections.emptyList();
             }
-            String errorMsg = String.format("Get file list from this path [%s] failed", hdfsPath);
+            String errorMsg =
+                    String.format(
+                            "Get file list from this path [%s] failed, caused by: %s",
+                            hdfsPath, getExceptionSummary(e));
             throw new FileConnectorException(
                     FileConnectorErrorCode.FILE_LIST_GET_FAILED, errorMsg, e);
         }
+    }
+
+    private static String getExceptionSummary(Throwable throwable) {
+        String message = throwable.getMessage();
+        if (StringUtils.isBlank(message)) {
+            return throwable.getClass().getName();
+        }
+        return throwable.getClass().getName() + ": " + message;
     }
 
     private static boolean isFileNotFound(Throwable throwable) {

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -55,11 +55,13 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
+import java.io.FileNotFoundException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -219,10 +221,25 @@ public class HiveSourceConfig implements Serializable {
         try {
             return readStrategy.getFileNamesByPath(hdfsPath);
         } catch (Exception e) {
+            if (isFileNotFound(e)) {
+                return Collections.emptyList();
+            }
             String errorMsg = String.format("Get file list from this path [%s] failed", hdfsPath);
             throw new FileConnectorException(
                     FileConnectorErrorCode.FILE_LIST_GET_FAILED, errorMsg, e);
         }
+    }
+
+    private static boolean isFileNotFound(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof FileNotFoundException
+                    || current instanceof org.apache.hadoop.fs.FileNotFoundException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private String parseFsDefaultName(Table table) {

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfig.java
@@ -49,6 +49,7 @@ import org.apache.seatunnel.connectors.seatunnel.hive.utils.HiveTableUtils;
 import org.apache.seatunnel.connectors.seatunnel.hive.utils.HiveTypeConvertor;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 
@@ -60,6 +61,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -245,12 +247,9 @@ public class HiveSourceConfig implements Serializable {
     private static boolean isFileNotFound(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {
-            if (current instanceof FileNotFoundException) {
-                return true;
-            }
-            String exceptionClass = current.getClass().getName();
-            if ("org.apache.hadoop.fs.FileNotFoundException".equals(exceptionClass)
-                    || "org.apache.hadoop.fs.PathNotFoundException".equals(exceptionClass)) {
+            if (current instanceof FileNotFoundException
+                    || current instanceof NoSuchFileException
+                    || current instanceof PathNotFoundException) {
                 return true;
             }
             current = current.getCause();

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfigEmptyFilesTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/source/config/HiveSourceConfigEmptyFilesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hive.source.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class HiveSourceConfigEmptyFilesTest {
+
+    @Test
+    void testBuildCatalogTableFromHiveMetaIncludesPartitionColumnsByDefault() {
+        Table table = newPartitionedTable();
+        ReadonlyConfig config = ReadonlyConfig.fromMap(new HashMap<>());
+
+        CatalogTable catalogTable = HiveSourceConfig.buildCatalogTableFromHiveMeta(config, table);
+        SeaTunnelRowType rowType = catalogTable.getSeaTunnelRowType();
+
+        Assertions.assertArrayEquals(
+                new String[] {"id", "name", "dt", "region"}, rowType.getFieldNames());
+        Assertions.assertEquals(Arrays.asList("dt", "region"), catalogTable.getPartitionKeys());
+    }
+
+    @Test
+    void testBuildCatalogTableFromHiveMetaCanDisablePartitionColumns() {
+        Table table = newPartitionedTable();
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("parse_partition_from_path", false);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        CatalogTable catalogTable = HiveSourceConfig.buildCatalogTableFromHiveMeta(config, table);
+        SeaTunnelRowType rowType = catalogTable.getSeaTunnelRowType();
+
+        Assertions.assertArrayEquals(new String[] {"id", "name"}, rowType.getFieldNames());
+        Assertions.assertEquals(Arrays.asList("dt", "region"), catalogTable.getPartitionKeys());
+    }
+
+    private static Table newPartitionedTable() {
+        Table table = new Table();
+        table.setDbName("default");
+        table.setTableName("t_partitioned");
+
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setCols(
+                Arrays.asList(
+                        new FieldSchema("id", "bigint", null),
+                        new FieldSchema("name", "string", null)));
+        table.setSd(sd);
+
+        List<FieldSchema> partitionKeys =
+                Arrays.asList(
+                        new FieldSchema("dt", "string", null),
+                        new FieldSchema("region", "int", null));
+        table.setPartitionKeys(partitionKeys);
+        return table;
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
@@ -105,6 +105,31 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                     + "    score  INT"
                     + ")";
 
+    private static final String CREATE_EMPTY_TEXT_SQL =
+            "CREATE TABLE IF NOT EXISTS default.test_hive_empty_text"
+                    + "("
+                    + "    pk_id  BIGINT,"
+                    + "    name   STRING,"
+                    + "    score  INT"
+                    + ")"
+                    + " ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LINES TERMINATED BY '\\n' STORED AS TEXTFILE";
+
+    private static final String CREATE_EMPTY_PARQUET_SQL =
+            "CREATE TABLE IF NOT EXISTS default.test_hive_empty_parquet"
+                    + "("
+                    + "    pk_id  BIGINT,"
+                    + "    name   STRING,"
+                    + "    score  INT"
+                    + ") STORED AS PARQUET";
+
+    private static final String CREATE_EMPTY_PARQUET_TARGET_SQL =
+            "CREATE TABLE IF NOT EXISTS default.test_hive_empty_parquet_target"
+                    + "("
+                    + "    pk_id  BIGINT,"
+                    + "    name   STRING,"
+                    + "    score  INT"
+                    + ") STORED AS PARQUET";
+
     private static final String HMS_HOST = "metastore";
     private static final String HIVE_SERVER_HOST = "hiveserver2";
 
@@ -258,6 +283,9 @@ public class HiveIT extends TestSuiteBase implements TestResource {
         try (Statement statement = this.hiveConnection.createStatement()) {
             statement.execute(CREATE_SQL);
             statement.execute(CREATE_FAILOVER_SQL);
+            statement.execute(CREATE_EMPTY_TEXT_SQL);
+            statement.execute(CREATE_EMPTY_PARQUET_SQL);
+            statement.execute(CREATE_EMPTY_PARQUET_TARGET_SQL);
             statement.execute(CREATE_REGEX_DB_A_SQL);
             statement.execute(CREATE_REGEX_DB_ABC_SQL);
             statement.execute(CREATE_REGEX_TABLE_1_SQL);
@@ -292,6 +320,18 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                 container,
                 "/fake_to_hive_metastore_uri_failover.conf",
                 "/hive_to_assert_metastore_uri_failover.conf");
+    }
+
+    @TestTemplate
+    public void testHiveSourceEmptyTextTable(TestContainer container) throws Exception {
+        Container.ExecResult execResult = container.executeJob("/hive_empty_text_to_assert.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
+    @TestTemplate
+    public void testHiveSourceEmptyParquetTableToHive(TestContainer container) throws Exception {
+        Container.ExecResult execResult = container.executeJob("/hive_empty_parquet_to_hive.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
     }
 
     @TestTemplate

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
@@ -122,6 +122,14 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                     + "    score  INT"
                     + ") STORED AS PARQUET";
 
+    private static final String CREATE_EMPTY_ORC_SQL =
+            "CREATE TABLE IF NOT EXISTS default.test_hive_empty_orc"
+                    + "("
+                    + "    pk_id  BIGINT,"
+                    + "    name   STRING,"
+                    + "    score  INT"
+                    + ") STORED AS ORC";
+
     private static final String CREATE_EMPTY_PARQUET_TARGET_SQL =
             "CREATE TABLE IF NOT EXISTS default.test_hive_empty_parquet_target"
                     + "("
@@ -285,6 +293,7 @@ public class HiveIT extends TestSuiteBase implements TestResource {
             statement.execute(CREATE_FAILOVER_SQL);
             statement.execute(CREATE_EMPTY_TEXT_SQL);
             statement.execute(CREATE_EMPTY_PARQUET_SQL);
+            statement.execute(CREATE_EMPTY_ORC_SQL);
             statement.execute(CREATE_EMPTY_PARQUET_TARGET_SQL);
             statement.execute(CREATE_REGEX_DB_A_SQL);
             statement.execute(CREATE_REGEX_DB_ABC_SQL);
@@ -325,6 +334,12 @@ public class HiveIT extends TestSuiteBase implements TestResource {
     @TestTemplate
     public void testHiveSourceEmptyTextTable(TestContainer container) throws Exception {
         Container.ExecResult execResult = container.executeJob("/hive_empty_text_to_assert.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
+    @TestTemplate
+    public void testHiveSourceEmptyOrcTable(TestContainer container) throws Exception {
+        Container.ExecResult execResult = container.executeJob("/hive_empty_orc_to_assert.conf");
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_orc_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_orc_to_assert.conf
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Hive {
+    table_name = "default.test_hive_empty_orc"
+    metastore_uri = "thrift://metastore:9083"
+    hive.hadoop.conf-path = "/tmp/hadoop"
+    plugin_output = hive_source
+  }
+}
+
+sink {
+  Assert {
+    plugin_input = hive_source
+    rules {
+      row_rules = [
+        {
+          rule_type = MAX_ROW
+          rule_value = 0
+        }
+      ]
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_parquet_to_hive.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_parquet_to_hive.conf
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Hive {
+    table_name = "default.test_hive_empty_parquet"
+    metastore_uri = "thrift://metastore:9083"
+    hive.hadoop.conf-path = "/tmp/hadoop"
+    plugin_output = hive_source
+  }
+}
+
+sink {
+  Hive {
+    plugin_input = hive_source
+    table_name = "default.test_hive_empty_parquet_target"
+    metastore_uri = "thrift://metastore:9083"
+    hive.hadoop.conf-path = "/tmp/hadoop"
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_text_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/resources/hive_empty_text_to_assert.conf
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Hive {
+    table_name = "default.test_hive_empty_text"
+    metastore_uri = "thrift://metastore:9083"
+    hive.hadoop.conf-path = "/tmp/hadoop"
+    plugin_output = hive_source
+  }
+}
+
+sink {
+  Assert {
+    plugin_input = hive_source
+    rules {
+      row_rules = [
+        {
+          rule_type = MAX_ROW
+          rule_value = 0
+        }
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
Fix Hive Source initialization failures when the Hive table (or selected partitions) contains **no readable data files** (e.g. newly created empty table, empty partitions, or filters result in no files).

Before this pr:
- TEXT tables may fail during source initialization with:
  - `java.lang.IndexOutOfBoundsException: Index: 0, Size: 0`
  - caused by file read strategy referencing `fileNames.get(0)` while `fileNames` is empty.
- ORC/PARQUET tables may build an empty (0-column) schema when no files exist, which can later fail Hive Sink initialization with:
  - `java.lang.IllegalArgumentException`
  - from `FileSinkConfig` precondition check (empty rowType).

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes.

This pr adds a Hive Metastore (HMS) schema fallback when the table/partition location contains no data files:
- Build a stable non-empty schema from HMS (table columns + optional partition columns), so the job can start and process **0 rows** gracefully.
- Keeps partition keys metadata in CatalogTable.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

1. Added unit test:

- `HiveSourceConfigEmptyFilesTest`

2. Added e2e coverage:

- Empty TEXT table read -> Assert (0 rows)
- Empty PARQUET table Hive -> Hive job init


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)