### PR TITLE
[Fix][Connector-V2] Fix wrong column discovery when tableNamePattern is treated as LIKE

### DIFF
--- a/docs/en/connectors/source/Jdbc.md
+++ b/docs/en/connectors/source/Jdbc.md
@@ -79,6 +79,13 @@ supports query SQL and can achieve projection effect.
 
 The JDBC Source connector supports two ways to specify tables:
 
+#### Notes
+
+- Many JDBC drivers treat `DatabaseMetaData.getColumns(..., schemaPattern, tableNamePattern, ...)` as SQL LIKE patterns.
+  If your schema/table names contain `_` or `%`, column discovery may return rows from other tables. SeaTunnel filters the
+  returned metadata rows by exact schema/table identifier to avoid mixing columns.
+- For case-sensitive databases, make sure the configured schema/table names use the exact identifier case.
+
 1. **Exact Table Path**: Use `table_path` to specify a single table with its full path.
    ```hocon
    table_path = "testdb.table1"

--- a/docs/en/connectors/source/SqlServer-CDC.md
+++ b/docs/en/connectors/source/SqlServer-CDC.md
@@ -27,6 +27,14 @@ import ChangeLog from '../changelog/connector-cdc-sqlserver.md';
 The Sql Server CDC connector allows for reading snapshot data and incremental data from SqlServer database. This document
 describes how to setup the Sql Server CDC connector to run SQL queries against SqlServer databases.
 
+:::tip
+
+When discovering table columns via JDBC metadata, SeaTunnel filters metadata rows by the exact schema/table identifier to
+avoid mixing columns from other tables (some drivers treat `schemaPattern`/`tableNamePattern` as SQL LIKE patterns). For
+case-sensitive databases, make sure the configured identifier case matches the database.
+
+:::
+
 ## Supported DataSource Info
 
 | Datasource |                      Supported versions                       |                    Driver                    |                              Url                              |                                 Maven                                 |

--- a/docs/zh/connectors/source/Jdbc.md
+++ b/docs/zh/connectors/source/Jdbc.md
@@ -73,6 +73,13 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 JDBC 源连接器支持两种方式指定表：
 
+#### 注意事项
+
+- 许多 JDBC 驱动会将 `DatabaseMetaData.getColumns(..., schemaPattern, tableNamePattern, ...)` 视为 SQL LIKE 的模式匹配。
+  当 schema/table 名称中包含 `_` 或 `%` 时，列发现可能会返回其他表的列。SeaTunnel 会按精确的 schema/table 标识符对返回结果做二次过滤，
+  以避免混入其他表的列。
+- 对于大小写敏感的数据库，请确保配置的 schema/table 名称与数据库中实际标识符大小写一致。
+
 1. **精确表路径**：使用 `table_path` 指定单个表及其完整路径。
    ```hocon
    table_path = "testdb.table1"

--- a/docs/zh/connectors/source/SqlServer-CDC.md
+++ b/docs/zh/connectors/source/SqlServer-CDC.md
@@ -26,6 +26,13 @@ import ChangeLog from '../changelog/connector-cdc-sqlserver.md';
 
 Sql Server CDC 连接器允许从 SqlServer 数据库读取快照数据和增量数据。本文档描述了如何设置 Sql Server CDC 连接器来对 SqlServer 数据库运行 SQL 查询。
 
+:::tip
+
+在通过 JDBC 元数据发现表列信息时，SeaTunnel 会按精确的 schema/table 标识符对返回结果做二次过滤，以避免混入其他表的列（部分驱动会将
+`schemaPattern`/`tableNamePattern` 视为 SQL LIKE 模式匹配）。对于大小写敏感的数据库，请确保配置的标识符大小写与数据库一致。
+
+:::
+
 ## 支持的数据源信息
 
 | 数据源    | 支持版本                                      | 驱动                                         | Url                                                           | Maven                                                                 |

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -705,6 +705,20 @@ public class SqlServerConnection extends JdbcConnection {
                         changeTable.getSourceTableId().table(),
                         null)) {
             while (rs.next()) {
+                // `tableNamePattern` is treated as a SQL LIKE pattern by many drivers, so filter
+                // the ResultSet by exact table/schema to avoid mixing columns from other tables.
+                String actualTableName = rs.getString("TABLE_NAME");
+                if (actualTableName == null
+                        || !actualTableName.equalsIgnoreCase(
+                                changeTable.getSourceTableId().table())) {
+                    continue;
+                }
+                String actualSchemaName = rs.getString("TABLE_SCHEM");
+                if (actualSchemaName == null
+                        || !actualSchemaName.equalsIgnoreCase(
+                                changeTable.getSourceTableId().schema())) {
+                    continue;
+                }
                 readTableColumn(rs, changeTable.getSourceTableId(), null)
                         .ifPresent(
                                 ce -> {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -19,6 +19,8 @@ package io.debezium.connector.sqlserver;
 
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.utils.JdbcIdentifierUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -696,8 +698,11 @@ public class SqlServerConnection extends JdbcConnection {
     public Table getTableSchemaFromTable(String databaseName, SqlServerChangeTable changeTable)
             throws SQLException {
         final DatabaseMetaData metadata = connection().getMetaData();
+        JdbcIdentifierUtils.IdentifierCaseStrategy identifierCaseStrategy =
+                JdbcIdentifierUtils.identifierCaseStrategy(metadata);
 
         List<Column> columns = new ArrayList<>();
+        int filteredRows = 0;
         try (ResultSet rs =
                 metadata.getColumns(
                         databaseName,
@@ -708,15 +713,19 @@ public class SqlServerConnection extends JdbcConnection {
                 // `tableNamePattern` is treated as a SQL LIKE pattern by many drivers, so filter
                 // the ResultSet by exact table/schema to avoid mixing columns from other tables.
                 String actualTableName = rs.getString("TABLE_NAME");
-                if (actualTableName == null
-                        || !actualTableName.equalsIgnoreCase(
-                                changeTable.getSourceTableId().table())) {
+                if (!JdbcIdentifierUtils.identifierEquals(
+                        identifierCaseStrategy,
+                        changeTable.getSourceTableId().table(),
+                        actualTableName)) {
+                    filteredRows++;
                     continue;
                 }
                 String actualSchemaName = rs.getString("TABLE_SCHEM");
-                if (actualSchemaName == null
-                        || !actualSchemaName.equalsIgnoreCase(
-                                changeTable.getSourceTableId().schema())) {
+                if (!JdbcIdentifierUtils.identifierEquals(
+                        identifierCaseStrategy,
+                        changeTable.getSourceTableId().schema(),
+                        actualSchemaName)) {
+                    filteredRows++;
                     continue;
                 }
                 readTableColumn(rs, changeTable.getSourceTableId(), null)
@@ -728,6 +737,14 @@ public class SqlServerConnection extends JdbcConnection {
                                     }
                                 });
             }
+        }
+        if (columns.isEmpty() && filteredRows > 0) {
+            LOGGER.warn(
+                    "No columns found for table '{}' in database '{}'. Filtered {} rows returned by JDBC driver. "
+                            + "The table may not exist or the database requires exact identifier case.",
+                    changeTable.getSourceTableId(),
+                    databaseName,
+                    filteredRows);
         }
 
         final List<String> pkColumnNames =

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.sqlserver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SqlServerConnectionTest {
+
+    @Test
+    void testGetTableSchemaFromTableFiltersOutWildcardTables() throws Exception {
+        String databaseName = "test_db";
+        TableId tableId = TableId.parse(databaseName + ".dbo.user_info");
+
+        SqlServerChangeTable changeTable = mock(SqlServerChangeTable.class);
+        when(changeTable.getSourceTableId()).thenReturn(tableId);
+        when(changeTable.getCapturedColumns())
+                .thenReturn(new HashSet<>(Collections.singletonList("id")));
+
+        ResultSet columnsRs = mock(ResultSet.class);
+        when(columnsRs.next()).thenReturn(true, true, false);
+        when(columnsRs.getString("TABLE_NAME")).thenReturn("user_info", "userAinfo");
+        when(columnsRs.getString("TABLE_SCHEM")).thenReturn("dbo", "dbo");
+        when(columnsRs.getString("COLUMN_NAME")).thenReturn("id", "bad");
+
+        DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+        when(metadata.getColumns(eq(databaseName), eq("dbo"), eq("user_info"), isNull()))
+                .thenReturn(columnsRs);
+
+        Connection jdbcConnection = mock(Connection.class);
+        when(jdbcConnection.getMetaData()).thenReturn(metadata);
+
+        TestSqlServerConnection connection = new TestSqlServerConnection(jdbcConnection);
+        Table table = connection.getTableSchemaFromTable(databaseName, changeTable);
+
+        Assertions.assertEquals(1, table.columns().size());
+        Assertions.assertEquals("id", table.columns().get(0).name());
+    }
+
+    @Test
+    void testGetTableSchemaFromTableCaseSensitiveRequiresExactMatch() throws Exception {
+        String databaseName = "test_db";
+        TableId tableId = TableId.parse(databaseName + ".dbo.UserInfo");
+
+        SqlServerChangeTable changeTable = mock(SqlServerChangeTable.class);
+        when(changeTable.getSourceTableId()).thenReturn(tableId);
+        when(changeTable.getCapturedColumns())
+                .thenReturn(new HashSet<>(Collections.singletonList("id")));
+
+        ResultSet columnsRs = mock(ResultSet.class);
+        when(columnsRs.next()).thenReturn(true, false);
+        when(columnsRs.getString("TABLE_NAME")).thenReturn("userinfo");
+        when(columnsRs.getString("TABLE_SCHEM")).thenReturn("dbo");
+        when(columnsRs.getString("COLUMN_NAME")).thenReturn("id");
+
+        DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+        when(metadata.supportsMixedCaseIdentifiers()).thenReturn(true);
+        when(metadata.getColumns(eq(databaseName), eq("dbo"), eq("UserInfo"), isNull()))
+                .thenReturn(columnsRs);
+
+        Connection jdbcConnection = mock(Connection.class);
+        when(jdbcConnection.getMetaData()).thenReturn(metadata);
+
+        TestSqlServerConnection connection = new TestSqlServerConnection(jdbcConnection);
+        Table table = connection.getTableSchemaFromTable(databaseName, changeTable);
+
+        Assertions.assertTrue(table.columns().isEmpty());
+    }
+
+    private static final class TestSqlServerConnection extends SqlServerConnection {
+        private final Connection jdbcConnection;
+
+        private TestSqlServerConnection(Connection jdbcConnection) {
+            super(
+                    JdbcConfiguration.adapt(Configuration.create().build()),
+                    SourceTimestampMode.COMMIT,
+                    mock(SqlServerValueConverters.class),
+                    SqlServerConnectionTest.class::getClassLoader,
+                    Collections.emptySet(),
+                    false);
+            this.jdbcConnection = jdbcConnection;
+        }
+
+        @Override
+        public synchronized Connection connection(boolean executeOnConnect) throws SQLException {
+            return jdbcConnection;
+        }
+
+        @Override
+        protected Optional<ColumnEditor> readTableColumn(
+                ResultSet columnMetadata, TableId tableId, Tables.ColumnNameFilter columnFilter)
+                throws SQLException {
+            String columnName = columnMetadata.getString("COLUMN_NAME");
+            ColumnEditor editor =
+                    Column.editor().name(columnName).type("INT").jdbcType(Types.INTEGER);
+            return Optional.of(editor);
+        }
+
+        @Override
+        protected List<String> readPrimaryKeyOrUniqueIndexNames(
+                DatabaseMetaData metadata, TableId tableId) throws SQLException {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionTest.java
@@ -34,7 +34,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,8 +51,7 @@ public class SqlServerConnectionTest {
 
         SqlServerChangeTable changeTable = mock(SqlServerChangeTable.class);
         when(changeTable.getSourceTableId()).thenReturn(tableId);
-        when(changeTable.getCapturedColumns())
-                .thenReturn(new HashSet<>(Collections.singletonList("id")));
+        when(changeTable.getCapturedColumns()).thenReturn(Collections.singletonList("id"));
 
         ResultSet columnsRs = mock(ResultSet.class);
         when(columnsRs.next()).thenReturn(true, true, false);
@@ -82,8 +80,7 @@ public class SqlServerConnectionTest {
 
         SqlServerChangeTable changeTable = mock(SqlServerChangeTable.class);
         when(changeTable.getSourceTableId()).thenReturn(tableId);
-        when(changeTable.getCapturedColumns())
-                .thenReturn(new HashSet<>(Collections.singletonList("id")));
+        when(changeTable.getCapturedColumns()).thenReturn(Collections.singletonList("id"));
 
         ResultSet columnsRs = mock(ResultSet.class);
         when(columnsRs.next()).thenReturn(true, false);

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcColumnConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcColumnConverter.java
@@ -26,6 +26,9 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -69,10 +72,14 @@ import static java.sql.Types.VARCHAR;
  */
 @Deprecated
 public class JdbcColumnConverter {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcColumnConverter.class);
 
     public static List<Column> convert(DatabaseMetaData metadata, TablePath tablePath)
             throws SQLException {
         List<Column> columns = new ArrayList<>();
+        int filteredRows = 0;
+        JdbcIdentifierUtils.IdentifierCaseStrategy identifierCaseStrategy =
+                JdbcIdentifierUtils.identifierCaseStrategy(metadata);
 
         try (ResultSet columnsResultSet =
                 metadata.getColumns(
@@ -85,14 +92,16 @@ public class JdbcColumnConverter {
                 // `tableNamePattern` is treated as a SQL LIKE pattern by many drivers, so filter
                 // the ResultSet by exact table/schema to avoid mixing columns from other tables.
                 String actualTableName = columnsResultSet.getString("TABLE_NAME");
-                if (actualTableName == null
-                        || !actualTableName.equalsIgnoreCase(tablePath.getTableName())) {
+                if (!JdbcIdentifierUtils.identifierEquals(
+                        identifierCaseStrategy, tablePath.getTableName(), actualTableName)) {
+                    filteredRows++;
                     continue;
                 }
                 if (tablePath.getSchemaName() != null) {
                     String actualSchemaName = columnsResultSet.getString("TABLE_SCHEM");
-                    if (actualSchemaName == null
-                            || !actualSchemaName.equalsIgnoreCase(tablePath.getSchemaName())) {
+                    if (!JdbcIdentifierUtils.identifierEquals(
+                            identifierCaseStrategy, tablePath.getSchemaName(), actualSchemaName)) {
+                        filteredRows++;
                         continue;
                     }
                 }
@@ -116,6 +125,15 @@ public class JdbcColumnConverter {
                                 comment);
                 columns.add(column);
             }
+        }
+        if (columns.isEmpty() && filteredRows > 0) {
+            LOG.warn(
+                    "No columns found for catalog '{}', schema '{}', table '{}'. Filtered {} rows returned by JDBC driver. "
+                            + "The table may not exist or the database requires exact identifier case.",
+                    tablePath.getDatabaseName(),
+                    tablePath.getSchemaName(),
+                    tablePath.getTableName(),
+                    filteredRows);
         }
         return columns;
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcColumnConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcColumnConverter.java
@@ -82,6 +82,21 @@ public class JdbcColumnConverter {
                         null)) {
 
             while (columnsResultSet.next()) {
+                // `tableNamePattern` is treated as a SQL LIKE pattern by many drivers, so filter
+                // the ResultSet by exact table/schema to avoid mixing columns from other tables.
+                String actualTableName = columnsResultSet.getString("TABLE_NAME");
+                if (actualTableName == null
+                        || !actualTableName.equalsIgnoreCase(tablePath.getTableName())) {
+                    continue;
+                }
+                if (tablePath.getSchemaName() != null) {
+                    String actualSchemaName = columnsResultSet.getString("TABLE_SCHEM");
+                    if (actualSchemaName == null
+                            || !actualSchemaName.equalsIgnoreCase(tablePath.getSchemaName())) {
+                        continue;
+                    }
+                }
+
                 String columnName = columnsResultSet.getString("COLUMN_NAME");
                 int jdbcType = columnsResultSet.getInt("DATA_TYPE");
                 String nativeType = columnsResultSet.getString("TYPE_NAME");

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcIdentifierUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/JdbcIdentifierUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.utils;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Locale;
+
+public final class JdbcIdentifierUtils {
+
+    private JdbcIdentifierUtils() {}
+
+    public enum IdentifierCaseStrategy {
+        CASE_SENSITIVE,
+        LOWER_CASE,
+        UPPER_CASE,
+        CASE_INSENSITIVE
+    }
+
+    /**
+     * Resolve case handling strategy for unquoted identifiers based on {@link DatabaseMetaData}.
+     *
+     * <p>Note: JDBC metadata APIs often treat {@code schemaPattern}/{@code tableNamePattern} as
+     * patterns (e.g. SQL LIKE), while identifier case sensitivity depends on the database. This
+     * method provides a best-effort strategy to compare identifiers returned by JDBC metadata APIs.
+     */
+    public static IdentifierCaseStrategy identifierCaseStrategy(DatabaseMetaData metadata)
+            throws SQLException {
+        if (metadata == null) {
+            return IdentifierCaseStrategy.CASE_INSENSITIVE;
+        }
+        if (metadata.supportsMixedCaseIdentifiers()) {
+            return IdentifierCaseStrategy.CASE_SENSITIVE;
+        }
+        if (metadata.storesLowerCaseIdentifiers()) {
+            return IdentifierCaseStrategy.LOWER_CASE;
+        }
+        if (metadata.storesUpperCaseIdentifiers()) {
+            return IdentifierCaseStrategy.UPPER_CASE;
+        }
+        return IdentifierCaseStrategy.CASE_INSENSITIVE;
+    }
+
+    public static boolean identifierEquals(
+            IdentifierCaseStrategy caseStrategy, String expected, String actual) {
+        if (expected == null) {
+            return true;
+        }
+        if (actual == null) {
+            return false;
+        }
+        switch (caseStrategy) {
+            case CASE_SENSITIVE:
+                return actual.equals(expected);
+            case LOWER_CASE:
+                return actual.toLowerCase(Locale.ROOT).equals(expected.toLowerCase(Locale.ROOT));
+            case UPPER_CASE:
+                return actual.toUpperCase(Locale.ROOT).equals(expected.toUpperCase(Locale.ROOT));
+            case CASE_INSENSITIVE:
+            default:
+                return actual.equalsIgnoreCase(expected);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectTypeMapper.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectTypeMapper.java
@@ -92,6 +92,22 @@ public interface JdbcDialectTypeMapper extends Serializable {
         try (ResultSet rs =
                 metadata.getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern)) {
             while (rs.next()) {
+                // `tableNamePattern` is treated as a SQL LIKE pattern by many drivers, so filter
+                // the ResultSet by exact table/schema to avoid mixing columns from other tables.
+                if (tableNamePattern != null) {
+                    String actualTableName = rs.getString("TABLE_NAME");
+                    if (actualTableName == null
+                            || !actualTableName.equalsIgnoreCase(tableNamePattern)) {
+                        continue;
+                    }
+                }
+                if (schemaPattern != null) {
+                    String actualSchemaName = rs.getString("TABLE_SCHEM");
+                    if (actualSchemaName == null
+                            || !actualSchemaName.equalsIgnoreCase(schemaPattern)) {
+                        continue;
+                    }
+                }
                 String columnName = rs.getString("COLUMN_NAME");
                 String nativeType = rs.getString("TYPE_NAME");
                 int sqlType = rs.getInt("DATA_TYPE");

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectTypeMapper.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectTypeMapper.java
@@ -21,6 +21,10 @@ import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.utils.JdbcIdentifierUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.sql.DatabaseMetaData;
@@ -46,6 +50,7 @@ import static java.sql.Types.VARCHAR;
 
 /** Separate the jdbc meta-information type to SeaTunnelDataType into the interface. */
 public interface JdbcDialectTypeMapper extends Serializable {
+    Logger LOG = LoggerFactory.getLogger(JdbcDialectTypeMapper.class);
 
     /**
      * @deprecated instead by {@link #mappingColumn(BasicTypeDefine)}
@@ -89,6 +94,9 @@ public interface JdbcDialectTypeMapper extends Serializable {
             String columnNamePattern)
             throws SQLException {
         List<Column> columns = new ArrayList<>();
+        int filteredRows = 0;
+        JdbcIdentifierUtils.IdentifierCaseStrategy identifierCaseStrategy =
+                JdbcIdentifierUtils.identifierCaseStrategy(metadata);
         try (ResultSet rs =
                 metadata.getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern)) {
             while (rs.next()) {
@@ -96,15 +104,17 @@ public interface JdbcDialectTypeMapper extends Serializable {
                 // the ResultSet by exact table/schema to avoid mixing columns from other tables.
                 if (tableNamePattern != null) {
                     String actualTableName = rs.getString("TABLE_NAME");
-                    if (actualTableName == null
-                            || !actualTableName.equalsIgnoreCase(tableNamePattern)) {
+                    if (!JdbcIdentifierUtils.identifierEquals(
+                            identifierCaseStrategy, tableNamePattern, actualTableName)) {
+                        filteredRows++;
                         continue;
                     }
                 }
                 if (schemaPattern != null) {
                     String actualSchemaName = rs.getString("TABLE_SCHEM");
-                    if (actualSchemaName == null
-                            || !actualSchemaName.equalsIgnoreCase(schemaPattern)) {
+                    if (!JdbcIdentifierUtils.identifierEquals(
+                            identifierCaseStrategy, schemaPattern, actualSchemaName)) {
+                        filteredRows++;
                         continue;
                     }
                 }
@@ -130,6 +140,15 @@ public interface JdbcDialectTypeMapper extends Serializable {
                                 .build();
                 columns.add(mappingColumn(typeDefine));
             }
+        }
+        if (columns.isEmpty() && filteredRows > 0) {
+            LOG.warn(
+                    "No columns found for catalog '{}', schema '{}', table '{}'. Filtered {} rows returned by JDBC driver. "
+                            + "The table may not exist or the database requires exact identifier case.",
+                    catalog,
+                    schemaPattern,
+                    tableNamePattern,
+                    filteredRows);
         }
         return columns;
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
@@ -35,7 +35,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
@@ -89,6 +92,79 @@ public class CatalogUtilsTest {
                             }
                         });
         Assertions.assertEquals("id comment", tableSchema2.getColumns().get(0).getComment());
+    }
+
+    @Test
+    void testGetTableSchemaFiltersOutOtherMatchedTables() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "user_info");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "id");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "id comment");
+                                    }
+                                });
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "userAinfo");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "bad");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "should be filtered");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "public", "user_info");
+
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(
+                        metadata,
+                        tablePath,
+                        new JdbcDialectTypeMapper() {
+                            @Override
+                            public Column mappingColumn(BasicTypeDefine typeDefine) {
+                                return PhysicalColumn.of(
+                                        typeDefine.getName(),
+                                        BasicType.VOID_TYPE,
+                                        typeDefine.getLength(),
+                                        typeDefine.isNullable(),
+                                        typeDefine.getScale(),
+                                        typeDefine.getComment());
+                            }
+                        });
+
+        Assertions.assertEquals(1, tableSchema.getColumns().size());
+        Assertions.assertEquals("id", tableSchema.getColumns().get(0).getName());
+        Assertions.assertEquals("id comment", tableSchema.getColumns().get(0).getComment());
+
+        TableSchema fallbackTableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertEquals(1, fallbackTableSchema.getColumns().size());
+        Assertions.assertEquals("id", fallbackTableSchema.getColumns().get(0).getName());
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/CatalogUtilsTest.java
@@ -36,6 +36,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +166,232 @@ public class CatalogUtilsTest {
                 CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
         Assertions.assertEquals(1, fallbackTableSchema.getColumns().size());
         Assertions.assertEquals("id", fallbackTableSchema.getColumns().get(0).getName());
+    }
+
+    @Test
+    void testGetTableSchemaFiltersOutPercentageWildcard() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "user%info");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "id");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "id comment");
+                                    }
+                                });
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "userXYZinfo");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "bad");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "should be filtered");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "public", "user%info");
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertEquals(1, tableSchema.getColumns().size());
+        Assertions.assertEquals("id", tableSchema.getColumns().get(0).getName());
+    }
+
+    @Test
+    void testGetTableSchemaFiltersOutSchemaWildcard() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "user_info");
+                                        put("TABLE_SCHEM", "pub_lic");
+                                        put("COLUMN_NAME", "id");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "id comment");
+                                    }
+                                });
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "user_info");
+                                        put("TABLE_SCHEM", "pubAlic");
+                                        put("COLUMN_NAME", "bad");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "should be filtered");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "pub_lic", "user_info");
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertEquals(1, tableSchema.getColumns().size());
+        Assertions.assertEquals("id", tableSchema.getColumns().get(0).getName());
+    }
+
+    @Test
+    void testGetTableSchemaEmptyWhenAllFiltered() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "other_table");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "bad");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "should be filtered");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "public", "user_info");
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertTrue(tableSchema.getColumns().isEmpty());
+    }
+
+    @Test
+    void testGetTableSchemaCaseSensitiveIdentifiersRequireExactMatch() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public boolean supportsMixedCaseIdentifiers() throws SQLException {
+                        return true;
+                    }
+
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "userinfo");
+                                        put("TABLE_SCHEM", "public");
+                                        put("COLUMN_NAME", "id");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "id comment");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "public", "UserInfo");
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertEquals(Collections.emptyList(), tableSchema.getColumns());
+    }
+
+    @Test
+    void testGetTableSchemaStoresUpperCaseIdentifiersCanMatchLowerCaseInput() throws SQLException {
+        TestDatabaseMetaData metadata =
+                new TestDatabaseMetaData() {
+                    @Override
+                    public boolean supportsMixedCaseIdentifiers() throws SQLException {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean storesUpperCaseIdentifiers() throws SQLException {
+                        return true;
+                    }
+
+                    @Override
+                    public java.sql.ResultSet getColumns(
+                            String catalog,
+                            String schemaPattern,
+                            String tableNamePattern,
+                            String columnNamePattern)
+                            throws SQLException {
+                        List<Map<String, Object>> value = new ArrayList<>();
+                        value.add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("TABLE_NAME", "USER_INFO");
+                                        put("TABLE_SCHEM", "PUBLIC");
+                                        put("COLUMN_NAME", "id");
+                                        put("DATA_TYPE", 1);
+                                        put("TYPE_NAME", "INT");
+                                        put("COLUMN_SIZE", 11);
+                                        put("DECIMAL_DIGITS", 0);
+                                        put("NULLABLE", 0);
+                                        put("REMARKS", "id comment");
+                                    }
+                                });
+                        return new TestResultSet(value);
+                    }
+                };
+
+        TablePath tablePath = TablePath.of("test_db", "public", "user_info");
+        TableSchema tableSchema =
+                CatalogUtils.getTableSchema(metadata, tablePath, new JdbcDialectTypeMapper() {});
+        Assertions.assertEquals(1, tableSchema.getColumns().size());
+        Assertions.assertEquals("id", tableSchema.getColumns().get(0).getName());
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/TestDatabaseMetaData.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/utils/TestDatabaseMetaData.java
@@ -664,6 +664,9 @@ public class TestDatabaseMetaData implements DatabaseMetaData {
         value.add(
                 new HashMap<String, Object>() {
                     {
+                        put("TABLE_CAT", catalog);
+                        put("TABLE_SCHEM", schemaPattern);
+                        put("TABLE_NAME", tableNamePattern);
                         put("COLUMN_NAME", "id");
                         put("DATA_TYPE", 1);
                         put("TYPE_NAME", "INT");


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Fixes #10410.

Some JDBC drivers treat `DatabaseMetaData#getColumns`'s `tableNamePattern` as a SQL `LIKE` pattern. When the target table name is “pattern-like” (e.g. contains `_` / `%`), the metadata query may return columns from other tables (for example, `user_info` can also match `userAinfo`), which leads to wrong schema/column discovery.

### Does this PR introduce _any_ user-facing change?
Yes. Previously, schema discovery could include extra columns from other matched tables; after this change, column discovery is restricted to the exact table/schema, producing the correct schema and avoiding downstream failures caused by wrong columns.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
- Added unit test: `CatalogUtilsTest#testGetTableSchemaFiltersOutOtherMatchedTables`.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)