### PR TITLE
[Bug][api] Support nested arrayType for SeaTunnelDataTypeConvertorUtil

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtil.java
@@ -233,6 +233,8 @@ public class SeaTunnelDataTypeConvertorUtil {
             case MAP:
                 MapType<?, ?> mapType = (MapType<?, ?>) dataType;
                 return new ArrayType<>(MapType.class, mapType);
+            case ARRAY:
+                return ArrayType.of(dataType);
             default:
                 throw CommonError.unsupportedDataType("SeaTunnel", genericType, field);
         }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/SeaTunnelDataTypeConvertorUtilTest.java
@@ -19,9 +19,13 @@ package org.apache.seatunnel.api.table.catalog;
 
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.VectorType;
 import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 
 import org.junit.jupiter.api.Assertions;
@@ -165,5 +169,158 @@ public class SeaTunnelDataTypeConvertorUtilTest {
                         SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
                                 "c_byte_row", "{c = byte}");
         Assertions.assertEquals(BasicType.BYTE_TYPE, byteRow.getFieldType(0));
+    }
+
+    @Test
+    public void testAllSupportedTypes() {
+        // Test basic types
+        Assertions.assertEquals(
+                BasicType.STRING_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_string", "string"));
+        Assertions.assertEquals(
+                BasicType.BOOLEAN_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_boolean", "boolean"));
+        Assertions.assertEquals(
+                BasicType.BYTE_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_tinyint", "tinyint"));
+        Assertions.assertEquals(
+                PrimitiveByteArrayType.INSTANCE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_bytes", "bytes"));
+        Assertions.assertEquals(
+                BasicType.SHORT_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_smallint", "smallint"));
+        Assertions.assertEquals(
+                BasicType.INT_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_int", "int"));
+        Assertions.assertEquals(
+                BasicType.LONG_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_bigint", "bigint"));
+        Assertions.assertEquals(
+                BasicType.FLOAT_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_float", "float"));
+        Assertions.assertEquals(
+                BasicType.DOUBLE_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_double", "double"));
+        Assertions.assertEquals(
+                BasicType.VOID_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_null", "null"));
+
+        // Test datetime types
+        Assertions.assertEquals(
+                LocalTimeType.LOCAL_DATE_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_date", "date"));
+        Assertions.assertEquals(
+                LocalTimeType.LOCAL_TIME_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType("c_time", "time"));
+        Assertions.assertEquals(
+                LocalTimeType.LOCAL_DATE_TIME_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_timestamp", "timestamp"));
+        Assertions.assertEquals(
+                LocalTimeType.OFFSET_DATE_TIME_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_timestamp_tz", "timestamp_tz"));
+
+        // Test vector types
+        Assertions.assertEquals(
+                VectorType.VECTOR_BINARY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_binary_vector", "binary_vector"));
+        Assertions.assertEquals(
+                VectorType.VECTOR_FLOAT_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_float_vector", "float_vector"));
+        Assertions.assertEquals(
+                VectorType.VECTOR_FLOAT16_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_float16_vector", "float16_vector"));
+        Assertions.assertEquals(
+                VectorType.VECTOR_BFLOAT16_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_bfloat16_vector", "bfloat16_vector"));
+        Assertions.assertEquals(
+                VectorType.VECTOR_SPARSE_FLOAT_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_sparse_float_vector", "sparse_float_vector"));
+
+        // Test complex types - Array
+        Assertions.assertEquals(
+                ArrayType.STRING_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_string_array", "array<string>"));
+        Assertions.assertEquals(
+                ArrayType.BOOLEAN_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_boolean_array", "array<boolean>"));
+        Assertions.assertEquals(
+                ArrayType.INT_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_int_array", "array<int>"));
+        Assertions.assertEquals(
+                ArrayType.LONG_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_bigint_array", "array<bigint>"));
+        Assertions.assertEquals(
+                ArrayType.FLOAT_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_float_array", "array<float>"));
+        Assertions.assertEquals(
+                ArrayType.DOUBLE_ARRAY_TYPE,
+                SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                        "c_double_array", "array<double>"));
+
+        // Test complex types - Map
+        MapType<?, ?> stringMapType =
+                (MapType<?, ?>)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_string_map", "map<string, string>");
+        Assertions.assertEquals(BasicType.STRING_TYPE, stringMapType.getKeyType());
+        Assertions.assertEquals(BasicType.STRING_TYPE, stringMapType.getValueType());
+
+        MapType<?, ?> intStringMapType =
+                (MapType<?, ?>)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_int_string_map", "map<int, string>");
+        Assertions.assertEquals(BasicType.INT_TYPE, intStringMapType.getKeyType());
+        Assertions.assertEquals(BasicType.STRING_TYPE, intStringMapType.getValueType());
+
+        // Test complex types - Decimal
+        DecimalType decimalType =
+                (DecimalType)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_decimal", "decimal(10,2)");
+        Assertions.assertEquals(10, decimalType.getPrecision());
+        Assertions.assertEquals(2, decimalType.getScale());
+
+        // Test complex types - Row
+        SeaTunnelRowType rowType =
+                (SeaTunnelRowType)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_row", "{c1 = string, c2 = int, c3 = boolean}");
+        Assertions.assertEquals(3, rowType.getFieldNames().length);
+        Assertions.assertEquals(3, rowType.getFieldTypes().length);
+        Assertions.assertEquals("c1", rowType.getFieldName(0));
+        Assertions.assertEquals(BasicType.STRING_TYPE, rowType.getFieldType(0));
+        Assertions.assertEquals("c2", rowType.getFieldName(1));
+        Assertions.assertEquals(BasicType.INT_TYPE, rowType.getFieldType(1));
+        Assertions.assertEquals("c3", rowType.getFieldName(2));
+        Assertions.assertEquals(BasicType.BOOLEAN_TYPE, rowType.getFieldType(2));
+
+        // Test nested complex types
+        ArrayType<?, ?> arrayOfArrayType =
+                (ArrayType<?, ?>)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_array_array", "array<array<int>>");
+        Assertions.assertEquals(ArrayType.INT_ARRAY_TYPE, arrayOfArrayType.getElementType());
+
+        MapType<?, ?> mapOfArrayType =
+                (MapType<?, ?>)
+                        SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
+                                "c_map_array", "map<string, array<int>>");
+        Assertions.assertEquals(BasicType.STRING_TYPE, mapOfArrayType.getKeyType());
+        Assertions.assertEquals(ArrayType.INT_ARRAY_TYPE, mapOfArrayType.getValueType());
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

Support nested arrayType for `SeaTunnelDataTypeConvertorUtil` and  supplement unit tests to fix insufficient original type coverage.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
no

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
SeaTunnelDataTypeConvertorUtilTest#testAllSupportedTypes

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)