### PR TITLE
[Feature][Glue Catalog] Add wrapper for providing Simple Glue Credentials when different from S3. 

### DIFF
--- a/docs/en/connectors/sink/Iceberg.md
+++ b/docs/en/connectors/sink/Iceberg.md
@@ -207,6 +207,55 @@ sink {
 
 ```
 
+### Glue Compatible Catalog with Custom Endpoint and Static Credentials
+
+```hocon
+sink {
+  Iceberg {
+    catalog_name = "seatunnel_test"
+    iceberg.catalog.config = {
+      warehouse     = "s3://your-bucket/warehouse/"
+      catalog-impl  = "org.apache.iceberg.aws.glue.GlueCatalog"
+      io-impl       = "org.apache.iceberg.aws.s3.S3FileIO"
+      client.region = "your-region"
+      
+      # Properties below must be supplied when using custom glue endpoints and static credentials
+      # Class Name of the provider you want to use
+      # We provide a StaticAWSCredential provider that you may use.
+      # If you need a different authentication method, you will need to provide
+      # your custom implementation and ensure that it is available in SEATUNNEL_HOME/lib
+      
+      client.credentials-provider="org.apache.seatunnel.connectors.seatunnel.iceberg.aws.StaticAwsCredentialsProvider"
+      
+      # Provide you AWS Access Key Id and Secret Access Key in the properties below
+      client.credentials-provider.access-key-id = "YOUR_ACCESS_KEY"
+      client.credentials-provider.secret-access-key = "YOUR_SECRET_ACCESS_KEY"
+      
+      # These additional settings may need to be set for your glue compatable catalog
+      glue.endpoint = "https://hostname:port"
+      glue.id = "YOUR_GLUE_CATALOG_ID"
+      
+      
+      
+      
+      
+    }
+    namespace = "seatunnel_namespace"
+    table     = "iceberg_sink_table"
+    iceberg.table.write-props = {
+      write.format.default = "parquet"
+      write.target-file-size-bytes = 536870912
+    }
+    iceberg.table.primary-keys = "id"
+    iceberg.table.partition-keys = "f_datetime"
+    iceberg.table.upsert-mode-enabled = true
+    iceberg.table.schema-evolution-enabled = true
+    case_sensitive = true
+  }
+}
+
+```
+
 ### AWS S3 Tables REST Catalog
 
 Amazon S3 Tables is a storage service for tabular data that's optimized for analytics workloads, with features designed to continuously improve query performance and reduce storage costs for tables. S3 Tables is purpose-built for storing tabular data, such as daily purchase transactions, streaming sensor data, or ad impressions. Tabular data represents data in columns and rows, like in a database table.

--- a/docs/en/connectors/source/Iceberg.md
+++ b/docs/en/connectors/source/Iceberg.md
@@ -198,6 +198,55 @@ source {
 }
 ```
 
+### Glue Compatible Catalog with Custom Endpoint and Static Credentials
+
+```hocon
+sink {
+  Iceberg {
+    catalog_name = "seatunnel_test"
+    iceberg.catalog.config = {
+      warehouse     = "s3://your-bucket/warehouse/"
+      catalog-impl  = "org.apache.iceberg.aws.glue.GlueCatalog"
+      io-impl       = "org.apache.iceberg.aws.s3.S3FileIO"
+      client.region = "your-region"
+      
+      # Properties below must be supplied when using custom glue endpoints and static credentials
+      # Class Name of the provider you want to use
+      # We provide a StaticAWSCredential provider that you may use.
+      # If you need a different authentication method, you will need to provide
+      # your custom implementation and ensure that it is available in SEATUNNEL_HOME/lib
+      
+      client.credentials-provider="org.apache.seatunnel.connectors.seatunnel.iceberg.aws.StaticAwsCredentialsProvider"
+      
+      # Provide you AWS Access Key Id and Secret Access Key in the properties below
+      client.credentials-provider.access-key-id = "YOUR_ACCESS_KEY"
+      client.credentials-provider.secret-access-key = "YOUR_SECRET_ACCESS_KEY"
+      
+      # These additional settings may need to be set for your glue compatable catalog
+      glue.endpoint = "https://hostname:port"
+      glue.id = "YOUR_GLUE_CATALOG_ID"
+      
+      
+      
+      
+      
+    }
+    namespace = "seatunnel_namespace"
+    table     = "iceberg_sink_table"
+    iceberg.table.write-props = {
+      write.format.default = "parquet"
+      write.target-file-size-bytes = 536870912
+    }
+    iceberg.table.primary-keys = "id"
+    iceberg.table.partition-keys = "f_datetime"
+    iceberg.table.upsert-mode-enabled = true
+    iceberg.table.schema-evolution-enabled = true
+    case_sensitive = true
+  }
+}
+
+```
+
 ### Column Projection
 
 ```hocon

--- a/seatunnel-connectors-v2/connector-iceberg/pom.xml
+++ b/seatunnel-connectors-v2/connector-iceberg/pom.xml
@@ -79,7 +79,19 @@
             <artifactId>sts</artifactId>
             <version>${software.amazon.awssdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>identity-spi</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/aws/StaticAwsCredentialsProvider.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/aws/StaticAwsCredentialsProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.iceberg.aws;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+import java.util.Map;
+
+public class StaticAwsCredentialsProvider implements AwsCredentialsProvider {
+
+    private final StaticCredentialsProvider delegate;
+
+    // Iceberg's factory looks specifically for this method signature
+    public static StaticAwsCredentialsProvider create(Map<String, String> properties) {
+        return new StaticAwsCredentialsProvider(properties);
+    }
+
+    private StaticAwsCredentialsProvider(Map<String, String> properties) {
+        // Properties passed here have the prefix "client.credentials-provider." removed
+        String accessKey = properties.get("access-key-id");
+        String secretKey = properties.get("secret-access-key");
+
+        if (accessKey == null || secretKey == null) {
+            throw new IllegalArgumentException(
+                    "Missing credentials. Use 'client.credentials-provider.access-key-id' "
+                            + "and 'client.credentials-provider.secret-access-key' in your catalog configuration.");
+        }
+
+        this.delegate =
+                StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey.trim(), secretKey.trim()));
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        return delegate.resolveCredentials();
+    }
+}

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/aws/StaticAwsCredentialsProviderTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/aws/StaticAwsCredentialsProviderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.iceberg.aws;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class StaticAwsCredentialsProviderTest {
+
+    @Test
+    void testCreateAndResolveCredentialsSuccess() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("access-key-id", " test-access-key ");
+        properties.put("secret-access-key", "test-secret-key");
+
+        StaticAwsCredentialsProvider provider = StaticAwsCredentialsProvider.create(properties);
+        AwsCredentials credentials = provider.resolveCredentials();
+
+        // Verify values are correctly mapped and trimmed
+        Assertions.assertEquals("test-access-key", credentials.accessKeyId());
+        Assertions.assertEquals("test-secret-key", credentials.secretAccessKey());
+    }
+
+    @Test
+    void testCreateMissingAccessKey() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("secret-access-key", "test-secret-key");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> StaticAwsCredentialsProvider.create(properties));
+
+        Assertions.assertTrue(exception.getMessage().contains("Missing credentials"));
+    }
+
+    @Test
+    void testCreateMissingSecretKey() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("access-key-id", "test-access-key");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> StaticAwsCredentialsProvider.create(properties));
+
+        Assertions.assertTrue(exception.getMessage().contains("Missing credentials"));
+    }
+
+    @Test
+    void testCreateWithEmptyProperties() {
+        Map<String, String> properties = new HashMap<>();
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> StaticAwsCredentialsProvider.create(properties));
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/pom.xml
@@ -25,6 +25,9 @@
     <artifactId>connector-iceberg-e2e</artifactId>
     <name>SeaTunnel : E2E : Connector V2 : Iceberg</name>
 
+    <properties>
+        <parquet.version>1.12.2</parquet.version>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -105,6 +108,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>${parquet.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${parquet.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
The current Iceberg connector simply passes iceberg.catalog.config through to Iceberg via CatalogUtil.buildIcebergCatalog (see IcebergCatalogLoader.java). The docs only show client.region and do not cover static AK/SK or client.credentials-provider. There is no existing wrapper that constructs a static AwsCredentialsProvider from configuration properties (contrast with S3File connector, which exposes access_key/secret_key as first-class options).

A PR adding a provider like StaticAwsCredentialsProvider (implementing AwsCredentialsProvider with a static create(Map<String,String>) factory) under connector-iceberg would be a good addition, along with a docs example:
```hocon
iceberg.catalog.config = {
  warehouse     = "s3://your-bucket/warehouse/"
  catalog-impl  = "org.apache.iceberg.aws.glue.GlueCatalog"
  io-impl       = "org.apache.iceberg.aws.s3.S3FileIO"
  client.region = "your-region"
  client.credentials-provider = "org.apache.seatunnel.connectors.seatunnel.iceberg.aws.StaticAwsCredentialsProvider"
  client.credentials-provider.access-key-id = "YOUR_ACCESS_KEY"
  client.credentials-provider.secret-access-key = "YOUR_SECRET_ACCESS_KEY"
}
```

### Purpose of this pull request

Provides wrapper around AWS authentication for StaticCredentialProvider to allow the use of static credentials with glue catlogs.

Closes #10392

### Does this PR introduce _any_ user-facing change?

- [x] Yes - Documentation Updated

### How was this patch tested?

<!--

1. Tested base implementation in my environment.
2. Added tests to connector. 

-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)