### PR TITLE
[Fix][Connector-Jdbc] Bump Redshift JDBC driver from 2.1.0.9 to 2.1.0.30 to fix OOM issues 

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/pom.xml
+++ b/seatunnel-connectors-v2/connector-jdbc/pom.xml
@@ -41,7 +41,7 @@
         <sqlite.version>3.39.3.0</sqlite.version>
         <tablestore.version>5.13.9</tablestore.version>
         <teradata.version>17.20.00.12</teradata.version>
-        <redshift.version>2.1.0.9</redshift.version>
+        <redshift.version>2.1.0.30</redshift.version>
         <saphana.version>2.23.10</saphana.version>
         <snowflake.version>3.13.29</snowflake.version>
         <vertica.version>12.0.3-0</vertica.version>

--- a/seatunnel-connectors-v2/connector-s3-redshift/pom.xml
+++ b/seatunnel-connectors-v2/connector-s3-redshift/pom.xml
@@ -30,7 +30,7 @@
     <name>SeaTunnel : Connectors V2 : S3 Redshift</name>
 
     <properties>
-        <redshift.version>2.1.0.9</redshift.version>
+        <redshift.version>2.1.0.30</redshift.version>
     </properties>
 
     <dependencies>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -98,7 +98,7 @@
                 <tablestore.version>5.13.9</tablestore.version>
                 <saphana.version>2.23.10</saphana.version>
                 <teradata.version>17.20.00.12</teradata.version>
-                <redshift.version>2.1.0.9</redshift.version>
+                <redshift.version>2.1.0.30</redshift.version>
                 <snowflake.version>3.13.29</snowflake.version>
 
                 <!-- Imap storage dependency package  -->


### PR DESCRIPTION
## Why
Refer to [RingBuffer growing beyond expected limits · Issue #88 · aws/amazon-redshift-jdbc-driver
github.com
](https://github.com/aws/amazon-redshift-jdbc-driver/issues/88)
Redshift JDBC 2.1.0.18 and below have OOM issues. This PR bumps the Redshift client to 2.1.0.30.

## What
- Update Redshift JDBC version to 2.1.0.30 in connector-jdbc, connector-s3-redshift, and seatunnel-dist.
