### PR TITLE
[Hotfix][CI] Update Qdrant image to v1.15.0 for compatibility

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/qdrant/QdrantIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/src/test/java/org/apache/seatunnel/e2e/connector/v2/qdrant/QdrantIT.java
@@ -62,7 +62,12 @@ public class QdrantIT extends TestSuiteBase implements TestResource {
     private static final String ALIAS = "qdrante2e";
     private static final String SOURCE_COLLECTION = "source_collection";
     private static final String SINK_COLLECTION = "sink_collection";
-    private static final String IMAGE = "qdrant/qdrant:latest";
+    /**
+     * Fixed Qdrant at v1.15.0 for stability; upgrading to v1.17.0+ requires ensuring the SeaTunnel
+     * Qdrant connector is compatible with the latest breaking changes.
+     */
+    private static final String IMAGE = "qdrant/qdrant:v1.15.0";
+
     private QdrantContainer container;
     private QdrantClient qdrantClient;
 
@@ -139,7 +144,7 @@ public class QdrantIT extends TestSuiteBase implements TestResource {
     public void testQdrant(TestContainer container)
             throws IOException, InterruptedException, ExecutionException {
         Container.ExecResult execResult = container.executeJob("/qdrant-to-qdrant.conf");
-        Assertions.assertEquals(execResult.getExitCode(), 0);
-        Assertions.assertEquals(qdrantClient.countAsync(SINK_COLLECTION).get(), 10);
+        Assertions.assertEquals(0, execResult.getExitCode());
+        Assertions.assertEquals(10, qdrantClient.countAsync(SINK_COLLECTION).get());
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixed Qdrant version to v1.15.0 due to major breaking changes (gRPC/Storage) in the latest versions that are currently incompatible with our environment.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)