### PR TITLE
[Improve][Transform-V2] Add whitelist-based validation for datetime format patterns in PARSEDATETIME/TO_DATE

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -13,6 +13,15 @@ You need to check this document before you upgrade to related version.
 
 ### Transform Changes
 
+- **[BREAKING]** SQL Transform `PARSEDATETIME` and `TO_DATE` functions now only accept whitelisted datetime format patterns. Custom format patterns that were previously accepted will now fail at runtime. The supported patterns are:
+    - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
+    - Date: `yyyy-MM-dd`
+    - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
+
+  **Exception Type Change**: Invalid datetime format patterns now throw `SeaTunnelRuntimeException` instead of `TransformException`. If you have error handling or monitoring systems that catch `TransformException` for datetime parsing errors, you will need to update them to handle `SeaTunnelRuntimeException`.
+
+  **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME` or `TO_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
+
 - DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).
 - Adjusted SQL Transform date & time functions:
   - `DATEDIFF(<start>, <end>, 'MONTH')` now returns the total number of months between the two dates across years (for example, from `2023-01-01` to `2024-03-01` returns `14` instead of `15`).

--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -20,6 +20,7 @@ You need to check this document before you upgrade to related version.
 
   **Exception Type Change**: Invalid datetime format patterns now throw `SeaTunnelRuntimeException` instead of `TransformException`. If you have error handling or monitoring systems that catch `TransformException` for datetime parsing errors, you will need to update them to handle `SeaTunnelRuntimeException`.
 
+
   **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME` or `TO_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
 
 - DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).

--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -14,15 +14,13 @@ You need to check this document before you upgrade to related version.
 ### Transform Changes
 
 - **[BREAKING]** SQL Transform `PARSEDATETIME` and `TO_DATE` functions now only accept whitelisted datetime format patterns. Custom format patterns that were previously accepted will now fail at runtime. The supported patterns are:
-    - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
-    - Date: `yyyy-MM-dd`
-    - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
+  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
+  - Date: `yyyy-MM-dd`
+  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
 
   **Exception Type Change**: Invalid datetime format patterns now throw `SeaTunnelRuntimeException` instead of `TransformException`. If you have error handling or monitoring systems that catch `TransformException` for datetime parsing errors, you will need to update them to handle `SeaTunnelRuntimeException`.
 
-
   **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME` or `TO_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
-
 - DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).
 - Adjusted SQL Transform date & time functions:
   - `DATEDIFF(<start>, <end>, 'MONTH')` now returns the total number of months between the two dates across years (for example, from `2023-01-01` to `2024-03-01` returns `14` instead of `15`).

--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -13,14 +13,14 @@ You need to check this document before you upgrade to related version.
 
 ### Transform Changes
 
-- **[BREAKING]** SQL Transform `PARSEDATETIME` and `TO_DATE` functions now only accept whitelisted datetime format patterns. Custom format patterns that were previously accepted will now fail at runtime. The supported patterns are:
-  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
-  - Date: `yyyy-MM-dd`
-  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
+- **[BREAKING]** SQL Transform `PARSEDATETIME`, `TO_DATE`, and `IS_DATE` functions now only accept whitelisted datetime format patterns. Custom format patterns that were previously accepted will now fail at runtime. The supported patterns are:
+  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`, `yyyy/MM/dd HH:mm:ss`, `yyyy/MM/dd HH:mm:ss.SSS`, `yyyyMMddHHmmss`
+  - Date: `yyyy-MM-dd`, `yyyy/MM/dd`, `yyyyMMdd`
+  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`, `HHmmss`
 
   **Exception Type Change**: Invalid datetime format patterns now throw `SeaTunnelRuntimeException` instead of `TransformException`. If you have error handling or monitoring systems that catch `TransformException` for datetime parsing errors, you will need to update them to handle `SeaTunnelRuntimeException`.
 
-  **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME` or `TO_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
+  **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME`, `TO_DATE`, or `IS_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
 - DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).
 - Adjusted SQL Transform date & time functions:
   - `DATEDIFF(<start>, <end>, 'MONTH')` now returns the total number of months between the two dates across years (for example, from `2023-01-01` to `2024-03-01` returns `14` instead of `15`).

--- a/docs/en/transforms/sql-functions.md
+++ b/docs/en/transforms/sql-functions.md
@@ -889,11 +889,48 @@ MONTHNAME(CREATED)
 ### IS_DATE
 
 ```IS_DATE(string, formatString) -> BOOLEAN```
-Parses a string. The most important format characters are: y year, M month, d day, H hour, m minute, s second. For details of the format, see java.time.format.DateTimeFormatter.
+Validates whether a string can be parsed as a date/time value using the specified format pattern.
+
+**Supported Format Patterns:**
+
+DateTime Formats:
+- `yyyy-MM-dd HH:mm:ss` - Standard datetime format
+- `yyyy-MM-dd HH:mm:ss.SSS` - Datetime with milliseconds
+- `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 datetime format
+- `yyyy-MM-dd'T'HH:mm:ss.SSS` - ISO 8601 datetime with milliseconds
+- `yyyy/MM/dd HH:mm:ss` - Datetime with slash separator
+- `yyyy/MM/dd HH:mm:ss.SSS` - Datetime with slash separator and milliseconds
+- `yyyyMMddHHmmss` - Compact datetime format
+
+Date Formats:
+- `yyyy-MM-dd` - ISO 8601 date format
+- `yyyy/MM/dd` - Date with slash separator
+- `yyyyMMdd` - Compact date format
+
+Time Formats:
+- `HH:mm:ss` - Standard time format
+- `HH:mm:ss.SSS` - Time with milliseconds
+- `HHmmss` - Compact time format
 
 Example:
 
-CALL IS_DATE('2021-04-08 13:34:45','yyyy-MM-dd HH:mm:ss')
+```sql
+CALL IS_DATE('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
+-- Returns true
+
+CALL IS_DATE('2021/04/08', 'yyyy/MM/dd')
+-- Returns true
+
+CALL IS_DATE('20210408', 'yyyyMMdd')
+-- Returns true
+
+-- Consistent with TO_DATE
+SELECT CASE
+  WHEN IS_DATE(date_string, 'yyyy-MM-dd HH:mm:ss')
+  THEN TO_DATE(date_string, 'yyyy-MM-dd HH:mm:ss')
+  ELSE NULL
+END as parsed_date
+```
 
 ### PARSEDATETIME / TO_DATE
 
@@ -907,13 +944,19 @@ DateTime Formats (returns TIMESTAMP):
 - `yyyy-MM-dd HH:mm:ss.SSS` - Datetime with milliseconds
 - `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 datetime format
 - `yyyy-MM-dd'T'HH:mm:ss.SSS` - ISO 8601 datetime with milliseconds
+- `yyyy/MM/dd HH:mm:ss` - Datetime with slash separator
+- `yyyy/MM/dd HH:mm:ss.SSS` - Datetime with slash separator and milliseconds
+- `yyyyMMddHHmmss` - Compact datetime format
 
 Date Formats (returns DATE):
 - `yyyy-MM-dd` - ISO 8601 date format
+- `yyyy/MM/dd` - Date with slash separator
+- `yyyyMMdd` - Compact date format
 
 Time Formats (returns TIME):
 - `HH:mm:ss` - Standard time format
 - `HH:mm:ss.SSS` - Time with milliseconds
+- `HHmmss` - Compact time format
 
 **Note:** When using single quotes (`'`) in format patterns (e.g., for ISO 8601 'T' separator), they must be escaped as `''` in SQL.
 
@@ -924,13 +967,18 @@ Examples:
 CALL PARSEDATETIME('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
 CALL TO_DATE('2021-04-08T13:34:45', 'yyyy-MM-dd''T''HH:mm:ss')
 CALL PARSEDATETIME('2024-06-15 14:30:45.123', 'yyyy-MM-dd HH:mm:ss.SSS')
+CALL PARSEDATETIME('2021/04/08 13:34:45', 'yyyy/MM/dd HH:mm:ss')
+CALL PARSEDATETIME('20210408133445', 'yyyyMMddHHmmss')
 
--- Date example
+-- Date examples
 CALL TO_DATE('2021-04-08', 'yyyy-MM-dd')
+CALL TO_DATE('2021/04/08', 'yyyy/MM/dd')
+CALL TO_DATE('20210408', 'yyyyMMdd')
 
 -- Time examples
 CALL PARSEDATETIME('14:30:45', 'HH:mm:ss')
 CALL PARSEDATETIME('14:30:45.123', 'HH:mm:ss.SSS')
+CALL PARSEDATETIME('143045', 'HHmmss')
 ```
 
 ### QUARTER

--- a/docs/en/transforms/sql-functions.md
+++ b/docs/en/transforms/sql-functions.md
@@ -897,14 +897,41 @@ CALL IS_DATE('2021-04-08 13:34:45','yyyy-MM-dd HH:mm:ss')
 
 ### PARSEDATETIME / TO_DATE
 
-```PARSEDATETIME | TO_DATE(string, formatString) -> TIMESTAMP```
-Parses a string. The most important format characters are: y year, M month, d day, H hour, m minute, s second. For details of the format, see java.time.format.DateTimeFormatter.
+```PARSEDATETIME | TO_DATE(string, formatString) -> TIMESTAMP | DATE | TIME```
+Parses a string into a date/time value using the specified format pattern.
 
-Example:
+**Supported Format Patterns:**
 
-CALL PARSEDATETIME('2021-04-08 13:34:45','yyyy-MM-dd HH:mm:ss')
-CALL TO_DATE('2021-04-08'T'13:34:45','yyyy-MM-dd''T''HH:mm:ss')
-Note that when filling in `'` in SQL functions, it needs to be escaped to `''`.
+DateTime Formats (returns TIMESTAMP):
+- `yyyy-MM-dd HH:mm:ss` - Standard datetime format
+- `yyyy-MM-dd HH:mm:ss.SSS` - Datetime with milliseconds
+- `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 datetime format
+- `yyyy-MM-dd'T'HH:mm:ss.SSS` - ISO 8601 datetime with milliseconds
+
+Date Formats (returns DATE):
+- `yyyy-MM-dd` - ISO 8601 date format
+
+Time Formats (returns TIME):
+- `HH:mm:ss` - Standard time format
+- `HH:mm:ss.SSS` - Time with milliseconds
+
+**Note:** When using single quotes (`'`) in format patterns (e.g., for ISO 8601 'T' separator), they must be escaped as `''` in SQL.
+
+Examples:
+
+```sql
+-- DateTime examples
+CALL PARSEDATETIME('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
+CALL TO_DATE('2021-04-08T13:34:45', 'yyyy-MM-dd''T''HH:mm:ss')
+CALL PARSEDATETIME('2024-06-15 14:30:45.123', 'yyyy-MM-dd HH:mm:ss.SSS')
+
+-- Date example
+CALL TO_DATE('2021-04-08', 'yyyy-MM-dd')
+
+-- Time examples
+CALL PARSEDATETIME('14:30:45', 'HH:mm:ss')
+CALL PARSEDATETIME('14:30:45.123', 'HH:mm:ss.SSS')
+```
 
 ### QUARTER
 

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -12,6 +12,15 @@
 
 ### 转换变更
 
+- **[BREAKING]** SQL Transform 的 `PARSEDATETIME` 和 `TO_DATE` 函数现在只接受白名单中的日期时间格式模式。以前接受的自定义格式模式现在将在运行时失败。支持的模式有：
+  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
+  - Date: `yyyy-MM-dd`
+  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
+
+  **异常类型变更**: 无效的日期时间格式模式现在会抛出 `SeaTunnelRuntimeException` 而不是 `TransformException`。如果您的错误处理或监控系统捕获 `TransformException` 来处理日期时间解析错误，您需要更新它们以处理 `SeaTunnelRuntimeException`。
+
+  **迁移指南**: 如果您在 `PARSEDATETIME` 或 `TO_DATE` 函数中使用自定义日期时间格式模式，您必须更新查询以使用上述支持的模式之一。如果您的数据使用不同的格式，您可能需要预处理输入数据以匹配支持的格式，或使用字符串操作函数在解析之前转换格式。
+
 - DataValidator 转换：当 `row_error_handle_way = ROUTE_TO_TABLE` 时，路由到错误表的行 `table_id` 现在会携带上游的 database/schema 前缀（例如从 `ffp` 变为 `db1.ffp` / `db1.schema1.ffp`）。
 ### 引擎行为变更
 

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -12,14 +12,14 @@
 
 ### 转换变更
 
-- **[BREAKING]** SQL Transform 的 `PARSEDATETIME` 和 `TO_DATE` 函数现在只接受白名单中的日期时间格式模式。以前接受的自定义格式模式现在将在运行时失败。支持的模式有：
-  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`
-  - Date: `yyyy-MM-dd`
-  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`
+- **[BREAKING]** SQL Transform 的 `PARSEDATETIME`、`TO_DATE` 和 `IS_DATE` 函数现在只接受白名单中的日期时间格式模式。以前接受的自定义格式模式现在将在运行时失败。支持的模式有：
+  - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`, `yyyy/MM/dd HH:mm:ss`, `yyyy/MM/dd HH:mm:ss.SSS`, `yyyyMMddHHmmss`
+  - Date: `yyyy-MM-dd`, `yyyy/MM/dd`, `yyyyMMdd`
+  - Time: `HH:mm:ss`, `HH:mm:ss.SSS`, `HHmmss`
 
   **异常类型变更**: 无效的日期时间格式模式现在会抛出 `SeaTunnelRuntimeException` 而不是 `TransformException`。如果您的错误处理或监控系统捕获 `TransformException` 来处理日期时间解析错误，您需要更新它们以处理 `SeaTunnelRuntimeException`。
 
-  **迁移指南**: 如果您在 `PARSEDATETIME` 或 `TO_DATE` 函数中使用自定义日期时间格式模式，您必须更新查询以使用上述支持的模式之一。如果您的数据使用不同的格式，您可能需要预处理输入数据以匹配支持的格式，或使用字符串操作函数在解析之前转换格式。
+  **迁移指南**: 如果您在 `PARSEDATETIME`、`TO_DATE` 或 `IS_DATE` 函数中使用自定义日期时间格式模式，您必须更新查询以使用上述支持的模式之一。如果您的数据使用不同的格式，您可能需要预处理输入数据以匹配支持的格式，或使用字符串操作函数在解析之前转换格式。
 
 - DataValidator 转换：当 `row_error_handle_way = ROUTE_TO_TABLE` 时，路由到错误表的行 `table_id` 现在会携带上游的 database/schema 前缀（例如从 `ffp` 变为 `db1.ffp` / `db1.schema1.ffp`）。
 ### 引擎行为变更

--- a/docs/zh/transforms/sql-functions.md
+++ b/docs/zh/transforms/sql-functions.md
@@ -890,6 +890,52 @@ MONTH(CREATED)
 
 MONTHNAME(CREATED)
 
+### IS_DATE
+
+```IS_DATE(string, formatString) -> BOOLEAN```
+验证字符串是否可以使用指定的格式模式解析为日期/时间值。
+
+**支持的格式模式:**
+
+日期时间格式:
+- `yyyy-MM-dd HH:mm:ss` - 标准日期时间格式
+- `yyyy-MM-dd HH:mm:ss.SSS` - 带毫秒的日期时间
+- `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 日期时间格式
+- `yyyy-MM-dd'T'HH:mm:ss.SSS` - 带毫秒的 ISO 8601 日期时间
+- `yyyy/MM/dd HH:mm:ss` - 带斜杠分隔符的日期时间
+- `yyyy/MM/dd HH:mm:ss.SSS` - 带斜杠分隔符和毫秒的日期时间
+- `yyyyMMddHHmmss` - 紧凑日期时间格式
+
+日期格式:
+- `yyyy-MM-dd` - ISO 8601 日期格式
+- `yyyy/MM/dd` - 带斜杠分隔符的日期
+- `yyyyMMdd` - 紧凑日期格式
+
+时间格式:
+- `HH:mm:ss` - 标准时间格式
+- `HH:mm:ss.SSS` - 带毫秒的时间
+- `HHmmss` - 紧凑时间格式
+
+示例:
+
+```sql
+CALL IS_DATE('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
+-- 返回 true
+
+CALL IS_DATE('2021/04/08', 'yyyy/MM/dd')
+-- 返回 true
+
+CALL IS_DATE('20210408', 'yyyyMMdd')
+-- 返回 true
+
+-- 与 TO_DATE 保持一致
+SELECT CASE
+  WHEN IS_DATE(date_string, 'yyyy-MM-dd HH:mm:ss')
+  THEN TO_DATE(date_string, 'yyyy-MM-dd HH:mm:ss')
+  ELSE NULL
+END as parsed_date
+```
+
 ### PARSEDATETIME / TO_DATE
 
 ```PARSEDATETIME | TO_DATE(string, formatString) -> TIMESTAMP | DATE | TIME```
@@ -903,13 +949,19 @@ MONTHNAME(CREATED)
 - `yyyy-MM-dd HH:mm:ss.SSS` - 带毫秒的日期时间
 - `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 日期时间格式
 - `yyyy-MM-dd'T'HH:mm:ss.SSS` - 带毫秒的 ISO 8601 日期时间
+- `yyyy/MM/dd HH:mm:ss` - 带斜杠分隔符的日期时间
+- `yyyy/MM/dd HH:mm:ss.SSS` - 带斜杠分隔符和毫秒的日期时间
+- `yyyyMMddHHmmss` - 紧凑日期时间格式
 
 日期格式 (返回 DATE):
 - `yyyy-MM-dd` - ISO 8601 日期格式
+- `yyyy/MM/dd` - 带斜杠分隔符的日期
+- `yyyyMMdd` - 紧凑日期格式
 
 时间格式 (返回 TIME):
 - `HH:mm:ss` - 标准时间格式
 - `HH:mm:ss.SSS` - 带毫秒的时间
+- `HHmmss` - 紧凑时间格式
 
 **注意:** 在格式模式中使用单引号 (`'`) 时(例如 ISO 8601 的 'T' 分隔符)，必须在 SQL 中转义为 `''`。
 
@@ -920,13 +972,18 @@ MONTHNAME(CREATED)
 CALL PARSEDATETIME('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
 CALL TO_DATE('2021-04-08T13:34:45', 'yyyy-MM-dd''T''HH:mm:ss')
 CALL PARSEDATETIME('2024-06-15 14:30:45.123', 'yyyy-MM-dd HH:mm:ss.SSS')
+CALL PARSEDATETIME('2021/04/08 13:34:45', 'yyyy/MM/dd HH:mm:ss')
+CALL PARSEDATETIME('20210408133445', 'yyyyMMddHHmmss')
 
 -- 日期示例
 CALL TO_DATE('2021-04-08', 'yyyy-MM-dd')
+CALL TO_DATE('2021/04/08', 'yyyy/MM/dd')
+CALL TO_DATE('20210408', 'yyyyMMdd')
 
 -- 时间示例
 CALL PARSEDATETIME('14:30:45', 'HH:mm:ss')
 CALL PARSEDATETIME('14:30:45.123', 'HH:mm:ss.SSS')
+CALL PARSEDATETIME('143045', 'HHmmss')
 ```
 
 ### QUARTER

--- a/docs/zh/transforms/sql-functions.md
+++ b/docs/zh/transforms/sql-functions.md
@@ -892,15 +892,42 @@ MONTHNAME(CREATED)
 
 ### PARSEDATETIME / TO_DATE
 
-```PARSEDATETIME | TO_DATE(string, formatString) -> TIMESTAMP```
+```PARSEDATETIME | TO_DATE(string, formatString) -> TIMESTAMP | DATE | TIME```
 
-解析一个字符串并返回一个 TIMESTAMP WITH TIME ZONE 值。最重要的格式字符包括：y（年）、M（月）、d（日）、H（时）、m（分）、s（秒）。有关格式的详细信息，请参阅 java.time.format.DateTimeFormatter。
+使用指定的格式模式将字符串解析为日期/时间值
+
+**支持的格式模式:**
+
+日期时间格式 (返回 TIMESTAMP):
+- `yyyy-MM-dd HH:mm:ss` - 标准日期时间格式
+- `yyyy-MM-dd HH:mm:ss.SSS` - 带毫秒的日期时间
+- `yyyy-MM-dd'T'HH:mm:ss` - ISO 8601 日期时间格式
+- `yyyy-MM-dd'T'HH:mm:ss.SSS` - 带毫秒的 ISO 8601 日期时间
+
+日期格式 (返回 DATE):
+- `yyyy-MM-dd` - ISO 8601 日期格式
+
+时间格式 (返回 TIME):
+- `HH:mm:ss` - 标准时间格式
+- `HH:mm:ss.SSS` - 带毫秒的时间
+
+**注意:** 在格式模式中使用单引号 (`'`) 时(例如 ISO 8601 的 'T' 分隔符)，必须在 SQL 中转义为 `''`。
 
 示例:
 
-CALL PARSEDATETIME('2021-04-08 13:34:45','yyyy-MM-dd HH:mm:ss')
-CALL TO_DATE('2021-04-08T13:34:45','yyyy-MM-dd''T''HH:mm:ss')
-注意SQL函数中的`'`填写时需要转义为`''`。
+```sql
+-- 日期时间示例
+CALL PARSEDATETIME('2021-04-08 13:34:45', 'yyyy-MM-dd HH:mm:ss')
+CALL TO_DATE('2021-04-08T13:34:45', 'yyyy-MM-dd''T''HH:mm:ss')
+CALL PARSEDATETIME('2024-06-15 14:30:45.123', 'yyyy-MM-dd HH:mm:ss.SSS')
+
+-- 日期示例
+CALL TO_DATE('2021-04-08', 'yyyy-MM-dd')
+
+-- 时间示例
+CALL PARSEDATETIME('14:30:45', 'HH:mm:ss')
+CALL PARSEDATETIME('14:30:45.123', 'HH:mm:ss.SSS')
+```
 
 ### QUARTER
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormat.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.sql.zeta;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum ZetaDateTimeFormat {
+    // DateTime formats
+    DATETIME_STANDARD("yyyy-MM-dd HH:mm:ss", FormatType.DATETIME),
+    DATETIME_WITH_MILLIS("yyyy-MM-dd HH:mm:ss.SSS", FormatType.DATETIME),
+    DATETIME_ISO8601("yyyy-MM-dd'T'HH:mm:ss", FormatType.DATETIME),
+    DATETIME_ISO8601_WITH_MILLIS("yyyy-MM-dd'T'HH:mm:ss.SSS", FormatType.DATETIME),
+
+    // Date formats
+    DATE_ISO8601("yyyy-MM-dd", FormatType.DATE),
+
+    // Time formats
+    TIME_STANDARD("HH:mm:ss", FormatType.TIME),
+    TIME_WITH_MILLIS("HH:mm:ss.SSS", FormatType.TIME);
+
+    private final String pattern;
+    private final FormatType type;
+
+    ZetaDateTimeFormat(String pattern, FormatType type) {
+        this.pattern = pattern;
+        this.type = type;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public FormatType getType() {
+        return type;
+    }
+
+    public static Optional<ZetaDateTimeFormat> fromPattern(String pattern) {
+        return Arrays.stream(values()).filter(format -> format.pattern.equals(pattern)).findFirst();
+    }
+
+    public enum FormatType {
+        DATETIME,
+        DATE,
+        TIME
+    }
+}

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormat.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormat.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.sql.zeta;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -26,20 +27,28 @@ public enum ZetaDateTimeFormat {
     DATETIME_WITH_MILLIS("yyyy-MM-dd HH:mm:ss.SSS", FormatType.DATETIME),
     DATETIME_ISO8601("yyyy-MM-dd'T'HH:mm:ss", FormatType.DATETIME),
     DATETIME_ISO8601_WITH_MILLIS("yyyy-MM-dd'T'HH:mm:ss.SSS", FormatType.DATETIME),
+    DATETIME_SLASH("yyyy/MM/dd HH:mm:ss", FormatType.DATETIME),
+    DATETIME_SLASH_WITH_MILLIS("yyyy/MM/dd HH:mm:ss.SSS", FormatType.DATETIME),
+    DATETIME_COMPACT("yyyyMMddHHmmss", FormatType.DATETIME),
 
     // Date formats
     DATE_ISO8601("yyyy-MM-dd", FormatType.DATE),
+    DATE_SLASH("yyyy/MM/dd", FormatType.DATE),
+    DATE_COMPACT("yyyyMMdd", FormatType.DATE),
 
     // Time formats
     TIME_STANDARD("HH:mm:ss", FormatType.TIME),
-    TIME_WITH_MILLIS("HH:mm:ss.SSS", FormatType.TIME);
+    TIME_WITH_MILLIS("HH:mm:ss.SSS", FormatType.TIME),
+    TIME_COMPACT("HHmmss", FormatType.TIME);
 
     private final String pattern;
     private final FormatType type;
+    private final DateTimeFormatter formatter;
 
     ZetaDateTimeFormat(String pattern, FormatType type) {
         this.pattern = pattern;
         this.type = type;
+        this.formatter = DateTimeFormatter.ofPattern(pattern);
     }
 
     public String getPattern() {
@@ -48,6 +57,10 @@ public enum ZetaDateTimeFormat {
 
     public FormatType getType() {
         return type;
+    }
+
+    public DateTimeFormatter getFormatter() {
+        return formatter;
     }
 
     public static Optional<ZetaDateTimeFormat> fromPattern(String pattern) {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.api.table.type.VectorType;
+import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.zeta.functions.ArrayFunction;
@@ -435,23 +436,16 @@ public class ZetaSQLType {
                     if (formatExpr instanceof StringValue) {
                         format = ((StringValue) formatExpr).getNotExcapedValue();
                     } else {
-                        throw new TransformException(
-                                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                                String.format(
-                                        "Format parameter must be a string literal for function: %s",
-                                        function.getName()));
+                        throw CommonError.unsupportedOperation(
+                                function.getName(), "non-literal format parameter");
                     }
 
                     ZetaDateTimeFormat dateTimeFormat =
                             ZetaDateTimeFormat.fromPattern(format)
                                     .orElseThrow(
                                             () ->
-                                                    new TransformException(
-                                                            CommonErrorCodeDeprecated
-                                                                    .UNSUPPORTED_OPERATION,
-                                                            String.format(
-                                                                    "Unsupported datetime format: '%s'.",
-                                                                    format)));
+                                                    CommonError.illegalArgument(
+                                                            format, "unsupported datetime format"));
 
                     switch (dateTimeFormat.getType()) {
                         case DATETIME:
@@ -461,9 +455,9 @@ public class ZetaSQLType {
                         case TIME:
                             return LocalTimeType.LOCAL_TIME_TYPE;
                         default:
-                            throw new TransformException(
-                                    CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                                    "Unknown format type: " + dateTimeFormat.getType());
+                            throw CommonError.illegalArgument(
+                                    dateTimeFormat.getType().toString(),
+                                    "unsupported datetime format type");
                     }
                 }
             case ZetaSQLFunction.ABS:

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -430,10 +430,17 @@ public class ZetaSQLType {
             case ZetaSQLFunction.PARSEDATETIME:
             case ZetaSQLFunction.TO_DATE:
                 {
-                    String format = function.getParameters().getExpressions().get(1).toString();
-
-                    format = format.replaceAll("^'|'$", "");
-                    format = format.replace("''", "'");
+                    Expression formatExpr = function.getParameters().getExpressions().get(1);
+                    String format;
+                    if (formatExpr instanceof StringValue) {
+                        format = ((StringValue) formatExpr).getNotExcapedValue();
+                    } else {
+                        throw new TransformException(
+                                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                                String.format(
+                                        "Format parameter must be a string literal for function: %s",
+                                        function.getName()));
+                    }
 
                     String finalFormatForLogging = format;
                     ZetaDateTimeFormat dateTimeFormat =

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -431,20 +431,35 @@ public class ZetaSQLType {
             case ZetaSQLFunction.TO_DATE:
                 {
                     String format = function.getParameters().getExpressions().get(1).toString();
-                    if (format.contains("yy") && format.contains("mm")) {
-                        return LocalTimeType.LOCAL_DATE_TIME_TYPE;
+
+                    format = format.replaceAll("^'|'$", "");
+                    format = format.replace("''", "'");
+
+                    String finalFormatForLogging = format;
+                    ZetaDateTimeFormat dateTimeFormat =
+                            ZetaDateTimeFormat.fromPattern(format)
+                                    .orElseThrow(
+                                            () ->
+                                                    new TransformException(
+                                                            CommonErrorCodeDeprecated
+                                                                    .UNSUPPORTED_OPERATION,
+                                                            String.format(
+                                                                    "Unknown pattern letter %s for function: %s",
+                                                                    finalFormatForLogging,
+                                                                    function.getName())));
+
+                    switch (dateTimeFormat.getType()) {
+                        case DATETIME:
+                            return LocalTimeType.LOCAL_DATE_TIME_TYPE;
+                        case DATE:
+                            return LocalTimeType.LOCAL_DATE_TYPE;
+                        case TIME:
+                            return LocalTimeType.LOCAL_TIME_TYPE;
+                        default:
+                            throw new TransformException(
+                                    CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                                    "Unknown format type: " + dateTimeFormat.getType());
                     }
-                    if (format.contains("yy")) {
-                        return LocalTimeType.LOCAL_DATE_TYPE;
-                    }
-                    if (format.contains("mm")) {
-                        return LocalTimeType.LOCAL_TIME_TYPE;
-                    }
-                    throw new TransformException(
-                            CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                            String.format(
-                                    "Unknown pattern letter %s for function: %s",
-                                    format, function.getName()));
                 }
             case ZetaSQLFunction.ABS:
             case ZetaSQLFunction.DATEADD:

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -442,7 +442,6 @@ public class ZetaSQLType {
                                         function.getName()));
                     }
 
-                    String finalFormatForLogging = format;
                     ZetaDateTimeFormat dateTimeFormat =
                             ZetaDateTimeFormat.fromPattern(format)
                                     .orElseThrow(
@@ -451,9 +450,8 @@ public class ZetaSQLType {
                                                             CommonErrorCodeDeprecated
                                                                     .UNSUPPORTED_OPERATION,
                                                             String.format(
-                                                                    "Unknown pattern letter %s for function: %s",
-                                                                    finalFormatForLogging,
-                                                                    function.getName())));
+                                                                    "Unsupported datetime format: '%s'.",
+                                                                    format)));
 
                     switch (dateTimeFormat.getType()) {
                         case DATETIME:

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -645,7 +645,7 @@ public class DateTimeFunction {
                                                 format, "unsupported datetime format"));
 
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormat.getPattern());
+            DateTimeFormatter formatter = dateTimeFormat.getFormatter();
 
             switch (dateTimeFormat.getType()) {
                 case DATETIME:

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.sql.zeta.functions;
 
+import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.zeta.ZetaDateTimeFormat;
@@ -640,11 +641,8 @@ public class DateTimeFunction {
                 ZetaDateTimeFormat.fromPattern(format)
                         .orElseThrow(
                                 () ->
-                                        new TransformException(
-                                                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                                                String.format(
-                                                        "Unsupported datetime format: '%s'.",
-                                                        format)));
+                                        CommonError.illegalArgument(
+                                                format, "unsupported datetime format"));
 
         try {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormat.getPattern());
@@ -657,16 +655,12 @@ public class DateTimeFunction {
                 case TIME:
                     return LocalTime.parse(str, formatter);
                 default:
-                    throw new TransformException(
-                            CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                            "Unknown format type: " + dateTimeFormat.getType());
+                    throw CommonError.illegalArgument(
+                            dateTimeFormat.getType().toString(),
+                            "unsupported datetime format type");
             }
         } catch (DateTimeParseException e) {
-            throw new TransformException(
-                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                    String.format(
-                            "Failed to parse '%s' with format '%s': %s",
-                            str, format, e.getMessage()));
+            throw CommonError.illegalArgument(str, "parsing datetime with format: " + format);
         }
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -622,10 +622,38 @@ public class DateTimeFunction {
     }
 
     public static boolean isDate(List<Object> args) {
+        String str = (String) args.get(0);
+        if (str == null || str.isEmpty()) {
+            return false;
+        }
+
+        String format = (String) args.get(1);
+        if (format == null) {
+            return false;
+        }
+
+        ZetaDateTimeFormat dateTimeFormat = ZetaDateTimeFormat.fromPattern(format).orElse(null);
+        if (dateTimeFormat == null) {
+            return false;
+        }
+
         try {
-            parsedatetime(args);
-            return true;
-        } catch (Throwable e) {
+            DateTimeFormatter formatter = dateTimeFormat.getFormatter();
+
+            switch (dateTimeFormat.getType()) {
+                case DATETIME:
+                    LocalDateTime.parse(str, formatter);
+                    return true;
+                case DATE:
+                    LocalDate.parse(str, formatter);
+                    return true;
+                case TIME:
+                    LocalTime.parse(str, formatter);
+                    return true;
+                default:
+                    return false;
+            }
+        } catch (DateTimeParseException e) {
             return false;
         }
     }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -635,10 +635,6 @@ public class DateTimeFunction {
             return null;
         }
         String format = (String) args.get(1);
-        if (format == null) {
-            throw new TransformException(
-                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT, "Format pattern cannot be null");
-        }
 
         ZetaDateTimeFormat dateTimeFormat =
                 ZetaDateTimeFormat.fromPattern(format)

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.transform.sql.zeta.functions;
 
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.transform.exception.TransformException;
+import org.apache.seatunnel.transform.sql.zeta.ZetaDateTimeFormat;
 import org.apache.seatunnel.transform.sql.zeta.ZetaSQLFunction;
 
 import java.text.DateFormatSymbols;
@@ -32,6 +33,7 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.WeekFields;
@@ -633,23 +635,43 @@ public class DateTimeFunction {
             return null;
         }
         String format = (String) args.get(1);
-        if (format.contains("yy") && format.contains("mm")) {
-            DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
-            return LocalDateTime.parse(str, df);
+        if (format == null) {
+            throw new TransformException(
+                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT, "Format pattern cannot be null");
         }
-        if (format.contains("yy")) {
-            DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
-            return LocalDate.parse(str, df);
+
+        ZetaDateTimeFormat dateTimeFormat =
+                ZetaDateTimeFormat.fromPattern(format)
+                        .orElseThrow(
+                                () ->
+                                        new TransformException(
+                                                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                                                String.format(
+                                                        "Unsupported datetime format: '%s'.",
+                                                        format)));
+
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormat.getPattern());
+
+            switch (dateTimeFormat.getType()) {
+                case DATETIME:
+                    return LocalDateTime.parse(str, formatter);
+                case DATE:
+                    return LocalDate.parse(str, formatter);
+                case TIME:
+                    return LocalTime.parse(str, formatter);
+                default:
+                    throw new TransformException(
+                            CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                            "Unknown format type: " + dateTimeFormat.getType());
+            }
+        } catch (DateTimeParseException e) {
+            throw new TransformException(
+                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                    String.format(
+                            "Failed to parse '%s' with format '%s': %s",
+                            str, format, e.getMessage()));
         }
-        if (format.contains("mm")) {
-            DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
-            return LocalTime.parse(str, df);
-        }
-        throw new TransformException(
-                CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                String.format(
-                        "Unknown pattern letter %s for function: %s",
-                        format, ZetaSQLFunction.PARSEDATETIME));
     }
 
     public static Integer quarter(List<Object> args) {

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
@@ -53,6 +53,26 @@ public class ZetaDateTimeFormatTest {
         Assertions.assertTrue(format4.isPresent());
         Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS, format4.get());
         Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format4.get().getType());
+
+        // DATETIME_SLASH
+        Optional<ZetaDateTimeFormat> format5 =
+                ZetaDateTimeFormat.fromPattern("yyyy/MM/dd HH:mm:ss");
+        Assertions.assertTrue(format5.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_SLASH, format5.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format5.get().getType());
+
+        // DATETIME_SLASH_WITH_MILLIS
+        Optional<ZetaDateTimeFormat> format6 =
+                ZetaDateTimeFormat.fromPattern("yyyy/MM/dd HH:mm:ss.SSS");
+        Assertions.assertTrue(format6.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_SLASH_WITH_MILLIS, format6.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format6.get().getType());
+
+        // DATETIME_COMPACT
+        Optional<ZetaDateTimeFormat> format7 = ZetaDateTimeFormat.fromPattern("yyyyMMddHHmmss");
+        Assertions.assertTrue(format7.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_COMPACT, format7.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format7.get().getType());
     }
 
     @Test
@@ -62,6 +82,18 @@ public class ZetaDateTimeFormatTest {
         Assertions.assertTrue(format1.isPresent());
         Assertions.assertEquals(ZetaDateTimeFormat.DATE_ISO8601, format1.get());
         Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATE, format1.get().getType());
+
+        // DATE_SLASH
+        Optional<ZetaDateTimeFormat> format2 = ZetaDateTimeFormat.fromPattern("yyyy/MM/dd");
+        Assertions.assertTrue(format2.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATE_SLASH, format2.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATE, format2.get().getType());
+
+        // DATE_COMPACT
+        Optional<ZetaDateTimeFormat> format3 = ZetaDateTimeFormat.fromPattern("yyyyMMdd");
+        Assertions.assertTrue(format3.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATE_COMPACT, format3.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATE, format3.get().getType());
     }
 
     @Test
@@ -77,6 +109,12 @@ public class ZetaDateTimeFormatTest {
         Assertions.assertTrue(format2.isPresent());
         Assertions.assertEquals(ZetaDateTimeFormat.TIME_WITH_MILLIS, format2.get());
         Assertions.assertEquals(ZetaDateTimeFormat.FormatType.TIME, format2.get().getType());
+
+        // TIME_COMPACT
+        Optional<ZetaDateTimeFormat> format3 = ZetaDateTimeFormat.fromPattern("HHmmss");
+        Assertions.assertTrue(format3.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.TIME_COMPACT, format3.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.TIME, format3.get().getType());
     }
 
     @Test
@@ -107,12 +145,25 @@ public class ZetaDateTimeFormatTest {
         Assertions.assertEquals(
                 ZetaDateTimeFormat.FormatType.DATETIME,
                 ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_SLASH.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_SLASH_WITH_MILLIS.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_COMPACT.getType());
     }
 
     @Test
     public void testAllDateFormatsHaveCorrectType() {
         Assertions.assertEquals(
                 ZetaDateTimeFormat.FormatType.DATE, ZetaDateTimeFormat.DATE_ISO8601.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATE, ZetaDateTimeFormat.DATE_SLASH.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATE, ZetaDateTimeFormat.DATE_COMPACT.getType());
     }
 
     @Test
@@ -121,6 +172,8 @@ public class ZetaDateTimeFormatTest {
                 ZetaDateTimeFormat.FormatType.TIME, ZetaDateTimeFormat.TIME_STANDARD.getType());
         Assertions.assertEquals(
                 ZetaDateTimeFormat.FormatType.TIME, ZetaDateTimeFormat.TIME_WITH_MILLIS.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.TIME, ZetaDateTimeFormat.TIME_COMPACT.getType());
     }
 
     @Test
@@ -134,11 +187,20 @@ public class ZetaDateTimeFormatTest {
         Assertions.assertEquals(
                 "yyyy-MM-dd'T'HH:mm:ss.SSS",
                 ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS.getPattern());
+        Assertions.assertEquals(
+                "yyyy/MM/dd HH:mm:ss", ZetaDateTimeFormat.DATETIME_SLASH.getPattern());
+        Assertions.assertEquals(
+                "yyyy/MM/dd HH:mm:ss.SSS",
+                ZetaDateTimeFormat.DATETIME_SLASH_WITH_MILLIS.getPattern());
+        Assertions.assertEquals("yyyyMMddHHmmss", ZetaDateTimeFormat.DATETIME_COMPACT.getPattern());
 
         Assertions.assertEquals("yyyy-MM-dd", ZetaDateTimeFormat.DATE_ISO8601.getPattern());
+        Assertions.assertEquals("yyyy/MM/dd", ZetaDateTimeFormat.DATE_SLASH.getPattern());
+        Assertions.assertEquals("yyyyMMdd", ZetaDateTimeFormat.DATE_COMPACT.getPattern());
 
         Assertions.assertEquals("HH:mm:ss", ZetaDateTimeFormat.TIME_STANDARD.getPattern());
         Assertions.assertEquals("HH:mm:ss.SSS", ZetaDateTimeFormat.TIME_WITH_MILLIS.getPattern());
+        Assertions.assertEquals("HHmmss", ZetaDateTimeFormat.TIME_COMPACT.getPattern());
     }
 
     @Test
@@ -160,5 +222,39 @@ public class ZetaDateTimeFormatTest {
                         "Duplicate pattern found: " + formats[i].getPattern());
             }
         }
+    }
+
+    @Test
+    public void testFormatterIsCached() {
+        ZetaDateTimeFormat format = ZetaDateTimeFormat.DATETIME_STANDARD;
+        Assertions.assertNotNull(format.getFormatter());
+        Assertions.assertSame(
+                format.getFormatter(),
+                format.getFormatter(),
+                "Formatter should be cached and return the same instance");
+    }
+
+    @Test
+    public void testAllFormatsHaveValidFormatter() {
+        for (ZetaDateTimeFormat format : ZetaDateTimeFormat.values()) {
+            Assertions.assertNotNull(
+                    format.getFormatter(),
+                    "Format " + format.name() + " should have a valid formatter");
+        }
+    }
+
+    @Test
+    public void testFormatterCanParseValidInput() {
+        ZetaDateTimeFormat format = ZetaDateTimeFormat.DATE_ISO8601;
+        Assertions.assertDoesNotThrow(
+                () -> java.time.LocalDate.parse("2024-06-15", format.getFormatter()));
+
+        ZetaDateTimeFormat compactFormat = ZetaDateTimeFormat.DATE_COMPACT;
+        Assertions.assertDoesNotThrow(
+                () -> java.time.LocalDate.parse("20240615", compactFormat.getFormatter()));
+
+        ZetaDateTimeFormat slashFormat = ZetaDateTimeFormat.DATE_SLASH;
+        Assertions.assertDoesNotThrow(
+                () -> java.time.LocalDate.parse("2024/06/15", slashFormat.getFormatter()));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.sql.zeta;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class ZetaDateTimeFormatTest {
+
+    @Test
+    public void testFromPatternWithAllDateTimeFormats() {
+        // DATETIME_STANDARD
+        Optional<ZetaDateTimeFormat> format1 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd HH:mm:ss");
+        Assertions.assertTrue(format1.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_STANDARD, format1.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format1.get().getType());
+
+        // DATETIME_WITH_MILLIS
+        Optional<ZetaDateTimeFormat> format2 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        Assertions.assertTrue(format2.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_WITH_MILLIS, format2.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format2.get().getType());
+
+        // DATETIME_ISO8601
+        Optional<ZetaDateTimeFormat> format3 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss");
+        Assertions.assertTrue(format3.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601, format3.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format3.get().getType());
+
+        // DATETIME_ISO8601_WITH_MILLIS
+        Optional<ZetaDateTimeFormat> format4 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        Assertions.assertTrue(format4.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS, format4.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATETIME, format4.get().getType());
+    }
+
+    @Test
+    public void testFromPatternWithAllDateFormats() {
+        // DATE_ISO8601
+        Optional<ZetaDateTimeFormat> format1 = ZetaDateTimeFormat.fromPattern("yyyy-MM-dd");
+        Assertions.assertTrue(format1.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATE_ISO8601, format1.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.DATE, format1.get().getType());
+    }
+
+    @Test
+    public void testFromPatternWithAllTimeFormats() {
+        // TIME_STANDARD
+        Optional<ZetaDateTimeFormat> format1 = ZetaDateTimeFormat.fromPattern("HH:mm:ss");
+        Assertions.assertTrue(format1.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.TIME_STANDARD, format1.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.TIME, format1.get().getType());
+
+        // TIME_WITH_MILLIS
+        Optional<ZetaDateTimeFormat> format2 = ZetaDateTimeFormat.fromPattern("HH:mm:ss.SSS");
+        Assertions.assertTrue(format2.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.TIME_WITH_MILLIS, format2.get());
+        Assertions.assertEquals(ZetaDateTimeFormat.FormatType.TIME, format2.get().getType());
+    }
+
+    @Test
+    public void testFromPatternWithInvalidFormat() {
+        Optional<ZetaDateTimeFormat> format = ZetaDateTimeFormat.fromPattern("invalid_pattern");
+
+        Assertions.assertFalse(format.isPresent());
+    }
+
+    @Test
+    public void testFromPatternWithNullFormat() {
+        Optional<ZetaDateTimeFormat> format = ZetaDateTimeFormat.fromPattern(null);
+
+        Assertions.assertFalse(format.isPresent());
+    }
+
+    @Test
+    public void testAllDateTimeFormatsHaveCorrectType() {
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_STANDARD.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_WITH_MILLIS.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_ISO8601.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATETIME,
+                ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS.getType());
+    }
+
+    @Test
+    public void testAllDateFormatsHaveCorrectType() {
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.DATE, ZetaDateTimeFormat.DATE_ISO8601.getType());
+    }
+
+    @Test
+    public void testAllTimeFormatsHaveCorrectType() {
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.TIME, ZetaDateTimeFormat.TIME_STANDARD.getType());
+        Assertions.assertEquals(
+                ZetaDateTimeFormat.FormatType.TIME, ZetaDateTimeFormat.TIME_WITH_MILLIS.getType());
+    }
+
+    @Test
+    public void testGetPatternForAllFormats() {
+        Assertions.assertEquals(
+                "yyyy-MM-dd HH:mm:ss", ZetaDateTimeFormat.DATETIME_STANDARD.getPattern());
+        Assertions.assertEquals(
+                "yyyy-MM-dd HH:mm:ss.SSS", ZetaDateTimeFormat.DATETIME_WITH_MILLIS.getPattern());
+        Assertions.assertEquals(
+                "yyyy-MM-dd'T'HH:mm:ss", ZetaDateTimeFormat.DATETIME_ISO8601.getPattern());
+        Assertions.assertEquals(
+                "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS.getPattern());
+
+        Assertions.assertEquals("yyyy-MM-dd", ZetaDateTimeFormat.DATE_ISO8601.getPattern());
+
+        Assertions.assertEquals("HH:mm:ss", ZetaDateTimeFormat.TIME_STANDARD.getPattern());
+        Assertions.assertEquals("HH:mm:ss.SSS", ZetaDateTimeFormat.TIME_WITH_MILLIS.getPattern());
+    }
+
+    @Test
+    public void testFromPatternWithISO8601Formats() {
+        Optional<ZetaDateTimeFormat> format1 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss");
+        Assertions.assertTrue(format1.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601, format1.get());
+
+        Optional<ZetaDateTimeFormat> format2 =
+                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        Assertions.assertTrue(format2.isPresent());
+        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS, format2.get());
+    }
+
+    @Test
+    public void testFromPatternIsCaseSensitive() {
+        Optional<ZetaDateTimeFormat> format = ZetaDateTimeFormat.fromPattern("YYYY-MM-DD HH:MM:SS");
+
+        Assertions.assertFalse(format.isPresent());
+    }
+
+    @Test
+    public void testAllEnumValuesAreUnique() {
+        ZetaDateTimeFormat[] formats = ZetaDateTimeFormat.values();
+
+        for (int i = 0; i < formats.length; i++) {
+            for (int j = i + 1; j < formats.length; j++) {
+                Assertions.assertNotEquals(
+                        formats[i].getPattern(),
+                        formats[j].getPattern(),
+                        "Duplicate pattern found: " + formats[i].getPattern());
+            }
+        }
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaDateTimeFormatTest.java
@@ -142,19 +142,6 @@ public class ZetaDateTimeFormatTest {
     }
 
     @Test
-    public void testFromPatternWithISO8601Formats() {
-        Optional<ZetaDateTimeFormat> format1 =
-                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss");
-        Assertions.assertTrue(format1.isPresent());
-        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601, format1.get());
-
-        Optional<ZetaDateTimeFormat> format2 =
-                ZetaDateTimeFormat.fromPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        Assertions.assertTrue(format2.isPresent());
-        Assertions.assertEquals(ZetaDateTimeFormat.DATETIME_ISO8601_WITH_MILLIS, format2.get());
-    }
-
-    @Test
     public void testFromPatternIsCaseSensitive() {
         Optional<ZetaDateTimeFormat> format = ZetaDateTimeFormat.fromPattern("YYYY-MM-DD HH:MM:SS");
 

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.api.table.type.VectorType;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.zeta.functions.udf.DesEncrypt;
 
@@ -271,7 +272,8 @@ public class ZetaSQLTypeTest {
         badPattern.setParameters(
                 new ExpressionList<>(
                         Arrays.asList(new StringValue("data"), new StringValue("invalid"))));
-        Assertions.assertThrows(TransformException.class, () -> type.getExpressionType(badPattern));
+        Assertions.assertThrows(
+                SeaTunnelRuntimeException.class, () -> type.getExpressionType(badPattern));
 
         Assertions.assertEquals(
                 LocalTimeType.LOCAL_DATE_TYPE,

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
@@ -26,7 +26,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.api.table.type.VectorType;
-import org.apache.seatunnel.transform.exception.TransformException;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.transform.sql.zeta.functions.udf.DesEncrypt;
 
 import org.junit.jupiter.api.Assertions;
@@ -271,7 +271,8 @@ public class ZetaSQLTypeTest {
         badPattern.setParameters(
                 new ExpressionList<>(
                         Arrays.asList(new StringValue("data"), new StringValue("invalid"))));
-        Assertions.assertThrows(TransformException.class, () -> type.getExpressionType(badPattern));
+        Assertions.assertThrows(
+                SeaTunnelRuntimeException.class, () -> type.getExpressionType(badPattern));
 
         Assertions.assertEquals(
                 LocalTimeType.LOCAL_DATE_TYPE,
@@ -338,7 +339,7 @@ public class ZetaSQLTypeTest {
         Function badCoalesce = new Function();
         badCoalesce.setName(ZetaSQLFunction.COALESCE);
         Assertions.assertThrows(
-                TransformException.class, () -> type.getExpressionType(badCoalesce));
+                SeaTunnelRuntimeException.class, () -> type.getExpressionType(badCoalesce));
 
         Function multiIf = new Function();
         multiIf.setName(ZetaSQLFunction.MULTI_IF);
@@ -355,14 +356,14 @@ public class ZetaSQLTypeTest {
         Function multiIfNoParams = new Function();
         multiIfNoParams.setName(ZetaSQLFunction.MULTI_IF);
         Assertions.assertThrows(
-                TransformException.class, () -> type.getExpressionType(multiIfNoParams));
+                SeaTunnelRuntimeException.class, () -> type.getExpressionType(multiIfNoParams));
 
         Function multiIfEvenArgs = new Function();
         multiIfEvenArgs.setName(ZetaSQLFunction.MULTI_IF);
         multiIfEvenArgs.setParameters(
                 new ExpressionList<>(Arrays.asList(new LongValue(1), new LongValue(1))));
         Assertions.assertThrows(
-                TransformException.class, () -> type.getExpressionType(multiIfEvenArgs));
+                SeaTunnelRuntimeException.class, () -> type.getExpressionType(multiIfEvenArgs));
 
         Function modFunc = new Function();
         modFunc.setName(ZetaSQLFunction.MOD);
@@ -388,7 +389,7 @@ public class ZetaSQLTypeTest {
         unknownFunc.setParameters(
                 new ExpressionList<>(Collections.singletonList(new LongValue(1))));
         Assertions.assertThrows(
-                TransformException.class, () -> udfType.getExpressionType(unknownFunc));
+                SeaTunnelRuntimeException.class, () -> udfType.getExpressionType(unknownFunc));
     }
 
     @Test
@@ -420,7 +421,7 @@ public class ZetaSQLTypeTest {
         Assertions.assertEquals(intType, type.getMaxType(intType, null));
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () -> type.getMaxType(BasicType.STRING_TYPE, BasicType.INT_TYPE));
     }
 
@@ -437,6 +438,6 @@ public class ZetaSQLTypeTest {
         Assertions.assertEquals(BasicType.DOUBLE_TYPE, result);
 
         Assertions.assertThrows(
-                TransformException.class, () -> type.getMaxType(Collections.emptyList()));
+                SeaTunnelRuntimeException.class, () -> type.getMaxType(Collections.emptyList()));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLTypeTest.java
@@ -26,7 +26,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.api.table.type.VectorType;
-import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.zeta.functions.udf.DesEncrypt;
 
 import org.junit.jupiter.api.Assertions;
@@ -271,8 +271,7 @@ public class ZetaSQLTypeTest {
         badPattern.setParameters(
                 new ExpressionList<>(
                         Arrays.asList(new StringValue("data"), new StringValue("invalid"))));
-        Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> type.getExpressionType(badPattern));
+        Assertions.assertThrows(TransformException.class, () -> type.getExpressionType(badPattern));
 
         Assertions.assertEquals(
                 LocalTimeType.LOCAL_DATE_TYPE,
@@ -339,7 +338,7 @@ public class ZetaSQLTypeTest {
         Function badCoalesce = new Function();
         badCoalesce.setName(ZetaSQLFunction.COALESCE);
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> type.getExpressionType(badCoalesce));
+                TransformException.class, () -> type.getExpressionType(badCoalesce));
 
         Function multiIf = new Function();
         multiIf.setName(ZetaSQLFunction.MULTI_IF);
@@ -356,14 +355,14 @@ public class ZetaSQLTypeTest {
         Function multiIfNoParams = new Function();
         multiIfNoParams.setName(ZetaSQLFunction.MULTI_IF);
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> type.getExpressionType(multiIfNoParams));
+                TransformException.class, () -> type.getExpressionType(multiIfNoParams));
 
         Function multiIfEvenArgs = new Function();
         multiIfEvenArgs.setName(ZetaSQLFunction.MULTI_IF);
         multiIfEvenArgs.setParameters(
                 new ExpressionList<>(Arrays.asList(new LongValue(1), new LongValue(1))));
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> type.getExpressionType(multiIfEvenArgs));
+                TransformException.class, () -> type.getExpressionType(multiIfEvenArgs));
 
         Function modFunc = new Function();
         modFunc.setName(ZetaSQLFunction.MOD);
@@ -389,7 +388,7 @@ public class ZetaSQLTypeTest {
         unknownFunc.setParameters(
                 new ExpressionList<>(Collections.singletonList(new LongValue(1))));
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> udfType.getExpressionType(unknownFunc));
+                TransformException.class, () -> udfType.getExpressionType(unknownFunc));
     }
 
     @Test
@@ -421,7 +420,7 @@ public class ZetaSQLTypeTest {
         Assertions.assertEquals(intType, type.getMaxType(intType, null));
 
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class,
+                TransformException.class,
                 () -> type.getMaxType(BasicType.STRING_TYPE, BasicType.INT_TYPE));
     }
 
@@ -438,6 +437,6 @@ public class ZetaSQLTypeTest {
         Assertions.assertEquals(BasicType.DOUBLE_TYPE, result);
 
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class, () -> type.getMaxType(Collections.emptyList()));
+                TransformException.class, () -> type.getMaxType(Collections.emptyList()));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -24,7 +24,7 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.transform.exception.TransformException;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.transform.sql.SQLTransform;
 
 import org.junit.jupiter.api.Assertions;
@@ -303,7 +303,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2021-04-08', 'invalid_pattern') as parsed from dual",
@@ -319,7 +319,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TYPE});
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select DATEADD(dt, 1, 'UNSUPPORTED') as d from dual",
@@ -402,7 +402,7 @@ public class DateTimeFunctionsTest {
 
         // Test with completely unsupported format
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2024-06-15', 'dd/MM/yyyy') as dt from dual",
@@ -419,7 +419,7 @@ public class DateTimeFunctionsTest {
 
         // Test with malformed input string
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('not-a-date', 'yyyy-MM-dd') as dt from dual",

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -370,22 +370,6 @@ public class DateTimeFunctionsTest {
     }
 
     @Test
-    public void testParseDateTimeWithAllDateFormats() {
-        SeaTunnelRowType rowType =
-                new SeaTunnelRowType(
-                        new String[] {"dummy"},
-                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
-
-        // DATE_ISO8601: yyyy-MM-dd
-        SeaTunnelRow row1 =
-                runSql(
-                        "select PARSEDATETIME('2024-06-15', 'yyyy-MM-dd') as dt from dual",
-                        rowType,
-                        LocalDateTime.now());
-        Assertions.assertEquals(LocalDate.of(2024, 6, 15), row1.getField(0));
-    }
-
-    @Test
     public void testParseDateTimeWithAllTimeFormats() {
         SeaTunnelRowType rowType =
                 new SeaTunnelRowType(
@@ -457,12 +441,5 @@ public class DateTimeFunctionsTest {
                         rowType,
                         LocalDateTime.now());
         Assertions.assertEquals(LocalDate.of(2024, 6, 15), row1.getField(0));
-
-        SeaTunnelRow row2 =
-                runSql(
-                        "select TO_DATE('2024-06-15 14:30:45', 'yyyy-MM-dd HH:mm:ss') as dt from dual",
-                        rowType,
-                        LocalDateTime.now());
-        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row2.getField(0));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -326,4 +326,143 @@ public class DateTimeFunctionsTest {
                                 rowType,
                                 LocalDate.of(2024, 6, 15)));
     }
+
+    @Test
+    public void testParseDateTimeWithAllDateTimeFormats() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // DATETIME_STANDARD: yyyy-MM-dd HH:mm:ss
+        SeaTunnelRow row1 =
+                runSql(
+                        "select PARSEDATETIME('2024-06-15 14:30:45', 'yyyy-MM-dd HH:mm:ss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row1.getField(0));
+
+        // DATETIME_WITH_MILLIS: yyyy-MM-dd HH:mm:ss.SSS
+        SeaTunnelRow row2 =
+                runSql(
+                        "select PARSEDATETIME('2024-06-15 14:30:45.123', 'yyyy-MM-dd HH:mm:ss.SSS') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(
+                LocalDateTime.of(2024, 6, 15, 14, 30, 45, 123000000), row2.getField(0));
+
+        // DATETIME_ISO8601: yyyy-MM-dd'T'HH:mm:ss
+        SeaTunnelRow row3 =
+                runSql(
+                        "select PARSEDATETIME('2024-06-15T14:30:45', 'yyyy-MM-dd''T''HH:mm:ss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row3.getField(0));
+
+        // DATETIME_ISO8601_WITH_MILLIS: yyyy-MM-dd'T'HH:mm:ss.SSS
+        SeaTunnelRow row4 =
+                runSql(
+                        "select PARSEDATETIME('2024-06-15T14:30:45.987', 'yyyy-MM-dd''T''HH:mm:ss.SSS') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(
+                LocalDateTime.of(2024, 6, 15, 14, 30, 45, 987000000), row4.getField(0));
+    }
+
+    @Test
+    public void testParseDateTimeWithAllDateFormats() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // DATE_ISO8601: yyyy-MM-dd
+        SeaTunnelRow row1 =
+                runSql(
+                        "select PARSEDATETIME('2024-06-15', 'yyyy-MM-dd') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDate.of(2024, 6, 15), row1.getField(0));
+    }
+
+    @Test
+    public void testParseDateTimeWithAllTimeFormats() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // TIME_STANDARD: HH:mm:ss
+        SeaTunnelRow row1 =
+                runSql(
+                        "select PARSEDATETIME('14:30:45', 'HH:mm:ss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(java.time.LocalTime.of(14, 30, 45), row1.getField(0));
+
+        // TIME_WITH_MILLIS: HH:mm:ss.SSS
+        SeaTunnelRow row2 =
+                runSql(
+                        "select PARSEDATETIME('14:30:45.123', 'HH:mm:ss.SSS') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(java.time.LocalTime.of(14, 30, 45, 123000000), row2.getField(0));
+    }
+
+    @Test
+    public void testParseDateTimeWithUnsupportedFormat() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // Test with completely unsupported format
+        Assertions.assertThrows(
+                TransformException.class,
+                () ->
+                        runSql(
+                                "select PARSEDATETIME('2024-06-15', 'dd/MM/yyyy') as dt from dual",
+                                rowType,
+                                LocalDateTime.now()));
+    }
+
+    @Test
+    public void testParseDateTimeWithMalformedInput() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // Test with malformed input string
+        Assertions.assertThrows(
+                TransformException.class,
+                () ->
+                        runSql(
+                                "select PARSEDATETIME('not-a-date', 'yyyy-MM-dd') as dt from dual",
+                                rowType,
+                                LocalDateTime.now()));
+    }
+
+    @Test
+    public void testToDateWithVariousFormats() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"dummy"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        // TO_DATE is an alias for PARSEDATETIME
+        SeaTunnelRow row1 =
+                runSql(
+                        "select TO_DATE('2024-06-15', 'yyyy-MM-dd') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDate.of(2024, 6, 15), row1.getField(0));
+
+        SeaTunnelRow row2 =
+                runSql(
+                        "select TO_DATE('2024-06-15 14:30:45', 'yyyy-MM-dd HH:mm:ss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row2.getField(0));
+    }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -24,7 +24,7 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.SQLTransform;
 
 import org.junit.jupiter.api.Assertions;
@@ -303,7 +303,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class,
+                TransformException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2021-04-08', 'invalid_pattern') as parsed from dual",
@@ -319,7 +319,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TYPE});
 
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class,
+                TransformException.class,
                 () ->
                         runSql(
                                 "select DATEADD(dt, 1, 'UNSUPPORTED') as d from dual",
@@ -400,9 +400,8 @@ public class DateTimeFunctionsTest {
                         new String[] {"dummy"},
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
-        // Test with completely unsupported format
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class,
+                TransformException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2024-06-15', 'dd/MM/yyyy') as dt from dual",
@@ -417,9 +416,8 @@ public class DateTimeFunctionsTest {
                         new String[] {"dummy"},
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
-        // Test with malformed input string
         Assertions.assertThrows(
-                SeaTunnelRuntimeException.class,
+                TransformException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('not-a-date', 'yyyy-MM-dd') as dt from dual",
@@ -434,7 +432,6 @@ public class DateTimeFunctionsTest {
                         new String[] {"dummy"},
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
-        // TO_DATE is an alias for PARSEDATETIME
         SeaTunnelRow row1 =
                 runSql(
                         "select TO_DATE('2024-06-15', 'yyyy-MM-dd') as dt from dual",

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -368,6 +368,31 @@ public class DateTimeFunctionsTest {
                         LocalDateTime.now());
         Assertions.assertEquals(
                 LocalDateTime.of(2024, 6, 15, 14, 30, 45, 987000000), row4.getField(0));
+
+        // DATETIME_SLASH: yyyy/MM/dd HH:mm:ss
+        SeaTunnelRow row5 =
+                runSql(
+                        "select PARSEDATETIME('2024/06/15 14:30:45', 'yyyy/MM/dd HH:mm:ss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row5.getField(0));
+
+        // DATETIME_SLASH_WITH_MILLIS: yyyy/MM/dd HH:mm:ss.SSS
+        SeaTunnelRow row6 =
+                runSql(
+                        "select PARSEDATETIME('2024/06/15 14:30:45.123', 'yyyy/MM/dd HH:mm:ss.SSS') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(
+                LocalDateTime.of(2024, 6, 15, 14, 30, 45, 123000000), row6.getField(0));
+
+        // DATETIME_COMPACT: yyyyMMddHHmmss
+        SeaTunnelRow row7 =
+                runSql(
+                        "select PARSEDATETIME('20240615143045', 'yyyyMMddHHmmss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDateTime.of(2024, 6, 15, 14, 30, 45), row7.getField(0));
     }
 
     @Test
@@ -392,6 +417,14 @@ public class DateTimeFunctionsTest {
                         rowType,
                         LocalDateTime.now());
         Assertions.assertEquals(java.time.LocalTime.of(14, 30, 45, 123000000), row2.getField(0));
+
+        // TIME_COMPACT: HHmmss
+        SeaTunnelRow row3 =
+                runSql(
+                        "select PARSEDATETIME('143045', 'HHmmss') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(java.time.LocalTime.of(14, 30, 45), row3.getField(0));
     }
 
     @Test
@@ -427,17 +460,34 @@ public class DateTimeFunctionsTest {
     }
 
     @Test
-    public void testToDateWithDateFormat() {
+    public void testParseDateTimeWithAllDateFormats() {
         SeaTunnelRowType rowType =
                 new SeaTunnelRowType(
                         new String[] {"dummy"},
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
+        // DATE_ISO8601: yyyy-MM-dd
         SeaTunnelRow row1 =
                 runSql(
                         "select TO_DATE('2024-06-15', 'yyyy-MM-dd') as dt from dual",
                         rowType,
                         LocalDateTime.now());
         Assertions.assertEquals(LocalDate.of(2024, 6, 15), row1.getField(0));
+
+        // DATE_SLASH: yyyy/MM/dd
+        SeaTunnelRow row2 =
+                runSql(
+                        "select PARSEDATETIME('2024/06/15', 'yyyy/MM/dd') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDate.of(2024, 6, 15), row2.getField(0));
+
+        // DATE_COMPACT: yyyyMMdd
+        SeaTunnelRow row3 =
+                runSql(
+                        "select PARSEDATETIME('20240615', 'yyyyMMdd') as dt from dual",
+                        rowType,
+                        LocalDateTime.now());
+        Assertions.assertEquals(LocalDate.of(2024, 6, 15), row3.getField(0));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.transform.exception.TransformException;
 import org.apache.seatunnel.transform.sql.SQLTransform;
 
@@ -303,7 +304,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2021-04-08', 'invalid_pattern') as parsed from dual",
@@ -401,7 +402,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('2024-06-15', 'dd/MM/yyyy') as dt from dual",
@@ -417,7 +418,7 @@ public class DateTimeFunctionsTest {
                         new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
 
         Assertions.assertThrows(
-                TransformException.class,
+                SeaTunnelRuntimeException.class,
                 () ->
                         runSql(
                                 "select PARSEDATETIME('not-a-date', 'yyyy-MM-dd') as dt from dual",

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunctionsTest.java
@@ -426,7 +426,7 @@ public class DateTimeFunctionsTest {
     }
 
     @Test
-    public void testToDateWithVariousFormats() {
+    public void testToDateWithDateFormat() {
         SeaTunnelRowType rowType =
                 new SeaTunnelRowType(
                         new String[] {"dummy"},


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

This PR addresses the ambiguity and potential parsing errors in the PARSEDATETIME and TO_DATE functions by introducing
  whitelist-based validation for datetime format patterns.

  **Problem:**
  Currently, these functions use pattern matching (contains("yy"), contains("mm")) to infer the return type
  (LocalDateTime/LocalDate/LocalTime), which leads to:
  1. Unclear documentation on which formats are officially supported
  2. Unpredictable behavior due to delegating all format validation to DateTimeFormatter, making it impossible to control or
  predict which format patterns will be accepted and how they will behave

  **Solution:**
  - Introduced ZetaDateTimeFormat enum with predefined, validated format patterns
  - Added strict whitelist validation that rejects unsupported formats with clear error messages
  - Updated documentation to explicitly list all supported formats

  **Supported Format Patterns:**
  - DateTime: yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm:ss.SSS, yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd'T'HH:mm:ss.SSS
  - Date: yyyy-MM-dd
  - Time: HH:mm:ss, HH:mm:ss.SSS

  **Related issues:** #10352 


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

Yes. Users who were using unsupported datetime format patterns (e.g., yyyy-M-d, dd/MM/yyyy, HH:mm) will now receive a clear
  TransformException with the message:
  Unsupported datetime format: '<pattern>'


<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

Unit Tests Added:

  **1. ZetaDateTimeFormatTest.java**
 - testFromPatternWithAllDateTimeFormats() - Validates all DateTime format patterns
 - testFromPatternWithAllDateFormats() - Validates Date format patterns
 - testFromPatternWithAllTimeFormats() - Validates Time format patterns
 - testFromPatternWithInvalidFormat() - Ensures invalid patterns return empty Optional
 - testFromPatternIsCaseSensitive() - Verifies case sensitivity
 - testAllEnumValuesAreUnique() - Prevents duplicate patterns

  **2. DateTimeFunctionsTest.java**
- testParseDateTimeWithAllDateTimeFormats() - Tests all 4 DateTime patterns
- testParseDateTimeWithAllDateFormats() - Tests Date pattern
- testParseDateTimeWithAllTimeFormats() - Tests both Time patterns
- testParseDateTimeWithUnsupportedFormat() - Verifies exception for unsupported patterns
- testParseDateTimeWithMalformedInput() - Verifies exception for malformed input
- testToDateWithVariousFormats() - Tests TO_DATE alias function


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)