### PR TITLE
[Improve][Docs] Add S3 Compatible Storage IMAP configuration example. Closes #10308

### DIFF
--- a/docs/en/engines/zeta/hybrid-cluster-deployment.md
+++ b/docs/en/engines/zeta/hybrid-cluster-deployment.md
@@ -343,7 +343,12 @@ netty-common-4.1.89.Final.jar
 seatunnel-hadoop3-3.1.4-uber.jar
 ```
 
-If you would like to use S3 Compatable storage such as Minio, you can configure it like this:
+It is possible to utilize S3 for IMAP storage. 
+
+The S3 configuration properties follow the Hadoop S3A filesystem (Native S3) standard. Specifically, we utilize the fs.s3a.access.key and fs.s3a.secret.key properties to ensure compatibility with existing Hadoop-based ecosystems.
+
+If you would like to use S3 compatible storage such as Minio, you can configure it like this:
+
 
 ```yaml
 map:
@@ -359,12 +364,20 @@ map:
          storage.type: s3
          s3.bucket: s3a://your-bucket
          fs.defaultFS: s3a://your-bucket
-         fs.s3a.endpoint: http[s]://your-s3-endpoint:port
-         fs.s3a.path.style.access: "true"
-         fs.s3a.access.key: s3_access_key
-         fs.s3a.secret.key: s3_secret_key
+         fs.s3a.endpoint: http://your-minio-endpoint:port
+         fs.s3a.path.style.access: true
+         fs.s3a.access.key: YOUR_ACCESS_KEY
+         fs.s3a.secret.key: YOUR_SECRET_KEY
          fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 ```
+
+Notice: When using S3, make sure that the following jars are in the lib directory.
+
+```
+seatunnel-hadoop3-3.1.4-uber.jar
+seatunnel-hadoop-aws.jar
+```
+
 
 ## 6. Configure The SeaTunnel Engine Client
 

--- a/docs/en/engines/zeta/hybrid-cluster-deployment.md
+++ b/docs/en/engines/zeta/hybrid-cluster-deployment.md
@@ -343,6 +343,29 @@ netty-common-4.1.89.Final.jar
 seatunnel-hadoop3-3.1.4-uber.jar
 ```
 
+If you would like to use S3 Compatable storage such as Minio, you can configure it like this:
+
+```yaml
+map:
+   engine*:
+     map-store:
+       enabled: true
+       initial-mode: EAGER
+       factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+       properties:
+         type: hdfs
+         namespace: /seatunnel/engine
+         clusterName: seatunnel
+         storage.type: s3
+         s3.bucket: s3a://your-bucket
+         fs.defaultFS: s3a://your-bucket
+         fs.s3a.endpoint: http[s]://your-s3-endpoint:port
+         fs.s3a.path.style.access: "true"
+         fs.s3a.access.key: s3_access_key
+         fs.s3a.secret.key: s3_secret_key
+         fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+```
+
 ## 6. Configure The SeaTunnel Engine Client
 
 All SeaTunnel Engine client configurations are in the `hazelcast-client.yaml`.

--- a/docs/en/engines/zeta/separated-cluster-deployment.md
+++ b/docs/en/engines/zeta/separated-cluster-deployment.md
@@ -287,6 +287,29 @@ netty-common-4.1.89.Final.jar
 seatunnel-hadoop3-3.1.4-uber.jar
 ```
 
+If you would like to use S3 Compatable storage such as Minio, you can configure it like this:
+
+```yaml
+map:
+   engine*:
+     map-store:
+       enabled: true
+       initial-mode: EAGER
+       factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+       properties:
+         type: hdfs
+         namespace: /seatunnel/engine
+         clusterName: seatunnel
+         storage.type: s3
+         s3.bucket: s3a://your-bucket
+         fs.defaultFS: s3a://your-bucket
+         fs.s3a.endpoint: http[s]://your-s3-endpoint:port
+         fs.s3a.path.style.access: "true"
+         fs.s3a.access.key: s3_access_key
+         fs.s3a.secret.key: s3_secret_key
+         fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+```
+
 ### 4.7 Job Scheduling Strategy
 
 When resources are insufficient, the job scheduling strategy can be configured in the following two modes:

--- a/docs/en/engines/zeta/separated-cluster-deployment.md
+++ b/docs/en/engines/zeta/separated-cluster-deployment.md
@@ -287,7 +287,11 @@ netty-common-4.1.89.Final.jar
 seatunnel-hadoop3-3.1.4-uber.jar
 ```
 
-If you would like to use S3 Compatable storage such as Minio, you can configure it like this:
+It is possible to utilize S3 for IMAP storage. 
+
+The S3 configuration properties follow the Hadoop S3A filesystem (Native S3) standard. Specifically, we utilize the fs.s3a.access.key and fs.s3a.secret.key properties to ensure compatibility with existing Hadoop-based ecosystems.
+
+If you would like to use S3 compatible storage such as Minio, you can configure it like this:
 
 ```yaml
 map:
@@ -303,11 +307,18 @@ map:
          storage.type: s3
          s3.bucket: s3a://your-bucket
          fs.defaultFS: s3a://your-bucket
-         fs.s3a.endpoint: http[s]://your-s3-endpoint:port
-         fs.s3a.path.style.access: "true"
-         fs.s3a.access.key: s3_access_key
-         fs.s3a.secret.key: s3_secret_key
+         fs.s3a.endpoint: http://your-minio-endpoint:port
+         fs.s3a.path.style.access: true
+         fs.s3a.access.key: YOUR_ACCESS_KEY
+         fs.s3a.secret.key: YOUR_SECRET_KEY
          fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+```
+
+Notice: When using S3, make sure that the following jars are in the lib directory.
+
+```
+seatunnel-hadoop3-3.1.4-uber.jar
+seatunnel-hadoop-aws.jar
 ```
 
 ### 4.7 Job Scheduling Strategy


### PR DESCRIPTION
### Purpose of the Request

This PR updates documentation for IMAP configuration. 

- The IMAP configuration does not currently provide an example for usage with S3 compatible object storage. This usage is currently un-documented. 

This PR updates the following documents with example configuration:

hybrid-cluster-deployment.md
separated-cluster-deployment.md

Fixes: #10308 

### How was this patch tested?
No tests needed


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)