### PR TITLE
[Fix][connector-cdc] Fix NPE when finishing snapshot split due to null splitId

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
@@ -43,6 +43,16 @@ import java.util.Queue;
 import java.util.Set;
 
 @Slf4j
+/**
+ * Split reader for incremental source (snapshot + incremental phase).
+ *
+ * <p><b>Thread safety:</b> This class is NOT thread-safe and is expected to be used from a single
+ * thread. The {@link #fetch()} method should be called sequentially without concurrent access. The
+ * {@link #close()} method should be called from the same thread or after all fetch calls have
+ * completed.
+ *
+ * @param <C> The type of source configuration.
+ */
 public class IncrementalSourceSplitReader<C extends SourceConfig>
         implements SplitReader<SourceRecords, SourceSplitBase> {
     private final Queue<SourceSplitBase> splits;
@@ -87,7 +97,21 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
             return finishedSnapshotSplit();
         }
         if (currentSplitId == null) {
-            throw new IOException("currentSplitId is null when emitting records");
+            log.warn(
+                    "Invalid state: currentSplitId is null when emitting records. "
+                            + "emittedFinishedSplitId={}, currentFetcher={}, isFinished={}",
+                    emittedFinishedSplitId,
+                    currentFetcher != null ? currentFetcher.getClass().getSimpleName() : "null",
+                    currentFetcher != null && currentFetcher.isFinished());
+            throw new IOException(
+                    String.format(
+                            "Invalid state: currentSplitId is null when emitting records. "
+                                    + "emittedFinishedSplitId=%s, currentFetcher=%s, isFinished=%s",
+                            emittedFinishedSplitId,
+                            currentFetcher != null
+                                    ? currentFetcher.getClass().getSimpleName()
+                                    : "null",
+                            currentFetcher != null && currentFetcher.isFinished()));
         }
         return ChangeEventRecords.forRecords(currentSplitId, dataIt);
     }
@@ -110,10 +134,14 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
 
     @Override
     public void close() throws Exception {
-        if (currentFetcher != null) {
-            log.info("Close current fetcher {}", currentFetcher.getClass().getCanonicalName());
-            currentFetcher.close();
+        try {
+            if (currentFetcher != null) {
+                log.info("Close current fetcher {}", currentFetcher.getClass().getCanonicalName());
+                currentFetcher.close();
+            }
+        } finally {
             currentSplitId = null;
+            emittedFinishedSplitId = null;
         }
     }
 
@@ -170,7 +198,21 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
     private RecordsWithSplitIds<SourceRecords> finishedSnapshotSplit() throws IOException {
         final String splitId = currentSplitId;
         if (splitId == null) {
-            throw new IOException("currentSplitId is null when finishing snapshot split");
+            log.warn(
+                    "Invalid state: currentSplitId is null when finishing snapshot split. "
+                            + "emittedFinishedSplitId={}, currentFetcher={}, isFinished={}",
+                    emittedFinishedSplitId,
+                    currentFetcher != null ? currentFetcher.getClass().getSimpleName() : "null",
+                    currentFetcher != null && currentFetcher.isFinished());
+            throw new IOException(
+                    String.format(
+                            "Invalid state: currentSplitId is null when finishing snapshot split. "
+                                    + "emittedFinishedSplitId=%s, currentFetcher=%s, isFinished=%s",
+                            emittedFinishedSplitId,
+                            currentFetcher != null
+                                    ? currentFetcher.getClass().getSimpleName()
+                                    : "null",
+                            currentFetcher != null && currentFetcher.isFinished()));
         }
         if (splitId.equals(emittedFinishedSplitId)) {
             return NoSplitRecords.INSTANCE;

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReader.java
@@ -37,8 +37,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Queue;
+import java.util.Set;
 
 @Slf4j
 public class IncrementalSourceSplitReader<C extends SourceConfig>
@@ -49,6 +51,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
     private Fetcher<SourceRecords, SourceSplitBase> currentFetcher;
 
     private String currentSplitId;
+    private String emittedFinishedSplitId;
     private final DataSourceDialect<C> dataSourceDialect;
     private final C sourceConfig;
     private final SchemaChangeResolver schemaChangeResolver;
@@ -70,6 +73,9 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
 
         checkSplitOrStartNext();
         checkNeedStopBinlogReader();
+        if (hasEmittedCurrentSplitFinished()) {
+            return NoSplitRecords.INSTANCE;
+        }
         Iterator<SourceRecords> dataIt = null;
         try {
             dataIt = currentFetcher.pollSplitRecords();
@@ -77,9 +83,13 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
             log.warn("fetch data failed.", e);
             throw new IOException(e);
         }
-        return dataIt == null
-                ? finishedSnapshotSplit()
-                : ChangeEventRecords.forRecords(currentSplitId, dataIt);
+        if (dataIt == null) {
+            return finishedSnapshotSplit();
+        }
+        if (currentSplitId == null) {
+            throw new IOException("currentSplitId is null when emitting records");
+        }
+        return ChangeEventRecords.forRecords(currentSplitId, dataIt);
     }
 
     @Override
@@ -123,6 +133,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
                 throw new IOException("Cannot fetch from another split - no split remaining.");
             }
             currentSplitId = nextSplit.splitId();
+            emittedFinishedSplitId = null;
 
             if (nextSplit.isSnapshotSplit()) {
                 if (currentFetcher == null) {
@@ -152,10 +163,38 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
         return currentFetcher == null || currentFetcher.isFinished();
     }
 
-    private ChangeEventRecords finishedSnapshotSplit() {
-        final ChangeEventRecords finishedRecords =
-                ChangeEventRecords.forFinishedSplit(currentSplitId);
-        currentSplitId = null;
-        return finishedRecords;
+    private boolean hasEmittedCurrentSplitFinished() {
+        return currentSplitId != null && currentSplitId.equals(emittedFinishedSplitId);
+    }
+
+    private RecordsWithSplitIds<SourceRecords> finishedSnapshotSplit() throws IOException {
+        final String splitId = currentSplitId;
+        if (splitId == null) {
+            throw new IOException("currentSplitId is null when finishing snapshot split");
+        }
+        if (splitId.equals(emittedFinishedSplitId)) {
+            return NoSplitRecords.INSTANCE;
+        }
+        emittedFinishedSplitId = splitId;
+        return ChangeEventRecords.forFinishedSplit(splitId);
+    }
+
+    private static final class NoSplitRecords implements RecordsWithSplitIds<SourceRecords> {
+        private static final NoSplitRecords INSTANCE = new NoSplitRecords();
+
+        @Override
+        public String nextSplit() {
+            return null;
+        }
+
+        @Override
+        public SourceRecords nextRecordFromSplit() {
+            throw new IllegalStateException("No split assigned");
+        }
+
+        @Override
+        public Set<String> finishedSplits() {
+            return Collections.emptySet();
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
@@ -74,6 +74,13 @@ public final class ChangeEventRecords implements RecordsWithSplitIds<SourceRecor
         return new ChangeEventRecords(splitId, recordsForSplit, Collections.emptySet());
     }
 
+    /**
+     * Creates a {@link ChangeEventRecords} that only indicates a split is finished.
+     *
+     * @param splitId the ID of the finished split, must not be null
+     * @return a new {@link ChangeEventRecords} instance
+     * @throws IllegalArgumentException if splitId is null
+     */
     public static ChangeEventRecords forFinishedSplit(final String splitId) {
         if (splitId == null) {
             throw new IllegalArgumentException("splitId must not be null");

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/split/ChangeEventRecords.java
@@ -75,6 +75,9 @@ public final class ChangeEventRecords implements RecordsWithSplitIds<SourceRecor
     }
 
     public static ChangeEventRecords forFinishedSplit(final String splitId) {
+        if (splitId == null) {
+            throw new IllegalArgumentException("splitId must not be null");
+        }
         return new ChangeEventRecords(null, null, Collections.singleton(splitId));
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReaderTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReaderTest.java
@@ -117,11 +117,44 @@ class IncrementalSourceSplitReaderTest {
         Mockito.verify(fetcher, Mockito.times(2)).pollSplitRecords();
     }
 
+    @Test
+    void testCloseClearsState() throws Exception {
+        DataSourceDialect<SourceConfig> dialect = Mockito.mock(DataSourceDialect.class);
+        SourceConfig config = Mockito.mock(SourceConfig.class);
+        SchemaChangeResolver resolver = Mockito.mock(SchemaChangeResolver.class);
+
+        IncrementalSourceSplitReader<SourceConfig> reader =
+                new IncrementalSourceSplitReader<SourceConfig>(0, dialect, config, resolver) {
+                    @Override
+                    protected void checkSplitOrStartNext() {}
+                };
+
+        @SuppressWarnings("unchecked")
+        Fetcher<SourceRecords, SourceSplitBase> fetcher = Mockito.mock(Fetcher.class);
+
+        setField(reader, "currentFetcher", fetcher);
+        setField(reader, "currentSplitId", "split-1");
+        setField(reader, "emittedFinishedSplitId", "split-1");
+
+        reader.close();
+
+        Assertions.assertNull(getField(reader, "currentSplitId"));
+        Assertions.assertNull(getField(reader, "emittedFinishedSplitId"));
+        Mockito.verify(fetcher, Mockito.times(1)).close();
+    }
+
     private static void setField(
             IncrementalSourceSplitReader<?> reader, String fieldName, Object value)
             throws Exception {
         Field field = IncrementalSourceSplitReader.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(reader, value);
+    }
+
+    private static Object getField(IncrementalSourceSplitReader<?> reader, String fieldName)
+            throws Exception {
+        Field field = IncrementalSourceSplitReader.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(reader);
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReaderTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/IncrementalSourceSplitReaderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.reader;
+
+import org.apache.seatunnel.connectors.cdc.base.config.SourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.dialect.DataSourceDialect;
+import org.apache.seatunnel.connectors.cdc.base.schema.SchemaChangeResolver;
+import org.apache.seatunnel.connectors.cdc.base.source.reader.external.Fetcher;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceRecords;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+class IncrementalSourceSplitReaderTest {
+
+    @Test
+    void testFetchFinishedSnapshotSplitEmitsFinishedOnlyOnce() throws Exception {
+        DataSourceDialect<SourceConfig> dialect = Mockito.mock(DataSourceDialect.class);
+        SourceConfig config = Mockito.mock(SourceConfig.class);
+        SchemaChangeResolver resolver = Mockito.mock(SchemaChangeResolver.class);
+
+        IncrementalSourceSplitReader<SourceConfig> reader =
+                new IncrementalSourceSplitReader<SourceConfig>(0, dialect, config, resolver) {
+                    @Override
+                    protected void checkSplitOrStartNext() {}
+                };
+
+        @SuppressWarnings("unchecked")
+        Fetcher<SourceRecords, SourceSplitBase> fetcher = Mockito.mock(Fetcher.class);
+        Mockito.when(fetcher.pollSplitRecords()).thenReturn(null);
+
+        setField(reader, "currentFetcher", fetcher);
+        setField(reader, "currentSplitId", "split-1");
+
+        RecordsWithSplitIds<SourceRecords> first = reader.fetch();
+        RecordsWithSplitIds<SourceRecords> second = reader.fetch();
+
+        Assertions.assertEquals(Collections.singleton("split-1"), first.finishedSplits());
+        Assertions.assertFalse(first.finishedSplits().contains(null));
+        Assertions.assertEquals(Collections.emptySet(), second.finishedSplits());
+        Assertions.assertFalse(second.finishedSplits().contains(null));
+        Mockito.verify(fetcher, Mockito.times(1)).pollSplitRecords();
+    }
+
+    @Test
+    void testFetchFinishedSnapshotSplitFailFastWhenCurrentSplitIdIsNull() throws Exception {
+        DataSourceDialect<SourceConfig> dialect = Mockito.mock(DataSourceDialect.class);
+        SourceConfig config = Mockito.mock(SourceConfig.class);
+        SchemaChangeResolver resolver = Mockito.mock(SchemaChangeResolver.class);
+
+        IncrementalSourceSplitReader<SourceConfig> reader =
+                new IncrementalSourceSplitReader<SourceConfig>(0, dialect, config, resolver) {
+                    @Override
+                    protected void checkSplitOrStartNext() {}
+                };
+
+        @SuppressWarnings("unchecked")
+        Fetcher<SourceRecords, SourceSplitBase> fetcher = Mockito.mock(Fetcher.class);
+        Mockito.when(fetcher.pollSplitRecords()).thenReturn(null);
+
+        setField(reader, "currentFetcher", fetcher);
+        setField(reader, "currentSplitId", null);
+
+        Assertions.assertThrows(IOException.class, reader::fetch);
+    }
+
+    @Test
+    void testFetchFinishedSnapshotSplitSupportsNextSplitAfterIdChanges() throws Exception {
+        DataSourceDialect<SourceConfig> dialect = Mockito.mock(DataSourceDialect.class);
+        SourceConfig config = Mockito.mock(SourceConfig.class);
+        SchemaChangeResolver resolver = Mockito.mock(SchemaChangeResolver.class);
+
+        IncrementalSourceSplitReader<SourceConfig> reader =
+                new IncrementalSourceSplitReader<SourceConfig>(0, dialect, config, resolver) {
+                    @Override
+                    protected void checkSplitOrStartNext() {}
+                };
+
+        @SuppressWarnings("unchecked")
+        Fetcher<SourceRecords, SourceSplitBase> fetcher = Mockito.mock(Fetcher.class);
+        Mockito.when(fetcher.pollSplitRecords()).thenReturn(null);
+
+        setField(reader, "currentFetcher", fetcher);
+        setField(reader, "currentSplitId", "split-1");
+
+        RecordsWithSplitIds<SourceRecords> first = reader.fetch();
+        RecordsWithSplitIds<SourceRecords> idle = reader.fetch();
+
+        setField(reader, "currentSplitId", "split-2");
+        RecordsWithSplitIds<SourceRecords> second = reader.fetch();
+
+        Assertions.assertEquals(Collections.singleton("split-1"), first.finishedSplits());
+        Assertions.assertEquals(Collections.emptySet(), idle.finishedSplits());
+        Assertions.assertEquals(Collections.singleton("split-2"), second.finishedSplits());
+        Mockito.verify(fetcher, Mockito.times(2)).pollSplitRecords();
+    }
+
+    private static void setField(
+            IncrementalSourceSplitReader<?> reader, String fieldName, Object value)
+            throws Exception {
+        Field field = IncrementalSourceSplitReader.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(reader, value);
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

This PR fixes issue #10398 where a job can fail with NullPointerException in SourceReaderBase.finishCurrentFetch caused by a null finished splitId propagated from CDC reader.

Root cause is that IncrementalSourceSplitReader may emit “split finished” more than once for the same split, and in some edge states it can construct a finished event with a null splitId. Since SourceReaderBase removes split state by splitId, a null key leads to ConcurrentHashMap.remove(null) NPE.
### Does this PR introduce _any_ user-facing change?
Yes.

Previously, some CDC jobs could fail with NullPointerException when finishing a snapshot split (internal null finished splitId). After this change, the finished-split event is emitted exactly once and splitId is guaranteed non-null, so the job no longer crashes with that NPE. If an invalid internal state occurs (currentSplitId == null), it now throws a clearer exception earlier.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
Added unit tests: IncrementalSourceSplitReaderTest
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)