### PR TITLE
[Hotfix][CI] Update testcontainers version to 1.21.4

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -682,7 +682,7 @@ jobs:
     steps:
       - name: install k8s
         run: |
-          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=777 sh -s - --docker
+          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=777 sh -s -
           cat /etc/rancher/k3s/k3s.yaml
           mkdir -p ~/.kube
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
@@ -698,7 +698,29 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: run seatunnel zeta on k8s test
+        # Sideload the SeaTunnel image into the k3s internal store.
+        # This is necessary because the k3s container runtime cannot natively
+        # access images residing only in the local Docker daemon.
         run: |
+          ./mvnw -B install -DskipTests -am
+          
+          TARGET_PATH="seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/resources"
+          mkdir -p $TARGET_PATH/jars $TARGET_PATH/bin $TARGET_PATH/connectors $TARGET_PATH/config
+          cp -r config/* $TARGET_PATH/config/
+          cp $TARGET_PATH/custom_config/hazelcast-kubernetes-discovery.yaml $TARGET_PATH/config/hazelcast.yaml
+          cp $TARGET_PATH/custom_config/hazelcast-client.yaml $TARGET_PATH/config/hazelcast-client.yaml
+          cp seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/target/seatunnel-hadoop3-3.1.4-uber.jar $TARGET_PATH/jars/
+          cp seatunnel-core/seatunnel-starter/target/seatunnel-starter.jar $TARGET_PATH/jars/
+          cp seatunnel-transforms-v2/target/seatunnel-transforms-v2.jar $TARGET_PATH/jars/
+          cp seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.sh $TARGET_PATH/bin/
+          cp seatunnel-core/seatunnel-starter/src/main/bin/seatunnel-cluster.sh $TARGET_PATH/bin/
+          cp $TARGET_PATH/custom_config/plugin-mapping.properties $TARGET_PATH/connectors/
+          cp seatunnel-connectors-v2/connector-fake/target/connector-fake*.jar $TARGET_PATH/connectors/
+          cp seatunnel-connectors-v2/connector-console/target/connector-console*.jar $TARGET_PATH/connectors/
+          
+          docker build -t seatunnel:latest -f $TARGET_PATH/seatunnel_dockerfile $TARGET_PATH
+          docker save seatunnel:latest | sudo k3s ctr images import -
+          
           ./mvnw -T 1 -B verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :seatunnel-engine-k8s-e2e -am -Pci
         env:
           MAVEN_OPTS: -Xmx4096m
@@ -1390,7 +1412,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 120
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
         <maven-scm-provider-jgit.version>2.0.0</maven-scm-provider-jgit.version>
-        <testcontainer.version>1.17.6</testcontainer.version>
+        <testcontainer.version>1.21.4</testcontainer.version>
         <spotless.version>2.29.0</spotless.version>
         <jsqlparser.version>4.9</jsqlparser.version>
         <json-path.version>2.7.0</json-path.version>

--- a/seatunnel-connectors-v2/connector-redis/pom.xml
+++ b/seatunnel-connectors-v2/connector-redis/pom.xml
@@ -70,6 +70,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <databend.jdbc.version>0.3.7</databend.jdbc.version>
-        <testcontainer.version>1.20.2</testcontainer.version>
     </properties>
 
     <dependencies>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
@@ -26,7 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Hudi</name>
 
     <properties>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
     </properties>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-s3-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-s3-e2e/pom.xml
@@ -26,7 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Iceberg : S3</name>
 
     <properties>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
         <hadoop3.version>3.1.4</hadoop3.version>
     </properties>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
@@ -24,10 +24,7 @@
 
     <artifactId>connector-jdbc-e2e-part-2</artifactId>
     <name>SeaTunnel : E2E : Connector V2 : Jdbc : Part 2</name>
-    <properties>
-        <testcontainer.milvus.version>1.19.8</testcontainer.milvus.version>
-        <testcontainer.oceanbase.version>1.20.1</testcontainer.oceanbase.version>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
@@ -51,12 +48,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>${testcontainer.milvus.version}</version>
+            <version>${testcontainer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oceanbase</artifactId>
-            <version>${testcontainer.oceanbase.version}</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- drivers -->

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>connector-milvus-e2e</artifactId>
     <name>SeaTunnel : E2E : Connector V2 : Milvus</name>
 
-    <properties>
-        <testcontainer.milvus.version>1.19.8</testcontainer.milvus.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
@@ -47,7 +43,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>${testcontainer.milvus.version}</version>
+            <version>${testcontainer.version}</version>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
@@ -26,7 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Paimon</name>
 
     <properties>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
     </properties>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>1.20.1</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/qdrant/QdrantIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/qdrant/QdrantIT.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -62,7 +61,13 @@ public class QdrantIT extends TestSuiteBase implements TestResource {
     private static final String ALIAS = "qdrante2e";
     private static final String SOURCE_COLLECTION = "source_collection";
     private static final String SINK_COLLECTION = "sink_collection";
-    private static final String IMAGE = "qdrant/qdrant:latest";
+
+    /**
+     * Fixed Qdrant at v1.15.0 for stability; upgrading to v1.17.0+ requires ensuring the SeaTunnel
+     * Qdrant connector is compatible with the latest breaking changes.
+     */
+    private static final String IMAGE = "qdrant/qdrant:v1.15.0";
+
     private QdrantContainer container;
     private QdrantClient qdrantClient;
 
@@ -136,10 +141,15 @@ public class QdrantIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
-    public void testQdrant(TestContainer container)
-            throws IOException, InterruptedException, ExecutionException {
+    public void testQdrant(TestContainer container) throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeJob("/qdrant-to-qdrant.conf");
-        Assertions.assertEquals(execResult.getExitCode(), 0);
-        Assertions.assertEquals(qdrantClient.countAsync(SINK_COLLECTION).get(), 10);
+        Assertions.assertEquals(0, execResult.getExitCode());
+        Awaitility.given()
+                .await()
+                .atMost(10L, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        10L, qdrantClient.countAsync(SINK_COLLECTION).get()));
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

The current CI process is consistently failing with the following error. 
```
[testcontainers-lifecycle-0] ERROR org.testcontainers.dockerclient.DockerClientProviderStrategy - Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
	UnixSocketClientProviderStrategy: failed with exception BadRequestException (Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
```
The root cause lies in a protocol incompatibility where the outdated Docker client embedded in Testcontainers attempts to communicate using API version 1.32, which falls below the minimum API threshold (1.44) enforced by the recently updated Docker host. As the Docker Engine has deprecated support for legacy versions, a library upgrade is mandatory to align the client-side API calls with the host's requirements.
For more detailed information regarding this issue, please refer to https://github.com/testcontainers/testcontainers-java/issues/11491 .

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)