### PR TITLE
[Fix][Connector-V2][SelectDBCloud] Fix NotSerializableException in engine sink action

### DIFF
--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
@@ -23,12 +23,15 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 @Setter
 @Getter
 @ToString
-public class SelectDBConfig {
+public class SelectDBConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private String loadUrl;
     private String jdbcUrl;

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/main/java/org/apache/seatunnel/connectors/selectdb/config/SelectDBConfig.java
@@ -46,7 +46,7 @@ public class SelectDBConfig implements Serializable {
     private Integer bufferSize;
     private Integer bufferCount;
     private Integer flushQueueSize;
-    private Properties StageLoadProps;
+    private Properties stageLoadProps;
 
     public static SelectDBConfig loadConfig(ReadonlyConfig pluginConfig) {
         SelectDBConfig selectdbConfig = new SelectDBConfig();

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/test/java/org/apache/seatunnel/connectors/selectdb/serialize/SelectDBConfigSerializableTest.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/test/java/org/apache/seatunnel/connectors/selectdb/serialize/SelectDBConfigSerializableTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.selectdb.serialize;
+
+import org.apache.seatunnel.connectors.selectdb.config.SelectDBConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Properties;
+
+public class SelectDBConfigSerializableTest {
+
+    @Test
+    void testSelectDBConfigSerializable() throws Exception {
+        SelectDBConfig config = new SelectDBConfig();
+        config.setLoadUrl("localhost:8080");
+        config.setJdbcUrl("localhost:9030");
+        config.setClusterName("cluster");
+        config.setUsername("user");
+        config.setPassword("pwd");
+        config.setTableIdentifier("db.table");
+        config.setEnableDelete(true);
+        config.setLabelPrefix("label");
+        config.setEnable2PC(true);
+        config.setMaxRetries(3);
+        config.setBufferSize(1024);
+        config.setBufferCount(2);
+        config.setFlushQueueSize(10);
+        Properties stageLoadProps = new Properties();
+        stageLoadProps.setProperty("file.type", "json");
+        config.setStageLoadProps(stageLoadProps);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ObjectOutputStream objectOutputStream =
+                        new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(config);
+            objectOutputStream.flush();
+            serialized = byteArrayOutputStream.toByteArray();
+        }
+
+        SelectDBConfig deserialized;
+        try (ObjectInputStream objectInputStream =
+                new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            deserialized = (SelectDBConfig) objectInputStream.readObject();
+        }
+
+        Assertions.assertEquals(config.getLoadUrl(), deserialized.getLoadUrl());
+        Assertions.assertEquals(config.getJdbcUrl(), deserialized.getJdbcUrl());
+        Assertions.assertEquals(config.getClusterName(), deserialized.getClusterName());
+        Assertions.assertEquals(config.getUsername(), deserialized.getUsername());
+        Assertions.assertEquals(config.getPassword(), deserialized.getPassword());
+        Assertions.assertEquals(config.getTableIdentifier(), deserialized.getTableIdentifier());
+        Assertions.assertEquals(config.getEnableDelete(), deserialized.getEnableDelete());
+        Assertions.assertEquals(config.getLabelPrefix(), deserialized.getLabelPrefix());
+        Assertions.assertEquals(config.isEnable2PC(), deserialized.isEnable2PC());
+        Assertions.assertEquals(config.getMaxRetries(), deserialized.getMaxRetries());
+        Assertions.assertEquals(config.getBufferSize(), deserialized.getBufferSize());
+        Assertions.assertEquals(config.getBufferCount(), deserialized.getBufferCount());
+        Assertions.assertEquals(config.getFlushQueueSize(), deserialized.getFlushQueueSize());
+        Assertions.assertEquals(
+                config.getStageLoadProps().getProperty("file.type"),
+                deserialized.getStageLoadProps().getProperty("file.type"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-selectdb-cloud/src/test/java/org/apache/seatunnel/connectors/selectdb/serialize/SelectDBConfigSerializableTest.java
+++ b/seatunnel-connectors-v2/connector-selectdb-cloud/src/test/java/org/apache/seatunnel/connectors/selectdb/serialize/SelectDBConfigSerializableTest.java
@@ -50,20 +50,7 @@ public class SelectDBConfigSerializableTest {
         stageLoadProps.setProperty("file.type", "json");
         config.setStageLoadProps(stageLoadProps);
 
-        byte[] serialized;
-        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                ObjectOutputStream objectOutputStream =
-                        new ObjectOutputStream(byteArrayOutputStream)) {
-            objectOutputStream.writeObject(config);
-            objectOutputStream.flush();
-            serialized = byteArrayOutputStream.toByteArray();
-        }
-
-        SelectDBConfig deserialized;
-        try (ObjectInputStream objectInputStream =
-                new ObjectInputStream(new ByteArrayInputStream(serialized))) {
-            deserialized = (SelectDBConfig) objectInputStream.readObject();
-        }
+        SelectDBConfig deserialized = roundTrip(config);
 
         Assertions.assertEquals(config.getLoadUrl(), deserialized.getLoadUrl());
         Assertions.assertEquals(config.getJdbcUrl(), deserialized.getJdbcUrl());
@@ -81,5 +68,52 @@ public class SelectDBConfigSerializableTest {
         Assertions.assertEquals(
                 config.getStageLoadProps().getProperty("file.type"),
                 deserialized.getStageLoadProps().getProperty("file.type"));
+    }
+
+    @Test
+    void testSelectDBConfigSerializableWithNullStageLoadProps() throws Exception {
+        SelectDBConfig config = new SelectDBConfig();
+        config.setLoadUrl("localhost:8080");
+        config.setJdbcUrl("localhost:9030");
+        config.setUsername("user");
+        config.setPassword("pwd");
+        // stageLoadProps not set, keep it null
+
+        SelectDBConfig deserialized = roundTrip(config);
+
+        Assertions.assertEquals(config.getLoadUrl(), deserialized.getLoadUrl());
+        Assertions.assertEquals(config.getJdbcUrl(), deserialized.getJdbcUrl());
+        Assertions.assertEquals(config.getUsername(), deserialized.getUsername());
+        Assertions.assertEquals(config.getPassword(), deserialized.getPassword());
+        Assertions.assertNull(deserialized.getStageLoadProps());
+    }
+
+    @Test
+    void testSelectDBConfigSerializableWithEmptyStageLoadProps() throws Exception {
+        SelectDBConfig config = new SelectDBConfig();
+        config.setLoadUrl("localhost:8080");
+        config.setStageLoadProps(new Properties());
+
+        SelectDBConfig deserialized = roundTrip(config);
+
+        Assertions.assertEquals(config.getLoadUrl(), deserialized.getLoadUrl());
+        Assertions.assertNotNull(deserialized.getStageLoadProps());
+        Assertions.assertTrue(deserialized.getStageLoadProps().isEmpty());
+    }
+
+    private static SelectDBConfig roundTrip(SelectDBConfig config) throws Exception {
+        byte[] serialized;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ObjectOutputStream objectOutputStream =
+                        new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(config);
+            objectOutputStream.flush();
+            serialized = byteArrayOutputStream.toByteArray();
+        }
+
+        try (ObjectInputStream objectInputStream =
+                new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (SelectDBConfig) objectInputStream.readObject();
+        }
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
fix https://github.com/apache/seatunnel/issues/10408， SelectDBConfig does not implement the Serializable interface, resulting in a direct NotSerializableException: SelectDBConfig being thrown when Hazelcast performs Java serialization at this step.

### Does this PR introduce _any_ user-facing change?
yes
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
unit test：add SelectDBConfigSerializableTest
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)