### PR TITLE
[Fix][Connector-V2][Redis] Fix RedisWriter custom key placeholder

### DIFF
--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriter.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
 public class RedisSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         implements SupportMultiTableSinkWriter<Void> {
     private static final Pattern LEGACY_PLACEHOLDER_PATTERN =
-            Pattern.compile("(?<!\\$)\\{([^{}]+)\\}");;
+            Pattern.compile("(?<!\\$)\\{([^{}]+)\\}");
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
     private final SeaTunnelRowType seaTunnelRowType;
     private final RedisParameters redisParameters;

--- a/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-redis/src/main/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriter.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
 public class RedisSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         implements SupportMultiTableSinkWriter<Void> {
     private static final Pattern LEGACY_PLACEHOLDER_PATTERN =
-            Pattern.compile("(?<!\\$)\\{([^}]+)\\}");
+            Pattern.compile("(?<!\\$)\\{([^{}]+)\\}");;
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
     private final SeaTunnelRowType seaTunnelRowType;
     private final RedisParameters redisParameters;

--- a/seatunnel-connectors-v2/connector-redis/src/test/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-redis/src/test/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriterTest.java
@@ -90,6 +90,29 @@ public class RedisSinkWriterTest {
     }
 
     @Test
+    void testGetCustomKeyWithMultipleCurlyBraces() {
+        // Set custom key mode
+        when(mockRedisParameters.getKeyField()).thenReturn("user:{${id}}:profile");
+        when(mockRedisParameters.getSupportCustomKey()).thenReturn(true);
+        when(mockRedisParameters.getRedisDataType()).thenReturn(RedisDataType.STRING);
+        when(mockRedisParameters.getExpire()).thenReturn(3600L);
+
+        redisSinkWriter = new RedisSinkWriter(rowType, mockRedisParameters);
+
+        // create test data
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "Alice", 25, "alice@test.com"});
+        row.setRowKind(RowKind.INSERT);
+
+        String customKey =
+                redisSinkWriter.getCustomKey(
+                        row,
+                        Arrays.asList(rowType.getFieldNames()),
+                        mockRedisParameters.getKeyField());
+
+        Assertions.assertEquals("user:{1}:profile", customKey);
+    }
+
+    @Test
     public void testLegacyCustomKey() {
         when(mockRedisParameters.getKeyField()).thenReturn("user:{id}:profile");
 
@@ -110,5 +133,28 @@ public class RedisSinkWriterTest {
                         mockRedisParameters.getKeyField());
 
         Assertions.assertEquals("user:1:profile", customKey);
+    }
+
+    @Test
+    public void testLegacyCustomKeyWithMultipleCurlyBraces() {
+        when(mockRedisParameters.getKeyField()).thenReturn("user:{{id}}:profile");
+
+        when(mockRedisParameters.getSupportCustomKey()).thenReturn(true);
+        when(mockRedisParameters.getRedisDataType()).thenReturn(RedisDataType.STRING);
+        when(mockRedisParameters.getExpire()).thenReturn(3600L);
+
+        redisSinkWriter = new RedisSinkWriter(rowType, mockRedisParameters);
+
+        // create test data
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "Alice", 25, "alice@test.com"});
+        row.setRowKind(RowKind.INSERT);
+
+        String customKey =
+                redisSinkWriter.getCustomKey(
+                        row,
+                        Arrays.asList(rowType.getFieldNames()),
+                        mockRedisParameters.getKeyField());
+
+        Assertions.assertEquals("user:{1}:profile", customKey);
     }
 }

--- a/seatunnel-connectors-v2/connector-redis/src/test/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-redis/src/test/java/org/apache/seatunnel/connectors/seatunnel/redis/sink/RedisSinkWriterTest.java
@@ -92,7 +92,7 @@ public class RedisSinkWriterTest {
     @Test
     void testGetCustomKeyWithMultipleCurlyBraces() {
         // Set custom key mode
-        when(mockRedisParameters.getKeyField()).thenReturn("user:{${id}}:profile");
+        when(mockRedisParameters.getKeyField()).thenReturn("user:{${id}}:${age}:profile");
         when(mockRedisParameters.getSupportCustomKey()).thenReturn(true);
         when(mockRedisParameters.getRedisDataType()).thenReturn(RedisDataType.STRING);
         when(mockRedisParameters.getExpire()).thenReturn(3600L);
@@ -109,7 +109,7 @@ public class RedisSinkWriterTest {
                         Arrays.asList(rowType.getFieldNames()),
                         mockRedisParameters.getKeyField());
 
-        Assertions.assertEquals("user:{1}:profile", customKey);
+        Assertions.assertEquals("user:{1}:25:profile", customKey);
     }
 
     @Test


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Fix Redis Connector RedisWriter custom key's placeholder when the custom_key configuration contains multiple layers of curly braces, this is useful when use HashTag in redis cluster mode.

For example there is a SeaTunnelRow{id=1}.

Before fix: 
custom_key: user:{${id}}:profile -> user:${id}:profile

After fix:
custom_key: user:{${id}}:profile -> user:{1}:profile

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
No


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
Add Unit tests in RedisSinkWriterTest.java, and all test passed.


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)