### PR TITLE
Fix seatunnel.sh breaking job name containing spaces

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleJdbcRowConverter.java
@@ -24,11 +24,16 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseI
 
 import javax.annotation.Nullable;
 
-import java.io.ByteArrayInputStream;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle.OracleTypeConverter.ORACLE_BLOB;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle.OracleTypeConverter.ORACLE_CLOB;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle.OracleTypeConverter.ORACLE_NCLOB;
 
 public class OracleJdbcRowConverter extends AbstractJdbcRowConverter {
 
@@ -47,9 +52,28 @@ public class OracleJdbcRowConverter extends AbstractJdbcRowConverter {
             throws SQLException {
         if (seaTunnelDataType.getSqlType().equals(SqlType.BYTES)) {
             if (ORACLE_BLOB.equals(sourceType)) {
-                statement.setBinaryStream(statementIndex, new ByteArrayInputStream((byte[]) value));
+                // Use BLOB object instead of setBinaryStream for Oracle LOB columns
+                // to avoid ORA-01461 error and compatibility with FieldNamedPreparedStatement
+                Connection connection = statement.getConnection();
+                Blob blob = connection.createBlob();
+                blob.setBytes(1, (byte[]) value);
+                statement.setBlob(statementIndex, blob);
             } else {
                 statement.setBytes(statementIndex, (byte[]) value);
+            }
+        } else if (seaTunnelDataType.getSqlType().equals(SqlType.STRING)) {
+            if (ORACLE_CLOB.equals(sourceType)) {
+                Connection connection = statement.getConnection();
+                Clob clob = connection.createClob();
+                clob.setString(1, (String) value);
+                statement.setClob(statementIndex, clob);
+            } else if (ORACLE_NCLOB.equals(sourceType)) {
+                Connection connection = statement.getConnection();
+                NClob nclob = connection.createNClob();
+                nclob.setString(1, (String) value);
+                statement.setNClob(statementIndex, nclob);
+            } else {
+                statement.setString(statementIndex, (String) value);
             }
         } else {
             super.setValueToStatementByDataType(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleJdbcRowConverter.java
@@ -24,10 +24,8 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseI
 
 import javax.annotation.Nullable;
 
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Connection;
-import java.sql.NClob;
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -52,26 +50,19 @@ public class OracleJdbcRowConverter extends AbstractJdbcRowConverter {
             throws SQLException {
         if (seaTunnelDataType.getSqlType().equals(SqlType.BYTES)) {
             if (ORACLE_BLOB.equals(sourceType)) {
-                // Use BLOB object instead of setBinaryStream for Oracle LOB columns
-                // to avoid ORA-01461 error and compatibility with FieldNamedPreparedStatement
-                Connection connection = statement.getConnection();
-                Blob blob = connection.createBlob();
-                blob.setBytes(1, (byte[]) value);
-                statement.setBlob(statementIndex, blob);
+                byte[] bytes = (byte[]) value;
+                statement.setBinaryStream(
+                        statementIndex, new ByteArrayInputStream(bytes), bytes.length);
             } else {
                 statement.setBytes(statementIndex, (byte[]) value);
             }
         } else if (seaTunnelDataType.getSqlType().equals(SqlType.STRING)) {
             if (ORACLE_CLOB.equals(sourceType)) {
-                Connection connection = statement.getConnection();
-                Clob clob = connection.createClob();
-                clob.setString(1, (String) value);
-                statement.setClob(statementIndex, clob);
+                String str = (String) value;
+                statement.setCharacterStream(statementIndex, new StringReader(str), str.length());
             } else if (ORACLE_NCLOB.equals(sourceType)) {
-                Connection connection = statement.getConnection();
-                NClob nclob = connection.createNClob();
-                nclob.setString(1, (String) value);
-                statement.setNClob(statementIndex, nclob);
+                String str = (String) value;
+                statement.setNCharacterStream(statementIndex, new StringReader(str), str.length());
             } else {
                 statement.setString(statementIndex, (String) value);
             }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/FieldNamedPreparedStatement.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/FieldNamedPreparedStatement.java
@@ -279,63 +279,85 @@ public class FieldNamedPreparedStatement implements PreparedStatement {
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setAsciiStream(index, x, length);
+        }
     }
 
     @Override
     public void setUnicodeStream(int parameterIndex, InputStream x, int length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setUnicodeStream(index, x, length);
+        }
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setBinaryStream(index, x, length);
+        }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, int length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setCharacterStream(index, reader, length);
+        }
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value, long length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setNCharacterStream(index, value, length);
+        }
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setClob(index, reader, length);
+        }
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setBlob(index, inputStream, length);
+        }
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setAsciiStream(index, x, length);
+        }
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, long length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setBinaryStream(index, x, length);
+        }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, long length)
             throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setCharacterStream(index, reader, length);
+        }
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setAsciiStream(index, x);
+        }
     }
 
     @Override
@@ -347,27 +369,37 @@ public class FieldNamedPreparedStatement implements PreparedStatement {
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setCharacterStream(index, reader);
+        }
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setNCharacterStream(index, value);
+        }
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setClob(index, reader);
+        }
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setBlob(index, inputStream);
+        }
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new UnsupportedOperationException();
+        for (int index : indexMapping[parameterIndex - 1]) {
+            statement.setNClob(index, reader);
+        }
     }
 
     @Override

--- a/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.sh
+++ b/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.sh
@@ -44,12 +44,11 @@ if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
 fi
 
-if [ $# == 0 ]
-then
-    args="-h"
-else
-    args=$@
+if [ $# == 0 ]; then
+    set -- -h
 fi
+args=("$@")
+args_str=" $* "
 
 set +u
 # SeaTunnel Engine Config
@@ -84,7 +83,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.isThreadContextMapInheritable=true"
 if [ -e "${CONF_DIR}/log4j2_client.properties" ]; then
   JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.logging.type=log4j2 -Dlog4j2.configurationFile=${CONF_DIR}/log4j2_client.properties"
   JAVA_OPTS="${JAVA_OPTS} -Dseatunnel.logs.path=${APP_DIR}/logs"
-  if [[ $args == *" -m local"* || $args == *" --master local"* || $args == *" -e local"* || $args == *" --deploy-mode local"* ]]; then
+  if [[ "$args_str" == *" -m local "* || "$args_str" == *" --master local "* || "$args_str" == *" -e local "* || "$args_str" == *" --deploy-mode local "* ]]; then
     ntime=$(echo `date "+%N"`|sed -r 's/^0+//')
     JAVA_OPTS="${JAVA_OPTS} -Dseatunnel.logs.file_name=seatunnel-starter-client-$((`date '+%s'`*1000+$ntime/1000000))"
   else
@@ -147,4 +146,4 @@ if [[ -n "$GC_LOG_PATH" ]]; then
   fi
 fi
 
-java ${JAVA_OPTS} -cp ${CLASS_PATH} ${APP_MAIN} ${args}
+java ${JAVA_OPTS} -cp ${CLASS_PATH} ${APP_MAIN} "${args[@]}"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOracleIT.java
@@ -181,6 +181,13 @@ public class JdbcOracleIT extends AbstractJdbcIT {
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 
+    @TestTemplate
+    public void testOracleLobWithFakeSource(TestContainer container) throws Exception {
+        Container.ExecResult execResult =
+                container.executeJob("/jdbc_oracle_fake_source_to_sink_with_lob.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
     @Override
     JdbcCase getJdbcCase() {
         Map<String, String> containerEnv = new HashMap<>();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
@@ -21,8 +21,8 @@
 ###### Without the fix in OracleJdbcRowConverter, this would fail with:
 ###### java.sql.BatchUpdateException: ORA-01461: can bind a LONG value only for insert into a LONG column
 ######
-###### The fix uses setBinaryStream() for BLOB and setCharacterStream() for CLOB/NCLOB
-###### instead of setBytes() and setString() to handle large LOB data correctly.
+###### The fix uses JDBC LOB objects (Connection#createBlob/createClob) when writing to Oracle LOB columns
+###### instead of binding large bytes/strings directly, to handle large LOB data correctly.
 ######
 
 env {
@@ -34,23 +34,33 @@ source {
   FakeSource {
     row.num = 100
     schema = {
-      fields {
-        # VARCHAR2(10) - small string
-        varchar_col = string
-        # CHAR(10) - small string
-        char_col = string
-        # CLOB - large string (> 4000 bytes to trigger the ORA-01461 error without fix)
-        clob_col = string
-        # BLOB - large bytes (> 4000 bytes to trigger the ORA-01461 error without fix)
-        blob_col = bytes
-        # INTEGER - primary key
-        id = int
-      }
+      columns = [
+        {
+          name = varchar_col
+          type = string
+          columnLength = 10
+        },
+        {
+          name = char_col
+          type = string
+          columnLength = 10
+        },
+        {
+          name = clob_col
+          type = string
+          columnLength = 5000
+        },
+        {
+          name = blob_col
+          type = bytes
+        },
+        {
+          name = id
+          type = int
+        }
+      ]
     }
-    string.template = ["SeaTunnel", "Apache", "Test"]
-    # Generate large string (> 4000 bytes) for CLOB testing
-    # Oracle VARCHAR2 max is 4000 bytes, CLOB is needed for larger data
-    string.length = 5000
+    string.length = 10
     # Generate large bytes (> 4000 bytes) for BLOB testing
     bytes.length = 5000
   }
@@ -70,4 +80,3 @@ sink {
     }
   }
 }
-

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file tests Oracle LOB types (BLOB, CLOB) with large data (> 4000 bytes)
+###### using FakeSource to generate test data
+######
+###### Without the fix in OracleJdbcRowConverter, this would fail with:
+###### java.sql.BatchUpdateException: ORA-01461: can bind a LONG value only for insert into a LONG column
+######
+###### The fix uses setBinaryStream() for BLOB and setCharacterStream() for CLOB/NCLOB
+###### instead of setBytes() and setString() to handle large LOB data correctly.
+######
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 100
+    schema = {
+      fields {
+        # VARCHAR2(10) - small string
+        varchar_col = string
+        # CHAR(10) - small string
+        char_col = string
+        # CLOB - large string (> 4000 bytes to trigger the ORA-01461 error without fix)
+        clob_col = string
+        # BLOB - large bytes (> 4000 bytes to trigger the ORA-01461 error without fix)
+        blob_col = bytes
+        # INTEGER - primary key
+        id = int
+      }
+    }
+    string.template = ["SeaTunnel", "Apache", "Test"]
+    # Generate large string (> 4000 bytes) for CLOB testing
+    # Oracle VARCHAR2 max is 4000 bytes, CLOB is needed for larger data
+    string.length = 5000
+    # Generate large bytes (> 4000 bytes) for BLOB testing
+    bytes.length = 5000
+  }
+}
+
+sink {
+  Jdbc {
+    driver = oracle.jdbc.driver.OracleDriver
+    url = "jdbc:oracle:thin:@e2e_oracleDb:1521/TESTUSER"
+    username = testUser
+    password = testPassword
+    # Insert LOB data (> 4000 bytes) into Oracle
+    # This tests that the fix correctly uses setBinaryStream() for BLOB and setCharacterStream() for CLOB
+    query = "INSERT INTO E2E_TABLE_SINK (VARCHAR_10_COL, CHAR_10_COL, CLOB_COL, BLOB_COL, INTEGER_COL) VALUES(?, ?, ?, ?, ?)"
+    properties {
+       database.oracle.jdbc.timezoneAsRegion = "false"
+    }
+  }
+}
+

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_oracle_fake_source_to_sink_with_lob.conf
@@ -21,7 +21,7 @@
 ###### Without the fix in OracleJdbcRowConverter, this would fail with:
 ###### java.sql.BatchUpdateException: ORA-01461: can bind a LONG value only for insert into a LONG column
 ######
-###### The fix uses JDBC LOB objects (Connection#createBlob/createClob) when writing to Oracle LOB columns
+###### The fix uses JDBC stream APIs when writing to Oracle LOB columns
 ###### instead of binding large bytes/strings directly, to handle large LOB data correctly.
 ######
 


### PR DESCRIPTION
## What changed
`seatunnel.sh` used `args=$@` and later executed `java ... ${args}`. When `-n` (job name) contains spaces, bash performs word-splitting and the job name is truncated (e.g. only the first word is kept).

This PR switches to an argument array and passes args with `"${args[@]}"`, preserving values with spaces.

## How to reproduce
```bash
./bin/seatunnel.sh -m cluster -c /path/to/conf -n "我是 割裂"
```

## Verification (argv observed by a fake java wrapper)
### Before
```
11:-n
12:我是
13:割裂
```

### After
```
11:-n
12:我是 割裂
```

## Notes
No functional changes for other args; local-mode log filename detection still works.

---

## 变更说明（中文）
`seatunnel.sh` 之前把参数拼成字符串（`args=$@`），并在执行时用 `${args}` 传给 Java，导致当 `-n` 的值包含空格时被 bash 二次分词，任务名会被截断。

本 PR 改为数组方式保存和传递参数（`args=("$@")` + `"${args[@]}"`），确保 `-n "我是 割裂"` 作为一个完整参数传入客户端。

复现与验证输出如上（Before/After）。