### PR TITLE
[Feature][Core] Add Dirty Data Collection Framework

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/SeaTunnelPluginLifeCycle.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/SeaTunnelPluginLifeCycle.java
@@ -42,4 +42,13 @@ public interface SeaTunnelPluginLifeCycle {
     default void prepare(Config pluginConfig) throws PrepareFailException {
         throw new UnsupportedOperationException("prepare method is not supported");
     }
+
+    /**
+     * Get the config of plugin.
+     *
+     * @return the plugin configuration
+     */
+    default Config getPluginConfig() {
+        throw new UnsupportedOperationException("getPluginConfig method is not supported");
+    }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/AlwaysDirtyDataValidator.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/AlwaysDirtyDataValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * A sample custom dirty data validator that marks every record as dirty. Used by integration tests
+ * to verify the custom validator SPI mechanism works. The message {@code [AlwaysDirtyValidator]}
+ * can be asserted in test logs.
+ */
+@AutoService(Factory.class)
+public class AlwaysDirtyDataValidator implements DirtyDataValidator {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public ValidationResult validate(SeaTunnelRow record, CatalogTable catalogTable) {
+        return ValidationResult.dirty(
+                "[AlwaysDirtyValidator] Record marked dirty by custom validator rule");
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A sample custom dirty record collector discovered via SPI. Logs each dirty record with a
+ * distinctive {@code [CountingCollector]} prefix so integration tests can verify that the custom
+ * SPI-based collector is actually being used.
+ */
+@Slf4j
+public class CountingDirtyRecordCollector implements DirtyRecordCollector {
+
+    private static final long serialVersionUID = 1L;
+
+    private final AtomicLong dirtyRecordCount = new AtomicLong(0);
+    private long threshold = -1;
+    private boolean failOnThreshold = false;
+
+    @Override
+    public void init(Config config) {
+        if (config.hasPath("threshold")) {
+            this.threshold = config.getLong("threshold");
+        }
+        if (config.hasPath("fail_on_threshold")) {
+            this.failOnThreshold = config.getBoolean("fail_on_threshold");
+        }
+        log.info(
+                "[CountingCollector] initialized, threshold={}, failOnThreshold={}",
+                threshold,
+                failOnThreshold);
+    }
+
+    @Override
+    public void collect(
+            int subTaskIndex,
+            SeaTunnelRow dirtyRecord,
+            Throwable exception,
+            String errorMessage,
+            CatalogTable catalogTable) {
+        long n = dirtyRecordCount.incrementAndGet();
+        log.error(
+                "[CountingCollector] dirty record #{}: SubTask={}, Record={}, Error={}",
+                n,
+                subTaskIndex,
+                dirtyRecord != null ? dirtyRecord.toString() : "null",
+                errorMessage != null ? errorMessage : "");
+        checkThresholdRuntime();
+    }
+
+    @Override
+    public long getDirtyRecordCount() {
+        return dirtyRecordCount.get();
+    }
+
+    @Override
+    public void checkThreshold() throws Exception {
+        if (threshold > 0 && dirtyRecordCount.get() >= threshold) {
+            String message =
+                    String.format(
+                            "[CountingCollector] threshold exceeded: %d >= %d",
+                            dirtyRecordCount.get(), threshold);
+            if (failOnThreshold) {
+                throw new RuntimeException(message);
+            } else {
+                log.warn(message);
+            }
+        }
+    }
+
+    private void checkThresholdRuntime() {
+        try {
+            checkThreshold();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
@@ -39,6 +39,7 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
     private final AtomicLong dirtyRecordCount = new AtomicLong(0);
     private long threshold = -1;
     private boolean failOnThreshold = false;
+    private transient Object distributedCounter;
 
     @Override
     public void init(Config config) {
@@ -55,6 +56,83 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
     }
 
     @Override
+    public void setDistributedCounter(Object counter) {
+        this.distributedCounter = counter;
+        log.debug(
+                "[CountingCollector] distributed counter set: {}",
+                counter != null ? counter.getClass().getName() : "null");
+    }
+
+    @Override
+    public void incrementDistributedCounter() {
+        if (distributedCounter == null) {
+            return;
+        }
+        try {
+            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
+                // spark LongAccumulator
+                distributedCounter
+                        .getClass()
+                        .getMethod("add", long.class)
+                        .invoke(distributedCounter, 1L);
+            } else if (distributedCounter.getClass().getName().contains("Counter")) {
+                // flink LongCounter
+                distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
+            } else {
+                // seaTunnel Counter
+                try {
+                    distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
+                } catch (NoSuchMethodException e) {
+                    distributedCounter
+                            .getClass()
+                            .getMethod("add", long.class)
+                            .invoke(distributedCounter, 1L);
+                }
+            }
+        } catch (Exception e) {
+            log.trace("Failed to increment distributed counter", e);
+        }
+    }
+
+    private long getDistributedCount() {
+        if (distributedCounter == null) {
+            return dirtyRecordCount.get();
+        }
+        try {
+            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
+                // spark LongAccumulator
+                return (Long)
+                        distributedCounter.getClass().getMethod("value").invoke(distributedCounter);
+            } else if (distributedCounter.getClass().getName().contains("Counter")) {
+                // flink Counter
+                return (Long)
+                        distributedCounter
+                                .getClass()
+                                .getMethod("getCount")
+                                .invoke(distributedCounter);
+            } else {
+                // seaTunnel Counter
+                try {
+                    return (Long)
+                            distributedCounter
+                                    .getClass()
+                                    .getMethod("getCount")
+                                    .invoke(distributedCounter);
+                } catch (NoSuchMethodException e) {
+                    return (Long)
+                            distributedCounter
+                                    .getClass()
+                                    .getMethod("value")
+                                    .invoke(distributedCounter);
+                }
+            }
+        } catch (Exception e) {
+            log.trace("Failed to get distributed count, using local count", e);
+            return dirtyRecordCount.get();
+        }
+    }
+
+    @Override
     public void collect(
             int subTaskIndex,
             SeaTunnelRow dirtyRecord,
@@ -62,6 +140,7 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
             String errorMessage,
             CatalogTable catalogTable) {
         long n = dirtyRecordCount.incrementAndGet();
+        incrementDistributedCounter();
         log.error(
                 "[CountingCollector] dirty record #{}: SubTask={}, Record={}, Error={}",
                 n,
@@ -78,11 +157,16 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public void checkThreshold() throws Exception {
-        if (threshold > 0 && dirtyRecordCount.get() >= threshold) {
+        if (threshold <= 0) {
+            return;
+        }
+
+        long count = getDistributedCount();
+        if (count >= threshold) {
             String message =
                     String.format(
-                            "[CountingCollector] threshold exceeded: %d >= %d",
-                            dirtyRecordCount.get(), threshold);
+                            "[CountingCollector] threshold exceeded: %d >= %d (distributed=%s)",
+                            count, threshold, distributedCounter != null);
             if (failOnThreshold) {
                 throw new RuntimeException(message);
             } else {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollector.java
@@ -20,11 +20,8 @@ package org.apache.seatunnel.api.sink;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
-import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A sample custom dirty record collector discovered via SPI. Logs each dirty record with a
@@ -36,10 +33,9 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
 
     private static final long serialVersionUID = 1L;
 
-    private final AtomicLong dirtyRecordCount = new AtomicLong(0);
+    private DistributedCounter dirtyRecordCounter = new LocalAtomicCounter();
     private long threshold = -1;
     private boolean failOnThreshold = false;
-    private transient Object distributedCounter;
 
     @Override
     public void init(Config config) {
@@ -56,91 +52,27 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
     }
 
     @Override
-    public void setDistributedCounter(Object counter) {
-        this.distributedCounter = counter;
+    public void setDistributedCounter(DistributedCounter counter) {
+        this.dirtyRecordCounter = counter != null ? counter : new LocalAtomicCounter();
         log.debug(
                 "[CountingCollector] distributed counter set: {}",
-                counter != null ? counter.getClass().getName() : "null");
+                dirtyRecordCounter.getClass().getName());
     }
 
     @Override
     public void incrementDistributedCounter() {
-        if (distributedCounter == null) {
-            return;
-        }
-        try {
-            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
-                // spark LongAccumulator
-                distributedCounter
-                        .getClass()
-                        .getMethod("add", long.class)
-                        .invoke(distributedCounter, 1L);
-            } else if (distributedCounter.getClass().getName().contains("Counter")) {
-                // flink LongCounter
-                distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
-            } else {
-                // seaTunnel Counter
-                try {
-                    distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
-                } catch (NoSuchMethodException e) {
-                    distributedCounter
-                            .getClass()
-                            .getMethod("add", long.class)
-                            .invoke(distributedCounter, 1L);
-                }
-            }
-        } catch (Exception e) {
-            log.trace("Failed to increment distributed counter", e);
-        }
-    }
-
-    private long getDistributedCount() {
-        if (distributedCounter == null) {
-            return dirtyRecordCount.get();
-        }
-        try {
-            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
-                // spark LongAccumulator
-                return (Long)
-                        distributedCounter.getClass().getMethod("value").invoke(distributedCounter);
-            } else if (distributedCounter.getClass().getName().contains("Counter")) {
-                // flink Counter
-                return (Long)
-                        distributedCounter
-                                .getClass()
-                                .getMethod("getCount")
-                                .invoke(distributedCounter);
-            } else {
-                // seaTunnel Counter
-                try {
-                    return (Long)
-                            distributedCounter
-                                    .getClass()
-                                    .getMethod("getCount")
-                                    .invoke(distributedCounter);
-                } catch (NoSuchMethodException e) {
-                    return (Long)
-                            distributedCounter
-                                    .getClass()
-                                    .getMethod("value")
-                                    .invoke(distributedCounter);
-                }
-            }
-        } catch (Exception e) {
-            log.trace("Failed to get distributed count, using local count", e);
-            return dirtyRecordCount.get();
-        }
+        dirtyRecordCounter.add(1L);
     }
 
     @Override
     public void collect(
             int subTaskIndex,
-            SeaTunnelRow dirtyRecord,
+            Object dirtyRecord,
             Throwable exception,
             String errorMessage,
             CatalogTable catalogTable) {
-        long n = dirtyRecordCount.incrementAndGet();
         incrementDistributedCounter();
+        long n = dirtyRecordCounter.value();
         log.error(
                 "[CountingCollector] dirty record #{}: SubTask={}, Record={}, Error={}",
                 n,
@@ -152,7 +84,7 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public long getDirtyRecordCount() {
-        return dirtyRecordCount.get();
+        return dirtyRecordCounter.value();
     }
 
     @Override
@@ -161,12 +93,11 @@ public class CountingDirtyRecordCollector implements DirtyRecordCollector {
             return;
         }
 
-        long count = getDistributedCount();
+        long count = dirtyRecordCounter.value();
         if (count >= threshold) {
             String message =
                     String.format(
-                            "[CountingCollector] threshold exceeded: %d >= %d (distributed=%s)",
-                            count, threshold, distributedCounter != null);
+                            "[CountingCollector] threshold exceeded: %d >= %d", count, threshold);
             if (failOnThreshold) {
                 throw new RuntimeException(message);
             } else {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/CountingDirtyRecordCollectorProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.factory.Factory;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * SPI provider for the "counting" type dirty record collector. Used by integration tests to verify
+ * that custom collectors registered via ServiceLoader are properly discovered and used.
+ */
+@AutoService(Factory.class)
+public class CountingDirtyRecordCollectorProvider implements DirtyRecordCollectorProvider {
+
+    @Override
+    public String getType() {
+        return "counting";
+    }
+
+    @Override
+    public DirtyRecordCollector createCollector() {
+        return new CountingDirtyRecordCollector();
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DefaultSinkWriterContext.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DefaultSinkWriterContext.java
@@ -17,30 +17,61 @@
 
 package org.apache.seatunnel.api.sink;
 
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
 import org.apache.seatunnel.api.common.metrics.AbstractMetricsContext;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
 
 /** The default {@link SinkWriter.Context} implement class. */
 public class DefaultSinkWriterContext implements SinkWriter.Context {
     private final int subtask;
     private final int numberOfParallelSubtasks;
     private final EventListener eventListener;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public DefaultSinkWriterContext(int subtask, int parallelism) {
-        this(subtask, parallelism, new DefaultEventProcessor());
+        this(subtask, parallelism, new DefaultEventProcessor(), NoOpDirtyRecordCollector.INSTANCE);
     }
 
     public DefaultSinkWriterContext(String jobId, int subtask, int parallelism) {
-        this(subtask, parallelism, new DefaultEventProcessor(jobId));
+        this(
+                subtask,
+                parallelism,
+                new DefaultEventProcessor(jobId),
+                NoOpDirtyRecordCollector.INSTANCE);
     }
 
     public DefaultSinkWriterContext(
             int subtask, int numberOfParallelSubtasks, EventListener eventListener) {
+        this(subtask, numberOfParallelSubtasks, eventListener, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public DefaultSinkWriterContext(
+            int subtask,
+            int numberOfParallelSubtasks,
+            EventListener eventListener,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.subtask = subtask;
         this.numberOfParallelSubtasks = numberOfParallelSubtasks;
         this.eventListener = eventListener;
+        this.dirtyRecordCollector = dirtyRecordCollector;
+    }
+
+    public DefaultSinkWriterContext(
+            int subtask,
+            int numberOfParallelSubtasks,
+            EventListener eventListener,
+            Config envConfig,
+            Config sinkConfig,
+            CatalogTable catalogTable) {
+        this.subtask = subtask;
+        this.numberOfParallelSubtasks = numberOfParallelSubtasks;
+        this.eventListener = eventListener;
+        this.dirtyRecordCollector =
+                DirtyCollectorConfigProcessor.processConfig(envConfig, sinkConfig, catalogTable);
     }
 
     @Override
@@ -62,5 +93,10 @@ public class DefaultSinkWriterContext implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return eventListener;
+    }
+
+    @Override
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
@@ -21,9 +21,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigValue;
 
-import org.apache.seatunnel.api.common.SeaTunnelPluginLifeCycle;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
-import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -94,23 +92,6 @@ public class DirtyCollectorConfigProcessor {
                             envConfig.getValue(DIRTY_VALIDATOR_CONFIG_KEY));
         }
         return mergedConfig;
-    }
-
-    public static DirtyRecordCollector initializeCollector(
-            SeaTunnelSink<SeaTunnelRow, ?, ?, ?> sink, CatalogTable[] catalogTables) {
-        Config pluginConfig = null;
-        if (sink instanceof SeaTunnelPluginLifeCycle) {
-            try {
-                pluginConfig = ((SeaTunnelPluginLifeCycle) sink).getPluginConfig();
-            } catch (UnsupportedOperationException ignored) {
-                log.debug(
-                        "Sink {} doesn't implement getPluginConfig",
-                        sink.getClass().getSimpleName());
-            }
-        }
-        CatalogTable catalogTable =
-                catalogTables != null && catalogTables.length > 0 ? catalogTables[0] : null;
-        return processConfig(null, pluginConfig, catalogTable);
     }
 
     public static DirtyRecordCollector processConfig(Config envConfig, Config sinkConfig) {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
@@ -88,6 +88,12 @@ public class DirtyCollectorConfigProcessor {
         return mergedConfig;
     }
 
+    public static boolean hasDirtyHandlingConfig(Config envConfig, Config sinkConfig) {
+        Config mergedConfig = getMergedSinkConfigForDirty(envConfig, sinkConfig);
+        return mergedConfig.hasPath(DIRTY_COLLECTOR_CONFIG_KEY)
+                || mergedConfig.hasPath(DIRTY_VALIDATOR_CONFIG_KEY);
+    }
+
     public static DirtyRecordCollector processConfig(Config envConfig, Config sinkConfig) {
         return processConfig(envConfig, sinkConfig, null);
     }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
@@ -65,19 +65,13 @@ public class DirtyCollectorConfigProcessor {
             return NoOpDirtyRecordCollector.INSTANCE;
         }
 
-        try {
-            Config collectorConfig = config.getConfig(DIRTY_COLLECTOR_CONFIG_KEY);
-            DirtyRecordCollector collector =
-                    DirtyRecordCollectorFactory.createCollector(collectorConfig);
-            log.info(
-                    "Successfully initialized dirty record collector: {}",
-                    collector.getClass().getSimpleName());
-            return collector;
-        } catch (Exception e) {
-            log.error(
-                    "Failed to initialize dirty record collector, using NoOp collector instead", e);
-            return NoOpDirtyRecordCollector.INSTANCE;
-        }
+        Config collectorConfig = config.getConfig(DIRTY_COLLECTOR_CONFIG_KEY);
+        DirtyRecordCollector collector =
+                DirtyRecordCollectorFactory.createCollector(collectorConfig);
+        log.info(
+                "Successfully initialized dirty record collector: {}",
+                collector.getClass().getSimpleName());
+        return collector;
     }
 
     public static Config getMergedSinkConfigForDirty(Config envConfig, Config sinkConfig) {
@@ -133,8 +127,8 @@ public class DirtyCollectorConfigProcessor {
         try {
             Config validatorConfig = config.getConfig(DIRTY_VALIDATOR_CONFIG_KEY);
             if (!validatorConfig.hasPath("type")) {
-                log.warn("Dirty validator configuration missing 'type' field");
-                return null;
+                throw new IllegalArgumentException(
+                        "dirty.validator is configured but missing required 'type' field.");
             }
 
             String validatorType = validatorConfig.getString("type");
@@ -142,17 +136,21 @@ public class DirtyCollectorConfigProcessor {
                     DirtyDataValidatorFactory.createValidator(
                             validatorType, validatorConfig, catalogTable);
 
-            if (validator != null) {
-                log.info("Successfully created dirty data validator: {}", validatorType);
-            } else {
-                log.warn("Failed to create dirty data validator: {}", validatorType);
+            if (validator == null) {
+                throw new IllegalArgumentException(
+                        "Could not resolve dirty.validator type '"
+                                + validatorType
+                                + "'. Ensure the implementation is on the classpath or registered via SPI.");
             }
 
+            log.info("Successfully created dirty data validator: {}", validatorType);
             return validator;
-
+        } catch (IllegalArgumentException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("Failed to create dirty data validator", e);
-            return null;
+            String validatorType = config.getConfig(DIRTY_VALIDATOR_CONFIG_KEY).getString("type");
+            throw new RuntimeException(
+                    "Failed to initialize dirty.validator of type '" + validatorType + "'", e);
         }
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyCollectorConfigProcessor.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigValue;
+
+import org.apache.seatunnel.api.common.SeaTunnelPluginLifeCycle;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import lombok.extern.slf4j.Slf4j;
+
+/** Configuration processor for dirty data collection functionality */
+@Slf4j
+public class DirtyCollectorConfigProcessor {
+
+    private static final String DIRTY_COLLECTOR_CONFIG_KEY = "dirty.collector";
+    private static final String DIRTY_VALIDATOR_CONFIG_KEY = "dirty.validator";
+
+    public static Config parseEnvDirtyConfig(Config envConfig) {
+        if (envConfig != null && envConfig.hasPath(DIRTY_COLLECTOR_CONFIG_KEY)) {
+            return envConfig.getConfig(DIRTY_COLLECTOR_CONFIG_KEY);
+        }
+        return null;
+    }
+
+    public static Config mergeConfig(Config sinkConfig, Config envDirtyConfig) {
+        if (sinkConfig == null) {
+            return ConfigFactory.empty();
+        }
+
+        if (sinkConfig.hasPath(DIRTY_COLLECTOR_CONFIG_KEY)) {
+            log.debug("Sink has its own dirty collector configuration, using sink config");
+            return sinkConfig;
+        }
+
+        if (envDirtyConfig != null) {
+            log.debug("Merging env dirty collector config into sink config");
+            ConfigValue envValue = envDirtyConfig.root();
+            return sinkConfig.withValue(DIRTY_COLLECTOR_CONFIG_KEY, envValue);
+        }
+
+        log.debug("No dirty collector configuration found");
+        return sinkConfig;
+    }
+
+    public static DirtyRecordCollector initializeCollector(Config config) {
+        if (config == null || !config.hasPath(DIRTY_COLLECTOR_CONFIG_KEY)) {
+            log.debug("No dirty collector configuration found, using NoOp collector");
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+
+        try {
+            Config collectorConfig = config.getConfig(DIRTY_COLLECTOR_CONFIG_KEY);
+            DirtyRecordCollector collector =
+                    DirtyRecordCollectorFactory.createCollector(collectorConfig);
+            log.info(
+                    "Successfully initialized dirty record collector: {}",
+                    collector.getClass().getSimpleName());
+            return collector;
+        } catch (Exception e) {
+            log.error(
+                    "Failed to initialize dirty record collector, using NoOp collector instead", e);
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+    }
+
+    public static Config getMergedSinkConfigForDirty(Config envConfig, Config sinkConfig) {
+        Config envDirtyConfig = parseEnvDirtyConfig(envConfig);
+        Config mergedConfig = mergeConfig(sinkConfig, envDirtyConfig);
+        if (envConfig != null
+                && envConfig.hasPath(DIRTY_VALIDATOR_CONFIG_KEY)
+                && !mergedConfig.hasPath(DIRTY_VALIDATOR_CONFIG_KEY)) {
+            mergedConfig =
+                    mergedConfig.withValue(
+                            DIRTY_VALIDATOR_CONFIG_KEY,
+                            envConfig.getValue(DIRTY_VALIDATOR_CONFIG_KEY));
+        }
+        return mergedConfig;
+    }
+
+    public static DirtyRecordCollector initializeCollector(
+            SeaTunnelSink<SeaTunnelRow, ?, ?, ?> sink, CatalogTable[] catalogTables) {
+        Config pluginConfig = null;
+        if (sink instanceof SeaTunnelPluginLifeCycle) {
+            try {
+                pluginConfig = ((SeaTunnelPluginLifeCycle) sink).getPluginConfig();
+            } catch (UnsupportedOperationException ignored) {
+                log.debug(
+                        "Sink {} doesn't implement getPluginConfig",
+                        sink.getClass().getSimpleName());
+            }
+        }
+        CatalogTable catalogTable =
+                catalogTables != null && catalogTables.length > 0 ? catalogTables[0] : null;
+        return processConfig(null, pluginConfig, catalogTable);
+    }
+
+    public static DirtyRecordCollector processConfig(Config envConfig, Config sinkConfig) {
+        return processConfig(envConfig, sinkConfig, null);
+    }
+
+    public static DirtyRecordCollector processConfig(
+            Config envConfig, Config sinkConfig, CatalogTable catalogTable) {
+        Config envDirtyConfig = parseEnvDirtyConfig(envConfig);
+        Config mergedConfig = mergeConfig(sinkConfig, envDirtyConfig);
+        if (envConfig != null
+                && envConfig.hasPath(DIRTY_VALIDATOR_CONFIG_KEY)
+                && !mergedConfig.hasPath(DIRTY_VALIDATOR_CONFIG_KEY)) {
+            log.debug("Merging env dirty validator config into sink config");
+            mergedConfig =
+                    mergedConfig.withValue(
+                            DIRTY_VALIDATOR_CONFIG_KEY,
+                            envConfig.getValue(DIRTY_VALIDATOR_CONFIG_KEY));
+        }
+
+        DirtyRecordCollector collector = initializeCollector(mergedConfig);
+
+        DirtyDataValidator validator = createValidator(mergedConfig, catalogTable);
+        if (validator != null) {
+            log.info(
+                    "Wrapping collector with ValidatingDirtyRecordCollector (validator={})",
+                    validator.getClass().getSimpleName());
+            collector = new ValidatingDirtyRecordCollector(collector, validator);
+        }
+
+        return collector;
+    }
+
+    public static DirtyDataValidator createValidator(Config config, CatalogTable catalogTable) {
+        if (config == null || !config.hasPath(DIRTY_VALIDATOR_CONFIG_KEY)) {
+            return null;
+        }
+
+        try {
+            Config validatorConfig = config.getConfig(DIRTY_VALIDATOR_CONFIG_KEY);
+            if (!validatorConfig.hasPath("type")) {
+                log.warn("Dirty validator configuration missing 'type' field");
+                return null;
+            }
+
+            String validatorType = validatorConfig.getString("type");
+            DirtyDataValidator validator =
+                    DirtyDataValidatorFactory.createValidator(
+                            validatorType, validatorConfig, catalogTable);
+
+            if (validator != null) {
+                log.info("Successfully created dirty data validator: {}", validatorType);
+            } else {
+                log.warn("Failed to create dirty data validator: {}", validatorType);
+            }
+
+            return validator;
+
+        } catch (Exception e) {
+            log.error("Failed to create dirty data validator", e);
+            return null;
+        }
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataAwareSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataAwareSinkWriter.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+public final class DirtyDataAwareSinkWriter<T, CommitInfoT, StateT>
+        implements SinkWriter<T, CommitInfoT, StateT> {
+
+    private final SinkWriter<T, CommitInfoT, StateT> delegate;
+    private final DirtyRecordCollector collector;
+    private final int subtaskIndex;
+    private final CatalogTable catalogTable;
+
+    public DirtyDataAwareSinkWriter(
+            SinkWriter<T, CommitInfoT, StateT> delegate,
+            DirtyRecordCollector collector,
+            int subtaskIndex) {
+        this(delegate, collector, subtaskIndex, null);
+    }
+
+    public DirtyDataAwareSinkWriter(
+            SinkWriter<T, CommitInfoT, StateT> delegate,
+            DirtyRecordCollector collector,
+            int subtaskIndex,
+            CatalogTable catalogTable) {
+        this.delegate = delegate;
+        this.collector = collector;
+        this.subtaskIndex = subtaskIndex;
+        this.catalogTable = catalogTable;
+    }
+
+    @Override
+    public void write(T element) throws IOException {
+        if (element instanceof SeaTunnelRow
+                && collector.validateAndCollectIfDirty(
+                        subtaskIndex, (SeaTunnelRow) element, catalogTable)) {
+            return;
+        }
+        try {
+            delegate.write(element);
+        } catch (Exception e) {
+            if (!tryCollect(element, e)) {
+                if (e instanceof IOException) {
+                    throw (IOException) e;
+                }
+                throw new IOException(e);
+            }
+        }
+    }
+
+    private boolean tryCollect(T element, Exception e) {
+        if (collector == null || collector instanceof NoOpDirtyRecordCollector) {
+            return false;
+        }
+        collector.collect(
+                subtaskIndex, element, e, "Write failed: " + e.getMessage(), catalogTable);
+        return true;
+    }
+
+    @Override
+    public void applySchemaChange(SchemaChangeEvent event) throws IOException {
+        delegate.applySchemaChange(event);
+    }
+
+    @Override
+    public Optional<CommitInfoT> prepareCommit() throws IOException {
+        return delegate.prepareCommit();
+    }
+
+    @Override
+    public Optional<CommitInfoT> prepareCommit(long checkpointId) throws IOException {
+        return delegate.prepareCommit(checkpointId);
+    }
+
+    @Override
+    public List<StateT> snapshotState(long checkpointId) throws IOException {
+        return delegate.snapshotState(checkpointId);
+    }
+
+    @Override
+    public void abortPrepare() {
+        delegate.abortPrepare();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataAwareSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataAwareSinkWriter.java
@@ -106,6 +106,22 @@ public final class DirtyDataAwareSinkWriter<T, CommitInfoT, StateT>
 
     @Override
     public void close() throws IOException {
-        delegate.close();
+        IOException closeException = null;
+        try {
+            delegate.close();
+        } catch (IOException e) {
+            closeException = e;
+            throw e;
+        } finally {
+            try {
+                collector.close();
+            } catch (Exception e) {
+                if (closeException != null) {
+                    closeException.addSuppressed(e);
+                } else {
+                    throw new IOException("Failed to close dirty record collector", e);
+                }
+            }
+        }
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataValidator.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataValidator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+
+/**
+ * User-defined dirty data validator interface. Extends {@link Factory} so that implementations are
+ * discovered via {@code FactoryUtil.discoverFactories()} — the same SPI used for connectors.
+ *
+ * <p>Register implementations in {@code
+ * META-INF/services/org.apache.seatunnel.api.table.factory.Factory}.
+ */
+public interface DirtyDataValidator extends Factory, Serializable {
+
+    default void init(Config config, CatalogTable catalogTable) throws Exception {}
+
+    ValidationResult validate(SeaTunnelRow record, CatalogTable catalogTable);
+
+    default void close() throws Exception {}
+
+    @Override
+    default String factoryIdentifier() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    default OptionRule optionRule() {
+        return OptionRule.builder().build();
+    }
+
+    @Getter
+    class ValidationResult implements Serializable {
+        private final boolean isDirty;
+        private final String errorMessage;
+        private final Throwable exception;
+
+        public ValidationResult(boolean isDirty, String errorMessage) {
+            this(isDirty, errorMessage, null);
+        }
+
+        public ValidationResult(boolean isDirty, String errorMessage, Throwable exception) {
+            this.isDirty = isDirty;
+            this.errorMessage = errorMessage;
+            this.exception = exception;
+        }
+
+        public static ValidationResult clean() {
+            return new ValidationResult(false, null);
+        }
+
+        public static ValidationResult dirty(String errorMessage) {
+            return new ValidationResult(true, errorMessage);
+        }
+
+        public static ValidationResult dirty(String errorMessage, Throwable exception) {
+            return new ValidationResult(true, errorMessage, exception);
+        }
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataValidatorFactory.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyDataValidatorFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.factory.FactoryUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+/**
+ * Factory for creating user-defined dirty data validators.
+ *
+ * <p>First tries direct class loading, then falls back to SPI discovery via {@link
+ * FactoryUtil#discoverFactories}.
+ */
+@Slf4j
+public class DirtyDataValidatorFactory {
+
+    public static DirtyDataValidator createValidator(
+            String validatorName, Config config, CatalogTable catalogTable) {
+        DirtyDataValidator validator = tryDirectInstantiation(validatorName, config, catalogTable);
+        if (validator != null) {
+            return validator;
+        }
+
+        try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            List<DirtyDataValidator> validators =
+                    FactoryUtil.discoverFactories(classLoader, DirtyDataValidator.class);
+
+            for (DirtyDataValidator v : validators) {
+                if (v.factoryIdentifier().equalsIgnoreCase(validatorName)
+                        || v.getClass().getSimpleName().equals(validatorName)
+                        || v.getClass().getName().equals(validatorName)) {
+                    v.init(config, catalogTable);
+                    log.info("Created dirty data validator via SPI: {}", v.getClass().getName());
+                    return v;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("SPI discovery failed for dirty data validator: {}", validatorName, e);
+        }
+
+        log.error("Could not create dirty data validator: {}", validatorName);
+        return null;
+    }
+
+    private static DirtyDataValidator tryDirectInstantiation(
+            String validatorName, Config config, CatalogTable catalogTable) {
+        String[] candidates = {
+            validatorName, "org.apache.seatunnel.api.sink." + validatorName,
+        };
+        for (String className : candidates) {
+            try {
+                Class<?> clazz = Class.forName(className);
+                if (DirtyDataValidator.class.isAssignableFrom(clazz)) {
+                    DirtyDataValidator validator =
+                            (DirtyDataValidator) clazz.getDeclaredConstructor().newInstance();
+                    validator.init(config, catalogTable);
+                    log.info("Created dirty data validator: {}", className);
+                    return validator;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
@@ -81,4 +81,8 @@ public interface DirtyRecordCollector extends Serializable {
     }
 
     default void checkThreshold() throws Exception {}
+
+    default void setDistributedCounter(Object counter) {}
+
+    default void incrementDistributedCounter() {}
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import java.io.Serializable;
+
+/**
+ * Base interface for dirty records collector. This interface is used to collect and record all
+ * dirty data content and exception information.
+ */
+public interface DirtyRecordCollector extends Serializable {
+
+    void collect(
+            final int subTaskIndex,
+            final SeaTunnelRow dirtyRecord,
+            final Throwable exception,
+            final String errorMessage,
+            final CatalogTable catalogTable);
+
+    default void collect(
+            final int subTaskIndex,
+            final SeaTunnelRow dirtyRecord,
+            final Throwable exception,
+            final String errorMessage) {
+        collect(subTaskIndex, dirtyRecord, exception, errorMessage, null);
+    }
+
+    default void collect(
+            final int subTaskIndex,
+            final SeaTunnelRow dirtyRecord,
+            final Throwable exception,
+            final CatalogTable catalogTable) {
+        collect(subTaskIndex, dirtyRecord, exception, "", catalogTable);
+    }
+
+    default void collect(
+            final int subTaskIndex, final SeaTunnelRow dirtyRecord, final Throwable exception) {
+        collect(subTaskIndex, dirtyRecord, exception, "", null);
+    }
+
+    default void init(Config config) throws Exception {}
+
+    default void init(Config config, CatalogTable catalogTable) throws Exception {
+        init(config);
+    }
+
+    default void collectFromUserRule(
+            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
+        collect(subTaskIndex, record, null, errorMessage, catalogTable);
+    }
+
+    default boolean validateAndCollectIfDirty(
+            int subTaskIndex, SeaTunnelRow record, CatalogTable catalogTable) {
+        return false;
+    }
+
+    default void close() throws Exception {}
+
+    default long getDirtyRecordCount() {
+        return 0L;
+    }
+
+    default void checkThreshold() throws Exception {}
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollector.java
@@ -32,14 +32,14 @@ public interface DirtyRecordCollector extends Serializable {
 
     void collect(
             final int subTaskIndex,
-            final SeaTunnelRow dirtyRecord,
+            final Object dirtyRecord,
             final Throwable exception,
             final String errorMessage,
             final CatalogTable catalogTable);
 
     default void collect(
             final int subTaskIndex,
-            final SeaTunnelRow dirtyRecord,
+            final Object dirtyRecord,
             final Throwable exception,
             final String errorMessage) {
         collect(subTaskIndex, dirtyRecord, exception, errorMessage, null);
@@ -47,14 +47,14 @@ public interface DirtyRecordCollector extends Serializable {
 
     default void collect(
             final int subTaskIndex,
-            final SeaTunnelRow dirtyRecord,
+            final Object dirtyRecord,
             final Throwable exception,
             final CatalogTable catalogTable) {
         collect(subTaskIndex, dirtyRecord, exception, "", catalogTable);
     }
 
     default void collect(
-            final int subTaskIndex, final SeaTunnelRow dirtyRecord, final Throwable exception) {
+            final int subTaskIndex, final Object dirtyRecord, final Throwable exception) {
         collect(subTaskIndex, dirtyRecord, exception, "", null);
     }
 
@@ -65,7 +65,7 @@ public interface DirtyRecordCollector extends Serializable {
     }
 
     default void collectFromUserRule(
-            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
+            int subTaskIndex, Object record, String errorMessage, CatalogTable catalogTable) {
         collect(subTaskIndex, record, null, errorMessage, catalogTable);
     }
 
@@ -82,7 +82,7 @@ public interface DirtyRecordCollector extends Serializable {
 
     default void checkThreshold() throws Exception {}
 
-    default void setDistributedCounter(Object counter) {}
+    default void setDistributedCounter(DistributedCounter counter) {}
 
     default void incrementDistributedCounter() {}
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorFactory.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorFactory.java
@@ -90,20 +90,20 @@ public class DirtyRecordCollectorFactory {
         }
 
         if (provider == null) {
-            log.warn(
-                    "No DirtyRecordCollectorProvider found for type '{}'. "
-                            + "Available types: {}. Using NoOp collector.",
-                    type,
-                    PROVIDERS.keySet());
-            return NoOpDirtyRecordCollector.INSTANCE;
+            throw new IllegalArgumentException(
+                    "Unknown dirty.collector type '"
+                            + type
+                            + "'. Available built-in types: "
+                            + PROVIDERS.keySet()
+                            + ". Register a custom DirtyRecordCollectorProvider via SPI.");
         }
 
         DirtyRecordCollector collector = provider.createCollector();
         try {
             collector.init(config);
         } catch (Exception e) {
-            log.error("Failed to initialize dirty record collector: {}", type, e);
-            return NoOpDirtyRecordCollector.INSTANCE;
+            throw new RuntimeException(
+                    "Failed to initialize dirty record collector of type '" + type + "'", e);
         }
 
         log.info(

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorFactory.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.factory.FactoryUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for creating dirty record collectors.
+ *
+ * <p>Built-in types ("log", "noop") are instantiated directly without SPI. Custom collector types
+ * are discovered via {@link FactoryUtil#discoverFactories}.
+ */
+@Slf4j
+public class DirtyRecordCollectorFactory {
+
+    private static final Map<String, DirtyRecordCollectorProvider> PROVIDERS =
+            new ConcurrentHashMap<>();
+
+    private static volatile boolean discovered = false;
+
+    static {
+        PROVIDERS.put("log", new LogDirtyRecordCollectorProvider());
+    }
+
+    private static void discoverCustomProviders() {
+        if (discovered) {
+            return;
+        }
+        synchronized (DirtyRecordCollectorFactory.class) {
+            if (discovered) {
+                return;
+            }
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                List<DirtyRecordCollectorProvider> providers =
+                        FactoryUtil.discoverFactories(
+                                classLoader, DirtyRecordCollectorProvider.class);
+                for (DirtyRecordCollectorProvider provider : providers) {
+                    String type = provider.getType().toLowerCase();
+                    PROVIDERS.putIfAbsent(type, provider);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to discover custom DirtyRecordCollectorProviders via SPI", e);
+            }
+            log.info(
+                    "DirtyRecordCollectorProvider discovery complete. Available types: {}",
+                    PROVIDERS.keySet());
+            discovered = true;
+        }
+    }
+
+    public static DirtyRecordCollector createCollector(Config config) {
+        if (config == null || !config.hasPath("type")) {
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+
+        String type = config.getString("type").toLowerCase();
+
+        if ("noop".equals(type) || "none".equals(type)) {
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+
+        DirtyRecordCollectorProvider provider = PROVIDERS.get(type);
+        if (provider == null) {
+            discoverCustomProviders();
+            provider = PROVIDERS.get(type);
+        }
+
+        if (provider == null) {
+            log.warn(
+                    "No DirtyRecordCollectorProvider found for type '{}'. "
+                            + "Available types: {}. Using NoOp collector.",
+                    type,
+                    PROVIDERS.keySet());
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+
+        DirtyRecordCollector collector = provider.createCollector();
+        try {
+            collector.init(config);
+        } catch (Exception e) {
+            log.error("Failed to initialize dirty record collector: {}", type, e);
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+
+        log.info(
+                "Created dirty record collector: type='{}', class={}",
+                type,
+                collector.getClass().getSimpleName());
+        return collector;
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
@@ -21,9 +21,7 @@ import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.factory.Factory;
 
 /**
- * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's Factory
- * so that providers are discovered via the standard {@code FactoryUtil.discoverFactories()}
- * mechanism.
+ * SPI interface for pluggable dirty record collector implementations.
  *
  * <p>Configuration example:
  *

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
@@ -21,9 +21,10 @@ import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.factory.Factory;
 
 /**
- * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's
- * Factory so that providers are discovered via the standard {@code
- * FactoryUtil.discoverFactories()} mechanism.
+ * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's Factory
+ * so that providers are discovered via the standard {@code FactoryUtil.discoverFactories()}
+ * mechanism.
+ *
  * <p>Configuration example:
  *
  * <pre>{@code

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
@@ -21,13 +21,9 @@ import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.factory.Factory;
 
 /**
- * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's {@link
- * Factory} so that providers are discovered via the standard {@code
+ * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's
+ * Factory so that providers are discovered via the standard {@code
  * FactoryUtil.discoverFactories()} mechanism.
- *
- * <p>Register implementations with {@code @AutoService(Factory.class)} or add the fully-qualified
- * class name to {@code META-INF/services/org.apache.seatunnel.api.table.factory.Factory}.
- *
  * <p>Configuration example:
  *
  * <pre>{@code

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.table.factory.Factory;
+
+/**
+ * SPI interface for pluggable dirty record collector implementations. Extends SeaTunnel's {@link
+ * Factory} so that providers are discovered via the standard {@code
+ * FactoryUtil.discoverFactories()} mechanism.
+ *
+ * <p>Register implementations with {@code @AutoService(Factory.class)} or add the fully-qualified
+ * class name to {@code META-INF/services/org.apache.seatunnel.api.table.factory.Factory}.
+ *
+ * <p>Configuration example:
+ *
+ * <pre>{@code
+ * env {
+ *   dirty.collector = {
+ *     type = my-custom-collector
+ *     my_option = value
+ *   }
+ * }
+ * }</pre>
+ */
+public interface DirtyRecordCollectorProvider extends Factory {
+
+    String getType();
+
+    DirtyRecordCollector createCollector();
+
+    @Override
+    default String factoryIdentifier() {
+        return getType();
+    }
+
+    @Override
+    default OptionRule optionRule() {
+        return OptionRule.builder().build();
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DistributedCounter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/DistributedCounter.java
@@ -15,36 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.common.sink;
+package org.apache.seatunnel.api.sink;
 
-import org.apache.seatunnel.api.sink.SinkWriter;
+import java.io.Serializable;
 
-import lombok.extern.slf4j.Slf4j;
+public interface DistributedCounter extends Serializable {
 
-import java.io.IOException;
-import java.util.Optional;
+    void add(long delta);
 
-@Slf4j
-public abstract class AbstractSinkWriter<T, StateT> implements SinkWriter<T, Void, StateT> {
-
-    protected SinkWriter.Context context;
-
-    protected AbstractSinkWriter() {}
-
-    protected AbstractSinkWriter(SinkWriter.Context context) {
-        this.context = context;
-    }
-
-    @Override
-    public abstract void write(T element) throws IOException;
-
-    @Override
-    public Optional<Void> prepareCommit() {
-        return Optional.empty();
-    }
-
-    @Override
-    public final void abortPrepare() {
-        // nothing
-    }
+    long value();
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LocalAtomicCounter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LocalAtomicCounter.java
@@ -15,36 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.common.sink;
+package org.apache.seatunnel.api.sink;
 
-import org.apache.seatunnel.api.sink.SinkWriter;
+import java.util.concurrent.atomic.AtomicLong;
 
-import lombok.extern.slf4j.Slf4j;
+public class LocalAtomicCounter implements DistributedCounter {
 
-import java.io.IOException;
-import java.util.Optional;
+    private static final long serialVersionUID = 1L;
 
-@Slf4j
-public abstract class AbstractSinkWriter<T, StateT> implements SinkWriter<T, Void, StateT> {
+    private final AtomicLong counter = new AtomicLong();
 
-    protected SinkWriter.Context context;
-
-    protected AbstractSinkWriter() {}
-
-    protected AbstractSinkWriter(SinkWriter.Context context) {
-        this.context = context;
+    @Override
+    public void add(long delta) {
+        counter.addAndGet(delta);
     }
 
     @Override
-    public abstract void write(T element) throws IOException;
-
-    @Override
-    public Optional<Void> prepareCommit() {
-        return Optional.empty();
-    }
-
-    @Override
-    public final void abortPrepare() {
-        // nothing
+    public long value() {
+        return counter.get();
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
@@ -153,9 +153,6 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
     }
 
     @Override
-    public void close() throws Exception {}
-
-    @Override
     public long getDirtyRecordCount() {
         return dirtyRecordCount.get();
     }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.utils.ExceptionUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A dirty record collector that logs dirty data information. */
+@Slf4j
+public class LogDirtyRecordCollector implements DirtyRecordCollector {
+
+    private static final long serialVersionUID = 1L;
+
+    private String logLevel = "ERROR";
+    private boolean includeStackTrace = true;
+    // -1 means no threshold
+    private long threshold = -1;
+    private boolean failOnThreshold = false;
+    private final AtomicLong dirtyRecordCount = new AtomicLong(0);
+
+    @Override
+    public void init(Config config) {
+        if (config.hasPath("log_level")) {
+            this.logLevel = config.getString("log_level").toUpperCase();
+        }
+        if (config.hasPath("include_stack_trace")) {
+            this.includeStackTrace = config.getBoolean("include_stack_trace");
+        }
+        if (config.hasPath("threshold")) {
+            this.threshold = config.getLong("threshold");
+        }
+        if (config.hasPath("fail_on_threshold")) {
+            this.failOnThreshold = config.getBoolean("fail_on_threshold");
+        }
+    }
+
+    @Override
+    public void init(Config config, CatalogTable catalogTable) throws Exception {
+        if (config != null && config.hasPath("dirty.collector")) {
+            init(config.getConfig("dirty.collector"));
+        } else if (config != null) {
+            init(config);
+        } else {
+            DirtyRecordCollector.super.init(config, catalogTable);
+        }
+    }
+
+    @Override
+    public void collect(
+            int subTaskIndex,
+            SeaTunnelRow dirtyRecord,
+            Throwable exception,
+            String errorMessage,
+            CatalogTable catalogTable) {
+
+        long currentCount = dirtyRecordCount.incrementAndGet();
+
+        String tableInfo = formatTableInfo(catalogTable);
+
+        String logMessage =
+                String.format(
+                        "Dirty record collected (exception) - SubTask: %d, %s, Count: %d, Record: %s, Error: %s",
+                        subTaskIndex,
+                        tableInfo,
+                        currentCount,
+                        dirtyRecord != null ? dirtyRecord.toString() : "null",
+                        errorMessage != null ? errorMessage : "");
+
+        if (includeStackTrace && exception != null) {
+            logMessage += "\nException: " + ExceptionUtils.getMessage(exception);
+        }
+
+        doLog(logMessage);
+        checkThresholdRuntime();
+    }
+
+    @Override
+    public void collectFromUserRule(
+            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
+
+        long currentCount = dirtyRecordCount.incrementAndGet();
+        String tableInfo = formatTableInfo(catalogTable);
+        String logMessage =
+                String.format(
+                        "Dirty record collected (user rule) - SubTask: %d, %s, Count: %d, Record: %s, Reason: %s",
+                        subTaskIndex,
+                        tableInfo,
+                        currentCount,
+                        record != null ? record.toString() : "null",
+                        errorMessage != null ? errorMessage : "");
+
+        doLog(logMessage);
+        checkThresholdRuntime();
+    }
+
+    private static String formatTableInfo(CatalogTable catalogTable) {
+        return catalogTable != null
+                ? String.format(
+                        "Table: %s.%s.%s",
+                        catalogTable.getTableId().getDatabaseName(),
+                        catalogTable.getTableId().getSchemaName(),
+                        catalogTable.getTableId().getTableName())
+                : "Table: unknown";
+    }
+
+    private void doLog(String logMessage) {
+        switch (logLevel) {
+            case "ERROR":
+                log.error(logMessage);
+                break;
+            case "WARN":
+                log.warn(logMessage);
+                break;
+            case "INFO":
+                log.info(logMessage);
+                break;
+            case "DEBUG":
+                log.debug(logMessage);
+                break;
+            default:
+                log.error(logMessage);
+        }
+    }
+
+    private void checkThresholdRuntime() {
+        try {
+            checkThreshold();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public long getDirtyRecordCount() {
+        return dirtyRecordCount.get();
+    }
+
+    @Override
+    public void checkThreshold() throws Exception {
+        if (threshold > 0 && dirtyRecordCount.get() >= threshold) {
+            String message =
+                    String.format(
+                            "Dirty record threshold exceeded: %d >= %d",
+                            dirtyRecordCount.get(), threshold);
+
+            if (failOnThreshold) {
+                log.error(message + " - Task will be failed!");
+                throw new RuntimeException(message);
+            } else {
+                log.warn(message + " - Threshold reached but task continues");
+            }
+        }
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
@@ -20,12 +20,17 @@ package org.apache.seatunnel.api.sink;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.utils.ExceptionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** A dirty record collector that logs dirty data information. */
 @Slf4j
@@ -35,69 +40,23 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
 
     private String logLevel = "ERROR";
     private boolean includeStackTrace = true;
-    // -1 means no threshold
     private long threshold = -1;
     private boolean failOnThreshold = false;
-    private final AtomicLong dirtyRecordCount = new AtomicLong(0);
-    private transient Object distributedCounter;
+    private String logPayload = "false";
+    private Set<String> maskFields = new HashSet<>();
+    private DistributedCounter dirtyRecordCounter = new LocalAtomicCounter();
 
     @Override
-    public void setDistributedCounter(Object counter) {
-        this.distributedCounter = counter;
+    public void setDistributedCounter(DistributedCounter counter) {
+        this.dirtyRecordCounter = counter != null ? counter : new LocalAtomicCounter();
         log.debug(
                 "[LogCollector] distributed counter set: {}",
-                counter != null ? counter.getClass().getName() : "null");
+                dirtyRecordCounter.getClass().getName());
     }
 
     @Override
     public void incrementDistributedCounter() {
-        if (distributedCounter == null) {
-            return;
-        }
-        try {
-            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
-                // spark LongAccumulator
-                distributedCounter
-                        .getClass()
-                        .getMethod("add", long.class)
-                        .invoke(distributedCounter, 1L);
-            } else {
-                // flink LongCounter or seaTunnel Counter
-                try {
-                    distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
-                } catch (NoSuchMethodException e) {
-                    distributedCounter
-                            .getClass()
-                            .getMethod("add", long.class)
-                            .invoke(distributedCounter, 1L);
-                }
-            }
-        } catch (Exception e) {
-            log.trace("Failed to increment distributed counter", e);
-        }
-    }
-
-    private long getDistributedCount() {
-        if (distributedCounter == null) {
-            return dirtyRecordCount.get();
-        }
-        try {
-            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
-                // spark LongAccumulator
-                return (Long)
-                        distributedCounter.getClass().getMethod("value").invoke(distributedCounter);
-            } else {
-                // flink or seaTunnel Counter
-                return (Long)
-                        distributedCounter
-                                .getClass()
-                                .getMethod("getCount")
-                                .invoke(distributedCounter);
-            }
-        } catch (Exception e) {
-            log.trace("Failed to get distributed count, using local count", e);
-            return dirtyRecordCount.get();
-        }
+        dirtyRecordCounter.add(1L);
     }
 
     @Override
@@ -113,6 +72,18 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
         }
         if (config.hasPath("fail_on_threshold")) {
             this.failOnThreshold = config.getBoolean("fail_on_threshold");
+        }
+        if (config.hasPath("log_payload")) {
+            this.logPayload = config.getString("log_payload").toLowerCase();
+        }
+        if (config.hasPath("mask_fields")) {
+            this.maskFields =
+                    config.getStringList("mask_fields").stream()
+                            .map(String::toLowerCase)
+                            .collect(Collectors.toSet());
+        }
+        if ("full".equals(logPayload)) {
+            log.warn("Dirty collector payload logging is enabled in full mode");
         }
     }
 
@@ -130,23 +101,20 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
     @Override
     public void collect(
             int subTaskIndex,
-            SeaTunnelRow dirtyRecord,
+            Object dirtyRecord,
             Throwable exception,
             String errorMessage,
             CatalogTable catalogTable) {
-
-        long currentCount = dirtyRecordCount.incrementAndGet();
         incrementDistributedCounter();
-
-        String tableInfo = formatTableInfo(catalogTable);
+        long currentCount = dirtyRecordCounter.value();
 
         String logMessage =
                 String.format(
                         "Dirty record collected (exception) - SubTask: %d, %s, Count: %d, Record: %s, Error: %s",
                         subTaskIndex,
-                        tableInfo,
+                        formatTableInfo(catalogTable),
                         currentCount,
-                        dirtyRecord != null ? dirtyRecord.toString() : "null",
+                        summarizeRecord(dirtyRecord, catalogTable),
                         errorMessage != null ? errorMessage : "");
 
         if (includeStackTrace && exception != null) {
@@ -159,19 +127,17 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public void collectFromUserRule(
-            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
-
-        long currentCount = dirtyRecordCount.incrementAndGet();
+            int subTaskIndex, Object record, String errorMessage, CatalogTable catalogTable) {
         incrementDistributedCounter();
+        long currentCount = dirtyRecordCounter.value();
 
-        String tableInfo = formatTableInfo(catalogTable);
         String logMessage =
                 String.format(
                         "Dirty record collected (user rule) - SubTask: %d, %s, Count: %d, Record: %s, Reason: %s",
                         subTaskIndex,
-                        tableInfo,
+                        formatTableInfo(catalogTable),
                         currentCount,
-                        record != null ? record.toString() : "null",
+                        summarizeRecord(record, catalogTable),
                         errorMessage != null ? errorMessage : "");
 
         doLog(logMessage);
@@ -186,6 +152,66 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
                         catalogTable.getTableId().getSchemaName(),
                         catalogTable.getTableId().getTableName())
                 : "Table: unknown";
+    }
+
+    private String summarizeRecord(Object dirtyRecord, CatalogTable catalogTable) {
+        if (!(dirtyRecord instanceof SeaTunnelRow)) {
+            return dirtyRecord == null
+                    ? "null"
+                    : "payloadType=" + dirtyRecord.getClass().getSimpleName();
+        }
+        SeaTunnelRow row = (SeaTunnelRow) dirtyRecord;
+        if ("fields".equals(logPayload)) {
+            return summarizeFieldNames(row, catalogTable);
+        }
+        if ("full".equals(logPayload)) {
+            return summarizeFullRow(row, catalogTable);
+        }
+        return "fields=" + row.getArity();
+    }
+
+    private String summarizeFieldNames(SeaTunnelRow row, CatalogTable catalogTable) {
+        List<String> fieldNames = getFieldNames(row, catalogTable);
+        List<String> nonNullFields = new ArrayList<>();
+        for (int i = 0; i < row.getArity(); i++) {
+            if (row.getField(i) != null) {
+                nonNullFields.add(fieldNames.get(i));
+            }
+        }
+        return "nonNullFields=" + nonNullFields;
+    }
+
+    private String summarizeFullRow(SeaTunnelRow row, CatalogTable catalogTable) {
+        List<String> fieldNames = getFieldNames(row, catalogTable);
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < row.getArity(); i++) {
+            String fieldName = fieldNames.get(i);
+            Object value = row.getField(i);
+            values.add(
+                    fieldName
+                            + "="
+                            + (maskFields.contains(fieldName.toLowerCase()) ? "***" : value));
+        }
+        return values.toString();
+    }
+
+    private List<String> getFieldNames(SeaTunnelRow row, CatalogTable catalogTable) {
+        if (catalogTable == null || catalogTable.getTableSchema() == null) {
+            return buildPositionalFieldNames(row.getArity());
+        }
+        List<Column> columns = catalogTable.getTableSchema().getColumns();
+        if (columns == null || columns.size() != row.getArity()) {
+            return buildPositionalFieldNames(row.getArity());
+        }
+        return columns.stream().map(Column::getName).collect(Collectors.toList());
+    }
+
+    private List<String> buildPositionalFieldNames(int arity) {
+        List<String> fieldNames = new ArrayList<>(arity);
+        for (int i = 0; i < arity; i++) {
+            fieldNames.add("field_" + i);
+        }
+        return fieldNames;
     }
 
     private void doLog(String logMessage) {
@@ -217,7 +243,7 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public long getDirtyRecordCount() {
-        return dirtyRecordCount.get();
+        return dirtyRecordCounter.value();
     }
 
     @Override
@@ -226,13 +252,10 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
             return;
         }
 
-        long count = getDistributedCount();
+        long count = dirtyRecordCounter.value();
         if (count >= threshold) {
             String message =
-                    String.format(
-                            "Dirty record threshold exceeded: %d >= %d (distributed=%s)",
-                            count, threshold, distributedCounter != null);
-
+                    String.format("Dirty record threshold exceeded: %d >= %d", count, threshold);
             if (failOnThreshold) {
                 log.error(message + " - Task will be failed!");
                 throw new RuntimeException(message);

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollector.java
@@ -39,6 +39,66 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
     private long threshold = -1;
     private boolean failOnThreshold = false;
     private final AtomicLong dirtyRecordCount = new AtomicLong(0);
+    private transient Object distributedCounter;
+
+    @Override
+    public void setDistributedCounter(Object counter) {
+        this.distributedCounter = counter;
+        log.debug(
+                "[LogCollector] distributed counter set: {}",
+                counter != null ? counter.getClass().getName() : "null");
+    }
+
+    @Override
+    public void incrementDistributedCounter() {
+        if (distributedCounter == null) {
+            return;
+        }
+        try {
+            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
+                // spark LongAccumulator
+                distributedCounter
+                        .getClass()
+                        .getMethod("add", long.class)
+                        .invoke(distributedCounter, 1L);
+            } else {
+                // flink LongCounter or seaTunnel Counter
+                try {
+                    distributedCounter.getClass().getMethod("inc").invoke(distributedCounter);
+                } catch (NoSuchMethodException e) {
+                    distributedCounter
+                            .getClass()
+                            .getMethod("add", long.class)
+                            .invoke(distributedCounter, 1L);
+                }
+            }
+        } catch (Exception e) {
+            log.trace("Failed to increment distributed counter", e);
+        }
+    }
+
+    private long getDistributedCount() {
+        if (distributedCounter == null) {
+            return dirtyRecordCount.get();
+        }
+        try {
+            if (distributedCounter.getClass().getName().contains("LongAccumulator")) {
+                // spark LongAccumulator
+                return (Long)
+                        distributedCounter.getClass().getMethod("value").invoke(distributedCounter);
+            } else {
+                // flink or seaTunnel Counter
+                return (Long)
+                        distributedCounter
+                                .getClass()
+                                .getMethod("getCount")
+                                .invoke(distributedCounter);
+            }
+        } catch (Exception e) {
+            log.trace("Failed to get distributed count, using local count", e);
+            return dirtyRecordCount.get();
+        }
+    }
 
     @Override
     public void init(Config config) {
@@ -76,6 +136,7 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
             CatalogTable catalogTable) {
 
         long currentCount = dirtyRecordCount.incrementAndGet();
+        incrementDistributedCounter();
 
         String tableInfo = formatTableInfo(catalogTable);
 
@@ -101,6 +162,8 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
             int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
 
         long currentCount = dirtyRecordCount.incrementAndGet();
+        incrementDistributedCounter();
+
         String tableInfo = formatTableInfo(catalogTable);
         String logMessage =
                 String.format(
@@ -159,11 +222,16 @@ public class LogDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public void checkThreshold() throws Exception {
-        if (threshold > 0 && dirtyRecordCount.get() >= threshold) {
+        if (threshold <= 0) {
+            return;
+        }
+
+        long count = getDistributedCount();
+        if (count >= threshold) {
             String message =
                     String.format(
-                            "Dirty record threshold exceeded: %d >= %d",
-                            dirtyRecordCount.get(), threshold);
+                            "Dirty record threshold exceeded: %d >= %d (distributed=%s)",
+                            count, threshold, distributedCounter != null);
 
             if (failOnThreshold) {
                 log.error(message + " - Task will be failed!");

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollectorProvider.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/LogDirtyRecordCollectorProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.factory.Factory;
+
+import com.google.auto.service.AutoService;
+
+/** Built-in provider for the "log" type dirty record collector. */
+@AutoService(Factory.class)
+public class LogDirtyRecordCollectorProvider implements DirtyRecordCollectorProvider {
+
+    @Override
+    public String getType() {
+        return "log";
+    }
+
+    @Override
+    public DirtyRecordCollector createCollector() {
+        return new LogDirtyRecordCollector();
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/NoOpDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/NoOpDirtyRecordCollector.java
@@ -18,7 +18,6 @@
 package org.apache.seatunnel.api.sink;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
-import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 
 /**
  * A no-operation dirty record collector that does nothing. This is used as a default implementation
@@ -35,8 +34,12 @@ public class NoOpDirtyRecordCollector implements DirtyRecordCollector {
     @Override
     public void collect(
             int subTaskIndex,
-            SeaTunnelRow dirtyRecord,
+            Object dirtyRecord,
             Throwable exception,
             String errorMessage,
             CatalogTable catalogTable) {}
+
+    private Object readResolve() {
+        return INSTANCE;
+    }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/NoOpDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/NoOpDirtyRecordCollector.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+/**
+ * A no-operation dirty record collector that does nothing. This is used as a default implementation
+ * when no dirty data collection is configured.
+ */
+public class NoOpDirtyRecordCollector implements DirtyRecordCollector {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final NoOpDirtyRecordCollector INSTANCE = new NoOpDirtyRecordCollector();
+
+    private NoOpDirtyRecordCollector() {}
+
+    @Override
+    public void collect(
+            int subTaskIndex,
+            SeaTunnelRow dirtyRecord,
+            Throwable exception,
+            String errorMessage,
+            CatalogTable catalogTable) {}
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SinkWriter.java
@@ -117,5 +117,12 @@ public interface SinkWriter<T, CommitInfoT, StateT> {
          * @return
          */
         EventListener getEventListener();
+
+        /**
+         * Get the dirty record collector for this writer.
+         *
+         * @return the dirty record collector
+         */
+        DirtyRecordCollector getDirtyRecordCollector();
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SinkWriter.java
@@ -123,6 +123,8 @@ public interface SinkWriter<T, CommitInfoT, StateT> {
          *
          * @return the dirty record collector
          */
-        DirtyRecordCollector getDirtyRecordCollector();
+        default DirtyRecordCollector getDirtyRecordCollector() {
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.api.sink;
 
+import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -42,13 +43,13 @@ public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
     public ValidatingDirtyRecordCollector(
             DirtyRecordCollector delegate, DirtyDataValidator validator) {
         this.delegate = delegate;
-        this.validator = validator;
+        this.validator = Preconditions.checkNotNull(validator, "validator cannot be null");
     }
 
     @Override
     public void collect(
             int subTaskIndex,
-            SeaTunnelRow dirtyRecord,
+            Object dirtyRecord,
             Throwable exception,
             String errorMessage,
             CatalogTable catalogTable) {
@@ -57,16 +58,13 @@ public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
 
     @Override
     public void collectFromUserRule(
-            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
+            int subTaskIndex, Object record, String errorMessage, CatalogTable catalogTable) {
         delegate.collectFromUserRule(subTaskIndex, record, errorMessage, catalogTable);
     }
 
     @Override
     public boolean validateAndCollectIfDirty(
             int subTaskIndex, SeaTunnelRow record, CatalogTable catalogTable) {
-        if (validator == null) {
-            return false;
-        }
         DirtyDataValidator.ValidationResult result;
         try {
             result = validator.validate(record, catalogTable);
@@ -98,9 +96,7 @@ public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
     @Override
     public void close() throws Exception {
         try {
-            if (validator != null) {
-                validator.close();
-            }
+            validator.close();
         } finally {
             delegate.close();
         }
@@ -117,7 +113,7 @@ public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
     }
 
     @Override
-    public void setDistributedCounter(Object counter) {
+    public void setDistributedCounter(DistributedCounter counter) {
         delegate.setDistributedCounter(counter);
     }
 

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
@@ -115,4 +115,14 @@ public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
     public void checkThreshold() throws Exception {
         delegate.checkThreshold();
     }
+
+    @Override
+    public void setDistributedCounter(Object counter) {
+        delegate.setDistributedCounter(counter);
+    }
+
+    @Override
+    public void incrementDistributedCounter() {
+        delegate.incrementDistributedCounter();
+    }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/ValidatingDirtyRecordCollector.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Decorator that adds user-defined validation to any {@link DirtyRecordCollector}. All collection
+ * methods delegate to the wrapped collector; {@link #validateAndCollectIfDirty} consults the {@link
+ * DirtyDataValidator} before writing and collects records that fail validation.
+ *
+ * <p>Created by {@link DirtyCollectorConfigProcessor} when a {@code dirty.validator} is configured.
+ */
+@Slf4j
+public class ValidatingDirtyRecordCollector implements DirtyRecordCollector {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DirtyRecordCollector delegate;
+    private final DirtyDataValidator validator;
+
+    public ValidatingDirtyRecordCollector(
+            DirtyRecordCollector delegate, DirtyDataValidator validator) {
+        this.delegate = delegate;
+        this.validator = validator;
+    }
+
+    @Override
+    public void collect(
+            int subTaskIndex,
+            SeaTunnelRow dirtyRecord,
+            Throwable exception,
+            String errorMessage,
+            CatalogTable catalogTable) {
+        delegate.collect(subTaskIndex, dirtyRecord, exception, errorMessage, catalogTable);
+    }
+
+    @Override
+    public void collectFromUserRule(
+            int subTaskIndex, SeaTunnelRow record, String errorMessage, CatalogTable catalogTable) {
+        delegate.collectFromUserRule(subTaskIndex, record, errorMessage, catalogTable);
+    }
+
+    @Override
+    public boolean validateAndCollectIfDirty(
+            int subTaskIndex, SeaTunnelRow record, CatalogTable catalogTable) {
+        if (validator == null) {
+            return false;
+        }
+        DirtyDataValidator.ValidationResult result;
+        try {
+            result = validator.validate(record, catalogTable);
+        } catch (Exception e) {
+            log.warn("User validator failed, treating as non-dirty: {}", e.getMessage());
+            return false;
+        }
+        if (result.isDirty()) {
+            collectFromUserRule(
+                    subTaskIndex,
+                    record,
+                    result.getErrorMessage() != null ? result.getErrorMessage() : "user rule",
+                    catalogTable);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void init(Config config) throws Exception {
+        delegate.init(config);
+    }
+
+    @Override
+    public void init(Config config, CatalogTable catalogTable) throws Exception {
+        delegate.init(config, catalogTable);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            if (validator != null) {
+                validator.close();
+            }
+        } finally {
+            delegate.close();
+        }
+    }
+
+    @Override
+    public long getDirtyRecordCount() {
+        return delegate.getDirtyRecordCount();
+    }
+
+    @Override
+    public void checkThreshold() throws Exception {
+        delegate.checkThreshold();
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/SinkContextProxy.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/SinkContextProxy.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.api.sink.multitablesink;
 
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 
 public class SinkContextProxy implements SinkWriter.Context {
@@ -53,5 +54,9 @@ public class SinkContextProxy implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return context.getEventListener();
+    }
+
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return context.getDirtyRecordCollector();
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class DirtyRecordCollectorTest {
+
+    @Test
+    void testConcurrentCollect() throws Exception {
+        CountingDirtyRecordCollector collector = new CountingDirtyRecordCollector();
+        int threadCount = 8;
+        int recordsPerThread = 200;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(
+                    () -> {
+                        try {
+                            for (int j = 0; j < recordsPerThread; j++) {
+                                collector.collect(0, new SeaTunnelRow(new Object[] {j}), null);
+                            }
+                        } finally {
+                            countDownLatch.countDown();
+                        }
+                    });
+        }
+
+        Assertions.assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        executorService.shutdownNow();
+        Assertions.assertEquals(threadCount * recordsPerThread, collector.getDirtyRecordCount());
+    }
+
+    @Test
+    void testThresholdBoundary() {
+        CountingDirtyRecordCollector collector = new CountingDirtyRecordCollector();
+        collector.init(ConfigFactory.parseString("threshold=2\nfail_on_threshold=true"));
+
+        Assertions.assertDoesNotThrow(
+                () -> collector.collect(0, new SeaTunnelRow(new Object[] {1}), null));
+        RuntimeException thresholdException =
+                Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> collector.collect(0, new SeaTunnelRow(new Object[] {2}), null));
+        Assertions.assertTrue(thresholdException.getMessage().contains("threshold exceeded"));
+
+        RuntimeException aboveThresholdException =
+                Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> collector.collect(0, new SeaTunnelRow(new Object[] {3}), null));
+        Assertions.assertTrue(aboveThresholdException.getMessage().contains("threshold exceeded"));
+    }
+
+    @Test
+    void testNoOpReadResolveSingleton() throws Exception {
+        Object restored = roundTrip(NoOpDirtyRecordCollector.INSTANCE);
+        Assertions.assertSame(NoOpDirtyRecordCollector.INSTANCE, restored);
+    }
+
+    @Test
+    void testDecoratorCollectsNonRowPayload() throws Exception {
+        CountingDirtyRecordCollector collector = new CountingDirtyRecordCollector();
+        DirtyDataAwareSinkWriter<String, Void, Void> writer =
+                new DirtyDataAwareSinkWriter<>(new FailingWriter(), collector, 1);
+
+        Assertions.assertDoesNotThrow(() -> writer.write("payload"));
+        Assertions.assertEquals(1L, collector.getDirtyRecordCount());
+    }
+
+    @Test
+    void testValidatingCollectorRequiresValidator() {
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new ValidatingDirtyRecordCollector(NoOpDirtyRecordCollector.INSTANCE, null));
+    }
+
+    @Test
+    void testCollectorServiceDiscovery() {
+        DirtyRecordCollector collector =
+                DirtyRecordCollectorFactory.createCollector(
+                        ConfigFactory.parseString("type=counting"));
+        Assertions.assertInstanceOf(CountingDirtyRecordCollector.class, collector);
+    }
+
+    @Test
+    void testValidatorServiceDiscovery() {
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("catalog", "db", "table"),
+                        TableSchema.builder().build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        "comment");
+        DirtyDataValidator validator =
+                DirtyDataValidatorFactory.createValidator(
+                        "AlwaysDirtyDataValidator", ConfigFactory.empty(), catalogTable);
+        Assertions.assertNotNull(validator);
+        Assertions.assertTrue(
+                validator.validate(new SeaTunnelRow(new Object[] {1}), catalogTable).isDirty());
+    }
+
+    private Object roundTrip(Object value) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            outputStream.writeObject(value);
+        }
+        try (ObjectInputStream inputStream =
+                new ObjectInputStream(
+                        new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
+            return inputStream.readObject();
+        }
+    }
+
+    private static class FailingWriter implements SinkWriter<String, Void, Void> {
+
+        @Override
+        public void write(String element) throws IOException {
+            throw new IOException("boom");
+        }
+
+        @Override
+        public Optional<Void> prepareCommit() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void abortPrepare() {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/DirtyRecordCollectorTest.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.api.sink;
 
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
+import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
@@ -135,6 +136,88 @@ public class DirtyRecordCollectorTest {
                 validator.validate(new SeaTunnelRow(new Object[] {1}), catalogTable).isDirty());
     }
 
+    @Test
+    void testSinkWriterContextDefaultCollectorIsNoOp() {
+        SinkWriter.Context context =
+                new SinkWriter.Context() {
+                    @Override
+                    public int getIndexOfSubtask() {
+                        return 0;
+                    }
+
+                    @Override
+                    public org.apache.seatunnel.api.common.metrics.MetricsContext
+                            getMetricsContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public EventListener getEventListener() {
+                        return null;
+                    }
+                };
+
+        Assertions.assertSame(NoOpDirtyRecordCollector.INSTANCE, context.getDirtyRecordCollector());
+    }
+
+    @Test
+    void testUnknownCollectorTypeFailsFast() {
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                DirtyRecordCollectorFactory.createCollector(
+                                        ConfigFactory.parseString("type=missing")));
+        Assertions.assertTrue(exception.getMessage().contains("Unknown dirty.collector type"));
+    }
+
+    @Test
+    void testMissingValidatorTypeFailsFast() {
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                DirtyCollectorConfigProcessor.createValidator(
+                                        ConfigFactory.parseString("dirty.validator={}"), null));
+        Assertions.assertTrue(exception.getMessage().contains("missing required 'type'"));
+    }
+
+    @Test
+    void testUnknownValidatorTypeFailsFast() {
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                DirtyCollectorConfigProcessor.createValidator(
+                                        ConfigFactory.parseString(
+                                                "dirty.validator { type = missing }"),
+                                        null));
+        Assertions.assertTrue(exception.getMessage().contains("Could not resolve dirty.validator"));
+    }
+
+    @Test
+    void testDirtyDataAwareWriterClosesCollector() throws Exception {
+        CloseTrackingCollector collector = new CloseTrackingCollector();
+        DirtyDataAwareSinkWriter<String, Void, Void> writer =
+                new DirtyDataAwareSinkWriter<>(new NoOpWriter(), collector, 1);
+
+        writer.close();
+
+        Assertions.assertTrue(collector.closed);
+    }
+
+    @Test
+    void testDirtyDataAwareWriterClosesCollectorWhenDelegateCloseFails() {
+        CloseTrackingCollector collector = new CloseTrackingCollector();
+        DirtyDataAwareSinkWriter<String, Void, Void> writer =
+                new DirtyDataAwareSinkWriter<>(new CloseFailingWriter(), collector, 1);
+
+        IOException exception = Assertions.assertThrows(IOException.class, writer::close);
+
+        Assertions.assertEquals("delegate-close", exception.getMessage());
+        Assertions.assertTrue(collector.closed);
+    }
+
     private Object roundTrip(Object value) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
@@ -163,6 +246,48 @@ public class DirtyRecordCollectorTest {
         public void abortPrepare() {}
 
         @Override
-        public void close() {}
+        public void close() throws IOException {}
+    }
+
+    private static class NoOpWriter implements SinkWriter<String, Void, Void> {
+
+        @Override
+        public void write(String element) {}
+
+        @Override
+        public Optional<Void> prepareCommit() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void abortPrepare() {}
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    private static class CloseFailingWriter extends NoOpWriter {
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException("delegate-close");
+        }
+    }
+
+    private static class CloseTrackingCollector implements DirtyRecordCollector {
+        private boolean closed;
+
+        @Override
+        public void collect(
+                int subTaskIndex,
+                Object dirtyRecord,
+                Throwable exception,
+                String errorMessage,
+                CatalogTable catalogTable) {}
+
+        @Override
+        public void close() {
+            closed = true;
+        }
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
@@ -21,6 +21,8 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.serialization.DefaultSerializer;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.catalog.TablePath;
@@ -100,6 +102,11 @@ public class MultiTableSinkWriterTest {
         @Override
         public EventListener getEventListener() {
             return new DefaultEventProcessor();
+        }
+
+        @Override
+        public DirtyRecordCollector getDirtyRecordCollector() {
+            return NoOpDirtyRecordCollector.INSTANCE;
         }
     }
 

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
@@ -21,8 +21,6 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.serialization.DefaultSerializer;
-import org.apache.seatunnel.api.sink.DirtyRecordCollector;
-import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.catalog.TablePath;
@@ -102,11 +100,6 @@ public class MultiTableSinkWriterTest {
         @Override
         public EventListener getEventListener() {
             return new DefaultEventProcessor();
-        }
-
-        @Override
-        public DirtyRecordCollector getDirtyRecordCollector() {
-            return NoOpDirtyRecordCollector.INSTANCE;
         }
     }
 

--- a/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/sink/AbstractSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/sink/AbstractSinkWriter.java
@@ -17,18 +17,110 @@
 
 package org.apache.seatunnel.connectors.seatunnel.common.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
 import java.util.Optional;
 
+@Slf4j
 public abstract class AbstractSinkWriter<T, StateT> implements SinkWriter<T, Void, StateT> {
+
+    protected SinkWriter.Context context;
+
+    protected AbstractSinkWriter() {}
+
+    protected AbstractSinkWriter(SinkWriter.Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Template method that wraps {@link #doWrite(Object)} with dirty data collection.
+     *
+     * <p>Override this method directly if you want full control over write + dirty handling.
+     * Override {@link #doWrite(Object)} if you only need to implement the write logic and want
+     * automatic dirty collection.
+     */
+    @Override
+    public void write(T element) throws IOException {
+        if (validateDirtyRecord(element)) {
+            return;
+        }
+        try {
+            doWrite(element);
+        } catch (Exception e) {
+            if (!tryCollectDirtyRecord(element, e)) {
+                if (e instanceof IOException) {
+                    throw (IOException) e;
+                }
+                throw new IOException(e);
+            }
+        }
+    }
+
+    /**
+     * Subclasses implement this method for actual write logic. Exceptions thrown here are
+     * automatically caught and routed to the dirty data collector.
+     *
+     * @param element the data to write
+     * @throws IOException if write fails and should be treated as dirty data
+     */
+    protected void doWrite(T element) throws IOException {
+        throw new UnsupportedOperationException(
+                "Subclass must override either write() or doWrite()");
+    }
+
+    /**
+     * Pre-validates the record against user-defined dirty rules. Returns true if the record was
+     * collected as dirty.
+     */
+    protected boolean validateDirtyRecord(T element) {
+        if (context == null) {
+            return false;
+        }
+        DirtyRecordCollector collector = context.getDirtyRecordCollector();
+        if (collector == null || collector instanceof NoOpDirtyRecordCollector) {
+            return false;
+        }
+        if (element instanceof SeaTunnelRow) {
+            return collector.validateAndCollectIfDirty(
+                    context.getIndexOfSubtask(), (SeaTunnelRow) element, null);
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to collect a failed record as dirty data. Returns true if the record was collected ,
+     * false if it should be re-thrown.
+     */
+    protected boolean tryCollectDirtyRecord(T element, Exception e) {
+        if (context == null) {
+            return false;
+        }
+        DirtyRecordCollector collector = context.getDirtyRecordCollector();
+        if (collector == null || collector instanceof NoOpDirtyRecordCollector) {
+            return false;
+        }
+        if (element instanceof SeaTunnelRow) {
+            collector.collect(
+                    context.getIndexOfSubtask(),
+                    (SeaTunnelRow) element,
+                    e,
+                    "Write failed: " + e.getMessage());
+            return true;
+        }
+        return false;
+    }
 
     @Override
     public Optional<Void> prepareCommit() {
         return Optional.empty();
     }
 
-    @Override
     public final void abortPrepare() {
         // nothing
     }

--- a/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/sink/AbstractSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/sink/AbstractSinkWriter.java
@@ -121,6 +121,7 @@ public abstract class AbstractSinkWriter<T, StateT> implements SinkWriter<T, Voi
         return Optional.empty();
     }
 
+    @Override
     public final void abortPrepare() {
         // nothing
     }

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSink.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSink.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.console.sink;
 
-import org.apache.seatunnel.shade.com.typesafe.config.Config;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSink;
@@ -39,14 +37,12 @@ public class ConsoleSink extends AbstractSimpleSink<SeaTunnelRow, Void>
     private final boolean isPrintData;
     private final int delayMs;
     private final CatalogTable catalogTable;
-    private final Config pluginConfig;
 
     public ConsoleSink(CatalogTable catalogTable, ReadonlyConfig options) {
         this.catalogTable = catalogTable;
         this.isPrintData = options.get(ConsoleSinkOptions.LOG_PRINT_DATA);
         this.delayMs = options.get(ConsoleSinkOptions.LOG_PRINT_DELAY);
         this.seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
-        this.pluginConfig = options.toConfig();
     }
 
     @Override
@@ -57,11 +53,6 @@ public class ConsoleSink extends AbstractSimpleSink<SeaTunnelRow, Void>
     @Override
     public String getPluginName() {
         return "Console";
-    }
-
-    @Override
-    public Config getPluginConfig() {
-        return pluginConfig;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSink.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSink.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.console.sink;
 
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSink;
@@ -37,12 +39,14 @@ public class ConsoleSink extends AbstractSimpleSink<SeaTunnelRow, Void>
     private final boolean isPrintData;
     private final int delayMs;
     private final CatalogTable catalogTable;
+    private final Config pluginConfig;
 
     public ConsoleSink(CatalogTable catalogTable, ReadonlyConfig options) {
         this.catalogTable = catalogTable;
         this.isPrintData = options.get(ConsoleSinkOptions.LOG_PRINT_DATA);
         this.delayMs = options.get(ConsoleSinkOptions.LOG_PRINT_DELAY);
         this.seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
+        this.pluginConfig = options.toConfig();
     }
 
     @Override
@@ -53,6 +57,11 @@ public class ConsoleSink extends AbstractSimpleSink<SeaTunnelRow, Void>
     @Override
     public String getPluginName() {
         return "Console";
+    }
+
+    @Override
+    public Config getPluginConfig() {
+        return pluginConfig;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
@@ -86,7 +86,7 @@ public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     }
 
     @Override
-    protected void doWrite(SeaTunnelRow element) {
+    public void write(SeaTunnelRow element) {
         if (element.getArity() == 0) {
             return;
         }

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkWriter.java
@@ -47,7 +47,6 @@ public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
 
     private SeaTunnelRowType seaTunnelRowType;
     private final AtomicLong rowCounter = new AtomicLong(0);
-    private final SinkWriter.Context context;
     private final DataTypeChangeEventHandler dataTypeChangeEventHandler;
 
     boolean isPrintData = true;
@@ -58,11 +57,12 @@ public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
             SinkWriter.Context context,
             boolean isPrintData,
             int delayMs) {
+        super(context);
         this.seaTunnelRowType = seaTunnelRowType;
-        this.context = context;
         this.isPrintData = isPrintData;
         this.delayMs = delayMs;
         this.dataTypeChangeEventHandler = new DataTypeChangeEventDispatcher();
+
         log.info("output rowType: {}", fieldsInfo(seaTunnelRowType));
     }
 
@@ -86,7 +86,7 @@ public class ConsoleSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     }
 
     @Override
-    public void write(SeaTunnelRow element) {
+    protected void doWrite(SeaTunnelRow element) {
         if (element.getArity() == 0) {
             return;
         }

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
@@ -21,8 +21,6 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.event.EventListener;
-import org.apache.seatunnel.api.sink.DirtyRecordCollector;
-import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -225,11 +223,6 @@ public class PaimonWriteTest {
                     @Override
                     public EventListener getEventListener() {
                         return null;
-                    }
-
-                    @Override
-                    public DirtyRecordCollector getDirtyRecordCollector() {
-                        return NoOpDirtyRecordCollector.INSTANCE;
                     }
                 };
     }

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/writer/PaimonWriteTest.java
@@ -21,6 +21,8 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -223,6 +225,11 @@ public class PaimonWriteTest {
                     @Override
                     public EventListener getEventListener() {
                         return null;
+                    }
+
+                    @Override
+                    public DirtyRecordCollector getDirtyRecordCollector() {
+                        return NoOpDirtyRecordCollector.INSTANCE;
                     }
                 };
     }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -201,6 +201,9 @@ public class SinkExecuteProcessor
         try {
             return DirtyCollectorConfigProcessor.processConfig(envConfig, sinkConfig);
         } catch (Exception e) {
+            if (DirtyCollectorConfigProcessor.hasDirtyHandlingConfig(envConfig, sinkConfig)) {
+                throw e;
+            }
             LOGGER.warn("Failed to create dirty record collector, using NoOp collector", e);
             return org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector.INSTANCE;
         }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -24,6 +24,8 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.PluginIdentifier;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.api.sink.DirtyCollectorConfigProcessor;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SaveModeExecuteWrapper;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -130,6 +132,9 @@ public class SinkExecuteProcessor
         for (int i = 0; i < plugins.size(); i++) {
             Optional<? extends Factory> factory = plugins.get(i);
             Config sinkConfig = pluginConfigs.get(i);
+            Config mergedSinkConfig =
+                    DirtyCollectorConfigProcessor.getMergedSinkConfigForDirty(
+                            envConfig, sinkConfig);
             DataStreamTableInfo stream =
                     fromSourceTable(sinkConfig, upstreamDataStreams).orElse(input);
             Map<TablePath, SeaTunnelSink> sinks = new HashMap<>();
@@ -137,7 +142,7 @@ public class SinkExecuteProcessor
                 SeaTunnelSink sink =
                         FactoryUtil.createAndPrepareSink(
                                 catalogTable,
-                                ReadonlyConfig.fromConfig(sinkConfig),
+                                ReadonlyConfig.fromConfig(mergedSinkConfig),
                                 classLoader,
                                 sinkConfig.getString(PLUGIN_NAME.key()),
                                 fallbackCreateSink,
@@ -175,13 +180,31 @@ public class SinkExecuteProcessor
                                 .name("BroadcastSchemaHandler")
                                 .setParallelism(parallelism);
             }
+
+            DirtyRecordCollector dirtyCollector = createDirtyRecordCollector(envConfig, sinkConfig);
+
             DataStreamSink<SeaTunnelRow> dataStreamSink =
-                    ds.sinkTo(new FlinkSink<>(sink, stream.getCatalogTables(), parallelism))
+                    stream.getDataStream()
+                            .sinkTo(
+                                    new FlinkSink<>(
+                                            sink,
+                                            stream.getCatalogTables(),
+                                            parallelism,
+                                            dirtyCollector))
                             .name(String.format("%s-Sink", sink.getPluginName()));
             dataStreamSink.setParallelism(parallelism);
         }
         // the sink is the last stream
         return null;
+    }
+
+    protected DirtyRecordCollector createDirtyRecordCollector(Config envConfig, Config sinkConfig) {
+        try {
+            return DirtyCollectorConfigProcessor.processConfig(envConfig, sinkConfig);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to create dirty record collector, using NoOp collector", e);
+            return org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector.INSTANCE;
+        }
     }
 
     // if not support multi table, rollback

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-13-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -184,8 +184,7 @@ public class SinkExecuteProcessor
             DirtyRecordCollector dirtyCollector = createDirtyRecordCollector(envConfig, sinkConfig);
 
             DataStreamSink<SeaTunnelRow> dataStreamSink =
-                    stream.getDataStream()
-                            .sinkTo(
+                    ds.sinkTo(
                                     new FlinkSink<>(
                                             sink,
                                             stream.getCatalogTables(),

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.core.starter.flink.execution;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSink;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -48,7 +49,7 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
 
     @Override
     protected DataStreamSink<SeaTunnelRow> createVersionSpecificDataStreamSink(
-            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig) {
+            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig, DirtyRecordCollector dirtyRecordCollector) {
         boolean isStreaming =
                 envConfig.hasPath("job.mode")
                         && STREAMING.toString().equalsIgnoreCase(envConfig.getString("job.mode"));
@@ -63,7 +64,9 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
                             .name("BroadcastSchemaHandler")
                             .setParallelism(parallelism);
         }
-        return ds.sinkTo(new FlinkSink<>(sink, stream.getCatalogTables(), parallelism))
+        return ds.sinkTo(
+                        new FlinkSink<>(
+                                sink, stream.getCatalogTables(), parallelism, dirtyRecordCollector))
                 .name(String.format("%s-Sink", sink.getPluginName()));
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -49,7 +49,11 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
 
     @Override
     protected DataStreamSink<SeaTunnelRow> createVersionSpecificDataStreamSink(
-            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig, DirtyRecordCollector dirtyRecordCollector) {
+            DataStreamTableInfo stream,
+            SeaTunnelSink sink,
+            int parallelism,
+            Config sinkConfig,
+            DirtyRecordCollector dirtyRecordCollector) {
         boolean isStreaming =
                 envConfig.hasPath("job.mode")
                         && STREAMING.toString().equalsIgnoreCase(envConfig.getString("job.mode"));

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractSinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractSinkExecuteProcessor.java
@@ -203,6 +203,9 @@ public abstract class AbstractSinkExecuteProcessor
         try {
             return DirtyCollectorConfigProcessor.processConfig(envConfig, sinkConfig, catalogTable);
         } catch (Exception e) {
+            if (DirtyCollectorConfigProcessor.hasDirtyHandlingConfig(envConfig, sinkConfig)) {
+                throw e;
+            }
             LOGGER.warn("Failed to create dirty record collector, using NoOp collector", e);
             return NoOpDirtyRecordCollector.INSTANCE;
         }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractSinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/AbstractSinkExecuteProcessor.java
@@ -24,6 +24,9 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.PluginIdentifier;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.api.sink.DirtyCollectorConfigProcessor;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SaveModeExecuteWrapper;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -130,6 +133,9 @@ public abstract class AbstractSinkExecuteProcessor
         for (int i = 0; i < plugins.size(); i++) {
             Optional<? extends Factory> factory = plugins.get(i);
             Config sinkConfig = pluginConfigs.get(i);
+            Config mergedSinkConfig =
+                    DirtyCollectorConfigProcessor.getMergedSinkConfigForDirty(
+                            envConfig, sinkConfig);
             DataStreamTableInfo stream =
                     fromSourceTable(sinkConfig, upstreamDataStreams).orElse(input);
             Map<TablePath, SeaTunnelSink> sinks = new HashMap<>();
@@ -138,7 +144,7 @@ public abstract class AbstractSinkExecuteProcessor
                 SeaTunnelSink sink =
                         FactoryUtil.createAndPrepareSink(
                                 catalogTable,
-                                ReadonlyConfig.fromConfig(sinkConfig),
+                                ReadonlyConfig.fromConfig(mergedSinkConfig),
                                 classLoader,
                                 sinkConfig.getString(PLUGIN_NAME.key()),
                                 fallbackCreateSink,
@@ -162,8 +168,15 @@ public abstract class AbstractSinkExecuteProcessor
                                     ? envConfig.getInt(EnvCommonOptions.PARALLELISM.key())
                                     : 1;
 
+            DirtyRecordCollector dirtyCollector =
+                    createDirtyRecordCollector(
+                            envConfig,
+                            sinkConfig,
+                            (CatalogTable) sink.getWriteCatalogTable().orElse(null));
+
             DataStreamSink<SeaTunnelRow> dataStreamSink =
-                    createVersionSpecificDataStreamSink(stream, sink, parallelism, sinkConfig);
+                    createVersionSpecificDataStreamSink(
+                            stream, sink, parallelism, sinkConfig, dirtyCollector);
 
             if (sinkParallelism || envParallelism) {
                 dataStreamSink.setParallelism(parallelism);
@@ -175,7 +188,25 @@ public abstract class AbstractSinkExecuteProcessor
 
     /** Create version-specific DataStreamSink with multi-table and parallelism support. */
     protected abstract DataStreamSink<SeaTunnelRow> createVersionSpecificDataStreamSink(
-            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig);
+            DataStreamTableInfo stream,
+            SeaTunnelSink sink,
+            int parallelism,
+            Config sinkConfig,
+            DirtyRecordCollector dirtyCollector);
+
+    protected DirtyRecordCollector createDirtyRecordCollector(Config envConfig, Config sinkConfig) {
+        return createDirtyRecordCollector(envConfig, sinkConfig, null);
+    }
+
+    protected DirtyRecordCollector createDirtyRecordCollector(
+            Config envConfig, Config sinkConfig, CatalogTable catalogTable) {
+        try {
+            return DirtyCollectorConfigProcessor.processConfig(envConfig, sinkConfig, catalogTable);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to create dirty record collector, using NoOp collector", e);
+            return NoOpDirtyRecordCollector.INSTANCE;
+        }
+    }
 
     // if not support multi table, rollback
     public SeaTunnelSink tryGenerateMultiTableSink(

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.core.starter.flink.execution;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
 import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSink;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -49,7 +50,7 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
 
     @Override
     protected DataStreamSink<SeaTunnelRow> createVersionSpecificDataStreamSink(
-            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig) {
+            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig, DirtyRecordCollector dirtyCollector) {
         boolean isStreaming =
                 envConfig.hasPath("job.mode")
                         && STREAMING.toString().equalsIgnoreCase(envConfig.getString("job.mode"));
@@ -66,7 +67,11 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
         }
         return ds.sinkTo(
                         SinkV1Adapter.wrap(
-                                new FlinkSink<>(sink, stream.getCatalogTables(), parallelism)))
+                                new FlinkSink<>(
+                                        sink,
+                                        stream.getCatalogTables(),
+                                        parallelism,
+                                        dirtyCollector)))
                 .name(String.format("%s-Sink", sink.getPluginName()));
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java
@@ -50,7 +50,11 @@ public class SinkExecuteProcessor extends AbstractSinkExecuteProcessor {
 
     @Override
     protected DataStreamSink<SeaTunnelRow> createVersionSpecificDataStreamSink(
-            DataStreamTableInfo stream, SeaTunnelSink sink, int parallelism, Config sinkConfig, DirtyRecordCollector dirtyCollector) {
+            DataStreamTableInfo stream,
+            SeaTunnelSink sink,
+            int parallelism,
+            Config sinkConfig,
+            DirtyRecordCollector dirtyCollector) {
         boolean isStreaming =
                 envConfig.hasPath("job.mode")
                         && STREAMING.toString().equalsIgnoreCase(envConfig.getString("job.mode"));

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-2-starter/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -24,6 +24,8 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.PluginIdentifier;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.api.sink.DirtyCollectorConfigProcessor;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SaveModeExecuteWrapper;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -108,6 +110,10 @@ public class SinkExecuteProcessor
                 sinkPluginDiscovery::createPluginInstance;
         for (int i = 0; i < plugins.size(); i++) {
             Config sinkConfig = pluginConfigs.get(i);
+            Config envConfig = sparkRuntimeEnvironment.getConfig();
+            Config mergedSinkConfig =
+                    DirtyCollectorConfigProcessor.getMergedSinkConfigForDirty(
+                            envConfig, sinkConfig);
             DatasetTableInfo datasetTableInfo =
                     fromSourceTable(sinkConfig, sparkRuntimeEnvironment, upstreamDataStreams)
                             .orElse(input);
@@ -132,7 +138,7 @@ public class SinkExecuteProcessor
                                 SeaTunnelSink<Object, Object, Object, Object> sink =
                                         FactoryUtil.createAndPrepareSink(
                                                 catalogTable,
-                                                ReadonlyConfig.fromConfig(sinkConfig),
+                                                ReadonlyConfig.fromConfig(mergedSinkConfig),
                                                 classLoader,
                                                 sinkConfig.getString(PLUGIN_NAME.key()),
                                                 fallbackCreateSink,
@@ -150,8 +156,17 @@ public class SinkExecuteProcessor
                     sparkRuntimeEnvironment.getSparkSession().sparkContext().applicationId();
             CatalogTable[] catalogTables =
                     datasetTableInfo.getCatalogTables().toArray(new CatalogTable[0]);
+            CatalogTable firstCatalogTable = catalogTables.length > 0 ? catalogTables[0] : null;
+            DirtyRecordCollector dirtyCollector =
+                    DirtyCollectorConfigProcessor.processConfig(
+                            envConfig, sinkConfig, firstCatalogTable);
             SparkSinkInjector.inject(
-                            dataset.write(), sink, catalogTables, applicationId, parallelism)
+                            dataset.write(),
+                            sink,
+                            catalogTables,
+                            applicationId,
+                            parallelism,
+                            dirtyCollector)
                     .option("checkpointLocation", "/tmp")
                     .save();
         }

--- a/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
+++ b/seatunnel-core/seatunnel-spark-starter/seatunnel-spark-starter-common/src/main/java/org/apache/seatunnel/core/starter/spark/execution/SinkExecuteProcessor.java
@@ -24,6 +24,8 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.PluginIdentifier;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.api.sink.DirtyCollectorConfigProcessor;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SaveModeExecuteWrapper;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -112,6 +114,10 @@ public class SinkExecuteProcessor
                 sinkPluginDiscovery::createPluginInstance;
         for (int i = 0; i < plugins.size(); i++) {
             Config sinkConfig = pluginConfigs.get(i);
+            Config envConfig = sparkRuntimeEnvironment.getConfig();
+            Config mergedSinkConfig =
+                    DirtyCollectorConfigProcessor.getMergedSinkConfigForDirty(
+                            envConfig, sinkConfig);
             DatasetTableInfo datasetTableInfo =
                     fromSourceTable(sinkConfig, sparkRuntimeEnvironment, upstreamDataStreams)
                             .orElse(input);
@@ -135,7 +141,7 @@ public class SinkExecuteProcessor
                                 SeaTunnelSink<Object, Object, Object, Object> sink =
                                         FactoryUtil.createAndPrepareSink(
                                                 catalogTable,
-                                                ReadonlyConfig.fromConfig(sinkConfig),
+                                                ReadonlyConfig.fromConfig(mergedSinkConfig),
                                                 classLoader,
                                                 sinkConfig.getString(PLUGIN_NAME.key()),
                                                 fallbackCreateSink,
@@ -152,8 +158,22 @@ public class SinkExecuteProcessor
                     sparkRuntimeEnvironment.getStreamingContext().sparkContext().applicationId();
             CatalogTable[] catalogTables =
                     datasetTableInfo.getCatalogTables().toArray(new CatalogTable[0]);
+            CatalogTable firstCatalogTable = catalogTables.length > 0 ? catalogTables[0] : null;
+            DirtyRecordCollector dirtyCollector =
+                    DirtyCollectorConfigProcessor.processConfig(
+                            envConfig, sinkConfig, firstCatalogTable);
+            log.info(
+                    "Dirty record collector for sink [{}]: type={}, classLoader={}",
+                    sinkConfig.getString(PLUGIN_NAME.key()),
+                    dirtyCollector != null ? dirtyCollector.getClass().getName() : "null",
+                    Thread.currentThread().getContextClassLoader().getClass().getName());
             SparkSinkInjector.inject(
-                            dataset.write(), sink, catalogTables, applicationId, parallelism)
+                            dataset.write(),
+                            sink,
+                            catalogTables,
+                            applicationId,
+                            parallelism,
+                            dirtyCollector)
                     .option("checkpointLocation", "/tmp")
                     .mode(SaveMode.Append)
                     .save();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCollectionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCollectionIT.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.fake;
+
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * Integration test for dirty data collection functionality. Tests the complete workflow using
+ * FakeSource -> Console pipeline where dirty data is defined via {@code dirty.validator} in env
+ * config.
+ *
+ * <p>The {@code AlwaysDirtyDataValidator} marks every record as dirty, causing the configured
+ * collector to log them.
+ */
+@Slf4j
+public class DirtyDataCollectionIT extends TestSuiteBase {
+
+    @TestTemplate
+    public void testDirtyDataCollectionLogging(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult result =
+                container.executeJob("/fake_to_console_dirty_collection_only.conf");
+
+        String stdout = result.getStdout();
+        String stderr = result.getStderr();
+        String serverLogs = container.getServerLogs();
+        String allLogs = stdout + "\n" + stderr + "\n" + serverLogs;
+
+        Assertions.assertEquals(0, result.getExitCode(), "Job should complete: stderr=" + stderr);
+
+        boolean hasDirtyCollected =
+                allLogs.contains("Dirty record collected")
+                        || allLogs.contains("user rule")
+                        || allLogs.contains("[AlwaysDirtyValidator]");
+        Assertions.assertTrue(
+                hasDirtyCollected,
+                "Expected dirty record collection logs. Log tail: "
+                        + allLogs.substring(Math.max(0, allLogs.length() - 500)));
+
+        log.info("Dirty data collection (logging only) test completed!");
+    }
+
+    @TestTemplate
+    public void testDirtyDataCollectionFailure(TestContainer container)
+            throws IOException, InterruptedException {
+
+        Container.ExecResult failResult =
+                container.executeJob("/fake_to_console_dirty_fail_threshold.conf");
+
+        log.info("Container exit code: {}", failResult.getExitCode());
+        String failOutput = failResult.getStdout();
+        String failErrorOutput = failResult.getStderr();
+        String serverLogs = container.getServerLogs();
+        String combinedOutput = failOutput + "\n" + failErrorOutput + "\n" + serverLogs;
+
+        boolean hasDirtyCollected =
+                combinedOutput.contains("Dirty record collected")
+                        || combinedOutput.contains("user rule")
+                        || combinedOutput.contains("[AlwaysDirtyValidator]");
+        Assertions.assertTrue(
+                hasDirtyCollected,
+                "Expected dirty collection log in output. Log tail: "
+                        + combinedOutput.substring(Math.max(0, combinedOutput.length() - 500)));
+
+        boolean hasThresholdMessage =
+                combinedOutput.contains("threshold exceeded")
+                        || combinedOutput.contains("Dirty record threshold exceeded");
+        Assertions.assertTrue(
+                hasThresholdMessage,
+                "Expected threshold exceeded message. Log tail: "
+                        + combinedOutput.substring(Math.max(0, combinedOutput.length() - 500)));
+
+        log.info("Dirty data threshold failure test completed!");
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCollectionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCollectionIT.java
@@ -71,11 +71,15 @@ public class DirtyDataCollectionIT extends TestSuiteBase {
         Container.ExecResult failResult =
                 container.executeJob("/fake_to_console_dirty_fail_threshold.conf");
 
-        log.info("Container exit code: {}", failResult.getExitCode());
-        String failOutput = failResult.getStdout();
-        String failErrorOutput = failResult.getStderr();
-        String serverLogs = container.getServerLogs();
-        String combinedOutput = failOutput + "\n" + failErrorOutput + "\n" + serverLogs;
+        Assertions.assertNotEquals(
+                0, failResult.getExitCode(), "Job should fail when dirty threshold is exceeded");
+
+        String combinedOutput =
+                failResult.getStdout()
+                        + "\n"
+                        + failResult.getStderr()
+                        + "\n"
+                        + container.getServerLogs();
 
         boolean hasDirtyCollected =
                 combinedOutput.contains("Dirty record collected")

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCustomExtensionIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fake/DirtyDataCustomExtensionIT.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.fake;
+
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * Integration tests for dirty data extension points:
+ *
+ * <ul>
+ *   <li>{@link #testCustomCollectorViaSPI} — verifies that a custom {@code
+ *       DirtyRecordCollectorProvider} registered via SPI is discovered and used at runtime (the
+ *       "counting" type backed by {@code CountingDirtyRecordCollector}).
+ *   <li>{@link #testCustomValidatorDefinition} — verifies that a custom {@code DirtyDataValidator}
+ *       registered via SPI can define "what counts as dirty" before the write happens (the {@code
+ *       AlwaysDirtyDataValidator} marks every record dirty via user-defined rule).
+ * </ul>
+ *
+ * Both tests use the FakeSource → Console pipeline with configuration in {@code env}.
+ */
+@Slf4j
+public class DirtyDataCustomExtensionIT extends TestSuiteBase {
+
+    @TestTemplate
+    public void testCustomCollectorViaSPI(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult result =
+                container.executeJob("/fake_to_console_custom_collector.conf");
+
+        String stdout = result.getStdout();
+        String stderr = result.getStderr();
+        String serverLogs = container.getServerLogs();
+        String allLogs = stdout + "\n" + stderr + "\n" + serverLogs;
+
+        log.info("Custom collector test exit code: {}", result.getExitCode());
+        Assertions.assertEquals(
+                0, result.getExitCode(), "Job should complete successfully: stderr=" + stderr);
+
+        boolean hasCountingMarker = allLogs.contains("[CountingCollector]");
+        Assertions.assertTrue(
+                hasCountingMarker,
+                "Expected [CountingCollector] marker in logs, proving the custom SPI collector was used. "
+                        + "Log snippet (last 500 chars): "
+                        + allLogs.substring(Math.max(0, allLogs.length() - 500)));
+
+        log.info("Custom collector SPI test passed — [CountingCollector] confirmed in logs");
+    }
+
+    @TestTemplate
+    public void testCustomValidatorDefinition(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult result =
+                container.executeJob("/fake_to_console_custom_validator.conf");
+
+        String stdout = result.getStdout();
+        String stderr = result.getStderr();
+        String serverLogs = container.getServerLogs();
+        String allLogs = stdout + "\n" + stderr + "\n" + serverLogs;
+
+        log.info("Custom validator test exit code: {}", result.getExitCode());
+        Assertions.assertEquals(
+                0, result.getExitCode(), "Job should complete successfully: stderr=" + stderr);
+
+        boolean hasUserRule = allLogs.contains("user rule");
+        Assertions.assertTrue(
+                hasUserRule,
+                "Expected 'user rule' in logs, proving records were caught by validator pre-check. "
+                        + "Log snippet (last 500 chars): "
+                        + allLogs.substring(Math.max(0, allLogs.length() - 500)));
+
+        boolean hasValidatorMarker = allLogs.contains("[AlwaysDirtyValidator]");
+        Assertions.assertTrue(
+                hasValidatorMarker,
+                "Expected [AlwaysDirtyValidator] marker in logs, proving the custom validator was used. "
+                        + "Log snippet (last 500 chars): "
+                        + allLogs.substring(Math.max(0, allLogs.length() - 500)));
+
+        log.info(
+                "Custom validator test passed — [AlwaysDirtyValidator] + 'user rule' confirmed in logs");
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_custom_collector.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_custom_collector.conf
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Verifies that a custom DirtyRecordCollector discovered via SPI is actually used.
+# The "counting" type maps to CountingDirtyRecordCollectorProvider which creates
+# CountingDirtyRecordCollector. We assert the distinctive [CountingCollector] marker
+# appears in the logs.
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  dirty.collector = {
+    type = "counting"
+    threshold = 1000
+    fail_on_threshold = false
+  }
+  dirty.validator = {
+    type = "AlwaysDirtyDataValidator"
+  }
+}
+
+source {
+  FakeSource {
+    row.num = 50
+    schema = {
+      fields {
+        id = "bigint"
+        name = "string"
+        age = "int"
+        status = "string"
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_custom_validator.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_custom_validator.conf
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Verifies that a custom DirtyDataValidator can define "what counts as dirty data".
+# AlwaysDirtyDataValidator marks every record as dirty before write.
+# We assert the distinctive [AlwaysDirtyValidator] message and "user rule" appear in logs.
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  dirty.collector = {
+    type = "log"
+    log_level = "ERROR"
+    include_stack_trace = false
+    threshold = 1000
+    fail_on_threshold = false
+  }
+  dirty.validator = {
+    type = "AlwaysDirtyDataValidator"
+  }
+}
+
+source {
+  FakeSource {
+    row.num = 30
+    schema = {
+      fields {
+        id = "bigint"
+        name = "string"
+        age = "int"
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_collection_only.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_collection_only.conf
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+
+  dirty.collector = {
+    type = "log"
+    log_level = "ERROR"
+    include_stack_trace = false
+    threshold = -1
+    fail_on_threshold = false
+  }
+
+  dirty.validator = {
+    type = "AlwaysDirtyDataValidator"
+  }
+}
+
+source {
+  FakeSource {
+    row.num = 50
+    schema = {
+      fields {
+        id = "bigint"
+        name = "string"
+        age = "int"
+        status = "string"
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_fail_threshold.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_fail_threshold.conf
@@ -27,7 +27,7 @@ env {
     threshold = 10
     fail_on_threshold = true
   }
-  
+
   dirty.validator = {
     type = "AlwaysDirtyDataValidator"
   }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_fail_threshold.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fake-e2e/src/test/resources/fake_to_console_dirty_fail_threshold.conf
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  execution.restart.strategy = "no"
+
+  dirty.collector = {
+    type = "log"
+    log_level = "ERROR"
+    include_stack_trace = true
+    threshold = 10
+    fail_on_threshold = true
+  }
+  
+  dirty.validator = {
+    type = "AlwaysDirtyDataValidator"
+  }
+}
+
+source {
+  FakeSource {
+    row.num = 100
+    schema = {
+      fields {
+        id = "bigint"
+        name = "string"
+        age = "int"
+        status = "string"
+      }
+    }
+    plugin_output = "fake"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fake"
+  }
+}

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SinkAction.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SinkAction.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.core.dag.actions;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.engine.core.job.ConnectorJarIdentifier;
 
@@ -29,6 +30,8 @@ import java.util.Set;
 
 public class SinkAction<IN, StateT, CommitInfoT, AggregatedCommitInfoT> extends AbstractAction {
     private final SeaTunnelSink<IN, StateT, CommitInfoT, AggregatedCommitInfoT> sink;
+
+    private DirtyRecordCollector dirtyRecordCollector;
 
     public SinkAction(
             long id,
@@ -63,6 +66,14 @@ public class SinkAction<IN, StateT, CommitInfoT, AggregatedCommitInfoT> extends 
 
     public SeaTunnelSink<IN, StateT, CommitInfoT, AggregatedCommitInfoT> getSink() {
         return sink;
+    }
+
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
+    }
+
+    public void setDirtyRecordCollector(DirtyRecordCollector dirtyRecordCollector) {
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -578,6 +578,14 @@ public class MultipleTableJobConfigParser {
         jarUrls.addAll(getSinkPluginJarPaths(sinkConfig));
         List<SinkAction<?, ?, ?, ?>> sinkActions = new ArrayList<>();
 
+        CatalogTable catalogTableSample =
+                !inputVertices.isEmpty() && !inputVertices.get(0).isEmpty()
+                        ? inputVertices.get(0).get(0)._1()
+                        : null;
+        DirtyRecordCollector dirtyRecordCollector =
+                DirtyCollectorConfigProcessor.processConfig(
+                        envConfig, sinkConfig, catalogTableSample);
+
         // union
         if (inputVertices.size() > 1) {
             Set<Action> inputActions =
@@ -597,7 +605,8 @@ public class MultipleTableJobConfigParser {
                             new HashSet<>(),
                             factoryId,
                             inputActionSample._2().getParallelism(),
-                            configIndex);
+                            configIndex,
+                            dirtyRecordCollector);
             sinkActions.add(sinkAction);
             return sinkActions;
         }
@@ -615,7 +624,8 @@ public class MultipleTableJobConfigParser {
                             new HashSet<>(),
                             factoryId,
                             tuple._2().getParallelism(),
-                            configIndex);
+                            configIndex,
+                            dirtyRecordCollector);
             sinkActions.add(sinkAction);
         }
         Optional<SinkAction<?, ?, ?, ?>> multiTableSink =
@@ -677,7 +687,8 @@ public class MultipleTableJobConfigParser {
             Set<ConnectorJarIdentifier> connectorJarIdentifiers,
             String factoryId,
             int parallelism,
-            int configIndex) {
+            int configIndex,
+            DirtyRecordCollector dirtyRecordCollector) {
 
         Function<PluginIdentifier, SeaTunnelSink> fallbackCreateSink =
                 pluginIdentifier -> {
@@ -709,12 +720,8 @@ public class MultipleTableJobConfigParser {
                         factoryUrls,
                         connectorJarIdentifiers,
                         actionConfig);
-        Config envConfig =
-                seaTunnelJobConfig.hasPath("env") ? seaTunnelJobConfig.getConfig("env") : null;
-        DirtyRecordCollector dirtyCollector =
-                DirtyCollectorConfigProcessor.processConfig(
-                        envConfig, readonlyConfig.toConfig(), catalogTable);
-        sinkAction.setDirtyRecordCollector(dirtyCollector);
+
+        sinkAction.setDirtyRecordCollector(dirtyRecordCollector);
         if (!isStartWithSavePoint) {
             handleSaveMode(sink);
         } else {

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -35,6 +35,8 @@ import org.apache.seatunnel.api.metalake.MetalakeConfigUtils;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
 import org.apache.seatunnel.api.options.EnvOptionRule;
+import org.apache.seatunnel.api.sink.DirtyCollectorConfigProcessor;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SaveModeExecuteLocation;
 import org.apache.seatunnel.api.sink.SaveModeExecuteWrapper;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
@@ -546,7 +548,11 @@ public class MultipleTableJobConfigParser {
             ClassLoader classLoader,
             LinkedHashMap<String, List<Tuple2<CatalogTable, Action>>> tableWithActionMap) {
 
-        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(sinkConfig);
+        Config envConfig =
+                seaTunnelJobConfig.hasPath("env") ? seaTunnelJobConfig.getConfig("env") : null;
+        Config mergedSinkConfig =
+                DirtyCollectorConfigProcessor.getMergedSinkConfigForDirty(envConfig, sinkConfig);
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(mergedSinkConfig);
         String factoryId = getFactoryId(readonlyConfig);
         List<String> inputIds = getInputIds(readonlyConfig);
 
@@ -699,6 +705,12 @@ public class MultipleTableJobConfigParser {
                         factoryUrls,
                         connectorJarIdentifiers,
                         actionConfig);
+        Config envConfig =
+                seaTunnelJobConfig.hasPath("env") ? seaTunnelJobConfig.getConfig("env") : null;
+        DirtyRecordCollector dirtyCollector =
+                DirtyCollectorConfigProcessor.processConfig(
+                        envConfig, readonlyConfig.toConfig(), catalogTable);
+        sinkAction.setDirtyRecordCollector(dirtyCollector);
         if (!isStartWithSavePoint) {
             handleSaveMode(sink);
         } else {

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -661,6 +661,10 @@ public class MultipleTableJobConfigParser {
                         jars,
                         new HashSet<>());
         multiTableAction.setParallelism(sinkActions.get(0).getParallelism());
+        DirtyRecordCollector dirtyCollector = sinkActions.get(0).getDirtyRecordCollector();
+        if (dirtyCollector != null) {
+            multiTableAction.setDirtyRecordCollector(dirtyCollector);
+        }
         return Optional.of(multiTableAction);
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/execution/ExecutionPlanGenerator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/execution/ExecutionPlanGenerator.java
@@ -96,6 +96,16 @@ public class ExecutionPlanGenerator {
                             action.getJarUrls(),
                             action.getConnectorJarIdentifiers(),
                             (SinkConfig) action.getConfig());
+            // preserve dirty collector and config map from original action
+            try {
+                SinkAction<?, ?, ?, ?> orig = (SinkAction<?, ?, ?, ?>) action;
+                SinkAction<?, ?, ?, ?> created = (SinkAction<?, ?, ?, ?>) newAction;
+                if (orig.getDirtyRecordCollector() != null) {
+                    created.setDirtyRecordCollector(orig.getDirtyRecordCollector());
+                }
+            } catch (Throwable t) {
+                log.warn("Failed to copy dirty collector/config from original SinkAction", t);
+            }
         } else if (action instanceof SourceAction) {
             newAction =
                     new SourceAction<>(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/context/SinkWriterContext.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/context/SinkWriterContext.java
@@ -21,6 +21,8 @@ import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 
 public class SinkWriterContext implements SinkWriter.Context {
@@ -30,12 +32,27 @@ public class SinkWriterContext implements SinkWriter.Context {
     private final int numberOfParallelSubtasks;
     private final MetricsContext metricsContext;
     private final EventListener eventListener;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public SinkWriterContext(
             int numberOfParallelSubtasks,
             int indexOfSubtask,
             MetricsContext metricsContext,
             EventListener eventListener) {
+        this(
+                numberOfParallelSubtasks,
+                indexOfSubtask,
+                metricsContext,
+                eventListener,
+                NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public SinkWriterContext(
+            int numberOfParallelSubtasks,
+            int indexOfSubtask,
+            MetricsContext metricsContext,
+            EventListener eventListener,
+            DirtyRecordCollector dirtyRecordCollector) {
         Preconditions.checkArgument(
                 numberOfParallelSubtasks >= 1, "Parallelism must be a positive number.");
         Preconditions.checkArgument(
@@ -44,6 +61,7 @@ public class SinkWriterContext implements SinkWriter.Context {
         this.indexOfSubtask = indexOfSubtask;
         this.metricsContext = metricsContext;
         this.eventListener = eventListener;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -63,5 +81,10 @@ public class SinkWriterContext implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return eventListener;
+    }
+
+    @Override
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.server.task.flow;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.sink.DirtyDataAwareSinkWriter;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkCommitter;
@@ -191,6 +192,15 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         return NoOpDirtyRecordCollector.INSTANCE;
     }
 
+    private SinkWriter<T, CommitInfoT, StateT> wrapWriterIfNeeded(
+            SinkWriter<T, CommitInfoT, StateT> rawWriter, DirtyRecordCollector collector) {
+        if (collector == null || collector instanceof NoOpDirtyRecordCollector) {
+            return rawWriter;
+        }
+        CatalogTable catalogTable = sinkAction.getSink().getWriteCatalogTable().orElse(null);
+        return new DirtyDataAwareSinkWriter<>(rawWriter, collector, indexID, catalogTable);
+    }
+
     @Override
     public void received(Record<?> record) {
         try {
@@ -354,9 +364,14 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
                         eventListener,
                         dirtyCollector);
         if (states.isEmpty()) {
-            this.writer = sinkAction.getSink().createWriter(writerContext);
+            this.writer =
+                    wrapWriterIfNeeded(
+                            sinkAction.getSink().createWriter(writerContext), dirtyCollector);
         } else {
-            this.writer = sinkAction.getSink().restoreWriter(writerContext, states);
+            this.writer =
+                    wrapWriterIfNeeded(
+                            sinkAction.getSink().restoreWriter(writerContext, states),
+                            dirtyCollector);
         }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.engine.server.task.flow;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SinkWriter.Context;
@@ -180,6 +182,15 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         }
     }
 
+    private DirtyRecordCollector createDirtyRecordCollector() {
+        DirtyRecordCollector collector = sinkAction.getDirtyRecordCollector();
+        if (collector != null) {
+            return collector;
+        }
+        log.debug("No pre-built dirty collector in SinkAction, using NoOp");
+        return NoOpDirtyRecordCollector.INSTANCE;
+    }
+
     @Override
     public void received(Record<?> record) {
         try {
@@ -332,9 +343,16 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
                                                                     .deserialize(bytes)))
                             .collect(Collectors.toList());
         }
+        // initialize dirty record collector
+        DirtyRecordCollector dirtyCollector = createDirtyRecordCollector();
+
         this.writerContext =
                 new SinkWriterContext(
-                        sinkAction.getParallelism(), indexID, metricsContext, eventListener);
+                        sinkAction.getParallelism(),
+                        indexID,
+                        metricsContext,
+                        eventListener,
+                        dirtyCollector);
         if (states.isEmpty()) {
             this.writer = sinkAction.getSink().createWriter(writerContext);
         } else {

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.DistributedCounter;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
@@ -70,7 +71,20 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
             MetricsContext ctx = getMetricsContext();
             if (ctx != null) {
                 Counter dirtyCounter = ctx.counter(DIRTY_RECORD_COUNT_METRIC);
-                dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+                dirtyRecordCollector.setDistributedCounter(
+                        new DistributedCounter() {
+                            private static final long serialVersionUID = 1L;
+
+                            @Override
+                            public void add(long delta) {
+                                dirtyCounter.inc(delta);
+                            }
+
+                            @Override
+                            public long value() {
+                                return dirtyCounter.getCount();
+                            }
+                        });
                 LOGGER.info(
                         "Set up Flink distributed counter for dirty record counting (subtask {})",
                         writerContext.getSubtaskId());

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.translation.flink.sink;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
 
@@ -40,11 +42,18 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     private final InitContext writerContext;
     private final EventListener eventListener;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public FlinkSinkWriterContext(InitContext writerContext, int parallelism) {
+        this(writerContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public FlinkSinkWriterContext(
+            InitContext writerContext, int parallelism, DirtyRecordCollector dirtyRecordCollector) {
         this.writerContext = writerContext;
         this.eventListener = new DefaultEventProcessor(getJobIdForV14(writerContext));
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -83,6 +92,11 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return eventListener;
+    }
+
+    @Override
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
     }
 
     private static StreamingRuntimeContext getStreamingRuntimeContextForV14(

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-13/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.flink.sink;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
@@ -38,11 +39,13 @@ import java.lang.reflect.Field;
 public class FlinkSinkWriterContext implements SinkWriter.Context {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FlinkMetricContext.class);
+    private static final String DIRTY_RECORD_COUNT_METRIC = "dirtyRecordCount";
 
     private final InitContext writerContext;
     private final EventListener eventListener;
     private final int parallelism;
     private final DirtyRecordCollector dirtyRecordCollector;
+    private MetricsContext metricsContext;
 
     public FlinkSinkWriterContext(InitContext writerContext, int parallelism) {
         this(writerContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
@@ -54,6 +57,27 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
         this.eventListener = new DefaultEventProcessor(getJobIdForV14(writerContext));
         this.parallelism = parallelism;
         this.dirtyRecordCollector = dirtyRecordCollector;
+
+        setupDistributedDirtyRecordCounter();
+    }
+
+    private void setupDistributedDirtyRecordCounter() {
+        if (dirtyRecordCollector == null
+                || dirtyRecordCollector instanceof NoOpDirtyRecordCollector) {
+            return;
+        }
+        try {
+            MetricsContext ctx = getMetricsContext();
+            if (ctx != null) {
+                Counter dirtyCounter = ctx.counter(DIRTY_RECORD_COUNT_METRIC);
+                dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+                LOGGER.info(
+                        "Set up Flink distributed counter for dirty record counting (subtask {})",
+                        writerContext.getSubtaskId());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to set up Flink distributed counter for dirty record counting", e);
+        }
     }
 
     @Override
@@ -68,10 +92,14 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
 
     @Override
     public MetricsContext getMetricsContext() {
+        if (metricsContext != null) {
+            return metricsContext;
+        }
         try {
             StreamingRuntimeContext runtimeContext =
                     getStreamingRuntimeContextForV14(writerContext);
-            return new FlinkMetricContext(runtimeContext);
+            metricsContext = new FlinkMetricContext(runtimeContext);
+            return metricsContext;
         } catch (Exception e) {
             LOGGER.info(
                     "Flink version is not 1.14.x, will initial MetricsContext using metricGroup");
@@ -83,7 +111,8 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
             Field field = writerContext.getClass().getDeclaredField("metricGroup");
             field.setAccessible(true);
             MetricGroup metricGroup = (MetricGroup) field.get(writerContext);
-            return new FlinkMetricContext(metricGroup);
+            metricsContext = new FlinkMetricContext(metricGroup);
+            return metricsContext;
         } catch (Exception e) {
             throw new IllegalStateException("Initial sink metrics failed", e);
         }

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.translation.flink.sink;
 
 import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.sink.DirtyDataAwareSinkWriter;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -88,9 +89,18 @@ public class FlinkSink<CommT, WriterStateT, GlobalCommT>
     public SinkWriter<SeaTunnelRow> createWriter(WriterInitContext context) throws IOException {
         FlinkSinkWriterContext writerContext =
                 new FlinkSinkWriterContext(context, parallelism, dirtyRecordCollector);
+        CatalogTable catalogTable = catalogTables.size() == 1 ? catalogTables.get(0) : null;
 
         org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT>
                 seatunnelWriter = seaTunnelSink.createWriter(writerContext);
+        if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+            seatunnelWriter =
+                    new DirtyDataAwareSinkWriter<>(
+                            seatunnelWriter,
+                            dirtyRecordCollector,
+                            writerContext.getIndexOfSubtask(),
+                            catalogTable);
+        }
 
         return new FlinkSinkWriter<>(seatunnelWriter, context, writerContext);
     }
@@ -154,12 +164,22 @@ public class FlinkSink<CommT, WriterStateT, GlobalCommT>
     public StatefulSinkWriter<SeaTunnelRow, FlinkWriterState<WriterStateT>> restoreWriter(
             WriterInitContext context, Collection<FlinkWriterState<WriterStateT>> recoveredState)
             throws IOException {
-        FlinkSinkWriterContext writerContext = new FlinkSinkWriterContext(context, parallelism);
+        FlinkSinkWriterContext writerContext =
+                new FlinkSinkWriterContext(context, parallelism, dirtyRecordCollector);
+        CatalogTable catalogTable = catalogTables.size() == 1 ? catalogTables.get(0) : null;
 
         if (recoveredState == null || recoveredState.isEmpty()) {
             // No state to restore, create new writer
             org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT>
                     seatunnelWriter = seaTunnelSink.createWriter(writerContext);
+            if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+                seatunnelWriter =
+                        new DirtyDataAwareSinkWriter<>(
+                                seatunnelWriter,
+                                dirtyRecordCollector,
+                                writerContext.getIndexOfSubtask(),
+                                catalogTable);
+            }
             return new FlinkSinkWriter<>(seatunnelWriter, context, writerContext);
         } else {
             // Restore from state
@@ -170,6 +190,14 @@ public class FlinkSink<CommT, WriterStateT, GlobalCommT>
 
             org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT>
                     seatunnelWriter = seaTunnelSink.restoreWriter(writerContext, states);
+            if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+                seatunnelWriter =
+                        new DirtyDataAwareSinkWriter<>(
+                                seatunnelWriter,
+                                dirtyRecordCollector,
+                                writerContext.getIndexOfSubtask(),
+                                catalogTable);
+            }
 
             // Find the maximum checkpoint ID from all recovered states to ensure consistency
             long maxCheckpointId =

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.translation.flink.sink;
 
 import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -48,16 +50,26 @@ public class FlinkSink<CommT, WriterStateT, GlobalCommT>
     private final SeaTunnelSink<SeaTunnelRow, WriterStateT, CommT, GlobalCommT> seaTunnelSink;
     private final List<CatalogTable> catalogTables;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     @SuppressWarnings("unchecked")
     public FlinkSink(
             SeaTunnelSink<?, ?, ?, ?> seaTunnelSink,
             List<CatalogTable> catalogTables,
             int parallelism) {
+        this(seaTunnelSink, catalogTables, parallelism, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public FlinkSink(
+            SeaTunnelSink<?, ?, ?, ?> seaTunnelSink,
+            List<CatalogTable> catalogTables,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.seaTunnelSink =
                 (SeaTunnelSink<SeaTunnelRow, WriterStateT, CommT, GlobalCommT>) seaTunnelSink;
         this.catalogTables = catalogTables;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -74,7 +86,8 @@ public class FlinkSink<CommT, WriterStateT, GlobalCommT>
 
     @Override
     public SinkWriter<SeaTunnelRow> createWriter(WriterInitContext context) throws IOException {
-        FlinkSinkWriterContext writerContext = new FlinkSinkWriterContext(context, parallelism);
+        FlinkSinkWriterContext writerContext =
+                new FlinkSinkWriterContext(context, parallelism, dirtyRecordCollector);
 
         org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT>
                 seatunnelWriter = seaTunnelSink.createWriter(writerContext);

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.flink.sink;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
@@ -35,10 +36,13 @@ import java.lang.reflect.Method;
 @Slf4j
 public class FlinkSinkWriterContext implements SinkWriter.Context {
 
+    private static final String DIRTY_RECORD_COUNT_METRIC = "dirtyRecordCount";
+
     private final WriterInitContext initContext;
     private final int parallelism;
     private final EventListener eventListener;
     private final DirtyRecordCollector dirtyRecordCollector;
+    private MetricsContext metricsContext;
 
     public FlinkSinkWriterContext(WriterInitContext initContext, int parallelism) {
         this(initContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
@@ -52,6 +56,34 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
         this.parallelism = parallelism;
         this.eventListener = new DefaultEventProcessor(getFlinkJobId(initContext));
         this.dirtyRecordCollector = dirtyRecordCollector;
+
+        // initialize metrics context and set up distributed dirty record counter
+        initMetricsContext();
+        setupDistributedDirtyRecordCounter();
+    }
+
+    private void initMetricsContext() {
+        RuntimeContext runtimeContext = getRuntimeContext();
+        if (runtimeContext != null) {
+            this.metricsContext = new FlinkMetricContext(runtimeContext);
+        }
+    }
+
+    private void setupDistributedDirtyRecordCounter() {
+        if (dirtyRecordCollector == null
+                || dirtyRecordCollector instanceof NoOpDirtyRecordCollector
+                || metricsContext == null) {
+            return;
+        }
+        try {
+            Counter dirtyCounter = metricsContext.counter(DIRTY_RECORD_COUNT_METRIC);
+            dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+            log.info(
+                    "Set up Flink distributed counter for dirty record counting (subtask {})",
+                    initContext.getTaskInfo().getIndexOfThisSubtask());
+        } catch (Exception e) {
+            log.warn("Failed to set up Flink distributed counter for dirty record counting", e);
+        }
     }
 
     @Override
@@ -66,7 +98,10 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
 
     @Override
     public MetricsContext getMetricsContext() {
-        return new FlinkMetricContext(getRuntimeContext());
+        if (metricsContext == null) {
+            initMetricsContext();
+        }
+        return metricsContext;
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.translation.flink.sink;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
 
@@ -36,11 +38,20 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     private final WriterInitContext initContext;
     private final int parallelism;
     private final EventListener eventListener;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public FlinkSinkWriterContext(WriterInitContext initContext, int parallelism) {
+        this(initContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public FlinkSinkWriterContext(
+            WriterInitContext initContext,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.initContext = initContext;
         this.parallelism = parallelism;
         this.eventListener = new DefaultEventProcessor(getFlinkJobId(initContext));
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -61,6 +72,11 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return eventListener;
+    }
+
+    @Override
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
     }
 
     public RuntimeContext getRuntimeContext() {

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.DistributedCounter;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
@@ -77,7 +78,20 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
         }
         try {
             Counter dirtyCounter = metricsContext.counter(DIRTY_RECORD_COUNT_METRIC);
-            dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+            dirtyRecordCollector.setDistributedCounter(
+                    new DistributedCounter() {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public void add(long delta) {
+                            dirtyCounter.inc(delta);
+                        }
+
+                        @Override
+                        public long value() {
+                            return dirtyCounter.getCount();
+                        }
+                    });
             log.info(
                     "Set up Flink distributed counter for dirty record counting (subtask {})",
                     initContext.getTaskInfo().getIndexOfThisSubtask());

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.translation.flink.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -29,6 +31,8 @@ import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.sql.DriverManager;
@@ -44,6 +48,7 @@ import java.util.stream.Collectors;
  * @param <WriterStateT> The generic type of writer state
  * @param <GlobalCommT> The generic type of global commit message
  */
+@Slf4j
 public class FlinkSink<InputT, CommT, WriterStateT, GlobalCommT>
         implements Sink<InputT, CommitWrapper<CommT>, FlinkWriterState<WriterStateT>, GlobalCommT> {
 
@@ -65,13 +70,24 @@ public class FlinkSink<InputT, CommT, WriterStateT, GlobalCommT>
 
     private final int parallelism;
 
+    private final DirtyRecordCollector dirtyRecordCollector;
+
     public FlinkSink(
             SeaTunnelSink<SeaTunnelRow, WriterStateT, CommT, GlobalCommT> sink,
             List<CatalogTable> catalogTables,
             int parallelism) {
+        this(sink, catalogTables, parallelism, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public FlinkSink(
+            SeaTunnelSink<SeaTunnelRow, WriterStateT, CommT, GlobalCommT> sink,
+            List<CatalogTable> catalogTables,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -79,7 +95,7 @@ public class FlinkSink<InputT, CommT, WriterStateT, GlobalCommT>
             Sink.InitContext context, List<FlinkWriterState<WriterStateT>> states)
             throws IOException {
         org.apache.seatunnel.api.sink.SinkWriter.Context stContext =
-                new FlinkSinkWriterContext(context, parallelism);
+                new FlinkSinkWriterContext(context, parallelism, dirtyRecordCollector);
         if (states == null || states.isEmpty()) {
             return new FlinkSinkWriter<>(sink.createWriter(stContext), 1, stContext);
         } else {

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.flink.sink;
 
+import org.apache.seatunnel.api.sink.DirtyDataAwareSinkWriter;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
@@ -96,15 +97,33 @@ public class FlinkSink<InputT, CommT, WriterStateT, GlobalCommT>
             throws IOException {
         org.apache.seatunnel.api.sink.SinkWriter.Context stContext =
                 new FlinkSinkWriterContext(context, parallelism, dirtyRecordCollector);
+        CatalogTable catalogTable = catalogTables.size() == 1 ? catalogTables.get(0) : null;
         if (states == null || states.isEmpty()) {
-            return new FlinkSinkWriter<>(sink.createWriter(stContext), 1, stContext);
+            org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT> writer =
+                    sink.createWriter(stContext);
+            if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+                writer =
+                        new DirtyDataAwareSinkWriter<>(
+                                writer,
+                                dirtyRecordCollector,
+                                stContext.getIndexOfSubtask(),
+                                catalogTable);
+            }
+            return new FlinkSinkWriter<>(writer, 1, stContext);
         } else {
             List<WriterStateT> restoredState =
                     states.stream().map(FlinkWriterState::getState).collect(Collectors.toList());
-            return new FlinkSinkWriter<>(
-                    sink.restoreWriter(stContext, restoredState),
-                    states.get(0).getCheckpointId() + 1,
-                    stContext);
+            org.apache.seatunnel.api.sink.SinkWriter<SeaTunnelRow, CommT, WriterStateT> writer =
+                    sink.restoreWriter(stContext, restoredState);
+            if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+                writer =
+                        new DirtyDataAwareSinkWriter<>(
+                                writer,
+                                dirtyRecordCollector,
+                                stContext.getIndexOfSubtask(),
+                                catalogTable);
+            }
+            return new FlinkSinkWriter<>(writer, states.get(0).getCheckpointId() + 1, stContext);
         }
     }
 

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.flink.sink;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
@@ -36,10 +37,13 @@ import java.lang.reflect.Field;
 @Slf4j
 public class FlinkSinkWriterContext implements SinkWriter.Context {
 
+    private static final String DIRTY_RECORD_COUNT_METRIC = "dirtyRecordCount";
+
     private final Sink.InitContext writerContext;
     private final EventListener eventListener;
     private final int parallelism;
     private final DirtyRecordCollector dirtyRecordCollector;
+    private final MetricsContext metricsContext;
 
     public FlinkSinkWriterContext(InitContext writerContext, int parallelism) {
         this(writerContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
@@ -51,6 +55,27 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
         this.eventListener = new DefaultEventProcessor(getFlinkJobId(writerContext));
         this.parallelism = parallelism;
         this.dirtyRecordCollector = dirtyRecordCollector;
+
+        // initialize metrics context and set up distributed dirty record counter
+        this.metricsContext =
+                new FlinkMetricContext(getStreamingRuntimeContextForV15(writerContext));
+        setupDistributedDirtyRecordCounter();
+    }
+
+    private void setupDistributedDirtyRecordCounter() {
+        if (dirtyRecordCollector == null
+                || dirtyRecordCollector instanceof NoOpDirtyRecordCollector) {
+            return;
+        }
+        try {
+            Counter dirtyCounter = metricsContext.counter(DIRTY_RECORD_COUNT_METRIC);
+            dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+            log.info(
+                    "Set up Flink distributed counter for dirty record counting (subtask {})",
+                    writerContext.getSubtaskId());
+        } catch (Exception e) {
+            log.warn("Failed to set up Flink distributed counter for dirty record counting", e);
+        }
     }
 
     @Override
@@ -65,7 +90,7 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
 
     @Override
     public MetricsContext getMetricsContext() {
-        return new FlinkMetricContext(getStreamingRuntimeContextForV15(writerContext));
+        return metricsContext;
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.translation.flink.sink;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
 
@@ -37,11 +39,18 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     private final Sink.InitContext writerContext;
     private final EventListener eventListener;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public FlinkSinkWriterContext(InitContext writerContext, int parallelism) {
+        this(writerContext, parallelism, NoOpDirtyRecordCollector.INSTANCE);
+    }
+
+    public FlinkSinkWriterContext(
+            InitContext writerContext, int parallelism, DirtyRecordCollector dirtyRecordCollector) {
         this.writerContext = writerContext;
         this.eventListener = new DefaultEventProcessor(getFlinkJobId(writerContext));
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
@@ -62,6 +71,11 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
     @Override
     public EventListener getEventListener() {
         return eventListener;
+    }
+
+    @Override
+    public DirtyRecordCollector getDirtyRecordCollector() {
+        return dirtyRecordCollector;
     }
 
     private static String getFlinkJobId(Sink.InitContext writerContext) {

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterContext.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.DistributedCounter;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.translation.flink.metric.FlinkMetricContext;
@@ -69,7 +70,20 @@ public class FlinkSinkWriterContext implements SinkWriter.Context {
         }
         try {
             Counter dirtyCounter = metricsContext.counter(DIRTY_RECORD_COUNT_METRIC);
-            dirtyRecordCollector.setDistributedCounter(dirtyCounter);
+            dirtyRecordCollector.setDistributedCounter(
+                    new DistributedCounter() {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public void add(long delta) {
+                            dirtyCounter.inc(delta);
+                        }
+
+                        @Override
+                        public long value() {
+                            return dirtyCounter.getCount();
+                        }
+                    });
             log.info(
                     "Set up Flink distributed counter for dirty record counting (subtask {})",
                     writerContext.getSubtaskId());

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSink.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -48,6 +49,8 @@ public class SparkSink<StateT, CommitInfoT, AggregatedCommitInfoT>
     private volatile String jobId;
 
     private volatile Integer parallelism;
+
+    private volatile DirtyRecordCollector dirtyRecordCollector;
 
     private void init(DataSourceOptions options) {
         if (sink == null) {
@@ -83,6 +86,12 @@ public class SparkSink<StateT, CommitInfoT, AggregatedCommitInfoT>
                                                     SparkSinkInjector.PARALLELISM
                                                             + " must be specified"));
         }
+        if (dirtyRecordCollector == null) {
+            this.dirtyRecordCollector =
+                    options.get(SparkSinkInjector.DIRTY_COLLECTOR)
+                            .map(s -> (DirtyRecordCollector) SerializationUtils.stringToObject(s))
+                            .orElse(null);
+        }
     }
 
     @Override
@@ -91,7 +100,8 @@ public class SparkSink<StateT, CommitInfoT, AggregatedCommitInfoT>
         init(options);
 
         try {
-            return new SparkStreamWriter<>(sink, catalogTables, jobId, parallelism);
+            return new SparkStreamWriter<>(
+                    sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
         } catch (IOException e) {
             throw new RuntimeException("find error when createStreamWriter", e);
         }
@@ -104,7 +114,8 @@ public class SparkSink<StateT, CommitInfoT, AggregatedCommitInfoT>
 
         try {
             return Optional.of(
-                    new SparkDataSourceWriter<>(sink, catalogTables, jobId, parallelism));
+                    new SparkDataSourceWriter<>(
+                            sink, catalogTables, jobId, parallelism, dirtyRecordCollector));
         } catch (IOException e) {
             throw new RuntimeException("find error when createStreamWriter", e);
         }

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSinkInjector.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSinkInjector.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.common.Constants;
@@ -35,6 +36,7 @@ public class SparkSinkInjector {
     public static final String SINK_CATALOG_TABLE = "sink.catalog.table";
     public static final String JOB_ID = "jobId";
     public static final String PARALLELISM = "parallelism";
+    public static final String DIRTY_COLLECTOR = "dirty.collector.serialized";
 
     public static DataStreamWriter<Row> inject(
             DataStreamWriter<Row> dataset,
@@ -42,12 +44,34 @@ public class SparkSinkInjector {
             CatalogTable[] catalogTables,
             String applicationId,
             int parallelism) {
-        return dataset.format(SPARK_SINK_CLASS_NAME)
-                .outputMode(OutputMode.Append())
-                .option(Constants.SINK_SERIALIZATION, SerializationUtils.objectToString(sink))
-                .option(SINK_CATALOG_TABLE, SerializationUtils.objectToString(catalogTables))
-                .option(JOB_ID, applicationId)
-                .option(PARALLELISM, parallelism);
+        return inject(dataset, sink, catalogTables, applicationId, parallelism, null);
+    }
+
+    public static DataStreamWriter<Row> inject(
+            DataStreamWriter<Row> dataset,
+            SeaTunnelSink<?, ?, ?, ?> sink,
+            CatalogTable[] catalogTables,
+            String applicationId,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
+        DataStreamWriter<Row> writer =
+                dataset.format(SPARK_SINK_CLASS_NAME)
+                        .outputMode(OutputMode.Append())
+                        .option(
+                                Constants.SINK_SERIALIZATION,
+                                SerializationUtils.objectToString(sink))
+                        .option(
+                                SINK_CATALOG_TABLE,
+                                SerializationUtils.objectToString(catalogTables))
+                        .option(JOB_ID, applicationId)
+                        .option(PARALLELISM, parallelism);
+        if (dirtyRecordCollector != null) {
+            writer =
+                    writer.option(
+                            DIRTY_COLLECTOR,
+                            SerializationUtils.objectToString(dirtyRecordCollector));
+        }
+        return writer;
     }
 
     public static DataFrameWriter<Row> inject(
@@ -56,10 +80,32 @@ public class SparkSinkInjector {
             CatalogTable[] catalogTables,
             String applicationId,
             int parallelism) {
-        return dataset.format(SPARK_SINK_CLASS_NAME)
-                .option(Constants.SINK_SERIALIZATION, SerializationUtils.objectToString(sink))
-                .option(SINK_CATALOG_TABLE, SerializationUtils.objectToString(catalogTables))
-                .option(JOB_ID, applicationId)
-                .option(PARALLELISM, parallelism);
+        return inject(dataset, sink, catalogTables, applicationId, parallelism, null);
+    }
+
+    public static DataFrameWriter<Row> inject(
+            DataFrameWriter<Row> dataset,
+            SeaTunnelSink<?, ?, ?, ?> sink,
+            CatalogTable[] catalogTables,
+            String applicationId,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
+        DataFrameWriter<Row> writer =
+                dataset.format(SPARK_SINK_CLASS_NAME)
+                        .option(
+                                Constants.SINK_SERIALIZATION,
+                                SerializationUtils.objectToString(sink))
+                        .option(
+                                SINK_CATALOG_TABLE,
+                                SerializationUtils.objectToString(catalogTables))
+                        .option(JOB_ID, applicationId)
+                        .option(PARALLELISM, parallelism);
+        if (dirtyRecordCollector != null) {
+            writer =
+                    writer.option(
+                            DIRTY_COLLECTOR,
+                            SerializationUtils.objectToString(dirtyRecordCollector));
+        }
+        return writer;
     }
 }

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataSourceWriter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataSourceWriter.java
@@ -17,7 +17,9 @@
 
 package org.apache.seatunnel.translation.spark.sink.writer;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.MultiTableResourceManager;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkAggregatedCommitter;
 import org.apache.seatunnel.api.sink.SupportResourceShare;
@@ -50,6 +52,7 @@ public class SparkDataSourceWriter<StateT, CommitInfoT, AggregatedCommitInfoT>
     protected final CatalogTable[] catalogTables;
     protected final String jobId;
     protected final int parallelism;
+    protected final DirtyRecordCollector dirtyRecordCollector;
 
     private MultiTableResourceManager resourceManager;
 
@@ -57,15 +60,19 @@ public class SparkDataSourceWriter<StateT, CommitInfoT, AggregatedCommitInfoT>
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, AggregatedCommitInfoT> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism)
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector)
             throws IOException {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector =
+                dirtyRecordCollector != null
+                        ? dirtyRecordCollector
+                        : NoOpDirtyRecordCollector.INSTANCE;
         this.sinkAggregatedCommitter = sink.createAggregatedCommitter().orElse(null);
         if (sinkAggregatedCommitter != null) {
-            // TODO close it
             if (this.sinkAggregatedCommitter instanceof SupportResourceShare) {
                 resourceManager =
                         ((SupportResourceShare) this.sinkAggregatedCommitter)
@@ -81,7 +88,8 @@ public class SparkDataSourceWriter<StateT, CommitInfoT, AggregatedCommitInfoT>
 
     @Override
     public DataWriterFactory<InternalRow> createWriterFactory() {
-        return new SparkDataWriterFactory<>(sink, catalogTables, jobId, parallelism);
+        return new SparkDataWriterFactory<>(
+                sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
@@ -28,13 +28,18 @@ import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.translation.spark.execution.MultiTableManager;
 
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
+import org.apache.spark.util.LongAccumulator;
+
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.sql.DriverManager;
 
+@Slf4j
 public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFactory<InternalRow> {
 
     static {
@@ -54,6 +59,7 @@ public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFa
     private final String jobId;
     private final int parallelism;
     private final DirtyRecordCollector dirtyRecordCollector;
+    private final LongAccumulator dirtyRecordAccumulator;
 
     SparkDataWriterFactory(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, ?> sink,
@@ -69,10 +75,39 @@ public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFa
                 dirtyRecordCollector != null
                         ? dirtyRecordCollector
                         : NoOpDirtyRecordCollector.INSTANCE;
+
+        this.dirtyRecordAccumulator = createSparkAccumulator(jobId);
+        if (this.dirtyRecordAccumulator != null) {
+            log.info("Created Spark LongAccumulator for distributed dirty record counting");
+        }
+    }
+
+    private LongAccumulator createSparkAccumulator(String jobId) {
+        try {
+            SparkSession session =
+                    SparkSession.getActiveSession().isDefined()
+                            ? SparkSession.getActiveSession().get()
+                            : null;
+            if (session != null) {
+                return session.sparkContext().longAccumulator("dirtyRecordCount_" + jobId);
+            }
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to create Spark accumulator for dirty record counting", e);
+            return null;
+        }
     }
 
     @Override
     public DataWriter<InternalRow> createDataWriter(int partitionId, long taskId, long epochId) {
+        if (dirtyRecordAccumulator != null
+                && !(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+            dirtyRecordCollector.setDistributedCounter(dirtyRecordAccumulator);
+            log.debug(
+                    "Set Spark accumulator to dirty record collector for partition {}",
+                    partitionId);
+        }
+
         org.apache.seatunnel.api.sink.SinkWriter.Context context =
                 new DefaultSinkWriterContext(
                         (int) taskId,

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
@@ -17,7 +17,10 @@
 
 package org.apache.seatunnel.translation.spark.sink.writer;
 
+import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
@@ -50,22 +53,32 @@ public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFa
     private final CatalogTable[] catalogTables;
     private final String jobId;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     SparkDataWriterFactory(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, ?> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism) {
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector =
+                dirtyRecordCollector != null
+                        ? dirtyRecordCollector
+                        : NoOpDirtyRecordCollector.INSTANCE;
     }
 
     @Override
     public DataWriter<InternalRow> createDataWriter(int partitionId, long taskId, long epochId) {
         org.apache.seatunnel.api.sink.SinkWriter.Context context =
-                new DefaultSinkWriterContext(jobId, (int) taskId, parallelism);
+                new DefaultSinkWriterContext(
+                        (int) taskId,
+                        parallelism,
+                        new DefaultEventProcessor(jobId),
+                        dirtyRecordCollector);
         SinkWriter<SeaTunnelRow, CommitInfoT, StateT> writer;
         SinkCommitter<CommitInfoT> committer;
         try {

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkDataWriterFactory.java
@@ -19,7 +19,9 @@ package org.apache.seatunnel.translation.spark.sink.writer;
 
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
+import org.apache.seatunnel.api.sink.DirtyDataAwareSinkWriter;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.DistributedCounter;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkCommitter;
@@ -102,7 +104,20 @@ public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFa
     public DataWriter<InternalRow> createDataWriter(int partitionId, long taskId, long epochId) {
         if (dirtyRecordAccumulator != null
                 && !(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
-            dirtyRecordCollector.setDistributedCounter(dirtyRecordAccumulator);
+            dirtyRecordCollector.setDistributedCounter(
+                    new DistributedCounter() {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public void add(long delta) {
+                            dirtyRecordAccumulator.add(delta);
+                        }
+
+                        @Override
+                        public long value() {
+                            return dirtyRecordAccumulator.value();
+                        }
+                    });
             log.debug(
                     "Set Spark accumulator to dirty record collector for partition {}",
                     partitionId);
@@ -120,6 +135,16 @@ public class SparkDataWriterFactory<CommitInfoT, StateT> implements DataWriterFa
             writer = sink.createWriter(context);
         } catch (IOException e) {
             throw new RuntimeException("Failed to create SinkWriter.", e);
+        }
+        if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+            writer =
+                    new DirtyDataAwareSinkWriter<>(
+                            writer,
+                            dirtyRecordCollector,
+                            context.getIndexOfSubtask(),
+                            catalogTables != null && catalogTables.length == 1
+                                    ? catalogTables[0]
+                                    : null);
         }
         try {
             committer = sink.createCommitter().orElse(null);

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkStreamWriter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-2.4/src/main/java/org/apache/seatunnel/translation/spark/sink/writer/SparkStreamWriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink.writer;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -36,9 +37,10 @@ public class SparkStreamWriter<StateT, CommitInfoT, AggregatedCommitInfoT>
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, AggregatedCommitInfoT> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism)
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector)
             throws IOException {
-        super(sink, catalogTables, jobId, parallelism);
+        super(sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SeaTunnelBatchWrite.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SeaTunnelBatchWrite.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.MultiTableResourceManager;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkAggregatedCommitter;
@@ -68,16 +69,21 @@ public class SeaTunnelBatchWrite<StateT, CommitInfoT, AggregatedCommitInfoT>
 
     private final int parallelism;
 
+    /** Pre-built collector passed from driver. */
+    private final DirtyRecordCollector dirtyRecordCollector;
+
     public SeaTunnelBatchWrite(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, AggregatedCommitInfoT> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism)
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector)
             throws IOException {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
         this.aggregatedCommitter = sink.createAggregatedCommitter().orElse(null);
         if (aggregatedCommitter != null) {
             if (this.aggregatedCommitter instanceof SupportResourceShare) {
@@ -95,7 +101,8 @@ public class SeaTunnelBatchWrite<StateT, CommitInfoT, AggregatedCommitInfoT>
 
     @Override
     public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
-        return new SeaTunnelSparkDataWriterFactory<>(sink, catalogTables, jobId, parallelism);
+        return new SeaTunnelSparkDataWriterFactory<>(
+                sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SeaTunnelSinkTable.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SeaTunnelSinkTable.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.translation.spark.sink;
 import org.apache.seatunnel.shade.com.google.common.collect.Sets;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -50,6 +51,7 @@ public class SeaTunnelSinkTable implements Table, SupportsWrite {
     private final CatalogTable[] catalogTables;
     private final String jobId;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public SeaTunnelSinkTable(Map<String, String> properties) {
         this.properties = properties;
@@ -74,11 +76,18 @@ public class SeaTunnelSinkTable implements Table, SupportsWrite {
                                         new IllegalArgumentException(
                                                 SparkSinkInjector.PARALLELISM
                                                         + " must be specified"));
+        String dirtyCollectorSerialization =
+                properties.getOrDefault(SparkSinkInjector.DIRTY_COLLECTOR, null);
+        this.dirtyRecordCollector =
+                dirtyCollectorSerialization != null
+                        ? SerializationUtils.stringToObject(dirtyCollectorSerialization)
+                        : null;
     }
 
     @Override
     public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-        return new SeaTunnelWriteBuilder<>(sink, catalogTables, jobId, parallelism);
+        return new SeaTunnelWriteBuilder<>(
+                sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
     }
 
     @Override

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSinkInjector.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/SparkSinkInjector.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.common.Constants;
@@ -37,19 +38,42 @@ public class SparkSinkInjector {
 
     public static final String PARALLELISM = "parallelism";
 
+    public static final String DIRTY_COLLECTOR = "dirty.collector.serialized";
+
     public static DataStreamWriter<Row> inject(
             DataStreamWriter<Row> dataset,
             SeaTunnelSink<?, ?, ?, ?> sink,
             CatalogTable[] catalogTables,
             String applicationId,
             int parallelism) {
-        return dataset.format(SINK_NAME)
-                .outputMode(OutputMode.Append())
-                .option(Constants.SINK_SERIALIZATION, SerializationUtils.objectToString(sink))
-                // TODO this should require fetching the catalog table in sink
-                .option(SINK_CATALOG_TABLE, SerializationUtils.objectToString(catalogTables))
-                .option(JOB_ID, applicationId)
-                .option(PARALLELISM, parallelism);
+        return inject(dataset, sink, catalogTables, applicationId, parallelism, null);
+    }
+
+    public static DataStreamWriter<Row> inject(
+            DataStreamWriter<Row> dataset,
+            SeaTunnelSink<?, ?, ?, ?> sink,
+            CatalogTable[] catalogTables,
+            String applicationId,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
+        DataStreamWriter<Row> writer =
+                dataset.format(SINK_NAME)
+                        .outputMode(OutputMode.Append())
+                        .option(
+                                Constants.SINK_SERIALIZATION,
+                                SerializationUtils.objectToString(sink))
+                        .option(
+                                SINK_CATALOG_TABLE,
+                                SerializationUtils.objectToString(catalogTables))
+                        .option(JOB_ID, applicationId)
+                        .option(PARALLELISM, parallelism);
+        if (dirtyRecordCollector != null) {
+            writer =
+                    writer.option(
+                            DIRTY_COLLECTOR,
+                            SerializationUtils.objectToString(dirtyRecordCollector));
+        }
+        return writer;
     }
 
     public static DataFrameWriter<Row> inject(
@@ -58,11 +82,32 @@ public class SparkSinkInjector {
             CatalogTable[] catalogTables,
             String applicationId,
             int parallelism) {
-        return dataset.format(SINK_NAME)
-                .option(Constants.SINK_SERIALIZATION, SerializationUtils.objectToString(sink))
-                // TODO this should require fetching the catalog table in sink
-                .option(SINK_CATALOG_TABLE, SerializationUtils.objectToString(catalogTables))
-                .option(JOB_ID, applicationId)
-                .option(PARALLELISM, parallelism);
+        return inject(dataset, sink, catalogTables, applicationId, parallelism, null);
+    }
+
+    public static DataFrameWriter<Row> inject(
+            DataFrameWriter<Row> dataset,
+            SeaTunnelSink<?, ?, ?, ?> sink,
+            CatalogTable[] catalogTables,
+            String applicationId,
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
+        DataFrameWriter<Row> writer =
+                dataset.format(SINK_NAME)
+                        .option(
+                                Constants.SINK_SERIALIZATION,
+                                SerializationUtils.objectToString(sink))
+                        .option(
+                                SINK_CATALOG_TABLE,
+                                SerializationUtils.objectToString(catalogTables))
+                        .option(JOB_ID, applicationId)
+                        .option(PARALLELISM, parallelism);
+        if (dirtyRecordCollector != null) {
+            writer =
+                    writer.option(
+                            DIRTY_COLLECTOR,
+                            SerializationUtils.objectToString(dirtyRecordCollector));
+        }
+        return writer;
     }
 }

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
@@ -17,7 +17,10 @@
 
 package org.apache.seatunnel.translation.spark.sink.write;
 
+import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
@@ -52,21 +55,32 @@ public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
     private final CatalogTable[] catalogTables;
     private final String jobId;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public SeaTunnelSparkDataWriterFactory(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, ?> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism) {
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector =
+                dirtyRecordCollector != null
+                        ? dirtyRecordCollector
+                        : NoOpDirtyRecordCollector.INSTANCE;
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
-        SinkWriter.Context context = new DefaultSinkWriterContext(jobId, (int) taskId, parallelism);
+        SinkWriter.Context context =
+                new DefaultSinkWriterContext(
+                        (int) taskId,
+                        parallelism,
+                        new DefaultEventProcessor(jobId),
+                        dirtyRecordCollector);
         SinkWriter<SeaTunnelRow, CommitInfoT, StateT> writer;
         SinkCommitter<CommitInfoT> committer;
         try {

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
@@ -19,7 +19,9 @@ package org.apache.seatunnel.translation.spark.sink.write;
 
 import org.apache.seatunnel.api.event.DefaultEventProcessor;
 import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
+import org.apache.seatunnel.api.sink.DirtyDataAwareSinkWriter;
 import org.apache.seatunnel.api.sink.DirtyRecordCollector;
+import org.apache.seatunnel.api.sink.DistributedCounter;
 import org.apache.seatunnel.api.sink.NoOpDirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkCommitter;
@@ -104,7 +106,20 @@ public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
         if (dirtyRecordAccumulator != null
                 && !(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
-            dirtyRecordCollector.setDistributedCounter(dirtyRecordAccumulator);
+            dirtyRecordCollector.setDistributedCounter(
+                    new DistributedCounter() {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public void add(long delta) {
+                            dirtyRecordAccumulator.add(delta);
+                        }
+
+                        @Override
+                        public long value() {
+                            return dirtyRecordAccumulator.value();
+                        }
+                    });
             log.debug(
                     "Set Spark accumulator to dirty record collector for partition {}",
                     partitionId);
@@ -122,6 +137,16 @@ public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
             writer = sink.createWriter(context);
         } catch (IOException e) {
             throw new RuntimeException("Failed to create SinkWriter.", e);
+        }
+        if (!(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+            writer =
+                    new DirtyDataAwareSinkWriter<>(
+                            writer,
+                            dirtyRecordCollector,
+                            context.getIndexOfSubtask(),
+                            catalogTables != null && catalogTables.length == 1
+                                    ? catalogTables[0]
+                                    : null);
         }
         try {
             committer = sink.createCommitter().orElse(null);

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelSparkDataWriterFactory.java
@@ -28,14 +28,20 @@ import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.translation.spark.execution.MultiTableManager;
 
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
+import org.apache.spark.util.LongAccumulator;
+
+import lombok.extern.slf4j.Slf4j;
+import scala.Option;
 
 import java.io.IOException;
 import java.sql.DriverManager;
 
+@Slf4j
 public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
         implements DataWriterFactory, StreamingDataWriterFactory {
 
@@ -56,6 +62,7 @@ public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
     private final String jobId;
     private final int parallelism;
     private final DirtyRecordCollector dirtyRecordCollector;
+    private final LongAccumulator dirtyRecordAccumulator;
 
     public SeaTunnelSparkDataWriterFactory(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, ?> sink,
@@ -71,10 +78,38 @@ public class SeaTunnelSparkDataWriterFactory<CommitInfoT, StateT>
                 dirtyRecordCollector != null
                         ? dirtyRecordCollector
                         : NoOpDirtyRecordCollector.INSTANCE;
+
+        this.dirtyRecordAccumulator = createSparkAccumulator(jobId);
+        if (this.dirtyRecordAccumulator != null) {
+            log.info("Created Spark LongAccumulator for distributed dirty record counting");
+        }
+    }
+
+    private LongAccumulator createSparkAccumulator(String jobId) {
+        try {
+            Option<LongAccumulator> sparkAccumulator =
+                    SparkSession.getActiveSession()
+                            .map(
+                                    session ->
+                                            session.sparkContext()
+                                                    .longAccumulator("dirtyRecordCount_" + jobId));
+            return sparkAccumulator.get();
+        } catch (Exception e) {
+            log.warn("Failed to create Spark accumulator for dirty record counting", e);
+            return null;
+        }
     }
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+        if (dirtyRecordAccumulator != null
+                && !(dirtyRecordCollector instanceof NoOpDirtyRecordCollector)) {
+            dirtyRecordCollector.setDistributedCounter(dirtyRecordAccumulator);
+            log.debug(
+                    "Set Spark accumulator to dirty record collector for partition {}",
+                    partitionId);
+        }
+
         SinkWriter.Context context =
                 new DefaultSinkWriterContext(
                         (int) taskId,

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelWrite.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelWrite.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink.write;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -34,22 +35,26 @@ public class SeaTunnelWrite<AggregatedCommitInfoT, CommitInfoT, StateT> implemen
     private final CatalogTable[] catalogTables;
     private final String jobId;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public SeaTunnelWrite(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, AggregatedCommitInfoT> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism) {
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
     public BatchWrite toBatch() {
         try {
-            return new SeaTunnelBatchWrite<>(sink, catalogTables, jobId, parallelism);
+            return new SeaTunnelBatchWrite<>(
+                    sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
         } catch (IOException e) {
             throw new RuntimeException("SeaTunnel Spark sink create batch failed", e);
         }
@@ -58,7 +63,8 @@ public class SeaTunnelWrite<AggregatedCommitInfoT, CommitInfoT, StateT> implemen
     @Override
     public StreamingWrite toStreaming() {
         try {
-            return new SeaTunnelBatchWrite<>(sink, catalogTables, jobId, parallelism);
+            return new SeaTunnelBatchWrite<>(
+                    sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
         } catch (IOException e) {
             throw new RuntimeException("SeaTunnel Spark sink create batch failed", e);
         }

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelWriteBuilder.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-3.3/src/main/java/org/apache/seatunnel/translation/spark/sink/write/SeaTunnelWriteBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.translation.spark.sink.write;
 
+import org.apache.seatunnel.api.sink.DirtyRecordCollector;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -31,20 +32,23 @@ public class SeaTunnelWriteBuilder<StateT, CommitInfoT, AggregatedCommitInfoT>
     private final CatalogTable[] catalogTables;
     private final String jobId;
     private final int parallelism;
+    private final DirtyRecordCollector dirtyRecordCollector;
 
     public SeaTunnelWriteBuilder(
             SeaTunnelSink<SeaTunnelRow, StateT, CommitInfoT, AggregatedCommitInfoT> sink,
             CatalogTable[] catalogTables,
             String jobId,
-            int parallelism) {
+            int parallelism,
+            DirtyRecordCollector dirtyRecordCollector) {
         this.sink = sink;
         this.catalogTables = catalogTables;
         this.jobId = jobId;
         this.parallelism = parallelism;
+        this.dirtyRecordCollector = dirtyRecordCollector;
     }
 
     @Override
     public Write build() {
-        return new SeaTunnelWrite<>(sink, catalogTables, jobId, parallelism);
+        return new SeaTunnelWrite<>(sink, catalogTables, jobId, parallelism, dirtyRecordCollector);
     }
 }


### PR DESCRIPTION
### Purpose of this pull request
Implement dirty data collection framework to record and handle dirty records across SeaTunnel sinks, enabling configurable collectors, validators, SPI extensions, and threshold-based failure policies.
**Design from:** https://github.com/apache/seatunnel/issues/4587

### Summary of changes

- Add `DirtyRecordCollector` interface with overloads, init, validation integration, and threshold support.

- Implement `LogDirtyRecordCollector`, `NoOpDirtyRecordCollector`, and example SPI collector `CountingDirtyRecordCollector` with providers.

- Add `DirtyDataValidator` SPI and `ValidatingDirtyRecordCollector` wrapper to support user-defined validation rules.

- Add `DirtyRecordCollectorFactory` and `DirtyCollectorConfigProcessor` to merge env and sink configs, instantiate collectors/validators and inject into sink writer context.

- Integrate collector initialization and propagation into engine/translation layers so writer contexts receive a collector instance.

- Add unit and e2e tests and example configs for built-in and custom collectors/validators.

### Architecture

- Config-driven: collector and validator configured under `env.dirty.collector` / `env.dirty.validator` or per-sink `dirty.collector` / `dirty.validator`. `DirtyCollectorConfigProcessor` merges env and sink configs and prefers sink-specific config.

- SPI extensibility: collectors and validators discovered via Factory/SPI. Built-in "log" collector provided; custom types (e.g., "counting") can be registered via ServiceLoader.

- Validation pipeline: when a `dirty.validator` is configured, a `ValidatingDirtyRecordCollector` wraps the collector and calls validator.validate(record, catalogTable); records flagged dirty are collected by the delegate.

- Runtime behavior: sinks call context.getDirtyRecordCollector().collect(...) on write failures; writers may call validateAndCollectIfDirty(...) before writing. Collectors track counts and enforce thresholds.

- Serialization/Injection: collector objects are instantiated and injected into sink writer

**Configuration Example:**
```
env {
  parallelism = 1
  job.mode = "BATCH"

  dirty.collector = {
    type = "log"
    log_level = "ERROR"
    threshold = 10
    fail_on_threshold = true
  }
  
  dirty.validator = {
    type = "AlwaysDirtyDataValidator"
  }
}

source {
  FakeSource {
    row.num = 100
    schema = {
      fields {
        id = "bigint"
        name = "string"
        age = "int"
        status = "string"
      }
    }
    plugin_output = "fake"
  }
}

sink {
  Console {
    plugin_input = "fake"
  }
}
```

### Does this PR introduce _any_ user-facing change?
 
Yes. Previously, there was no unified dirty data collection capability; this PR introduces a configurable dirty data collection framework, allowing users to record and process dirty data via configuration or SPI-enabled collectors/validators.

**Major Changes:** Added configuration items `env.dirty.collector`  and `env.dirty.validator`(Currently, only the relevant configurations have been added for ConsoleSink; the others sink need to be implemented manually.); provided built-in log and example counting collectors; supports custom collectors/validators via SPI.

**Compatibility and Default Behavior:** `NoOpDirtyRecordCollector` is used when not configured. Enabling a threshold allows configuration to determine whether tasks fail due to exceeding the threshold.


### How was this patch tested?

Unit tests for config merging, factory discovery and basic collector behaviors.
E2E tests `DirtyDataCollectionIT`, `DirtyDataCustomExtensionIT` for:

- [ ] Built-in log collector.
- [ ] Custom SPI collector/validator usage.
- [ ] Threshold and fail-on-threshold behavior.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)