### PR TITLE
[Improve][seatunnel-api] Unify non-relational data source multi-table mode schema configuration parameters

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
@@ -59,11 +59,16 @@ public interface CatalogOptions {
                             "The table names RegEx of the database to capture."
                                     + "The table name needs to include the database name, for example: database_.*\\.table_.*");
 
+    /**
+     * This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS. {@link
+     * org.apache.seatunnel.api.options.table.TableSchemaOptions}
+     */
+    @Deprecated
     Option<List<Map<String, Object>>> TABLE_LIST =
             Options.key("table_list")
                     .type(new TypeReference<List<Map<String, Object>>>() {})
                     .noDefaultValue()
                     .withDescription(
-                            "SeaTunnel Multi Table Schema, acts on structed data sources. "
+                            "This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS.SeaTunnel Multi Table Schema, acts on structed data sources. "
                                     + "such as jdbc, paimon, doris, etc");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
@@ -69,6 +69,6 @@ public interface CatalogOptions {
                     .type(new TypeReference<List<Map<String, Object>>>() {})
                     .noDefaultValue()
                     .withDescription(
-                            "This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS. SeaTunnel Multi Table Schema, acts on structed data sources. "
+                            "This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS. SeaTunnel Multi Table Schema, acts on structured and unstructured data sources. "
                                     + "such as jdbc, paimon, doris, etc");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/CatalogOptions.java
@@ -69,6 +69,6 @@ public interface CatalogOptions {
                     .type(new TypeReference<List<Map<String, Object>>>() {})
                     .noDefaultValue()
                     .withDescription(
-                            "This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS.SeaTunnel Multi Table Schema, acts on structed data sources. "
+                            "This parameter is deprecated, please use parameter: TableSchemaOptions.TABLE_CONFIGS. SeaTunnel Multi Table Schema, acts on structed data sources. "
                                     + "such as jdbc, paimon, doris, etc");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/TableSchemaOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/table/TableSchemaOptions.java
@@ -38,6 +38,6 @@ public interface TableSchemaOptions {
                     .type(new TypeReference<List<Map<String, Object>>>() {})
                     .noDefaultValue()
                     .withDescription(
-                            "SeaTunnel Multi Table Schema, acts on unstructed data sources. "
-                                    + "such as file, assert, mongodb, etc");
+                            "SeaTunnel Multi Table Schema, acts on structured and unstructured data sources. "
+                                    + "such as file, assert, mongodb, jdbc, paimon, doris, etc");
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/config/MaxcomputeBaseOptions.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/config/MaxcomputeBaseOptions.java
@@ -17,14 +17,10 @@
 
 package org.apache.seatunnel.connectors.seatunnel.maxcompute.config;
 
-import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
-
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
 
 public class MaxcomputeBaseOptions implements Serializable {
 
@@ -53,12 +49,6 @@ public class MaxcomputeBaseOptions implements Serializable {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("Your Maxcompute project which is created in Alibaba Cloud");
-
-    public static final Option<List<Map<String, Object>>> TABLE_LIST =
-            Options.key("table_list")
-                    .type(new TypeReference<List<Map<String, Object>>>() {})
-                    .noDefaultValue()
-                    .withDescription("List of tables to be written to MaxCompute.");
 
     public static final Option<String> TABLE_NAME =
             Options.key("table_name")

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSource.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSource.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceReader;
@@ -79,9 +80,9 @@ public class MaxcomputeSource
         } else {
             try (MaxComputeCatalog catalog = new MaxComputeCatalog("maxcompute", readonlyConfig)) {
                 catalog.open();
-                if (readonlyConfig.getOptional(MaxcomputeSourceOptions.TABLE_LIST).isPresent()) {
+                if (readonlyConfig.getOptional(CatalogOptions.TABLE_LIST).isPresent()) {
                     for (Map<String, Object> subConfig :
-                            readonlyConfig.get(MaxcomputeSourceOptions.TABLE_LIST)) {
+                            readonlyConfig.get(CatalogOptions.TABLE_LIST)) {
                         ReadonlyConfig subReadonlyConfig = ReadonlyConfig.fromMap(subConfig);
                         String project =
                                 subReadonlyConfig

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
 
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -52,7 +53,7 @@ public class MaxcomputeSourceFactory implements TableSourceFactory {
                         MaxcomputeSourceOptions.PROJECT,
                         MaxcomputeSourceOptions.READ_COLUMNS,
                         MaxcomputeSourceOptions.TUNNEL_ENDPOINT)
-                .exclusive(MaxcomputeSourceOptions.TABLE_LIST, MaxcomputeSourceOptions.TABLE_NAME)
+                .exclusive(CatalogOptions.TABLE_LIST, MaxcomputeSourceOptions.TABLE_NAME)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSourceOptions.java
@@ -17,13 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.paimon.config;
 
-import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
-
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
-
-import java.util.List;
-import java.util.Map;
 
 public class PaimonSourceOptions extends PaimonBaseOptions {
 
@@ -32,10 +27,4 @@ public class PaimonSourceOptions extends PaimonBaseOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The query of paimon source");
-
-    public static final Option<List<Map<String, Object>>> TABLE_LIST =
-            Options.key("table_list")
-                    .type(new TypeReference<List<Map<String, Object>>>() {})
-                    .noDefaultValue()
-                    .withDescription("table list config");
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSourceTableConfig.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.config;
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 
 import lombok.Getter;
@@ -50,8 +51,8 @@ public class PaimonSourceTableConfig implements Serializable {
     }
 
     public static List<PaimonSourceTableConfig> of(ReadonlyConfig config) {
-        if (config.getOptional(PaimonSourceOptions.TABLE_LIST).isPresent()) {
-            List<Map<String, Object>> maps = config.get(PaimonSourceOptions.TABLE_LIST);
+        if (config.getOptional(CatalogOptions.TABLE_LIST).isPresent()) {
+            List<Map<String, Object>> maps = config.get(CatalogOptions.TABLE_LIST);
             return maps.stream()
                     .map(ReadonlyConfig::fromMap)
                     .map(PaimonSourceTableConfig::parsePaimonSourceConfig)

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/PaimonSourceFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.source;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -54,7 +55,7 @@ public class PaimonSourceFactory implements TableSourceFactory {
                         PaimonSourceOptions.QUERY_SQL,
                         PaimonSourceOptions.HADOOP_CONF,
                         PaimonSourceOptions.HADOOP_CONF_PATH)
-                .exclusive(PaimonSourceOptions.TABLE, PaimonSourceOptions.TABLE_LIST)
+                .exclusive(PaimonSourceOptions.TABLE, CatalogOptions.TABLE_LIST)
                 .conditional(
                         PaimonSourceOptions.CATALOG_TYPE,
                         PaimonCatalogEnum.HIVE,

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/config/StarRocksSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/config/StarRocksSourceOptions.java
@@ -17,13 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.starrocks.config;
 
-import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
-
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
-
-import java.util.List;
-import java.util.Map;
 
 public class StarRocksSourceOptions extends StarRocksBaseOptions {
     private static final long DEFAULT_SCAN_MEM_LIMIT = 1024 * 1024 * 1024L;
@@ -77,10 +72,4 @@ public class StarRocksSourceOptions extends StarRocksBaseOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("The parameter of the scan data from be");
-
-    public static final Option<List<Map<String, Object>>> TABLE_LIST =
-            Options.key("table_list")
-                    .type(new TypeReference<List<Map<String, Object>>>() {})
-                    .noDefaultValue()
-                    .withDescription("table list config");
 }

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/config/StarRocksSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/config/StarRocksSourceTableConfig.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.starrocks.config;
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
@@ -70,8 +71,8 @@ public class StarRocksSourceTableConfig implements Serializable {
 
     public static List<StarRocksSourceTableConfig> of(ReadonlyConfig config) {
 
-        if (config.getOptional(StarRocksSourceOptions.TABLE_LIST).isPresent()) {
-            List<Map<String, Object>> maps = config.get(StarRocksSourceOptions.TABLE_LIST);
+        if (config.getOptional(CatalogOptions.TABLE_LIST).isPresent()) {
+            List<Map<String, Object>> maps = config.get(CatalogOptions.TABLE_LIST);
             return maps.stream()
                     .map(ReadonlyConfig::fromMap)
                     .map(StarRocksSourceTableConfig::parseStarRocksSourceConfig)

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceFactory.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.starrocks.source;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.options.table.CatalogOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -59,7 +60,7 @@ public class StarRocksSourceFactory implements TableSourceFactory {
                         StarRocksSourceOptions.SCAN_KEEP_ALIVE_MIN,
                         StarRocksSourceOptions.SCAN_BATCH_ROWS,
                         StarRocksSourceOptions.SCAN_CONNECT_TIMEOUT)
-                .exclusive(StarRocksSourceOptions.TABLE, StarRocksSourceOptions.TABLE_LIST)
+                .exclusive(StarRocksSourceOptions.TABLE, CatalogOptions.TABLE_LIST)
                 .build();
     }
 


### PR DESCRIPTION
### Summary

This pull request **unifies configuration parameters for multi-table mode schema in non-relational data sources**. It improves consistency and clarity in how multi-table schema options are defined and used across different non-relational connectors in SeaTunnel.

### What’s Changed

- Standardize schema-related configuration parameters for multi-table mode
- Improve usability of configuration options for non-relational data sources
- Align naming and semantics of related properties to be more intuitive

### Backwards Compatibility

This change is additive and should not break existing configurations. However, users leveraging non-relational multi-table features may see clearer parameter names.
