### PR TITLE
[Fix][Transform-V2][DataValidator] Fix ROUTE_TO_TABLE routing when tableId has db/schema prefix

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -13,6 +13,7 @@ You need to check this document before you upgrade to related version.
 
 ### Transform Changes
 
+- DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).
 - Adjusted SQL Transform date & time functions:
   - `DATEDIFF(<start>, <end>, 'MONTH')` now returns the total number of months between the two dates across years (for example, from `2023-01-01` to `2024-03-01` returns `14` instead of `15`).
   - `WEEK(<datetime>)` now returns the ISO week number directly (previous behavior added an extra `+1` to the ISO week value).

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -12,6 +12,7 @@
 
 ### 转换变更
 
+- DataValidator 转换：当 `row_error_handle_way = ROUTE_TO_TABLE` 时，路由到错误表的行 `table_id` 现在会携带上游的 database/schema 前缀（例如从 `ffp` 变为 `db1.ffp` / `db1.schema1.ffp`）。
 ### 引擎行为变更
 
 ### 依赖升级

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestDataValidatorIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestDataValidatorIT.java
@@ -71,6 +71,14 @@ public class TestDataValidatorIT extends TestSuiteBase {
     }
 
     @TestTemplate
+    public void testDataValidatorWithRouteToTableAndDatabasePrefix(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult execResult =
+                container.executeJob("/data_validator_route_to_table_with_db_prefix.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+    }
+
+    @TestTemplate
     public void testDataValidatorWithUDF(TestContainer container)
             throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeJob("/data_validator_email_udf.conf");

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/data_validator_route_to_table_with_db_prefix.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/data_validator_route_to_table_with_db_prefix.conf
@@ -1,0 +1,179 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file demonstrates DataValidator transform with ROUTE_TO_TABLE mode
+###### when the upstream table_id includes database prefix (e.g. db.table).
+######
+
+env {
+  job.mode = "BATCH"
+  parallelism = 1
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    row.num = 10
+    schema = {
+      table = "db.fake"
+      fields {
+        id = "int"
+        name = "string"
+        age = "int"
+        email = "string"
+      }
+    }
+    rows = [
+      {fields = [1, "John Doe", 25, "john@example.com"], kind = INSERT}
+      {fields = [2, "Jane Smith", 30, "jane@example.com"], kind = INSERT}
+      {fields = [3, "Charlie Wilson", 32, "charlie@example.com"], kind = INSERT}
+      {fields = [4, null, 30, "invalid@example.com"], kind = INSERT}  # Invalid: null name
+      {fields = [5, "Bob Johnson", 200, "bob@example.com"], kind = INSERT}  # Invalid: age > 150
+      {fields = [6, "Alice Brown", 28, "invalid-email"], kind = INSERT}  # Invalid: bad email format
+    ]
+  }
+}
+
+transform {
+  DataValidator {
+    plugin_input = "fake"
+    plugin_output = "validated"
+    row_error_handle_way = "ROUTE_TO_TABLE"
+    row_error_handle_way.error_table = "error_data"
+    field_rules = [
+      {
+        field_name = "name"
+        rule_type = "NOT_NULL"
+      },
+      {
+        field_name = "age"
+        rule_type = "RANGE"
+        min_value = "0"
+        max_value = "150"
+      },
+      {
+        field_name = "email"
+        rule_type = "REGEX"
+        pattern = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$"
+      }
+    ]
+  }
+}
+
+sink {
+  Assert {
+    plugin_input = "validated"
+    rules = {
+      tables_configs = [
+        {
+          table_path = "db.fake"
+          row_rules = [
+            {
+              rule_type = MIN_ROW
+              rule_value = 3
+            },
+            {
+              rule_type = MAX_ROW
+              rule_value = 3
+            }
+          ],
+          field_rules = [
+            {
+              field_name = id
+              field_type = int
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = name
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = age
+              field_type = int
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = email
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            }
+          ]
+        },
+        {
+          table_path = "db.error_data"
+          row_rules = [
+            {
+              rule_type = MIN_ROW
+              rule_value = 3
+            },
+            {
+              rule_type = MAX_ROW
+              rule_value = 3
+            }
+          ],
+          field_rules = [
+            {
+              field_name = source_table_id
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = original_data
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = validation_errors
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransform.java
@@ -71,13 +71,7 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
                         .orElse(ErrorHandleWay.FAIL);
         this.errorTable =
                 readonlyConfig.getOptional(TransformCommonOptions.ERROR_TABLE_OPTION).orElse(null);
-        this.errorTablePath =
-                errorTable == null || errorTable.isEmpty()
-                        ? null
-                        : TablePath.of(
-                                inputCatalogTable.getTablePath().getDatabaseName(),
-                                inputCatalogTable.getTablePath().getSchemaName(),
-                                errorTable);
+        this.errorTablePath = resolveErrorTablePath(errorTable, inputCatalogTable.getTablePath());
         this.resultHandler = new ValidationResultHandler();
         this.fieldValidators = initializeFieldValidators();
     }
@@ -129,7 +123,7 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
             } else if (errorHandleWay.allowRouteToTable()) {
                 // Route invalid data to error table by setting tableId
                 if (errorTablePath != null) {
-                    String sourceTableId = inputCatalogTable.getTableId().toString();
+                    String sourceTableId = formatTableIdentifier(inputCatalogTable.getTableId());
                     String sourceTablePath = inputCatalogTable.getTablePath().toString();
                     SeaTunnelRow errorRow =
                             generateErrorRow(
@@ -149,6 +143,39 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
             }
         }
         return inputRow;
+    }
+
+    private static TablePath resolveErrorTablePath(String errorTable, TablePath inputTablePath) {
+        if (errorTable == null) {
+            return null;
+        }
+        String trimmed = errorTable.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (trimmed.contains(".")) {
+            boolean schemaFirst =
+                    inputTablePath.getDatabaseName() == null
+                            && inputTablePath.getSchemaName() != null;
+            return TablePath.of(trimmed, schemaFirst);
+        }
+        return TablePath.of(
+                inputTablePath.getDatabaseName(), inputTablePath.getSchemaName(), trimmed);
+    }
+
+    private static String formatTableIdentifier(TableIdentifier tableIdentifier) {
+        List<String> parts = new ArrayList<>();
+        if (tableIdentifier.getCatalogName() != null) {
+            parts.add(tableIdentifier.getCatalogName());
+        }
+        if (tableIdentifier.getDatabaseName() != null) {
+            parts.add(tableIdentifier.getDatabaseName());
+        }
+        if (tableIdentifier.getSchemaName() != null) {
+            parts.add(tableIdentifier.getSchemaName());
+        }
+        parts.add(tableIdentifier.getTableName());
+        return String.join(".", parts);
     }
 
     @Override

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransform.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.LocalTimeType;
@@ -59,6 +60,7 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
     private final ValidationResultHandler resultHandler;
     private final ErrorHandleWay errorHandleWay;
     private final String errorTable;
+    private final TablePath errorTablePath;
 
     public DataValidatorTransform(ReadonlyConfig readonlyConfig, CatalogTable catalogTable) {
         super(catalogTable);
@@ -67,15 +69,15 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
                 readonlyConfig
                         .getOptional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
                         .orElse(ErrorHandleWay.FAIL);
-        // For ROUTE_TO_TABLE mode, use row_error_handle_way.error_table, otherwise fallback to
-        // error_table
         this.errorTable =
-                readonlyConfig
-                        .getOptional(TransformCommonOptions.ERROR_TABLE_OPTION)
-                        .orElse(
-                                readonlyConfig
-                                        .getOptional(TransformCommonOptions.ERROR_TABLE_OPTION)
-                                        .orElse(null));
+                readonlyConfig.getOptional(TransformCommonOptions.ERROR_TABLE_OPTION).orElse(null);
+        this.errorTablePath =
+                errorTable == null || errorTable.isEmpty()
+                        ? null
+                        : TablePath.of(
+                                inputCatalogTable.getTablePath().getDatabaseName(),
+                                inputCatalogTable.getTablePath().getSchemaName(),
+                                errorTable);
         this.resultHandler = new ValidationResultHandler();
         this.fieldValidators = initializeFieldValidators();
     }
@@ -126,7 +128,7 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
                 return null; // Skip this row
             } else if (errorHandleWay.allowRouteToTable()) {
                 // Route invalid data to error table by setting tableId
-                if (errorTable != null && !errorTable.isEmpty()) {
+                if (errorTablePath != null) {
                     String sourceTableId = inputCatalogTable.getTableId().toString();
                     String sourceTablePath = inputCatalogTable.getTablePath().toString();
                     SeaTunnelRow errorRow =
@@ -135,10 +137,10 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
                                     inputCatalogTable.getTableSchema().toPhysicalRowDataType(),
                                     sourceTableId,
                                     sourceTablePath,
-                                    fieldResults,
-                                    errorTable);
-                    errorRow.setTableId(errorTable);
-                    log.debug("Routing invalid data to unified error table: {}", errorTable);
+                                    fieldResults);
+                    String errorTableId = errorTablePath.toString();
+                    errorRow.setTableId(errorTableId);
+                    log.debug("Routing invalid data to unified error table: {}", errorTableId);
                     return errorRow;
                 } else {
                     log.warn("Error table not configured, skipping invalid row");
@@ -154,12 +156,10 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
         List<CatalogTable> outputTables = new ArrayList<>();
 
         outputTables.add(getProducedCatalogTable());
-        if (errorHandleWay.allowRouteToTable() && errorTable != null && !errorTable.isEmpty()) {
+        if (errorHandleWay.allowRouteToTable() && errorTablePath != null) {
             TableIdentifier errorTableId =
                     TableIdentifier.of(
-                            inputCatalogTable.getTableId().getCatalogName(),
-                            inputCatalogTable.getTableId().getDatabaseName(),
-                            errorTable);
+                            inputCatalogTable.getTableId().getCatalogName(), errorTablePath);
             CatalogTable errorCatalogTable =
                     CatalogTable.of(
                             errorTableId,
@@ -216,8 +216,7 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
             SeaTunnelRowType originalRowType,
             String sourceTableId,
             String sourceTablePath,
-            Map<String, List<ValidationResult>> fieldResults,
-            String errorTable) {
+            Map<String, List<ValidationResult>> fieldResults) {
 
         try {
             String validationErrorsJson = generateValidationErrorsJson(fieldResults);
@@ -228,7 +227,6 @@ public class DataValidatorTransform extends AbstractCatalogSupportMapTransform {
             errorRow.setField(2, originalDataJson);
             errorRow.setField(3, validationErrorsJson);
             errorRow.setField(4, LocalDateTime.now());
-            errorRow.setTableId(errorTable);
 
             return errorRow;
 

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.validator;
+
+import org.apache.seatunnel.shade.com.google.common.collect.ImmutableMap;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataValidatorTransformTest {
+
+    private static ReadonlyConfig routeToTableConfig(String errorTableName) {
+        return ReadonlyConfig.fromMap(
+                ImmutableMap.of(
+                        "row_error_handle_way",
+                        "ROUTE_TO_TABLE",
+                        "row_error_handle_way.error_table",
+                        errorTableName,
+                        "field_rules",
+                        Arrays.asList(
+                                ImmutableMap.of("field_name", "name", "rule_type", "NOT_NULL"))));
+    }
+
+    @Test
+    void routeToTableShouldUseSameDatabaseInErrorRowTableId() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+
+        DataValidatorTransform transform =
+                new DataValidatorTransform(routeToTableConfig("ffp"), inputCatalogTable);
+
+        SeaTunnelRow invalidRow = new SeaTunnelRow(new Object[] {1, null});
+        SeaTunnelRow routedRow = transform.map(invalidRow);
+
+        assertEquals("db1.ffp", routedRow.getTableId());
+
+        List<CatalogTable> producedTables = transform.getProducedCatalogTables();
+        assertEquals(2, producedTables.size());
+        assertEquals("db1.source", producedTables.get(0).getTablePath().toString());
+        assertEquals("db1.ffp", producedTables.get(1).getTablePath().toString());
+    }
+
+    @Test
+    void routeToTableShouldPreserveSchemaInErrorRowTableId() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable(
+                        "catalog", "db1", "schema1", "source", inputRowType);
+
+        DataValidatorTransform transform =
+                new DataValidatorTransform(routeToTableConfig("ffp"), inputCatalogTable);
+
+        SeaTunnelRow invalidRow = new SeaTunnelRow(new Object[] {1, null});
+        SeaTunnelRow routedRow = transform.map(invalidRow);
+
+        assertEquals("db1.schema1.ffp", routedRow.getTableId());
+
+        List<CatalogTable> producedTables = transform.getProducedCatalogTables();
+        assertEquals(2, producedTables.size());
+        assertEquals("db1.schema1.source", producedTables.get(0).getTablePath().toString());
+        assertEquals("db1.schema1.ffp", producedTables.get(1).getTablePath().toString());
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
@@ -94,4 +94,50 @@ public class DataValidatorTransformTest {
         assertEquals("db1.schema1.source", producedTables.get(0).getTablePath().toString());
         assertEquals("db1.schema1.ffp", producedTables.get(1).getTablePath().toString());
     }
+
+    @Test
+    void routeToTableShouldWorkWithoutDatabaseAndSchemaPrefix() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", null, null, "source", inputRowType);
+
+        DataValidatorTransform transform =
+                new DataValidatorTransform(routeToTableConfig("ffp"), inputCatalogTable);
+
+        SeaTunnelRow invalidRow = new SeaTunnelRow(new Object[] {1, null});
+        SeaTunnelRow routedRow = transform.map(invalidRow);
+
+        assertEquals("ffp", routedRow.getTableId());
+
+        List<CatalogTable> producedTables = transform.getProducedCatalogTables();
+        assertEquals(2, producedTables.size());
+        assertEquals("source", producedTables.get(0).getTablePath().toString());
+        assertEquals("ffp", producedTables.get(1).getTablePath().toString());
+    }
+
+    @Test
+    void routeToTableShouldRespectQualifiedErrorTablePath() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+
+        DataValidatorTransform transform =
+                new DataValidatorTransform(routeToTableConfig("db2.ffp"), inputCatalogTable);
+
+        SeaTunnelRow invalidRow = new SeaTunnelRow(new Object[] {1, null});
+        SeaTunnelRow routedRow = transform.map(invalidRow);
+
+        assertEquals("db2.ffp", routedRow.getTableId());
+
+        List<CatalogTable> producedTables = transform.getProducedCatalogTables();
+        assertEquals(2, producedTables.size());
+        assertEquals("db1.source", producedTables.get(0).getTablePath().toString());
+        assertEquals("db2.ffp", producedTables.get(1).getTablePath().toString());
+    }
 }


### PR DESCRIPTION

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
https://github.com/apache/seatunnel/issues/10343
Fix `DataValidator` transform in `row_error_handle_way = ROUTE_TO_TABLE` mode: when the upstream `table_id` contains database/schema prefix (e.g. `db.table` / `db.schema.table`), invalid rows were previously routed to an unqualified `error_table`, which causes routing mismatch and may drop schema information in produced tables.  
This PR derives the error table `TablePath` from the input table path and uses it consistently for `SeaTunnelRow#setTableId` and produced `CatalogTable`.

### Does this PR introduce _any_ user-facing change?
Yes (bug fix). Previously the routed invalid row `table_id` was `error_table`; now it becomes `db.error_table` / `db.schema.error_table` to match the upstream table path.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

- Unit tests: `seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java`

- E2E: `TestDataValidatorIT#testDataValidatorWithRouteToTableAndDatabasePrefix` with `data_validator_route_to_table_with_db_prefix.conf`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)