### PR TITLE
[Feature][Connector-V2] Support sync_mode=update for FtpFile/SftpFile/LocalFile source (binary)

### DIFF
--- a/docs/en/connectors/source/FtpFile.md
+++ b/docs/en/connectors/source/FtpFile.md
@@ -76,6 +76,11 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 | null_format                 | string  | no       | -                           |
 | binary_chunk_size           | int     | no       | 1024                        |
 | binary_complete_file_mode   | boolean | no       | false                       |
+| sync_mode                   | string  | no       | full                        |
+| target_path                 | string  | no       | -                           |
+| target_hadoop_conf          | map     | no       | -                           |
+| update_strategy             | string  | no       | distcp                      |
+| compare_mode                | string  | no       | len_mtime                   |
 | common-options              |         | no       | -                           |
 | file_filter_modified_start  | string  | no       | -                           | 
 | file_filter_modified_end    | string  | no       | -                           | 
@@ -434,6 +439,27 @@ Only used when file_format_type is binary.
 
 Whether to read the complete file as a single chunk instead of splitting into chunks. When enabled, the entire file content will be read into memory at once. Default is false.
 
+### sync_mode [string]
+
+File sync mode. Supported values: `full` (default), `update`.
+When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
+
+### target_path [string]
+
+Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).
+
+### target_hadoop_conf [map]
+
+Only used when `sync_mode=update`. Extra Hadoop configuration for target filesystem. You can set `fs.defaultFS` in this map to override target defaultFS.
+
+### update_strategy [string]
+
+Only used when `sync_mode=update`. Supported values: `distcp` (default), `strict`.
+
+### compare_mode [string]
+
+Only used when `sync_mode=update`. Supported values: `len_mtime` (default), `checksum` (only valid when `update_strategy=strict`).
+
 ### file_filter_modified_start [string]
 
 File modification time filter. The connector will filter some files base on the last modification start time (include start time). The default data format is `yyyy-MM-dd HH:mm:ss`.
@@ -568,6 +594,47 @@ sink {
   }
 }
 
+```
+
+### Incremental Sync (sync_mode=update, binary)
+
+`sync_mode=update` compares files between source and `target_path`, then only reads new/changed files.
+In most cases, `target_path` should be aligned with sink `path` (same filesystem and same relative paths).
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FtpFile {
+    host = "192.168.31.48"
+    port = 21
+    user = tyrantlucifer
+    password = tianchao
+
+    path = "/seatunnel/read/binary/"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/seatunnel/read/binary2/"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+sink {
+  FtpFile {
+    host = "192.168.31.48"
+    port = 21
+    user = tyrantlucifer
+    password = tianchao
+
+    path = "/seatunnel/read/binary2/"
+    tmp_path = "/seatunnel/read/binary2-tmp/"
+    file_format_type = "binary"
+  }
+}
 ```
 
 ### Filter File

--- a/docs/en/connectors/source/FtpFile.md
+++ b/docs/en/connectors/source/FtpFile.md
@@ -444,6 +444,25 @@ Whether to read the complete file as a single chunk instead of splitting into ch
 File sync mode. Supported values: `full` (default), `update`.
 When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
 
+**Performance considerations**
+- Update mode triggers an extra `getFileStatus` call on the target for each source file.
+- For remote file systems (FTP/SFTP), this adds per-file network overhead. It is not recommended for massive small-file scenarios.
+
+**Requirements / limitations**
+- `target_path` should typically align with sink `path` (same filesystem and same relative path layout).
+- When `update_strategy=distcp`, correctness depends on source/target clock synchronization.
+- When `compare_mode=checksum`, filesystem checksum support is required. If checksum is unavailable, SeaTunnel falls back to content comparison (more expensive) and logs a warning.
+
+Example:
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).

--- a/docs/en/connectors/source/LocalFile.md
+++ b/docs/en/connectors/source/LocalFile.md
@@ -76,6 +76,11 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 | null_format                | string  | no       | -                                    |
 | binary_chunk_size          | int     | no       | 1024                                 |
 | binary_complete_file_mode  | boolean | no       | false                                |
+| sync_mode                  | string  | no       | full                                 |
+| target_path                | string  | no       | -                                    |
+| target_hadoop_conf         | map     | no       | -                                    |
+| update_strategy            | string  | no       | distcp                               |
+| compare_mode               | string  | no       | len_mtime                            |
 | common-options             |         | no       | -                                    |
 | tables_configs             | list    | no       | used to define a multiple table task |
 | file_filter_modified_start | string  | no       | -                                    |
@@ -410,6 +415,27 @@ Only used when file_format_type is binary.
 
 Whether to read the complete file as a single chunk instead of splitting into chunks. When enabled, the entire file content will be read into memory at once. Default is false.
 
+### sync_mode [string]
+
+File sync mode. Supported values: `full` (default), `update`.
+When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
+
+### target_path [string]
+
+Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).
+
+### target_hadoop_conf [map]
+
+Only used when `sync_mode=update`. Extra Hadoop configuration for target filesystem. You can set `fs.defaultFS` in this map to override target defaultFS.
+
+### update_strategy [string]
+
+Only used when `sync_mode=update`. Supported values: `distcp` (default), `strict`.
+
+### compare_mode [string]
+
+Only used when `sync_mode=update`. Supported values: `len_mtime` (default), `checksum` (only valid when `update_strategy=strict`).
+
 ### file_filter_modified_start [string]
 
 File modification time filter. The connector will filter some files base on the last modification start time (include start time). The default data format is `yyyy-MM-dd HH:mm:ss`.
@@ -560,6 +586,37 @@ sink {
   }
 }
 
+```
+
+### Incremental Sync (sync_mode=update, binary)
+
+`sync_mode=update` compares files between source and `target_path`, then only reads new/changed files.
+In most cases, `target_path` should be aligned with sink `path` (same filesystem and same relative paths).
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  LocalFile {
+    path = "/seatunnel/read/binary/"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/seatunnel/read/binary2/"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+sink {
+  LocalFile {
+    path = "/seatunnel/read/binary2/"
+    tmp_path = "/seatunnel/read/binary2-tmp/"
+    file_format_type = "binary"
+  }
+}
 ```
 
 ### Filter File

--- a/docs/en/connectors/source/LocalFile.md
+++ b/docs/en/connectors/source/LocalFile.md
@@ -420,6 +420,25 @@ Whether to read the complete file as a single chunk instead of splitting into ch
 File sync mode. Supported values: `full` (default), `update`.
 When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
 
+**Performance considerations**
+- Update mode triggers an extra `getFileStatus` call on the target for each source file.
+- It is not recommended for massive small-file scenarios.
+
+**Requirements / limitations**
+- `target_path` should typically align with sink `path` (same filesystem and same relative path layout).
+- When `update_strategy=distcp`, correctness depends on source/target clock synchronization.
+- When `compare_mode=checksum`, filesystem checksum support is required. If checksum is unavailable, SeaTunnel falls back to content comparison (more expensive) and logs a warning.
+
+Example:
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).

--- a/docs/en/connectors/source/SftpFile.md
+++ b/docs/en/connectors/source/SftpFile.md
@@ -107,6 +107,11 @@ The File does not have a specific type list, and we can indicate which SeaTunnel
 | null_format                | string  | no       | -                             | Only used when file_format_type is text. null_format to define which strings can be represented as null. e.g: `\N`                                                                                                                                                                                                                                                              |
 | binary_chunk_size          | int     | no       | 1024                          | Only used when file_format_type is binary. The chunk size (in bytes) for reading binary files. Default is 1024 bytes. Larger values may improve performance for large files but use more memory.                                                                                                                                                                                |
 | binary_complete_file_mode  | boolean | no       | false                         | Only used when file_format_type is binary. Whether to read the complete file as a single chunk instead of splitting into chunks. When enabled, the entire file content will be read into memory at once. Default is false.                                                                                                                                                      |
+| sync_mode                  | string  | no       | full                          | File sync mode. Supported values: `full`, `update`. When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).                                                                                                                               |
+| target_path                | string  | no       | -                             | Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).                                                                                                                                                                                                           |
+| target_hadoop_conf         | map     | no       | -                             | Only used when `sync_mode=update`. Extra Hadoop configuration for target filesystem. You can set `fs.defaultFS` in this map to override target defaultFS.                                                                                                                                                                           |
+| update_strategy            | string  | no       | distcp                        | Only used when `sync_mode=update`. Supported values: `distcp` (default), `strict`.                                                                                                                                                                                                                                               |
+| compare_mode               | string  | no       | len_mtime                     | Only used when `sync_mode=update`. Supported values: `len_mtime` (default), `checksum` (only valid when `update_strategy=strict`).                                                                                                                                                                                              |
 | common-options             |         | No       | -                             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                                                                                                                                                                              |
 | file_filter_modified_start | string  | no       | -                             | File modification time filter. The connector will filter some files base on the last modification start time (include start time). The default data format is `yyyy-MM-dd HH:mm:ss`.                                                                                                                                                                                            |
 | file_filter_modified_end   | string  | no       | -                             | File modification time filter. The connector will filter some files base on the last modification end time (not include end time). The default data format is `yyyy-MM-dd HH:mm:ss`.                                                                                                                                                                                            |
@@ -292,6 +297,27 @@ Only used when file_format_type is binary.
 
 Whether to read the complete file as a single chunk instead of splitting into chunks. When enabled, the entire file content will be read into memory at once. Default is false.
 
+### sync_mode [string]
+
+File sync mode. Supported values: `full` (default), `update`.
+When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
+
+### target_path [string]
+
+Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).
+
+### target_hadoop_conf [map]
+
+Only used when `sync_mode=update`. Extra Hadoop configuration for target filesystem. You can set `fs.defaultFS` in this map to override target defaultFS.
+
+### update_strategy [string]
+
+Only used when `sync_mode=update`. Supported values: `distcp` (default), `strict`.
+
+### compare_mode [string]
+
+Only used when `sync_mode=update`. Supported values: `len_mtime` (default), `checksum` (only valid when `update_strategy=strict`).
+
 ### quote_char [string]
 
 A single character that encloses CSV fields, allowing fields with commas, line breaks, or quotes to be read correctly.
@@ -436,6 +462,48 @@ source {
 
 sink {
   Console {
+  }
+}
+```
+
+### Incremental Sync (sync_mode=update, binary)
+
+`sync_mode=update` compares files between source and `target_path`, then only reads new/changed files.
+In most cases, `target_path` should be aligned with sink `path` (same filesystem and same relative paths).
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "tmp/seatunnel/update/dst"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+
+sink {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/dst"
+    tmp_path = "tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
   }
 }
 ```

--- a/docs/en/connectors/source/SftpFile.md
+++ b/docs/en/connectors/source/SftpFile.md
@@ -302,6 +302,25 @@ Whether to read the complete file as a single chunk instead of splitting into ch
 File sync mode. Supported values: `full` (default), `update`.
 When `update`, the source compares files between source/target and only reads new/changed files (currently only supports `file_format_type=binary`).
 
+**Performance considerations**
+- Update mode triggers an extra `getFileStatus` call on the target for each source file.
+- For remote file systems (FTP/SFTP), this adds per-file network overhead. It is not recommended for massive small-file scenarios.
+
+**Requirements / limitations**
+- `target_path` should typically align with sink `path` (same filesystem and same relative path layout).
+- When `update_strategy=distcp`, correctness depends on source/target clock synchronization.
+- When `compare_mode=checksum`, filesystem checksum support is required. If checksum is unavailable, SeaTunnel falls back to content comparison (more expensive) and logs a warning.
+
+Example:
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 Only used when `sync_mode=update`. Target base path used for comparison (it should usually be the same as sink `path`).

--- a/docs/zh/connectors/source/FtpFile.md
+++ b/docs/zh/connectors/source/FtpFile.md
@@ -72,6 +72,11 @@ import ChangeLog from '../changelog/connector-file-ftp.md';
 | null_format                 | string  | 否    | -                   |
 | binary_chunk_size           | int     | 否    | 1024                |
 | binary_complete_file_mode   | boolean | 否    | false               |
+| sync_mode                   | string  | 否    | full                |
+| target_path                 | string  | 否    | -                   |
+| target_hadoop_conf          | map     | 否    | -                   |
+| update_strategy             | string  | 否    | distcp              |
+| compare_mode                | string  | 否    | len_mtime           |
 | common-options              |         | 否    | -                   |
 | file_filter_modified_start  | string  | 否    | -                   | 
 | file_filter_modified_end    | string  | 否    | -                   | 
@@ -404,6 +409,27 @@ SeaTunnel 将从源文件中跳过前 2 行。
 
 是否将完整文件作为单个块读取，而不是分割成块。启用时，整个文件内容将一次性读入内存。默认为 false。
 
+### sync_mode [string]
+
+文件同步模式，支持：`full`（默认）、`update`。
+当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
+
+### target_path [string]
+
+仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。
+
+### target_hadoop_conf [map]
+
+仅在 `sync_mode=update` 时使用。目标端 Hadoop 配置（可选），可在其中设置 `fs.defaultFS` 覆盖目标 defaultFS。
+
+### update_strategy [string]
+
+仅在 `sync_mode=update` 时使用。支持：`distcp`（默认）、`strict`。
+
+### compare_mode [string]
+
+仅在 `sync_mode=update` 时使用。支持：`len_mtime`（默认）、`checksum`（仅在 `update_strategy=strict` 时可用）。
+
 ### file_filter_modified_start
 
 按照最后修改时间过滤文件。 要过滤的开始时间(包括改时间),时间格式是：`yyyy-MM-dd HH:mm:ss`。
@@ -538,6 +564,47 @@ sink {
   }
 }
 
+```
+
+### 增量同步（sync_mode=update，仅 binary）
+
+`sync_mode=update` 会对比 source 与 `target_path`，仅读取新增/变更文件。
+多数情况下，`target_path` 需要与 sink 的 `path` 对齐（同一文件系统、相同相对路径）。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FtpFile {
+    host = "192.168.31.48"
+    port = 21
+    user = tyrantlucifer
+    password = tianchao
+
+    path = "/seatunnel/read/binary/"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/seatunnel/read/binary2/"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+sink {
+  FtpFile {
+    host = "192.168.31.48"
+    port = 21
+    user = tyrantlucifer
+    password = tianchao
+
+    path = "/seatunnel/read/binary2/"
+    tmp_path = "/seatunnel/read/binary2-tmp/"
+    file_format_type = "binary"
+  }
+}
 ```
 
 ### 过滤文件

--- a/docs/zh/connectors/source/FtpFile.md
+++ b/docs/zh/connectors/source/FtpFile.md
@@ -414,6 +414,25 @@ SeaTunnel 将从源文件中跳过前 2 行。
 文件同步模式，支持：`full`（默认）、`update`。
 当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
 
+**性能注意事项**
+- Update 模式会对每个源文件额外发起一次到目标端的 `getFileStatus` 用于对比。
+- 对于远程文件系统（FTP/SFTP），会带来按文件的网络开销，不建议用于海量小文件场景。
+
+**要求 / 限制**
+- `target_path` 通常应与 sink 的 `path` 一致（同一文件系统且相对路径结构一致）。
+- 使用 `update_strategy=distcp` 时，依赖源/目标端时钟同步，否则可能误判。
+- 使用 `compare_mode=checksum` 时，需要文件系统支持 checksum；若无法获取 checksum，SeaTunnel 会降级为内容比较（开销更大）并打印告警日志。
+
+示例：
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。

--- a/docs/zh/connectors/source/LocalFile.md
+++ b/docs/zh/connectors/source/LocalFile.md
@@ -421,6 +421,25 @@ null_format 定义哪些字符串可以表示为 null。
 文件同步模式，支持：`full`（默认）、`update`。
 当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
 
+**性能注意事项**
+- Update 模式会对每个源文件额外发起一次到目标端的 `getFileStatus` 用于对比。
+- 不建议用于海量小文件场景。
+
+**要求 / 限制**
+- `target_path` 通常应与 sink 的 `path` 一致（同一文件系统且相对路径结构一致）。
+- 使用 `update_strategy=distcp` 时，依赖源/目标端时钟同步，否则可能误判。
+- 使用 `compare_mode=checksum` 时，需要文件系统支持 checksum；若无法获取 checksum，SeaTunnel 会降级为内容比较（开销更大）并打印告警日志。
+
+示例：
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。

--- a/docs/zh/connectors/source/LocalFile.md
+++ b/docs/zh/connectors/source/LocalFile.md
@@ -76,6 +76,11 @@ import ChangeLog from '../changelog/connector-file-local.md';
 | null_format                | string  | 否    | -                   |
 | binary_chunk_size          | int     | 否    | 1024                |
 | binary_complete_file_mode  | boolean | 否    | false               |
+| sync_mode                  | string  | 否    | full                |
+| target_path                | string  | 否    | -                   |
+| target_hadoop_conf         | map     | 否    | -                   |
+| update_strategy            | string  | 否    | distcp              |
+| compare_mode               | string  | 否    | len_mtime           |
 | common-options             |         | 否    | -                   |
 | tables_configs             | list    | 否    | 用于定义多表任务            |
 | file_filter_modified_start | string  | 否    | -                   | 
@@ -411,6 +416,27 @@ null_format 定义哪些字符串可以表示为 null。
 
 是否将完整文件作为单个块读取，而不是分割成块。启用时，整个文件内容将一次性读入内存。默认为 false。
 
+### sync_mode [string]
+
+文件同步模式，支持：`full`（默认）、`update`。
+当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
+
+### target_path [string]
+
+仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。
+
+### target_hadoop_conf [map]
+
+仅在 `sync_mode=update` 时使用。目标端 Hadoop 配置（可选），可在其中设置 `fs.defaultFS` 覆盖目标 defaultFS。
+
+### update_strategy [string]
+
+仅在 `sync_mode=update` 时使用。支持：`distcp`（默认）、`strict`。
+
+### compare_mode [string]
+
+仅在 `sync_mode=update` 时使用。支持：`len_mtime`（默认）、`checksum`（仅在 `update_strategy=strict` 时可用）。
+
 ### file_filter_modified_start
 
 按照最后修改时间过滤文件。 要过滤的开始时间(包括改时间),时间格式是：`yyyy-MM-dd HH:mm:ss`。
@@ -561,6 +587,37 @@ sink {
   }
 }
 
+```
+
+### 增量同步（sync_mode=update，仅 binary）
+
+`sync_mode=update` 会对比 source 与 `target_path`，仅读取新增/变更文件。
+多数情况下，`target_path` 需要与 sink 的 `path` 对齐（同一文件系统、相同相对路径）。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  LocalFile {
+    path = "/seatunnel/read/binary/"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/seatunnel/read/binary2/"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+sink {
+  LocalFile {
+    path = "/seatunnel/read/binary2/"
+    tmp_path = "/seatunnel/read/binary2-tmp/"
+    file_format_type = "binary"
+  }
+}
 ```
 
 ### 过滤文件

--- a/docs/zh/connectors/source/SftpFile.md
+++ b/docs/zh/connectors/source/SftpFile.md
@@ -107,6 +107,11 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 | null_format                | string  | 否    | -                   | 仅在file_format_type为text时使用。null_format用于定义哪些字符串可以表示为null。例如：`\N`                                                                                                                                                                                   |
 | binary_chunk_size          | int     | 否    | 1024                | 仅在file_format_type为binary时使用。读取二进制文件的块大小（以字节为单位）。默认为1024字节。较大的值可能会提高大文件的性能，但会使用更多内存。                                                                                                                                                               |
 | binary_complete_file_mode  | boolean | 否    | false               | 仅在file_format_type为binary时使用。是否将完整文件作为单个块读取，而不是分割成块。启用时，整个文件内容将一次性读入内存。默认为false。                                                                                                                                                                   |
+| sync_mode                  | string  | 否    | full                | 文件同步模式，支持：`full`（默认）、`update`。当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。                                                                                                                                                          |
+| target_path                | string  | 否    | -                   | 仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。                                                                                                                                                                                         |
+| target_hadoop_conf         | map     | 否    | -                   | 仅在 `sync_mode=update` 时使用。目标端 Hadoop 配置（可选），可在其中设置 `fs.defaultFS` 覆盖目标 defaultFS。                                                                                                                                                                                     |
+| update_strategy            | string  | 否    | distcp              | 仅在 `sync_mode=update` 时使用。支持：`distcp`（默认）、`strict`。                                                                                                                                                                                     |
+| compare_mode               | string  | 否    | len_mtime           | 仅在 `sync_mode=update` 时使用。支持：`len_mtime`（默认）、`checksum`（仅在 `update_strategy=strict` 时可用）。                                                                                                                                             |
 | common-options             |         | 否    | -                   | 数据源插件通用参数，请参考[数据源通用选项](../common-options/source-common-options.md)了解详情。                                                                                                                                                                                           |
 | file_filter_modified_start | string  | 否    | -                   | 按照最后修改时间过滤文件。 要过滤的开始时间(包括改时间),时间格式是：`yyyy-MM-dd HH:mm:ss`                                                                                                                                                                                          |
 | file_filter_modified_end   | string  | 否    | -                   | 按照最后修改时间过滤文件。 要过滤的结束时间(不包括改时间),时间格式是：`yyyy-MM-dd HH:mm:ss`                                                                                                                                                                                         |
@@ -291,6 +296,27 @@ markdown 解析器提取各种元素，包括标题、段落、列表、代码�
 
 是否将完整文件作为单个块读取，而不是分割成块。启用时，整个文件内容将一次性读入内存。默认为false。
 
+### sync_mode [string]
+
+文件同步模式，支持：`full`（默认）、`update`。
+当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
+
+### target_path [string]
+
+仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。
+
+### target_hadoop_conf [map]
+
+仅在 `sync_mode=update` 时使用。目标端 Hadoop 配置（可选），可在其中设置 `fs.defaultFS` 覆盖目标 defaultFS。
+
+### update_strategy [string]
+
+仅在 `sync_mode=update` 时使用。支持：`distcp`（默认）、`strict`。
+
+### compare_mode [string]
+
+仅在 `sync_mode=update` 时使用。支持：`len_mtime`（默认）、`checksum`（仅在 `update_strategy=strict` 时可用）。
+
 ### schema [config]
 
 #### fields [Config]
@@ -427,6 +453,48 @@ source {
 
 sink {
   Console {
+  }
+}
+```
+
+### 增量同步（sync_mode=update，仅 binary）
+
+`sync_mode=update` 会对比 source 与 `target_path`，仅读取新增/变更文件。
+多数情况下，`target_path` 需要与 sink 的 `path` 对齐（同一文件系统、相同相对路径）。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "tmp/seatunnel/update/dst"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+
+sink {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/dst"
+    tmp_path = "tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
   }
 }
 ```

--- a/docs/zh/connectors/source/SftpFile.md
+++ b/docs/zh/connectors/source/SftpFile.md
@@ -301,6 +301,25 @@ markdown 解析器提取各种元素，包括标题、段落、列表、代码�
 文件同步模式，支持：`full`（默认）、`update`。
 当 `update` 时，对源/目标进行对比，只读取新增/变更文件（目前仅支持 `file_format_type=binary`）。
 
+**性能注意事项**
+- Update 模式会对每个源文件额外发起一次到目标端的 `getFileStatus` 用于对比。
+- 对于远程文件系统（FTP/SFTP），会带来按文件的网络开销，不建议用于海量小文件场景。
+
+**要求 / 限制**
+- `target_path` 通常应与 sink 的 `path` 一致（同一文件系统且相对路径结构一致）。
+- 使用 `update_strategy=distcp` 时，依赖源/目标端时钟同步，否则可能误判。
+- 使用 `compare_mode=checksum` 时，需要文件系统支持 checksum；若无法获取 checksum，SeaTunnel 会降级为内容比较（开销更大）并打印告警日志。
+
+示例：
+
+```hocon
+sync_mode = "update"
+file_format_type = "binary"
+target_path = "/path/to/your/sink/path"
+update_strategy = "distcp"
+compare_mode = "len_mtime"
+```
+
 ### target_path [string]
 
 仅在 `sync_mode=update` 时使用。目标端基础路径（通常应与 sink 的 `path` 一致），用于对比同相对路径文件。

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
@@ -780,7 +780,7 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
         return new Path(targetBasePath, cleanRelativePath).toString();
     }
 
-    private static String resolveRelativePath(String basePath, String fullFilePath) {
+    protected static String resolveRelativePath(String basePath, String fullFilePath) {
         String base = normalizePathPart(basePath);
         String file = normalizePathPart(fullFilePath);
         if (StringUtils.isBlank(file)) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
@@ -123,6 +123,11 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
     protected transient boolean shareTargetFileSystemProxy;
     protected transient boolean checksumUnavailableWarned;
 
+    private static final class UpdateModeStats {
+        private long scanned;
+        private long skipped;
+    }
+
     @Override
     public void init(HadoopConf conf) {
         this.hadoopConf = conf;
@@ -146,46 +151,74 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
     @Override
     public List<String> getFileNamesByPath(String path) throws IOException {
         ArrayList<String> fileNames = new ArrayList<>();
+        UpdateModeStats updateModeStats = enableUpdateSync ? new UpdateModeStats() : null;
+        collectFileNamesByPath(path, fileNames, updateModeStats);
+        if (updateModeStats != null) {
+            log.info(
+                    "Update sync mode statistics: scanned={}, skipped={}, to_sync={}",
+                    updateModeStats.scanned,
+                    updateModeStats.skipped,
+                    updateModeStats.scanned - updateModeStats.skipped);
+        }
+        return fileNames;
+    }
+
+    private void collectFileNamesByPath(
+            String path, List<String> fileNames, UpdateModeStats updateModeStats)
+            throws IOException {
         FileStatus[] stats = hadoopFileSystemProxy.listStatus(path);
         for (FileStatus fileStatus : stats) {
             if (fileStatus.isDirectory()) {
                 // skip hidden tmp directory, such as .hive-staging_hive
                 if (!fileStatus.getPath().getName().startsWith(".")) {
-                    fileNames.addAll(getFileNamesByPath(fileStatus.getPath().toString()));
+                    collectFileNamesByPath(
+                            fileStatus.getPath().toString(), fileNames, updateModeStats);
                 }
                 continue;
             }
-            if (fileStatus.isFile() && filterFileByPattern(fileStatus) && fileStatus.getLen() > 0) {
-                // filter '_SUCCESS' file
-                if (!fileStatus.getPath().getName().equals("_SUCCESS")
-                        && !fileStatus.getPath().getName().startsWith(".")
-                        && filterFileByModificationDate(fileStatus)) {
+            if (!fileStatus.isFile()
+                    || !filterFileByPattern(fileStatus)
+                    || fileStatus.getLen() <= 0) {
+                continue;
+            }
 
-                    String filePath = fileStatus.getPath().toString();
-                    if (!readPartitions.isEmpty()) {
-                        for (String readPartition : readPartitions) {
-                            if (filePath.contains(readPartition)) {
-                                if (shouldSyncFileInUpdateMode(fileStatus)) {
-                                    fileNames.add(filePath);
-                                    this.fileNames.add(filePath);
-                                }
-                                break;
-                            }
-                        }
-                    } else {
-                        if (shouldSyncFileInUpdateMode(fileStatus)) {
-                            fileNames.add(filePath);
-                            this.fileNames.add(filePath);
-                        }
+            // filter '_SUCCESS' file and hidden files
+            String fileName = fileStatus.getPath().getName();
+            if (fileName.equals("_SUCCESS")
+                    || fileName.startsWith(".")
+                    || !filterFileByModificationDate(fileStatus)) {
+                continue;
+            }
+
+            String filePath = fileStatus.getPath().toString();
+            if (StringUtils.isNotEmpty(filenameExtension)
+                    && !filePath.endsWith(filenameExtension)) {
+                continue;
+            }
+
+            if (!readPartitions.isEmpty()) {
+                boolean partitionMatched = false;
+                for (String readPartition : readPartitions) {
+                    if (filePath.contains(readPartition)) {
+                        partitionMatched = true;
+                        break;
                     }
                 }
+                if (!partitionMatched) {
+                    continue;
+                }
+            }
+
+            if (updateModeStats != null) {
+                updateModeStats.scanned++;
+            }
+            if (shouldSyncFileInUpdateMode(fileStatus)) {
+                fileNames.add(filePath);
+                this.fileNames.add(filePath);
+            } else if (updateModeStats != null) {
+                updateModeStats.skipped++;
             }
         }
-        if (StringUtils.isNotEmpty(filenameExtension)) {
-            this.fileNames.removeIf(fileName -> !fileName.endsWith(filenameExtension));
-            fileNames.removeIf(fileName -> !fileName.endsWith(filenameExtension));
-        }
-        return fileNames;
     }
 
     private Date getFileModifiedDate(String modifiedDate) {
@@ -303,6 +336,12 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
         enableUpdateSync = syncMode == FileSyncMode.UPDATE;
         if (enableUpdateSync) {
             validateUpdateSyncConfig(pluginConfig);
+            log.info(
+                    "Update sync mode enabled: source_path={}, target_path={}, update_strategy={}, compare_mode={}",
+                    maskUriUserInfo(sourceRootPath),
+                    maskUriUserInfo(targetPath),
+                    updateStrategy.name().toLowerCase(Locale.ROOT),
+                    compareMode.name().toLowerCase(Locale.ROOT));
         }
     }
 
@@ -701,37 +740,73 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
         long targetMtime = targetFileStatus.getModificationTime();
 
         if (updateStrategy == FileUpdateStrategy.DISTCP) {
-            return sourceMtime > targetMtime;
+            if (sourceMtime > targetMtime) {
+                return true;
+            }
+            logUpdateModeSkip(sourceFilePath, targetFilePath, "distcp: target newer or same");
+            return false;
         }
 
         if (updateStrategy == FileUpdateStrategy.STRICT) {
             if (compareMode == FileCompareMode.LEN_MTIME) {
-                return sourceMtime != targetMtime;
+                if (sourceMtime != targetMtime) {
+                    return true;
+                }
+                logUpdateModeSkip(
+                        sourceFilePath, targetFilePath, "strict len_mtime: len and mtime equal");
+                return false;
             }
             if (compareMode == FileCompareMode.CHECKSUM) {
-                FileChecksum sourceChecksum = hadoopFileSystemProxy.getFileChecksum(sourceFilePath);
-                FileChecksum targetChecksum =
-                        targetHadoopFileSystemProxy.getFileChecksum(targetFilePath);
-                if (sourceChecksum == null || targetChecksum == null) {
+                FileChecksum sourceChecksum = null;
+                FileChecksum targetChecksum = null;
+                Exception checksumException = null;
+                try {
+                    sourceChecksum = hadoopFileSystemProxy.getFileChecksum(sourceFilePath);
+                    targetChecksum = targetHadoopFileSystemProxy.getFileChecksum(targetFilePath);
+                } catch (Exception e) {
+                    checksumException = e;
+                }
+
+                if (checksumException != null || sourceChecksum == null || targetChecksum == null) {
                     if (!checksumUnavailableWarned) {
-                        log.warn(
-                                "File checksum is not available, fallback to content comparison. source={}, target={}",
-                                sourceFilePath,
-                                targetFilePath);
+                        if (checksumException == null) {
+                            log.warn(
+                                    "File checksum is not available, fallback to content comparison. source={}, target={}",
+                                    maskUriUserInfo(sourceFilePath),
+                                    maskUriUserInfo(targetFilePath));
+                        } else {
+                            log.warn(
+                                    "File checksum is not available, fallback to content comparison. source={}, target={}",
+                                    maskUriUserInfo(sourceFilePath),
+                                    maskUriUserInfo(targetFilePath),
+                                    checksumException);
+                        }
                         checksumUnavailableWarned = true;
                     }
                     try {
-                        return !fileContentEquals(sourceFilePath, targetFilePath);
+                        boolean sameContent = fileContentEquals(sourceFilePath, targetFilePath);
+                        if (sameContent) {
+                            logUpdateModeSkip(
+                                    sourceFilePath,
+                                    targetFilePath,
+                                    "strict checksum: content equal (checksum unavailable)");
+                        }
+                        return !sameContent;
                     } catch (Exception e) {
                         log.warn(
                                 "Fallback content comparison failed, fallback to COPY. source={}, target={}",
-                                sourceFilePath,
-                                targetFilePath,
+                                maskUriUserInfo(sourceFilePath),
+                                maskUriUserInfo(targetFilePath),
                                 e);
                         return true;
                     }
                 }
-                return !checksumEquals(sourceChecksum, targetChecksum);
+                if (checksumEquals(sourceChecksum, targetChecksum)) {
+                    logUpdateModeSkip(
+                            sourceFilePath, targetFilePath, "strict checksum: checksum equal");
+                    return false;
+                }
+                return true;
             }
         }
 
@@ -780,6 +855,16 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
         return new Path(targetBasePath, cleanRelativePath).toString();
     }
 
+    /**
+     * Resolve relative path from {@code basePath} to {@code fullFilePath}.
+     *
+     * <p><b>NOTE:</b> This method is intended for internal use by specific read strategies (for
+     * example {@link BinaryReadStrategy}) that need custom path resolution logic.
+     *
+     * @param basePath base directory path
+     * @param fullFilePath full file path
+     * @return relative path from base to file
+     */
     protected static String resolveRelativePath(String basePath, String fullFilePath) {
         String base = normalizePathPart(basePath);
         String file = normalizePathPart(fullFilePath);
@@ -811,6 +896,35 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
             return new Path(path).toUri().getPath();
         } catch (Exception e) {
             return path;
+        }
+    }
+
+    private static String maskUriUserInfo(String rawPath) {
+        if (StringUtils.isBlank(rawPath)) {
+            return rawPath;
+        }
+        try {
+            java.net.URI uri = new Path(rawPath).toUri();
+            if (uri.getUserInfo() == null || uri.getAuthority() == null) {
+                return rawPath;
+            }
+            String maskedAuthority = uri.getAuthority().replace(uri.getUserInfo() + "@", "***@");
+            return uri.getScheme()
+                    + "://"
+                    + maskedAuthority
+                    + (uri.getPath() == null ? "" : uri.getPath());
+        } catch (Exception e) {
+            return rawPath;
+        }
+    }
+
+    private void logUpdateModeSkip(String sourceFilePath, String targetFilePath, String reason) {
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Update sync mode skipped file: source={}, target={}, reason={}",
+                    maskUriUserInfo(sourceFilePath),
+                    maskUriUserInfo(targetFilePath),
+                    reason);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/BinaryReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/BinaryReadStrategy.java
@@ -29,8 +29,8 @@ import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
 import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.Path;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -45,7 +45,8 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
                         PrimitiveByteArrayType.INSTANCE, BasicType.STRING_TYPE, BasicType.LONG_TYPE
                     });
 
-    private File basePath;
+    private String basePath;
+    private transient Boolean basePathIsFile;
     private int binaryChunkSize = FileBaseSourceOptions.BINARY_CHUNK_SIZE.defaultValue();
     private boolean completeFileMode =
             FileBaseSourceOptions.BINARY_COMPLETE_FILE_MODE.defaultValue();
@@ -53,7 +54,8 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
     @Override
     public void init(HadoopConf conf) {
         super.init(conf);
-        basePath = new File(pluginConfig.getString(FileBaseSourceOptions.FILE_PATH.key()));
+        basePath = pluginConfig.getString(FileBaseSourceOptions.FILE_PATH.key());
+        basePathIsFile = null;
 
         // Load binary chunk size configuration
         if (pluginConfig.hasPath(FileBaseSourceOptions.BINARY_CHUNK_SIZE.key())) {
@@ -80,18 +82,7 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
     public void read(String path, String tableId, Collector<SeaTunnelRow> output)
             throws IOException, FileConnectorException {
         try (InputStream inputStream = hadoopFileSystemProxy.getInputStream(path)) {
-            String relativePath;
-            if (hadoopFileSystemProxy.isFile(basePath.getAbsolutePath())) {
-                relativePath = basePath.getName();
-            } else {
-                relativePath =
-                        path.substring(
-                                path.indexOf(basePath.getAbsolutePath())
-                                        + basePath.getAbsolutePath().length());
-                if (relativePath.startsWith(File.separator)) {
-                    relativePath = relativePath.substring(File.separator.length());
-                }
-            }
+            String relativePath = resolveBinaryRelativePath(path);
 
             if (completeFileMode) {
                 // Read entire file as a single chunk
@@ -107,6 +98,16 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
             MetadataUtil.setBinaryRowComplete(endRow);
             output.collect(endRow);
         }
+    }
+
+    private String resolveBinaryRelativePath(String filePath) throws IOException {
+        if (basePathIsFile == null) {
+            basePathIsFile = hadoopFileSystemProxy.isFile(basePath);
+        }
+        if (Boolean.TRUE.equals(basePathIsFile)) {
+            return new Path(filePath).getName();
+        }
+        return resolveRelativePath(basePath, filePath);
     }
 
     /** Read the entire file as a single chunk. */

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/BinaryReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/BinaryReadStrategy.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.file.source.reader;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.MetadataUtil;
@@ -46,7 +47,7 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
                     });
 
     private String basePath;
-    private transient Boolean basePathIsFile;
+    private transient boolean basePathIsFile;
     private int binaryChunkSize = FileBaseSourceOptions.BINARY_CHUNK_SIZE.defaultValue();
     private boolean completeFileMode =
             FileBaseSourceOptions.BINARY_COMPLETE_FILE_MODE.defaultValue();
@@ -55,7 +56,15 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
     public void init(HadoopConf conf) {
         super.init(conf);
         basePath = pluginConfig.getString(FileBaseSourceOptions.FILE_PATH.key());
-        basePathIsFile = null;
+        try {
+            basePathIsFile = hadoopFileSystemProxy.isFile(basePath);
+        } catch (IOException e) {
+            throw new FileConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    "Failed to determine whether file source path is a file or directory: "
+                            + basePath,
+                    e);
+        }
 
         // Load binary chunk size configuration
         if (pluginConfig.hasPath(FileBaseSourceOptions.BINARY_CHUNK_SIZE.key())) {
@@ -100,11 +109,8 @@ public class BinaryReadStrategy extends AbstractReadStrategy {
         }
     }
 
-    private String resolveBinaryRelativePath(String filePath) throws IOException {
-        if (basePathIsFile == null) {
-            basePathIsFile = hadoopFileSystemProxy.isFile(basePath);
-        }
-        if (Boolean.TRUE.equals(basePathIsFile)) {
+    private String resolveBinaryRelativePath(String filePath) {
+        if (basePathIsFile) {
             return new Path(filePath).getName();
         }
         return resolveRelativePath(basePath, filePath);

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/reader/BinaryReadStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/reader/BinaryReadStrategyTest.java
@@ -139,8 +139,43 @@ public class BinaryReadStrategyTest {
         Assertions.assertEquals(0L, row.getField(2));
     }
 
+    @Test
+    public void testBinaryRelativePath_WhenBaseIsFile() throws IOException {
+        File testFile = createTestFile("test_binary_base_is_file.bin", 10);
+
+        Config config = createConfig(testFile.getAbsolutePath(), null, null);
+        binaryReadStrategy.setPluginConfig(config);
+        binaryReadStrategy.init(localConf);
+
+        TestCollector collector = new TestCollector();
+        binaryReadStrategy.read(testFile.getAbsolutePath(), "test_table", collector);
+
+        List<SeaTunnelRow> rows = collector.getRows();
+        Assertions.assertFalse(rows.isEmpty());
+        Assertions.assertEquals("test_binary_base_is_file.bin", rows.get(0).getField(1));
+    }
+
+    @Test
+    public void testBinaryRelativePath_WhenBaseIsDirectoryWithSubDir() throws IOException {
+        File testFile = createTestFile("subdir/test_binary_in_sub.bin", 10);
+
+        Config config = createConfig(tempDir.toFile().getAbsolutePath(), null, null);
+        binaryReadStrategy.setPluginConfig(config);
+        binaryReadStrategy.init(localConf);
+
+        TestCollector collector = new TestCollector();
+        binaryReadStrategy.read(testFile.getAbsolutePath(), "test_table", collector);
+
+        List<SeaTunnelRow> rows = collector.getRows();
+        Assertions.assertFalse(rows.isEmpty());
+        Assertions.assertEquals("subdir/test_binary_in_sub.bin", rows.get(0).getField(1));
+    }
+
     private File createTestFile(String fileName, int sizeInBytes) throws IOException {
         File testFile = tempDir.resolve(fileName).toFile();
+        if (testFile.getParentFile() != null) {
+            testFile.getParentFile().mkdirs();
+        }
 
         if (sizeInBytes > 0) {
             try (FileOutputStream fos = new FileOutputStream(testFile)) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategyTest.java
@@ -300,6 +300,30 @@ public class AbstractReadStrategyTest {
         }
     }
 
+    @Test
+    void testResolveRelativePathWithSftpUri() {
+        String basePath = "sftp://server:22/path";
+        String fullFilePath = "sftp://server:22/path/sub/file.txt";
+        Assertions.assertEquals(
+                "sub/file.txt", AbstractReadStrategy.resolveRelativePath(basePath, fullFilePath));
+    }
+
+    @Test
+    void testResolveRelativePathWithFtpUri() {
+        String basePath = "ftp://server:21/tmp/seatunnel/read";
+        String fullFilePath = "ftp://server:21/tmp/seatunnel/read/file.txt";
+        Assertions.assertEquals(
+                "file.txt", AbstractReadStrategy.resolveRelativePath(basePath, fullFilePath));
+    }
+
+    @Test
+    void testResolveRelativePathWithCustomSchemeUri() {
+        String basePath = "default.default_sftp://sftp:22/tmp/seatunnel/update/src";
+        String fullFilePath = "default.default_sftp://sftp:22/tmp/seatunnel/update/src/test.bin_0";
+        Assertions.assertEquals(
+                "test.bin_0", AbstractReadStrategy.resolveRelativePath(basePath, fullFilePath));
+    }
+
     private static Map<String, Object> buildBasePluginConfigWithPartitions() {
         Map<String, Object> config = new HashMap<>();
         config.put(FileBaseSourceOptions.FILE_PATH.key(), "/tmp/dt=2024-01-01");

--- a/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/source/FtpFileSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/source/FtpFileSourceFactory.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileFormat;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileSystemType;
 import org.apache.seatunnel.connectors.seatunnel.file.ftp.config.FtpFileSourceOptions;
 
@@ -101,6 +102,15 @@ public class FtpFileSourceFactory implements TableSourceFactory {
                 .optional(FtpFileSourceOptions.FTP_CONTROL_ENCODING)
                 .optional(FileBaseSourceOptions.QUOTE_CHAR)
                 .optional(FileBaseSourceOptions.ESCAPE_CHAR)
+                .optional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileBaseSourceOptions.TARGET_HADOOP_CONF,
+                        FileBaseSourceOptions.UPDATE_STRATEGY,
+                        FileBaseSourceOptions.COMPARE_MODE)
+                .conditional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileSyncMode.UPDATE,
+                        FileBaseSourceOptions.TARGET_PATH)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/FtpFileFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-ftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/ftp/FtpFileFactoryTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.file.ftp;
 
+import org.apache.seatunnel.api.configuration.util.Expression;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.RequiredOption;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.ftp.sink.FtpFileSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.file.ftp.source.FtpFileSourceFactory;
 
@@ -27,7 +32,28 @@ class FtpFileFactoryTest {
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new FtpFileSourceFactory()).optionRule());
+        OptionRule optionRule = (new FtpFileSourceFactory()).optionRule();
+        Assertions.assertNotNull(optionRule);
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.SYNC_MODE));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.TARGET_HADOOP_CONF));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.UPDATE_STRATEGY));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.COMPARE_MODE));
+
+        Expression expectExpression =
+                Expression.of(FileBaseSourceOptions.SYNC_MODE, FileSyncMode.UPDATE);
+        Assertions.assertTrue(
+                optionRule.getRequiredOptions().stream()
+                        .filter(RequiredOption.ConditionalRequiredOptions.class::isInstance)
+                        .map(RequiredOption.ConditionalRequiredOptions.class::cast)
+                        .filter(
+                                required ->
+                                        required.getOptions()
+                                                .contains(FileBaseSourceOptions.TARGET_PATH))
+                        .anyMatch(required -> expectExpression.equals(required.getExpression())));
         Assertions.assertNotNull((new FtpFileSinkFactory()).optionRule());
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-local/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/local/source/LocalFileSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-local/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/local/source/LocalFileSourceFactory.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileFormat;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileSystemType;
 import org.apache.seatunnel.connectors.seatunnel.file.local.config.LocalFileSourceOptions;
 
@@ -108,6 +109,15 @@ public class LocalFileSourceFactory implements TableSourceFactory {
                 .optional(FileBaseSourceOptions.READ_COLUMNS)
                 .optional(FileBaseSourceOptions.QUOTE_CHAR)
                 .optional(FileBaseSourceOptions.ESCAPE_CHAR)
+                .optional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileBaseSourceOptions.TARGET_HADOOP_CONF,
+                        FileBaseSourceOptions.UPDATE_STRATEGY,
+                        FileBaseSourceOptions.COMPARE_MODE)
+                .conditional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileSyncMode.UPDATE,
+                        FileBaseSourceOptions.TARGET_PATH)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-local/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/local/LocalFileFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-local/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/local/LocalFileFactoryTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.file.local;
 
+import org.apache.seatunnel.api.configuration.util.Expression;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.RequiredOption;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.local.sink.LocalFileSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.file.local.source.LocalFileSourceFactory;
 
@@ -28,6 +33,27 @@ class LocalFileFactoryTest {
     @Test
     void optionRule() {
         Assertions.assertNotNull((new LocalFileSinkFactory()).optionRule());
-        Assertions.assertNotNull((new LocalFileSourceFactory()).optionRule());
+        OptionRule optionRule = (new LocalFileSourceFactory()).optionRule();
+        Assertions.assertNotNull(optionRule);
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.SYNC_MODE));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.TARGET_HADOOP_CONF));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.UPDATE_STRATEGY));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.COMPARE_MODE));
+
+        Expression expectExpression =
+                Expression.of(FileBaseSourceOptions.SYNC_MODE, FileSyncMode.UPDATE);
+        Assertions.assertTrue(
+                optionRule.getRequiredOptions().stream()
+                        .filter(RequiredOption.ConditionalRequiredOptions.class::isInstance)
+                        .map(RequiredOption.ConditionalRequiredOptions.class::cast)
+                        .filter(
+                                required ->
+                                        required.getOptions()
+                                                .contains(FileBaseSourceOptions.TARGET_PATH))
+                        .anyMatch(required -> expectExpression.equals(required.getExpression())));
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/source/SftpFileSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/source/SftpFileSourceFactory.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileFormat;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileSystemType;
 import org.apache.seatunnel.connectors.seatunnel.file.sftp.config.SftpFileSourceOptions;
 
@@ -90,6 +91,15 @@ public class SftpFileSourceFactory implements TableSourceFactory {
                 .optional(FileBaseSourceOptions.READ_COLUMNS)
                 .optional(FileBaseSourceOptions.QUOTE_CHAR)
                 .optional(FileBaseSourceOptions.ESCAPE_CHAR)
+                .optional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileBaseSourceOptions.TARGET_HADOOP_CONF,
+                        FileBaseSourceOptions.UPDATE_STRATEGY,
+                        FileBaseSourceOptions.COMPARE_MODE)
+                .conditional(
+                        FileBaseSourceOptions.SYNC_MODE,
+                        FileSyncMode.UPDATE,
+                        FileBaseSourceOptions.TARGET_PATH)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/SftpFileFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/SftpFileFactoryTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.file.sftp;
 
+import org.apache.seatunnel.api.configuration.util.Expression;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.RequiredOption;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileSyncMode;
 import org.apache.seatunnel.connectors.seatunnel.file.sftp.sink.SftpFileSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.file.sftp.source.SftpFileSourceFactory;
 
@@ -27,7 +32,28 @@ class SftpFileFactoryTest {
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new SftpFileSourceFactory()).optionRule());
+        OptionRule optionRule = (new SftpFileSourceFactory()).optionRule();
+        Assertions.assertNotNull(optionRule);
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.SYNC_MODE));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.TARGET_HADOOP_CONF));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.UPDATE_STRATEGY));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(FileBaseSourceOptions.COMPARE_MODE));
+
+        Expression expectExpression =
+                Expression.of(FileBaseSourceOptions.SYNC_MODE, FileSyncMode.UPDATE);
+        Assertions.assertTrue(
+                optionRule.getRequiredOptions().stream()
+                        .filter(RequiredOption.ConditionalRequiredOptions.class::isInstance)
+                        .map(RequiredOption.ConditionalRequiredOptions.class::cast)
+                        .filter(
+                                required ->
+                                        required.getOptions()
+                                                .contains(FileBaseSourceOptions.TARGET_PATH))
+                        .anyMatch(required -> expectExpression.equals(required.getExpression())));
         Assertions.assertNotNull((new SftpFileSinkFactory()).optionRule());
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
@@ -69,6 +69,8 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
 
     private static final int FTP_PORT = 21;
 
+    private static final String FTP_CONTAINER_HOME = "/home/vsftpd/seatunnel";
+
     private static final String USERNAME = "seatunnel";
 
     private static final String PASSWORD = "pass";
@@ -204,6 +206,32 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals("5", resultExecResult.getStdout().trim());
 
         deleteFileFromContainer(homePath);
+    }
+
+    @TestTemplate
+    public void testFtpBinaryUpdateModeDistcp(TestContainer container)
+            throws IOException, InterruptedException {
+        resetUpdateTestPath();
+        putFtpFile("/tmp/seatunnel/update/src/test.bin", "abc");
+
+        Container.ExecResult firstRun = container.executeJob("/text/ftp_binary_update_distcp.conf");
+        Assertions.assertEquals(0, firstRun.getExitCode(), firstRun.getStderr());
+        Assertions.assertEquals("abc", readFtpFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        // Make target newer with same length, distcp strategy should SKIP overwrite.
+        putFtpFile("/tmp/seatunnel/update/dst/test.bin", "zzz");
+        Container.ExecResult secondRun =
+                container.executeJob("/text/ftp_binary_update_distcp.conf");
+        Assertions.assertEquals(0, secondRun.getExitCode(), secondRun.getStderr());
+        Assertions.assertEquals("zzz", readFtpFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        // Change source length, distcp strategy should COPY overwrite.
+        putFtpFile("/tmp/seatunnel/update/src/test.bin", "abcd");
+        Container.ExecResult thirdRun = container.executeJob("/text/ftp_binary_update_distcp.conf");
+        Assertions.assertEquals(0, thirdRun.getExitCode(), thirdRun.getStderr());
+        Assertions.assertEquals("abcd", readFtpFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        deleteFileFromContainer(FTP_CONTAINER_HOME + "/tmp/seatunnel/update");
     }
 
     @TestTemplate
@@ -381,6 +409,53 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         helper.execute("/text/multiple_table_fake_to_ftp_file_text_2.conf");
         Assertions.assertEquals(getFileListFromContainer(homePath + path3).size(), 2);
         Assertions.assertEquals(getFileListFromContainer(homePath + path4).size(), 2);
+    }
+
+    private void resetUpdateTestPath() throws IOException, InterruptedException {
+        deleteFileFromContainer(FTP_CONTAINER_HOME + "/tmp/seatunnel/update");
+        Container.ExecResult mkdirResult =
+                ftpContainer.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + FTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/src "
+                                + FTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/dst "
+                                + FTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/tmp");
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+        ftpContainer.execInContainer(
+                "sh", "-c", "chmod -R 777 " + FTP_CONTAINER_HOME + "/tmp/seatunnel/update || true");
+        ftpContainer.execInContainer(
+                "sh",
+                "-c",
+                "chown -R ftp:ftp " + FTP_CONTAINER_HOME + "/tmp/seatunnel/update || true");
+    }
+
+    private void putFtpFile(String ftpPath, String content)
+            throws IOException, InterruptedException {
+        String containerPath = FTP_CONTAINER_HOME + ftpPath;
+        String command =
+                "mkdir -p $(dirname '"
+                        + containerPath
+                        + "') && printf '"
+                        + content
+                        + "' > '"
+                        + containerPath
+                        + "' && chmod 666 '"
+                        + containerPath
+                        + "'";
+        Container.ExecResult putResult = ftpContainer.execInContainer("sh", "-c", command);
+        Assertions.assertEquals(0, putResult.getExitCode(), putResult.getStderr());
+    }
+
+    private String readFtpFile(String ftpPath) throws IOException, InterruptedException {
+        String containerPath = FTP_CONTAINER_HOME + ftpPath;
+        Container.ExecResult catResult =
+                ftpContainer.execInContainer("sh", "-c", "cat '" + containerPath + "'");
+        Assertions.assertEquals(0, catResult.getExitCode(), catResult.getStderr());
+        return catResult.getStdout() == null ? "" : catResult.getStdout().trim();
     }
 
     @SneakyThrows

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
@@ -466,15 +466,71 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
     }
 
     private String getFtpUserHomeDir() throws IOException, InterruptedException {
+        // Prefer vsftpd local_root as the real filesystem root used by FTP paths in test configs.
+        // In some images, FTP users are created as virtual users and may not exist in /etc/passwd.
+        try {
+            Container.ExecResult confResult =
+                    ftpContainer.execInContainer("sh", "-c", "cat /etc/vsftpd/vsftpd.conf");
+            if (confResult.getExitCode() == 0 && StringUtils.isNotBlank(confResult.getStdout())) {
+                Properties properties = new Properties();
+                properties.load(new StringReader(confResult.getStdout()));
+                String localRoot = properties.getProperty("local_root");
+                if (StringUtils.isNotBlank(localRoot)) {
+                    String resolved =
+                            localRoot
+                                    .trim()
+                                    .replace("${FTP_USER}", USERNAME)
+                                    .replace("$FTP_USER", USERNAME)
+                                    .replace("${USER}", USERNAME)
+                                    .replace("$USER", USERNAME);
+                    if (StringUtils.isNotBlank(resolved)) {
+                        return resolved;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to resolve ftp local_root from vsftpd.conf, fallback to default.", e);
+        }
+
+        // Fallback: resolve from /etc/passwd if user exists
         Container.ExecResult homeResult =
                 ftpContainer.execInContainer(
-                        "sh", "-c", "grep '^" + USERNAME + ":' /etc/passwd | cut -d: -f6");
-        Assertions.assertEquals(0, homeResult.getExitCode(), homeResult.getStderr());
-        String homeDir = homeResult.getStdout() == null ? "" : homeResult.getStdout().trim();
-        Assertions.assertTrue(
-                StringUtils.isNotBlank(homeDir),
-                "Cannot resolve ftp home directory for user: " + USERNAME);
-        return homeDir;
+                        "sh",
+                        "-c",
+                        "awk -F: '$1==\""
+                                + USERNAME
+                                + "\"{print $6}' /etc/passwd 2>/dev/null || true");
+        if (homeResult.getExitCode() == 0) {
+            String homeDir = homeResult.getStdout() == null ? "" : homeResult.getStdout().trim();
+            if (StringUtils.isNotBlank(homeDir)) {
+                return homeDir;
+            }
+        }
+
+        // Last resort: use default directory used by fauria/vsftpd.
+        String defaultRoot = "/home/vsftpd";
+        if (containerDirExists(defaultRoot)) {
+            log.warn(
+                    "Cannot resolve ftp home directory for user: {}, fallback to {}",
+                    USERNAME,
+                    defaultRoot);
+            return defaultRoot;
+        }
+        String defaultUserRoot = defaultRoot + "/" + USERNAME;
+        log.warn(
+                "Cannot resolve ftp home directory for user: {}, fallback to {}",
+                USERNAME,
+                defaultUserRoot);
+        return defaultUserRoot;
+    }
+
+    private boolean containerDirExists(String path) throws IOException, InterruptedException {
+        Container.ExecResult result =
+                ftpContainer.execInContainer(
+                        "sh", "-c", "test -d '" + path + "' && echo true || echo false");
+        return result.getExitCode() == 0
+                && StringUtils.equalsIgnoreCase(
+                        (result.getStdout() == null ? "" : result.getStdout().trim()), "true");
     }
 
     private void ensureReadJsonInputFile() throws IOException, InterruptedException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/ftp/FtpFileIT.java
@@ -69,13 +69,13 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
 
     private static final int FTP_PORT = 21;
 
-    private static final String FTP_CONTAINER_HOME = "/home/vsftpd/seatunnel";
-
     private static final String USERNAME = "seatunnel";
 
     private static final String PASSWORD = "pass";
 
     private GenericContainer<?> ftpContainer;
+
+    private String ftpHomeDir;
 
     private String ftpPassiveAddress;
 
@@ -136,36 +136,39 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
 
         log.info("ftp container started");
 
+        ftpHomeDir = getFtpUserHomeDir();
+
         ContainerUtil.copyFileIntoContainers(
                 "/json/e2e.json",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/json/name=tyrantlucifer/hobby=coding/e2e.json",
+                ftpHomeDir + "/tmp/seatunnel/read/json/name=tyrantlucifer/hobby=coding/e2e.json",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
                 "/text/e2e.txt",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/text/name=tyrantlucifer/hobby=coding/e2e.txt",
+                ftpHomeDir + "/tmp/seatunnel/read/text/name=tyrantlucifer/hobby=coding/e2e.txt",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
                 "/text/e2e-txt.zip",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/zip/txt/single/e2e-txt.zip",
+                ftpHomeDir + "/tmp/seatunnel/read/zip/txt/single/e2e-txt.zip",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
                 "/excel/e2e.xlsx",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/excel/name=tyrantlucifer/hobby=coding/e2e.xlsx",
+                ftpHomeDir + "/tmp/seatunnel/read/excel/name=tyrantlucifer/hobby=coding/e2e.xlsx",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
                 "/excel/e2e.xlsx",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/excel_filter/name=tyrantlucifer/hobby=coding/e2e_filter.xlsx",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/excel_filter/name=tyrantlucifer/hobby=coding/e2e_filter.xlsx",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
-                "/excel/e2e.xlsx", "/home/vsftpd/seatunnel/e2e.xlsx", ftpContainer);
+                "/excel/e2e.xlsx", ftpHomeDir + "/e2e.xlsx", ftpContainer);
 
-        ftpContainer.execInContainer("sh", "-c", "chmod -R 777 /home/vsftpd/seatunnel/");
-        ftpContainer.execInContainer("sh", "-c", "chown -R ftp:ftp /home/vsftpd/seatunnel/");
+        ftpContainer.execInContainer("sh", "-c", "chmod -R 777 " + ftpHomeDir + "/");
+        ftpContainer.execInContainer("sh", "-c", "chown -R ftp:ftp " + ftpHomeDir + "/");
     }
 
     @TestTemplate
@@ -177,7 +180,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
                 container, "/text/ftp_file_text_to_assert_for_passive.conf", configParams);
         assertJobExecution(container, "/text/fake_to_ftp_file_text_for_passive.conf", configParams);
 
-        String homePath = "/home/vsftpd/seatunnel/tmp/seatunnel/passive_text";
+        String homePath = ftpHomeDir + "/tmp/seatunnel/passive_text";
         // test write ftp text file
         Assertions.assertEquals(1, getFileListFromContainer(homePath).size());
 
@@ -196,7 +199,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         Container.ExecResult execResult = container.executeJob("/text/ftp_to_ftp_for_binary.conf");
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
 
-        String homePath = "/home/vsftpd/seatunnel/uploads/seatunnel";
+        String homePath = ftpHomeDir + "/uploads/seatunnel";
         Assertions.assertEquals(1, getFileListFromContainer(homePath).size());
 
         // Confirm data is written correctly
@@ -231,7 +234,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals(0, thirdRun.getExitCode(), thirdRun.getStderr());
         Assertions.assertEquals("abcd", readFtpFile("/tmp/seatunnel/update/dst/test.bin"));
 
-        deleteFileFromContainer(FTP_CONTAINER_HOME + "/tmp/seatunnel/update");
+        deleteFileFromContainer(ftpHomeDir + "/tmp/seatunnel/update");
     }
 
     @TestTemplate
@@ -240,28 +243,33 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
 
         ContainerUtil.copyFileIntoContainers(
                 "/json/e2e.json",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter/json/name=tyrantlucifer/hobby=coding/e2e.json",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/filter/json/name=tyrantlucifer/hobby=coding/e2e.json",
                 ftpContainer);
         ContainerUtil.copyFileIntoContainers(
                 "/json/e2e.json",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter/json2025/name=tyrantlucifer/hobby=coding/e2e_2025.json",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/filter/json2025/name=tyrantlucifer/hobby=coding/e2e_2025.json",
                 ftpContainer);
         ContainerUtil.copyFileIntoContainers(
                 "/text/e2e.txt",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter/json2025/name=tyrantlucifer/hobby=coding/e2e_2025.txt",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/filter/json2025/name=tyrantlucifer/hobby=coding/e2e_2025.txt",
                 ftpContainer);
         ContainerUtil.copyFileIntoContainers(
                 "/json/e2e.json",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter/json2024/name=tyrantlucifer/hobby=coding/e2e_2024.json",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/filter/json2024/name=tyrantlucifer/hobby=coding/e2e_2024.json",
                 ftpContainer);
 
         ContainerUtil.copyFileIntoContainers(
                 "/text/e2e.txt",
-                "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter/text/name=tyrantlucifer/hobby=coding/e2e.txt",
+                ftpHomeDir
+                        + "/tmp/seatunnel/read/filter/text/name=tyrantlucifer/hobby=coding/e2e.txt",
                 ftpContainer);
 
-        ftpContainer.execInContainer("sh", "-c", "chmod -R 777 /home/vsftpd/seatunnel/");
-        ftpContainer.execInContainer("sh", "-c", "chown -R ftp:ftp /home/vsftpd/seatunnel/");
+        ftpContainer.execInContainer("sh", "-c", "chmod -R 777 " + ftpHomeDir + "/");
+        ftpContainer.execInContainer("sh", "-c", "chown -R ftp:ftp " + ftpHomeDir + "/");
 
         TestHelper helper = new TestHelper(container);
         // -----filter based on the file directory at the same time, the expression needs to start
@@ -272,7 +280,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         helper.execute("/json/ftp_to_access_for_json_name_filter.conf");
 
         // delete path
-        String filterPath = "/home/vsftpd/seatunnel/tmp/seatunnel/read/filter";
+        String filterPath = ftpHomeDir + "/tmp/seatunnel/read/filter";
         deleteFileFromContainer(filterPath);
     }
 
@@ -308,6 +316,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         // test write ftp json file
         helper.execute("/json/fake_to_ftp_file_json.conf");
         // test read ftp json file
+        ensureReadJsonInputFile();
         helper.execute("/json/ftp_file_json_to_assert.conf");
         // test write ftp parquet file
         helper.execute("/parquet/fake_to_ftp_file_parquet.conf");
@@ -317,7 +326,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         helper.execute("/excel/fake_source_to_ftp_root_path_excel.conf");
         // test ftp source support multipleTable
 
-        String homePath = "/home/vsftpd/seatunnel";
+        String homePath = ftpHomeDir;
         String sink01 = "/tmp/seatunnel/json/sink/multiplesource/fake01";
         String sink02 = "/tmp/seatunnel/json/sink/multiplesource/fake02";
         deleteFileFromContainer(homePath + sink01);
@@ -336,7 +345,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
         String specialPath = "/tmp/seatunnel/test spaces";
         String fileName = "file with spaces.txt";
         String fullPath = specialPath + "/" + fileName;
-        String homePath = "/home/vsftpd/seatunnel";
+        String homePath = ftpHomeDir;
         String containerPath = homePath + fullPath;
 
         try {
@@ -383,7 +392,7 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
             throws IOException, InterruptedException {
         TestHelper helper = new TestHelper(container);
         // test mult table and save_mode:RECREATE_SCHEMA DROP_DATA
-        String homePath = "/home/vsftpd/seatunnel";
+        String homePath = ftpHomeDir;
         String path1 = "/tmp/seatunnel_mult/text/source_1";
         String path2 = "/tmp/seatunnel_mult/text/source_2";
         deleteFileFromContainer(homePath + path1);
@@ -412,30 +421,28 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
     }
 
     private void resetUpdateTestPath() throws IOException, InterruptedException {
-        deleteFileFromContainer(FTP_CONTAINER_HOME + "/tmp/seatunnel/update");
+        deleteFileFromContainer(ftpHomeDir + "/tmp/seatunnel/update");
         Container.ExecResult mkdirResult =
                 ftpContainer.execInContainer(
                         "sh",
                         "-c",
                         "mkdir -p "
-                                + FTP_CONTAINER_HOME
+                                + ftpHomeDir
                                 + "/tmp/seatunnel/update/src "
-                                + FTP_CONTAINER_HOME
+                                + ftpHomeDir
                                 + "/tmp/seatunnel/update/dst "
-                                + FTP_CONTAINER_HOME
+                                + ftpHomeDir
                                 + "/tmp/seatunnel/update/tmp");
         Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
         ftpContainer.execInContainer(
-                "sh", "-c", "chmod -R 777 " + FTP_CONTAINER_HOME + "/tmp/seatunnel/update || true");
+                "sh", "-c", "chmod -R 777 " + ftpHomeDir + "/tmp/seatunnel/update || true");
         ftpContainer.execInContainer(
-                "sh",
-                "-c",
-                "chown -R ftp:ftp " + FTP_CONTAINER_HOME + "/tmp/seatunnel/update || true");
+                "sh", "-c", "chown -R ftp:ftp " + ftpHomeDir + "/tmp/seatunnel/update || true");
     }
 
     private void putFtpFile(String ftpPath, String content)
             throws IOException, InterruptedException {
-        String containerPath = FTP_CONTAINER_HOME + ftpPath;
+        String containerPath = ftpHomeDir + ftpPath;
         String command =
                 "mkdir -p $(dirname '"
                         + containerPath
@@ -451,11 +458,42 @@ public class FtpFileIT extends TestSuiteBase implements TestResource {
     }
 
     private String readFtpFile(String ftpPath) throws IOException, InterruptedException {
-        String containerPath = FTP_CONTAINER_HOME + ftpPath;
+        String containerPath = ftpHomeDir + ftpPath;
         Container.ExecResult catResult =
                 ftpContainer.execInContainer("sh", "-c", "cat '" + containerPath + "'");
         Assertions.assertEquals(0, catResult.getExitCode(), catResult.getStderr());
         return catResult.getStdout() == null ? "" : catResult.getStdout().trim();
+    }
+
+    private String getFtpUserHomeDir() throws IOException, InterruptedException {
+        Container.ExecResult homeResult =
+                ftpContainer.execInContainer(
+                        "sh", "-c", "grep '^" + USERNAME + ":' /etc/passwd | cut -d: -f6");
+        Assertions.assertEquals(0, homeResult.getExitCode(), homeResult.getStderr());
+        String homeDir = homeResult.getStdout() == null ? "" : homeResult.getStdout().trim();
+        Assertions.assertTrue(
+                StringUtils.isNotBlank(homeDir),
+                "Cannot resolve ftp home directory for user: " + USERNAME);
+        return homeDir;
+    }
+
+    private void ensureReadJsonInputFile() throws IOException, InterruptedException {
+        Container.ExecResult mkdirResult =
+                ftpContainer.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + ftpHomeDir
+                                + "/tmp/seatunnel/read/json/name=tyrantlucifer/hobby=coding");
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+        ContainerUtil.copyFileIntoContainers(
+                "/json/e2e.json",
+                ftpHomeDir + "/tmp/seatunnel/read/json/name=tyrantlucifer/hobby=coding/e2e.json",
+                ftpContainer);
+        Container.ExecResult chmodResult =
+                ftpContainer.execInContainer(
+                        "sh", "-c", "chmod -R 777 " + ftpHomeDir + "/tmp/seatunnel/read");
+        Assertions.assertEquals(0, chmodResult.getExitCode(), chmodResult.getStderr());
     }
 
     @SneakyThrows

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/resources/text/ftp_binary_update_distcp.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-ftp-e2e/src/test/resources/text/ftp_binary_update_distcp.conf
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FtpFile {
+    host = "ftp"
+    port = 21
+    user = seatunnel
+    password = pass
+
+    path = "/tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/tmp/seatunnel/update/dst"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+
+sink {
+  FtpFile {
+    host = "ftp"
+    port = 21
+    user = seatunnel
+    password = pass
+
+    path = "/tmp/seatunnel/update/dst"
+    tmp_path = "/tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/local/LocalFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/local/LocalFileIT.java
@@ -453,6 +453,34 @@ public class LocalFileIT extends TestSuiteBase {
 
     @TestTemplate
     @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason =
+                    "sync_mode=update needs to compare source/target on the same filesystem. Local filesystem is not shared between engine master/workers in Flink/Spark E2E.")
+    public void testLocalFileBinaryUpdateModeStrictChecksum(TestContainer container)
+            throws IOException, InterruptedException {
+        resetUpdateTestPath();
+        putLocalFile("/tmp/seatunnel/update/src/test.bin", "abc");
+
+        TestHelper helper = new TestHelper(container);
+        helper.execute("/binary/local_file_binary_update_strict_checksum.conf");
+        Assertions.assertEquals("abc", readLocalFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        long firstMtimeSeconds = getLocalFileMtimeSeconds("/tmp/seatunnel/update/dst/test.bin");
+        Thread.sleep(1100);
+
+        helper.execute("/binary/local_file_binary_update_strict_checksum.conf");
+        long secondMtimeSeconds = getLocalFileMtimeSeconds("/tmp/seatunnel/update/dst/test.bin");
+        Assertions.assertEquals(
+                firstMtimeSeconds,
+                secondMtimeSeconds,
+                "Strict checksum should skip unchanged files and keep target mtime");
+
+        baseContainer.execInContainer("sh", "-c", "rm -rf /tmp/seatunnel/update");
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
             value = {TestContainerId.SPARK_2_4},
             type = {EngineType.FLINK},
             disabledReason =
@@ -546,6 +574,14 @@ public class LocalFileIT extends TestSuiteBase {
                 baseContainer.execInContainer("sh", "-c", "cat '" + filePath + "'");
         Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
         return result.getStdout() == null ? "" : result.getStdout().trim();
+    }
+
+    private long getLocalFileMtimeSeconds(String filePath)
+            throws IOException, InterruptedException {
+        Container.ExecResult result =
+                baseContainer.execInContainer("sh", "-c", "stat -c %Y '" + filePath + "'");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+        return Long.parseLong(result.getStdout().trim());
     }
 
     private Path convertToLzoFile(File file) throws IOException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/local/LocalFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/local/LocalFileIT.java
@@ -40,6 +40,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.shaded.com.github.dockerjava.core.command.ExecStartResultCallback;
 
@@ -424,6 +425,34 @@ public class LocalFileIT extends TestSuiteBase {
 
     @TestTemplate
     @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason =
+                    "sync_mode=update needs to compare source/target on the same filesystem. Local filesystem is not shared between engine master/workers in Flink/Spark E2E.")
+    public void testLocalFileBinaryUpdateModeDistcp(TestContainer container)
+            throws IOException, InterruptedException {
+        resetUpdateTestPath();
+        putLocalFile("/tmp/seatunnel/update/src/test.bin", "abc");
+
+        TestHelper helper = new TestHelper(container);
+        helper.execute("/binary/local_file_binary_update_distcp.conf");
+        Assertions.assertEquals("abc", readLocalFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        // Make target newer with same length, distcp strategy should SKIP overwrite.
+        putLocalFile("/tmp/seatunnel/update/dst/test.bin", "zzz");
+        helper.execute("/binary/local_file_binary_update_distcp.conf");
+        Assertions.assertEquals("zzz", readLocalFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        // Change source length, distcp strategy should COPY overwrite.
+        putLocalFile("/tmp/seatunnel/update/src/test.bin", "abcd");
+        helper.execute("/binary/local_file_binary_update_distcp.conf");
+        Assertions.assertEquals("abcd", readLocalFile("/tmp/seatunnel/update/dst/test.bin"));
+
+        baseContainer.execInContainer("sh", "-c", "rm -rf /tmp/seatunnel/update");
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
             value = {TestContainerId.SPARK_2_4},
             type = {EngineType.FLINK},
             disabledReason =
@@ -485,6 +514,38 @@ public class LocalFileIT extends TestSuiteBase {
         Assertions.assertFalse(localFileCatalog.isExistsData(tablePath));
         localFileCatalog.dropTable(tablePath, false);
         Assertions.assertFalse(localFileCatalog.tableExists(tablePath));
+    }
+
+    private void resetUpdateTestPath() throws IOException, InterruptedException {
+        Container.ExecResult result =
+                baseContainer.execInContainer(
+                        "sh",
+                        "-c",
+                        "rm -rf /tmp/seatunnel/update && mkdir -p /tmp/seatunnel/update/src /tmp/seatunnel/update/dst /tmp/seatunnel/update/tmp");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+    }
+
+    private void putLocalFile(String filePath, String content)
+            throws IOException, InterruptedException {
+        String command =
+                "mkdir -p $(dirname '"
+                        + filePath
+                        + "') && printf '"
+                        + content
+                        + "' > '"
+                        + filePath
+                        + "' && chmod 666 '"
+                        + filePath
+                        + "'";
+        Container.ExecResult result = baseContainer.execInContainer("sh", "-c", command);
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+    }
+
+    private String readLocalFile(String filePath) throws IOException, InterruptedException {
+        Container.ExecResult result =
+                baseContainer.execInContainer("sh", "-c", "cat '" + filePath + "'");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+        return result.getStdout() == null ? "" : result.getStdout().trim();
     }
 
     private Path convertToLzoFile(File file) throws IOException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/resources/binary/local_file_binary_update_distcp.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/resources/binary/local_file_binary_update_distcp.conf
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  LocalFile {
+    path = "/tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/tmp/seatunnel/update/dst"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel/update/dst"
+    tmp_path = "/tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/resources/binary/local_file_binary_update_strict_checksum.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/src/test/resources/binary/local_file_binary_update_strict_checksum.conf
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  LocalFile {
+    path = "/tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "/tmp/seatunnel/update/dst"
+    update_strategy = "strict"
+    compare_mode = "checksum"
+  }
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel/update/dst"
+    tmp_path = "/tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.shaded.com.github.dockerjava.core.command.ExecStartResultCallback;
@@ -60,6 +61,8 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
     private static final int SFTP_PORT = 22;
 
     private static final int SFTP_BIND_PORT = 2222;
+
+    private static final String SFTP_CONTAINER_HOME = "/home/seatunnel";
 
     private static final String USERNAME = "seatunnel";
 
@@ -212,6 +215,32 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
+    public void testSftpBinaryUpdateModeDistcp(TestContainer container)
+            throws IOException, InterruptedException {
+        resetUpdateTestPath();
+        putSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/src/test.bin", "abc");
+
+        TestHelper helper = new TestHelper(container);
+        helper.execute("/text/sftp_binary_update_distcp.conf");
+        Assertions.assertEquals(
+                "abc", readSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/dst/test.bin"));
+
+        // Make target newer with same length, distcp strategy should SKIP overwrite.
+        putSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/dst/test.bin", "zzz");
+        helper.execute("/text/sftp_binary_update_distcp.conf");
+        Assertions.assertEquals(
+                "zzz", readSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/dst/test.bin"));
+
+        // Change source length, distcp strategy should COPY overwrite.
+        putSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/src/test.bin", "abcd");
+        helper.execute("/text/sftp_binary_update_distcp.conf");
+        Assertions.assertEquals(
+                "abcd", readSftpFile(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update/dst/test.bin"));
+
+        deleteFileFromContainer(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update");
+    }
+
+    @TestTemplate
     public void testMultipleTableAndSaveMode(TestContainer container)
             throws IOException, InterruptedException {
         TestHelper helper = new TestHelper(container);
@@ -242,6 +271,49 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
         helper.execute("/text/multiple_fake_to_sftp_file_text_append.conf");
         Assertions.assertEquals(getFileListFromContainer(homePath + path3).size(), 2);
         Assertions.assertEquals(getFileListFromContainer(homePath + path4).size(), 2);
+    }
+
+    private void resetUpdateTestPath() throws IOException, InterruptedException {
+        deleteFileFromContainer(SFTP_CONTAINER_HOME + "/tmp/seatunnel/update");
+        Container.ExecResult mkdirResult =
+                sftpContainer.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + SFTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/src "
+                                + SFTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/dst "
+                                + SFTP_CONTAINER_HOME
+                                + "/tmp/seatunnel/update/tmp");
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+        sftpContainer.execInContainer(
+                "sh",
+                "-c",
+                "chmod -R 777 " + SFTP_CONTAINER_HOME + "/tmp/seatunnel/update || true");
+    }
+
+    private void putSftpFile(String containerPath, String content)
+            throws IOException, InterruptedException {
+        String command =
+                "mkdir -p $(dirname '"
+                        + containerPath
+                        + "') && printf '"
+                        + content
+                        + "' > '"
+                        + containerPath
+                        + "' && chmod 666 '"
+                        + containerPath
+                        + "'";
+        Container.ExecResult putResult = sftpContainer.execInContainer("sh", "-c", command);
+        Assertions.assertEquals(0, putResult.getExitCode(), putResult.getStderr());
+    }
+
+    private String readSftpFile(String containerPath) throws IOException, InterruptedException {
+        Container.ExecResult catResult =
+                sftpContainer.execInContainer("sh", "-c", "cat '" + containerPath + "'");
+        Assertions.assertEquals(0, catResult.getExitCode(), catResult.getStderr());
+        return catResult.getStdout() == null ? "" : catResult.getStdout().trim();
     }
 
     @SneakyThrows

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/resources/text/sftp_binary_update_distcp.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/resources/text/sftp_binary_update_distcp.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+
+  # You can set spark configuration here
+  spark.app.name = "SeaTunnel"
+  spark.executor.instances = 1
+  spark.executor.cores = 1
+  spark.executor.memory = "1g"
+  spark.master = local
+}
+
+source {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/src"
+    file_format_type = "binary"
+
+    sync_mode = "update"
+    target_path = "tmp/seatunnel/update/dst"
+    update_strategy = "distcp"
+    compare_mode = "len_mtime"
+  }
+}
+
+sink {
+  SftpFile {
+    host = "sftp"
+    port = 22
+    user = seatunnel
+    password = pass
+
+    path = "tmp/seatunnel/update/dst"
+    tmp_path = "tmp/seatunnel/update/tmp"
+    file_format_type = "binary"
+  }
+}
+


### PR DESCRIPTION

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

This PR implements  for apache/seatunnel#10414 (“no repeated transfers”) by reusing the existing sync_mode=update (binary-only) logic and exposing the related configuration options for FtpFile / SftpFile / LocalFile sources. It also adds E2E coverage and minimal user docs/examples for update mode.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?
Yes.

Previously, sync_mode=update was not available/exposed for FtpFile / SftpFile / LocalFile sources, so users could not enable incremental/dedup read behavior for these sources.

After this change, users can configure sync_mode=update (currently only supports file_format_type=binary) to compare source files with target_path and only read new/changed files. Documentation in both docs/en and docs/zh is updated with a minimal example that clarifies target_path should typically align with the sink path.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?
Unit tests
E2E
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ * ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)