### PR TITLE
[Bug][connector-jdbc] Fix integer overflow when merging table schema with large column length

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtils.java
@@ -332,23 +332,22 @@ public class JdbcCatalogUtils {
                                                                             .get(column.getName())
                                                                             .getDataType()
                                                                             .getSqlType())
-                                            ? PhysicalColumn.of(
+                                            ? new PhysicalColumn(
                                                     column.getName(),
                                                     column.getDataType(),
-                                                    column.getColumnLength() == null
-                                                            ? null
-                                                            : Math.toIntExact(
-                                                                    column.getColumnLength()),
+                                                    column.getColumnLength(),
+                                                    column.getScale(),
                                                     column.isNullable(),
                                                     column.getDefaultValue(),
                                                     columnsOfPath
                                                             .get(column.getName())
                                                             .getComment(),
                                                     column.getSourceType(),
+                                                    column.getSinkType(),
+                                                    column.getOptions(),
                                                     column.isUnsigned(),
                                                     column.isZeroFill(),
                                                     column.getBitLen(),
-                                                    column.getOptions(),
                                                     column.getLongColumnLength())
                                             : column;
                                 })

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcCatalogUtilsTest.java
@@ -336,6 +336,94 @@ public class JdbcCatalogUtilsTest {
     }
 
     @Test
+    public void testColumnNotIncludeMergeWithLargeColumnLength() {
+        long largeLength = 4294967295L;
+
+        CatalogTable tableOfPath =
+                CatalogTable.of(
+                        TableIdentifier.of("mysql-1", "database-x", null, "table-x"),
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.of(
+                                                "id",
+                                                BasicType.LONG_TYPE,
+                                                (Long) null,
+                                                false,
+                                                null,
+                                                "id comment"))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "config",
+                                                BasicType.STRING_TYPE,
+                                                largeLength,
+                                                false,
+                                                null,
+                                                "config comment"))
+                                .build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        null);
+
+        CatalogTable tableOfQuery =
+                CatalogTable.of(
+                        TableIdentifier.of("default", null, null, "default"),
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.of(
+                                                "id",
+                                                BasicType.LONG_TYPE,
+                                                (Long) null,
+                                                true,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "config",
+                                                BasicType.STRING_TYPE,
+                                                largeLength,
+                                                true,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "dummy",
+                                                BasicType.INT_TYPE,
+                                                (Long) null,
+                                                true,
+                                                null,
+                                                null))
+                                .build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        null);
+
+        CatalogTable mergeTable = JdbcCatalogUtils.mergeCatalogTable(tableOfPath, tableOfQuery);
+
+        Assertions.assertEquals(
+                tableOfPath.getTableId().toTablePath(), mergeTable.getTableId().toTablePath());
+        Assertions.assertEquals(
+                tableOfQuery.getTableId().getCatalogName(),
+                mergeTable.getTableId().getCatalogName());
+
+        Map<String, Column> mergedColumns =
+                mergeTable.getTableSchema().getColumns().stream()
+                        .collect(Collectors.toMap(e -> e.getName(), e -> e));
+
+        Column mergedId = mergedColumns.get("id");
+        Column mergedConfig = mergedColumns.get("config");
+
+        Assertions.assertNotNull(mergedId);
+        Assertions.assertNotNull(mergedConfig);
+
+        // The merge should use the query column as base, and fill comment from the table_path.
+        Assertions.assertTrue(mergedId.isNullable());
+        Assertions.assertEquals("id comment", mergedId.getComment());
+
+        Assertions.assertEquals(Long.valueOf(largeLength), mergedConfig.getColumnLength());
+        Assertions.assertEquals("config comment", mergedConfig.getComment());
+    }
+
+    @Test
     public void testDecimalColumnMerge() {
         CatalogTable tableOfQuery =
                 CatalogTable.of(


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Fixes #10386 

When reading MySQL tables that contain LONGTEXT/LONGBLOB (columnLength can be 2^32-1) and configuring both `table_path` and `query`, `JdbcCatalogUtils.mergeCatalogTable` rebuilt columns using `Math.toIntExact(column.getColumnLength())`, which can overflow and fail the job at startup. This PR removes the unsafe Long→int conversion and preserves the long column length while still merging column comments from `table_path`.

### Does this PR introduce _any_ user-facing change?
Yes. Previously the job could fail during startup with `java.lang.ArithmeticException: integer overflow` when `table_path` and `query` were used together and a column length exceeded `Integer.MAX_VALUE`; now the job can start normally and schema merge succeeds.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

Added unit test: `JdbcCatalogUtilsTest#testColumnNotIncludeMergeWithLargeColumnLength`
### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)