### PR TITLE
[Fix][Zeta] Preserve job name containing spaces in seatunnel.sh

### DIFF
--- a/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.sh
+++ b/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.sh
@@ -44,12 +44,11 @@ if [ -f "${CONF_DIR}/seatunnel-env.sh" ]; then
     . "${CONF_DIR}/seatunnel-env.sh"
 fi
 
-if [ $# == 0 ]
-then
-    args="-h"
-else
-    args=$@
+if [ $# == 0 ]; then
+    set -- -h
 fi
+args=("$@")
+args_str=" $* "
 
 set +u
 # SeaTunnel Engine Config
@@ -84,7 +83,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.isThreadContextMapInheritable=true"
 if [ -e "${CONF_DIR}/log4j2_client.properties" ]; then
   JAVA_OPTS="${JAVA_OPTS} -Dhazelcast.logging.type=log4j2 -Dlog4j2.configurationFile=${CONF_DIR}/log4j2_client.properties"
   JAVA_OPTS="${JAVA_OPTS} -Dseatunnel.logs.path=${APP_DIR}/logs"
-  if [[ $args == *" -m local"* || $args == *" --master local"* || $args == *" -e local"* || $args == *" --deploy-mode local"* ]]; then
+  if [[ "$args_str" == *" -m local "* || "$args_str" == *" --master local "* || "$args_str" == *" -e local "* || "$args_str" == *" --deploy-mode local "* ]]; then
     ntime=$(echo `date "+%N"`|sed -r 's/^0+//')
     JAVA_OPTS="${JAVA_OPTS} -Dseatunnel.logs.file_name=seatunnel-starter-client-$((`date '+%s'`*1000+$ntime/1000000))"
   else
@@ -147,4 +146,4 @@ if [[ -n "$GC_LOG_PATH" ]]; then
   fi
 fi
 
-java ${JAVA_OPTS} -cp ${CLASS_PATH} ${APP_MAIN} ${args}
+java ${JAVA_OPTS} -cp ${CLASS_PATH} ${APP_MAIN} "${args[@]}"


### PR DESCRIPTION
## Problem
When submitting a job via `seatunnel.sh`, a job name containing spaces is broken due to bash word-splitting.

Example:
```bash
./bin/seatunnel.sh -m cluster -c /path/to/conf -n "I am split"
```
Actual behavior: only the first token is treated as the job name.

## Root cause
The script stores arguments as a plain string (`args=$@`) and later runs:
```bash
java ... ${args}
```
This triggers word-splitting again.

## Solution
Store CLI arguments as an array and pass them to Java with `"${args[@]}"` so quoted values remain a single argument.

## Verification (observed argv)
Before:
```
... 
-n
I
am
split
```
After:
```
...
-n
I am split
```

## Impact
Only affects argument forwarding; no behavior change for other flags.
