### PR TITLE
[Fix][Connector-V2][Hbase] Fix ERROR_WHEN_DATA_EXISTS NPE on empty table

### DIFF
--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/client/HbaseClient.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/client/HbaseClient.java
@@ -310,15 +310,13 @@ public class HbaseClient {
      * @return true if the table has data, false otherwise
      */
     public boolean isExistsData(String databaseName, String tableName) {
-        try {
-            Table table = connection.getTable(TableName.valueOf(databaseName, tableName));
-            Scan scan = new Scan();
-            scan.setCaching(1);
-            scan.setLimit(1);
-            try (ResultScanner scanner = table.getScanner(scan)) {
-                Result result = scanner.next();
-                return !result.isEmpty();
-            }
+        Scan scan = new Scan();
+        scan.setCaching(1);
+        scan.setLimit(1);
+        try (Table table = connection.getTable(TableName.valueOf(databaseName, tableName));
+                ResultScanner scanner = table.getScanner(scan)) {
+            Result result = scanner.next();
+            return result != null && !result.isEmpty();
         } catch (IOException e) {
             throw new HbaseConnectorException(
                     HbaseConnectorErrorCode.TABLE_QUERY_EXCEPTION,

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/client/HbaseClientTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/client/HbaseClientTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hbase.client;
+
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
+
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.BufferedMutatorParams;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+class HbaseClientTest {
+
+    @Test
+    void testIsExistsDataReturnsFalseWhenScannerNextReturnsNull() throws Exception {
+        Connection connection = Mockito.mock(Connection.class);
+        Table table = Mockito.mock(Table.class);
+        ResultScanner scanner = Mockito.mock(ResultScanner.class);
+        Mockito.when(connection.getTable(any(TableName.class))).thenReturn(table);
+        Mockito.when(table.getScanner(any(Scan.class))).thenReturn(scanner);
+        Mockito.when(scanner.next()).thenReturn(null);
+
+        HbaseClient client = newHbaseClient(connection);
+
+        assertFalse(client.isExistsData("ns", "tbl"));
+    }
+
+    @Test
+    void testIsExistsDataReturnsTrueWhenScannerHasResult() throws Exception {
+        Connection connection = Mockito.mock(Connection.class);
+        Table table = Mockito.mock(Table.class);
+        ResultScanner scanner = Mockito.mock(ResultScanner.class);
+        Result result = Mockito.mock(Result.class);
+        Mockito.when(result.isEmpty()).thenReturn(false);
+        Mockito.when(connection.getTable(any(TableName.class))).thenReturn(table);
+        Mockito.when(table.getScanner(any(Scan.class))).thenReturn(scanner);
+        Mockito.when(scanner.next()).thenReturn(result);
+
+        HbaseClient client = newHbaseClient(connection);
+
+        assertTrue(client.isExistsData("ns", "tbl"));
+    }
+
+    private HbaseClient newHbaseClient(Connection connection) throws Exception {
+        HbaseClient.hbaseConfiguration = HBaseConfiguration.create();
+        Mockito.when(connection.getAdmin()).thenReturn(Mockito.mock(Admin.class));
+        Mockito.when(connection.getBufferedMutator(any(BufferedMutatorParams.class)))
+                .thenReturn(Mockito.mock(BufferedMutator.class));
+        HbaseParameters hbaseParameters = Mockito.mock(HbaseParameters.class);
+        Mockito.when(hbaseParameters.getNamespace()).thenReturn("ns");
+        Mockito.when(hbaseParameters.getTable()).thenReturn("tbl");
+        Mockito.when(hbaseParameters.getWriteBufferSize()).thenReturn(1);
+
+        Constructor<HbaseClient> constructor =
+                HbaseClient.class.getDeclaredConstructor(Connection.class, HbaseParameters.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(connection, hbaseParameters);
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hbase/HbaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hbase/HbaseIT.java
@@ -167,6 +167,17 @@ public class HbaseIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
+    public void testHbaseSinkWithErrorWhenDataExistsOnEmptyTable(TestContainer container)
+            throws IOException, InterruptedException {
+        deleteData(table);
+        Assertions.assertEquals(0, countData(table));
+        Container.ExecResult execResult =
+                container.executeJob("/fake_to_hbase_with_error_when_data_exists.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+        Assertions.assertEquals(5, countData(table));
+    }
+
+    @TestTemplate
     public void testHbaseSinkWithRecreateSchema(TestContainer container)
             throws IOException, InterruptedException {
         String tableName = "seatunnel_test_with_recreate_schema";


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Fix NPE in HBase data-exists check. ResultScanner#next() may return null when the table/result set is empty, which previously caused ERROR_WHEN_DATA_EXISTS to fail unexpectedly. Make the check null-safe and close Table/ResultScanner via try-with-resources.

### Does this PR introduce _any_ user-facing change?
Yes. With HBase sink data_save_mode = ERROR_WHEN_DATA_EXISTS, writing to an existing but empty table used to fail with NPE; now it succeeds and writes data. Behavior when the target table already has data is unchanged (still fails as expected).
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

- Added unit test: HbaseClientTest

- Added e2e test: HbaseIT#testHbaseSinkWithErrorWhenDataExistsOnEmptyTable

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)ty table
