### PR TITLE
implement SingleStore connector

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -112,6 +112,7 @@ If one dialect not supported by SeaTunnel, it will use the default dialect `Gene
 | Vertica   | OceanBase    | XUGU     |
 | IRIS      | Inceptor     | Highgo   |
 | DSQL      |              |          |
+| SingleStore | -           | -        |
 ### database [string]
 
 Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.
@@ -282,6 +283,7 @@ there are some reference value for params above.
 | opengauss         | org.opengauss.Driver                         | jdbc:opengauss://localhost:5432/postgres                            | /                                                  | https://repo1.maven.org/maven2/org/opengauss/opengauss-jdbc/5.1.0-og/opengauss-jdbc-5.1.0-og.jar                              |
 | Highgo            | com.highgo.jdbc.Driver                       | jdbc:highgo://localhost:5866/highgo                                 | /                                                  | https://repo1.maven.org/maven2/com/highgo/HgdbJdbc/6.2.3/HgdbJdbc-6.2.3.jar                                                   |
 | Dsql              | org.postgresql.Driver                        | jdbc:postgresql://Amazon Aurora DSQL Cluster Endpoint:5432/postgres | org.postgresql.xa.PGXADataSource                   | https://mvnrepository.com/artifact/org.postgresql/postgresql                                                                  |
+| SingleStore       | com.singlestore.jdbc.Driver                  | jdbc:singlestore://localhost:3306/test                              | /                                                  | https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client                                                   |
 
 ## Example
 

--- a/docs/en/connectors/sink/SingleStore.md
+++ b/docs/en/connectors/sink/SingleStore.md
@@ -1,0 +1,99 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
+# SingleStore
+
+> JDBC SingleStore Sink Connector
+
+## Description
+
+Write data to SingleStore (formerly MemSQL) through JDBC. SingleStore is a high-performance real-time analytical database that is MySQL-compatible. The connector uses the JDBC sink with the SingleStore dialect and supports upsert via `ON DUPLICATE KEY UPDATE`.
+
+## Supported SingleStore Version
+
+- SingleStore v7.1+
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Using Dependency
+
+### For Spark/Flink Engine
+
+> 1. You need to ensure that the [SingleStore JDBC driver](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) has been placed in directory `${SEATUNNEL_HOME}/plugins/`.
+
+### For SeaTunnel Zeta Engine
+
+> 1. You need to ensure that the [SingleStore JDBC driver](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) has been placed in directory `${SEATUNNEL_HOME}/lib/`.
+
+## Key Features
+
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] Upsert via primary key (ON DUPLICATE KEY UPDATE)
+
+## Supported DataSource Info
+
+| Datasource  | Driver                      | URL                                   | Maven                                                                 |
+|-------------|-----------------------------|---------------------------------------|-----------------------------------------------------------------------|
+| SingleStore | com.singlestore.jdbc.Driver | jdbc:singlestore://host:3306/database | [Download](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) |
+
+### Connection URL Format
+
+Same as [SingleStore Source](source/SingleStore.md#connection-url-format): `jdbc:singlestore://host:port/database[?params]`
+
+## Sink Options
+
+All options of the [JDBC Sink](Jdbc.md) connector apply. Key options for SingleStore:
+
+| Name          | Type   | Required | Default | Description                                                                 |
+|---------------|--------|----------|---------|-----------------------------------------------------------------------------|
+| url           | String | Yes      | -       | JDBC connection URL. Example: `jdbc:singlestore://localhost:3306/test`     |
+| driver        | String | Yes      | -       | JDBC driver class: `com.singlestore.jdbc.Driver`                            |
+| username      | String | No       | -       | Database user name                                                         |
+| password      | String | No       | -       | Database password                                                          |
+| database      | String | No       | -       | Target database (use with `table`)                                          |
+| table         | String | No       | -       | Target table name (use with `database`)                                     |
+| primary_keys  | Array  | No       | -       | Primary key columns for upsert                                              |
+| dialect       | String | No       | -       | Optional. Set to `SingleStore` when URL does not start with `jdbc:singlestore:` |
+| enable_upsert | Boolean | No     | true    | Enable upsert (ON DUPLICATE KEY UPDATE) when primary_keys are set           |
+
+## Example
+
+### Write to table
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    database = "test"
+    table = "my_table"
+    primary_keys = ["id"]
+  }
+}
+```
+
+### With batch and properties
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?rewriteBatchedStatements=true"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    database = "test"
+    table = "my_table"
+    primary_keys = ["id"]
+    batch_size = 1000
+    properties {
+      rewriteBatchedStatements = true
+    }
+  }
+}
+```

--- a/docs/en/connectors/source/Jdbc.md
+++ b/docs/en/connectors/source/Jdbc.md
@@ -229,6 +229,7 @@ If one dialect not supported by SeaTunnel, it will use the default dialect `Gene
 | SqlServer | Tablestore   | Teradata |
 | Vertica   | OceanBase    | XUGU     |
 | IRIS      | Inceptor     | Highgo   |
+| SingleStore | -           | -        |
 
 
 ## Parallel Reader
@@ -285,6 +286,7 @@ there are some reference value for params above.
 | Highgo            | com.highgo.jdbc.Driver                              | jdbc:highgo://localhost:5866/highgo                                    | https://repo1.maven.org/maven2/com/highgo/HgdbJdbc/6.2.3/HgdbJdbc-6.2.3.jar                                                   |
 | Presto            | com.facebook.presto.jdbc.PrestoDriver               | jdbc:presto://localhost:8080/presto                                    | https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.279/presto-jdbc-0.279.jar                                    |
 | Trino             | io.trino.jdbc.TrinoDriver                           | jdbc:trino://localhost:8080/trino                                      | https://repo1.maven.org/maven2/io/trino/trino-jdbc/460/trino-jdbc-460.jar                                                     |
+| SingleStore       | com.singlestore.jdbc.Driver                         | jdbc:singlestore://localhost:3306/test                                | https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client                                                   |
 
 ## Example
 
@@ -349,6 +351,22 @@ source {
     password = "password"
     query = "SELECT ID, NAME, CONTENT_BLOB FROM MY_TABLE"
     handle_blob_as_string = true  # Enable BLOB to String conversion for Oracle
+  }
+}
+```
+
+#### Case 5 SingleStore Source
+
+SingleStore (formerly MemSQL) is a MySQL-compatible high-performance real-time analytical database. Use the SingleStore JDBC driver and URL. You can optionally set `dialect = "SingleStore"` when the URL is not `jdbc:singlestore:`.
+
+```
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?user=root&password=myPassword"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
   }
 }
 ```

--- a/docs/en/connectors/source/SingleStore.md
+++ b/docs/en/connectors/source/SingleStore.md
@@ -1,0 +1,123 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
+# SingleStore
+
+> JDBC SingleStore Source Connector
+
+## Description
+
+Read data from SingleStore (formerly MemSQL) through JDBC. SingleStore is a high-performance real-time analytical database that is MySQL-compatible. The connector uses the JDBC source with the SingleStore dialect.
+
+## Supported SingleStore Version
+
+- SingleStore v7.1+
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Using Dependency
+
+### For Spark/Flink Engine
+
+> 1. You need to ensure that the [SingleStore JDBC driver](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) has been placed in directory `${SEATUNNEL_HOME}/plugins/`.
+
+### For SeaTunnel Zeta Engine
+
+> 1. You need to ensure that the [SingleStore JDBC driver](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) has been placed in directory `${SEATUNNEL_HOME}/lib/`.
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table reading](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+| Datasource  | Driver                      | URL                                      | Maven                                                                 |
+|-------------|-----------------------------|------------------------------------------|-----------------------------------------------------------------------|
+| SingleStore | com.singlestore.jdbc.Driver | jdbc:singlestore://host:3306/database    | [Download](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) |
+
+### Connection URL Format
+
+The SingleStore JDBC URL has the following format:
+
+```
+jdbc:singlestore:[loadbalance:|sequential:]//<host>[:port]/[database][?<key1>=<value1>[&<key2>=<value2>]]
+```
+
+- Default port is `3306`.
+- Example: `jdbc:singlestore://localhost:3306/test?user=root&password=myPassword`
+- For load balancing: `jdbc:singlestore:loadbalance://host1,host2/db`
+- For sequential failover: `jdbc:singlestore:sequential://host1,host2/db`
+
+## Data Type Mapping
+
+SingleStore is MySQL-compatible. Data type mapping follows the same as [MySQL JDBC Source](Mysql.md#data-type-mapping) (TINYINT, INT, BIGINT, VARCHAR, TEXT, DATETIME, etc.).
+
+## Source Options
+
+All options of the [JDBC Source](Jdbc.md) connector apply. Key options for SingleStore:
+
+| Name        | Type   | Required | Default | Description                                                                 |
+|-------------|--------|----------|---------|-----------------------------------------------------------------------------|
+| url         | String | Yes      | -       | JDBC connection URL. Example: `jdbc:singlestore://localhost:3306/test`      |
+| driver      | String | Yes      | -       | JDBC driver class: `com.singlestore.jdbc.Driver`                           |
+| username    | String | No       | -       | Database user name                                                         |
+| password    | String | No       | -       | Database password                                                          |
+| query       | String | No       | -       | Query statement. Use either `query` or `table_path` / `table_list`          |
+| table_path  | String | No       | -       | Full table path, e.g. `mydb.mytable`                                        |
+| dialect     | String | No       | -       | Optional. Set to `SingleStore` when URL does not start with `jdbc:singlestore:` |
+
+## Example
+
+### Read by table_path
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
+  }
+}
+```
+
+### Read by query
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    query = "SELECT * FROM my_table WHERE id > 100"
+  }
+}
+```
+
+### With connection parameters
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?rewriteBatchedStatements=true"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
+    properties {
+      defaultFetchSize = 1000
+    }
+  }
+}
+```

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -109,6 +109,7 @@ Postgres 9.5及以下版本，请设置为 `postgresLow` 来支持 CDC
 | Vertica   | OceanBase  | XUGU     |
 | IRIS      | Inceptor   | Highgo   |
 | DSQL      |            |          |
+| SingleStore | -         | -        |
 
 ### database [string]
 
@@ -269,6 +270,7 @@ Amazon Aurora DSQL 所在的区域。 该参考仅适用于 dialect="dsql"
 | opengauss  | org.opengauss.Driver                         | jdbc:opengauss://localhost:5432/postgres                           | /                                                  | https://repo1.maven.org/maven2/org/opengauss/opengauss-jdbc/5.1.0-og/opengauss-jdbc-5.1.0-og.jar   |
 | Highgo     | com.highgo.jdbc.Driver                       | jdbc:highgo://localhost:5866/highgo                                | /                                                  | https://repo1.maven.org/maven2/com/highgo/HgdbJdbc/6.2.3/HgdbJdbc-6.2.3.jar                        |
 | Dsql       | org.postgresql.Driver                        | jdbc:postgresql://Amazon Aurora DSQL Cluster Endpoint:5432/postgres | org.postgresql.xa.PGXADataSource                   | https://mvnrepository.com/artifact/org.postgresql/postgresql                                                                  |
+| SingleStore | com.singlestore.jdbc.Driver                  | jdbc:singlestore://localhost:3306/test                              | /                                                  | https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client                                                   |
 
 ## 示例
 

--- a/docs/zh/connectors/sink/SingleStore.md
+++ b/docs/zh/connectors/sink/SingleStore.md
@@ -1,0 +1,99 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
+# SingleStore
+
+> JDBC SingleStore 目标连接器
+
+## 描述
+
+通过 JDBC 将数据写入 SingleStore（原 MemSQL）。SingleStore 是兼容 MySQL 的高性能实时分析数据库。本连接器使用 JDBC 目标配合 SingleStore 方言，支持通过 `ON DUPLICATE KEY UPDATE` 实现 upsert。
+
+## 支持的 SingleStore 版本
+
+- SingleStore v7.1+
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 使用依赖
+
+### 对于 Spark/Flink 引擎
+
+> 1. 您需要确保 [SingleStore JDBC 驱动](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
+
+### 对于 SeaTunnel Zeta 引擎
+
+> 1. 您需要确保 [SingleStore JDBC 驱动](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
+
+## 关键特性
+
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] 通过主键实现 Upsert（ON DUPLICATE KEY UPDATE）
+
+## 支持的数据源信息
+
+| 数据源    | 驱动                        | URL                                   | Maven                                                                 |
+|----------|-----------------------------|---------------------------------------|-----------------------------------------------------------------------|
+| SingleStore | com.singlestore.jdbc.Driver | jdbc:singlestore://host:3306/database | [下载](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) |
+
+### 连接 URL 格式
+
+与 [SingleStore 源](source/SingleStore.md#连接-url-格式) 相同：`jdbc:singlestore://host:port/database[?params]`
+
+## 目标选项
+
+所有 [JDBC 目标](Jdbc.md) 连接器选项均适用。SingleStore 关键选项如下：
+
+| 参数名         | 类型    | 必须 | 默认值 | 描述                                                                 |
+|----------------|--------|------|--------|----------------------------------------------------------------------|
+| url            | String | 是   | -      | JDBC 连接 URL。示例：`jdbc:singlestore://localhost:3306/test`        |
+| driver         | String | 是   | -      | JDBC 驱动类：`com.singlestore.jdbc.Driver`                           |
+| username       | String | 否   | -      | 数据库用户名                                                         |
+| password       | String | 否   | -      | 数据库密码                                                           |
+| database       | String | 否   | -      | 目标数据库（与 `table` 配合使用）                                    |
+| table          | String | 否   | -      | 目标表名（与 `database` 配合使用）                                   |
+| primary_keys   | Array  | 否   | -      | 主键列，用于 upsert                                                  |
+| dialect        | String | 否   | -      | 可选。当 URL 不以 `jdbc:singlestore:` 开头时，设置为 `SingleStore`   |
+| enable_upsert   | Boolean | 否 | true   | 设置 primary_keys 时启用 upsert（ON DUPLICATE KEY UPDATE）           |
+
+## 示例
+
+### 写入表
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    database = "test"
+    table = "my_table"
+    primary_keys = ["id"]
+  }
+}
+```
+
+### 带批量和属性
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?rewriteBatchedStatements=true"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    database = "test"
+    table = "my_table"
+    primary_keys = ["id"]
+    batch_size = 1000
+    properties {
+      rewriteBatchedStatements = true
+    }
+  }
+}
+```

--- a/docs/zh/connectors/source/Jdbc.md
+++ b/docs/zh/connectors/source/Jdbc.md
@@ -223,6 +223,7 @@ int_type_narrowing = false
 | SqlServer | Tablestore | Teradata |
 | Vertica   | OceanBase | XUGU |
 | IRIS      | Inceptor | Highgo |
+| SingleStore | -       | -      |
 
 ## 并行读取器
 
@@ -260,6 +261,7 @@ JDBC 源连接器支持从表中并行读取数据。SeaTunnel 将使用某些�
 | kingbase          | com.kingbase8.Driver                                | jdbc:kingbase8://localhost:54321/db_test                               | https://repo1.maven.org/maven2/cn/com/kingbase/kingbase8/8.6.0/kingbase8-8.6.0.jar                                            |
 | oceanbase         | com.oceanbase.jdbc.Driver                           | jdbc:oceanbase://localhost:2881                                        | https://repo1.maven.org/maven2/com/oceanbase/oceanbase-client/2.4.12/oceanbase-client-2.4.12.jar                              |
 | hive              | org.apache.hive.jdbc.HiveDriver                     | jdbc:hive2://localhost:10000                                           | https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3-standalone.jar                                 |
+| SingleStore       | com.singlestore.jdbc.Driver                         | jdbc:singlestore://localhost:3306/test                                 | https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client                                                   |
 
 ## 示例
 
@@ -324,6 +326,22 @@ source {
     password = "password"
     query = "SELECT ID, NAME, CONTENT_BLOB FROM MY_TABLE"
     handle_blob_as_string = true  # 为 Oracle 启用 BLOB 到字符串转换
+  }
+}
+```
+
+#### 情况 5 SingleStore 源
+
+SingleStore（原 MemSQL）是兼容 MySQL 的高性能实时分析数据库。使用 SingleStore JDBC 驱动和 URL。当 URL 不是 `jdbc:singlestore:` 时，可设置 `dialect = "SingleStore"`。
+
+```
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?user=root&password=myPassword"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
   }
 }
 ```

--- a/docs/zh/connectors/source/SingleStore.md
+++ b/docs/zh/connectors/source/SingleStore.md
@@ -1,0 +1,123 @@
+import ChangeLog from '../changelog/connector-jdbc.md';
+
+# SingleStore
+
+> JDBC SingleStore 源连接器
+
+## 描述
+
+通过 JDBC 从 SingleStore（原 MemSQL）读取数据。SingleStore 是兼容 MySQL 的高性能实时分析数据库。本连接器使用 JDBC 源配合 SingleStore 方言。
+
+## 支持的 SingleStore 版本
+
+- SingleStore v7.1+
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 使用依赖
+
+### 对于 Spark/Flink 引擎
+
+> 1. 您需要确保 [SingleStore JDBC 驱动](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
+
+### 对于 SeaTunnel Zeta 引擎
+
+> 1. 您需要确保 [SingleStore JDBC 驱动](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
+
+## 关键特性
+
+- [x] [批](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义 split](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
+
+## 支持的数据源信息
+
+| 数据源    | 驱动                        | URL                                   | Maven                                                                 |
+|----------|-----------------------------|---------------------------------------|-----------------------------------------------------------------------|
+| SingleStore | com.singlestore.jdbc.Driver | jdbc:singlestore://host:3306/database | [下载](https://mvnrepository.com/artifact/com.singlestore/singlestore-jdbc-client) |
+
+### 连接 URL 格式
+
+SingleStore JDBC URL 格式如下：
+
+```
+jdbc:singlestore:[loadbalance:|sequential:]//<host>[:port]/[database][?<key1>=<value1>[&<key2>=<value2>]]
+```
+
+- 默认端口为 `3306`。
+- 示例：`jdbc:singlestore://localhost:3306/test?user=root&password=myPassword`
+- 负载均衡：`jdbc:singlestore:loadbalance://host1,host2/db`
+- 顺序故障转移：`jdbc:singlestore:sequential://host1,host2/db`
+
+## 数据类型映射
+
+SingleStore 兼容 MySQL。数据类型映射与 [MySQL JDBC 源](Mysql.md#数据类型映射) 相同（TINYINT、INT、BIGINT、VARCHAR、TEXT、DATETIME 等）。
+
+## 源选项
+
+所有 [JDBC 源](Jdbc.md) 连接器选项均适用。SingleStore 关键选项如下：
+
+| 参数名     | 类型   | 必须 | 默认值 | 描述                                                                 |
+|------------|--------|------|--------|----------------------------------------------------------------------|
+| url        | String | 是   | -      | JDBC 连接 URL。示例：`jdbc:singlestore://localhost:3306/test`        |
+| driver     | String | 是   | -      | JDBC 驱动类：`com.singlestore.jdbc.Driver`                           |
+| username   | String | 否   | -      | 数据库用户名                                                         |
+| password   | String | 否   | -      | 数据库密码                                                           |
+| query      | String | 否   | -      | 查询语句。可使用 `query` 或 `table_path` / `table_list`               |
+| table_path | String | 否   | -      | 完整表路径，如 `mydb.mytable`                                        |
+| dialect    | String | 否   | -      | 可选。当 URL 不以 `jdbc:singlestore:` 开头时，设置为 `SingleStore`   |
+
+## 示例
+
+### 按表路径读取
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
+  }
+}
+```
+
+### 按查询读取
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    query = "SELECT * FROM my_table WHERE id > 100"
+  }
+}
+```
+
+### 带连接参数
+
+```hocon
+source {
+  Jdbc {
+    url = "jdbc:singlestore://localhost:3306/test?rewriteBatchedStatements=true"
+    driver = "com.singlestore.jdbc.Driver"
+    user = "root"
+    password = "myPassword"
+    table_path = "test.my_table"
+    properties {
+      defaultFetchSize = 1000
+    }
+  }
+}
+```

--- a/seatunnel-connectors-v2/connector-jdbc/pom.xml
+++ b/seatunnel-connectors-v2/connector-jdbc/pom.xml
@@ -60,6 +60,7 @@
         <trino.version>460</trino.version>
         <aws.sdk.version>2.31.30</aws.sdk.version>
         <duckdb.version>1.3.1.0</duckdb.version>
+        <singlestore.jdbc.version>1.2.8</singlestore.jdbc.version>
     </properties>
 
     <dependencyManagement>
@@ -252,6 +253,12 @@
                 <version>${duckdb.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>com.singlestore</groupId>
+                <artifactId>singlestore-jdbc-client</artifactId>
+                <version>${singlestore.jdbc.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -387,6 +394,10 @@
             <groupId>org.duckdb</groupId>
             <artifactId>duckdb_jdbc</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.singlestore</groupId>
+            <artifactId>singlestore-jdbc-client</artifactId>
         </dependency>
         <!-- AWS SDK for DSQL -->
         <dependency>

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/DatabaseIdentifier.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/DatabaseIdentifier.java
@@ -49,4 +49,5 @@ public class DatabaseIdentifier {
     public static final String PRESTO = "Presto";
     public static final String DUCKDB = "DuckDB";
     public static final String DSQL = "Dsql";
+    public static final String SINGLESTORE = "SingleStore";
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialect.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.singlestore;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql.MysqlDialect;
+
+/**
+ * JDBC dialect for SingleStore (formerly MemSQL), a high-performance real-time analytical database.
+ * SingleStore is MySQL-compatible, so this dialect extends {@link MysqlDialect} and reuses MySQL
+ * type mapping and row conversion.
+ */
+public class SingleStoreDialect extends MysqlDialect {
+
+    public SingleStoreDialect() {}
+
+    public SingleStoreDialect(String fieldIde) {
+        super(fieldIde);
+    }
+
+    @Override
+    public String dialectName() {
+        return DatabaseIdentifier.SINGLESTORE;
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialectFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialectFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.singlestore;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectFactory;
+
+import com.google.auto.service.AutoService;
+
+import javax.annotation.Nonnull;
+
+/** Factory for {@link SingleStoreDialect}. */
+@AutoService(JdbcDialectFactory.class)
+public class SingleStoreDialectFactory implements JdbcDialectFactory {
+    @Override
+    public String dialectFactoryName() {
+        return DatabaseIdentifier.SINGLESTORE;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) {
+        return url != null && url.startsWith("jdbc:singlestore:");
+    }
+
+    @Override
+    public JdbcDialect create() {
+        return new SingleStoreDialect();
+    }
+
+    @Override
+    public JdbcDialect create(@Nonnull String compatibleMode, String fieldIde) {
+        return new SingleStoreDialect(fieldIde);
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectLoaderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialectLoaderTest.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect;
 
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql.MysqlDialect;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.singlestore.SingleStoreDialect;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,19 @@ public class JdbcDialectLoaderTest {
         JdbcDialect jdbcDialect =
                 JdbcDialectLoader.load("jdbc:mysql://localhost:3306/test", null, "");
         Assertions.assertInstanceOf(MysqlDialect.class, jdbcDialect);
+    }
+
+    @Test
+    public void shouldFindSingleStoreDialect() throws Exception {
+        JdbcDialect jdbcDialect =
+                JdbcDialectLoader.load("jdbc:singlestore://localhost:3306/test", null, "");
+        Assertions.assertInstanceOf(SingleStoreDialect.class, jdbcDialect);
+    }
+
+    @Test
+    public void shouldFindSingleStoreDialectByDialect() throws Exception {
+        JdbcDialect jdbcDialect = JdbcDialectLoader.load("jdbc:other://host/db", "SingleStore", "");
+        Assertions.assertInstanceOf(SingleStoreDialect.class, jdbcDialect);
     }
 
     /** Test for {@link JdbcDialectLoader} for appointDialect */

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/singlestore/SingleStoreDialectTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.singlestore;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+/** Unit tests for {@link SingleStoreDialect}. */
+public class SingleStoreDialectTest {
+
+    @Test
+    public void testDialectName() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertEquals(DatabaseIdentifier.SINGLESTORE, dialect.dialectName());
+    }
+
+    @Test
+    public void testRowConverter() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertNotNull(dialect.getRowConverter());
+        Assertions.assertEquals(
+                DatabaseIdentifier.MYSQL, dialect.getRowConverter().converterName());
+    }
+
+    @Test
+    public void testTypeConverter() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertNotNull(dialect.getTypeConverter());
+    }
+
+    @Test
+    public void testQuoteIdentifier() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertEquals("`col`", dialect.quoteIdentifier("col"));
+    }
+
+    @Test
+    public void testTableIdentifier() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertEquals("`mydb`.`mytable`", dialect.tableIdentifier("mydb", "mytable"));
+    }
+
+    @Test
+    public void testUpsertStatement() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        String[] fieldNames = new String[] {"id", "name", "value"};
+        String[] uniqueKeyFields = new String[] {"id"};
+        Optional<String> upsert =
+                dialect.getUpsertStatement("db", "t", fieldNames, uniqueKeyFields);
+        Assertions.assertTrue(upsert.isPresent());
+        Assertions.assertTrue(upsert.get().contains("ON DUPLICATE KEY UPDATE"));
+        Assertions.assertTrue(upsert.get().contains("`id`=VALUES(`id`)"));
+        Assertions.assertTrue(upsert.get().contains("`name`=VALUES(`name`)"));
+        Assertions.assertTrue(upsert.get().contains("`value`=VALUES(`value`)"));
+    }
+
+    @Test
+    public void testHashModForField() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        String expr = dialect.hashModForField("pk", 10);
+        Assertions.assertTrue(expr.contains("CRC32"));
+        Assertions.assertTrue(expr.contains("`pk`"));
+        Assertions.assertTrue(expr.contains("10"));
+    }
+
+    @Test
+    public void testDefaultParameter() {
+        SingleStoreDialect dialect = new SingleStoreDialect();
+        Assertions.assertTrue(dialect.defaultParameter().containsKey("rewriteBatchedStatements"));
+        Assertions.assertEquals("true", dialect.defaultParameter().get("rewriteBatchedStatements"));
+    }
+
+    @Test
+    public void testSingleStoreDialectFactoryAcceptsUrl() {
+        SingleStoreDialectFactory factory = new SingleStoreDialectFactory();
+        Assertions.assertTrue(factory.acceptsURL("jdbc:singlestore://localhost:3306/test"));
+        Assertions.assertTrue(factory.acceptsURL("jdbc:singlestore:loadbalance://host1,host2/db"));
+        Assertions.assertFalse(factory.acceptsURL("jdbc:mysql://localhost:3306/test"));
+        Assertions.assertFalse(factory.acceptsURL(null));
+    }
+
+    @Test
+    public void testSingleStoreDialectFactoryDialectName() {
+        SingleStoreDialectFactory factory = new SingleStoreDialectFactory();
+        Assertions.assertEquals(DatabaseIdentifier.SINGLESTORE, factory.dialectFactoryName());
+    }
+
+    @Test
+    public void testCreateDialect() {
+        SingleStoreDialectFactory factory = new SingleStoreDialectFactory();
+        JdbcDialect dialect = factory.create();
+        Assertions.assertInstanceOf(SingleStoreDialect.class, dialect);
+        JdbcDialect dialectWithFieldIde = factory.create("", "LOWERCASE");
+        Assertions.assertInstanceOf(SingleStoreDialect.class, dialectWithFieldIde);
+    }
+}


### PR DESCRIPTION
1. SingleStore 兼容 JDBC 连接器支持（connector-jdbc）
DatabaseIdentifier.java
新增常量：SINGLESTORE = "SingleStore" ;
 internal/dialect/singlestore/SingleStoreDialect.java（新建）
继承 MysqlDialect，名称为 SingleStore。
SingleStore 与 MySQL 兼容，复用 MySQL 的类型转换、行转换、upsert（ON DUPLICATE KEY UPDATE）等逻辑。
internal/dialect/singlestore/SingleStoreDialectFactory.java（新建）
使用 @AutoService(JdbcDialectFactory.class) 注册 SPI。
dialectFactoryName() 返回 "SingleStore"。
acceptsURL(url) 对 jdbc:singlestore: 返回 true。
connector-jdbc/pom.xml
增加 SingleStore JDBC 驱动依赖：com.singlestore:singlestore-jdbc-client:1.2.8（provided）。

2. 单元测试
JdbcDialectLoaderTest.java
shouldFindSingleStoreDialect()：用 URL jdbc:singlestore://localhost:3306/test 加载，断言为 SingleStoreDialect。
shouldFindSingleStoreDialectByDialect()：用 dialect = "SingleStore" 加载，断言为 SingleStoreDialect。
internal/dialect/singlestore/SingleStoreDialectTest.java（新建）
覆盖：dialectName、getRowConverter、getTypeConverter、quoteIdentifier、tableIdentifier、getUpsertStatement、hashModForField、defaultParameter。
覆盖 Factory：acceptsURL、dialectFactoryName、create / create(compatibleMode, fieldIde)。

3. 文档（中英文）
JDBC 源/目标（en/zh）
在 dialect 列表中增加 SingleStore。
在附录的“数据源 / driver / url / Maven”表中增加 SingleStore 一行。
英文 Jdbc 源文档中增加 “Case 5 SingleStore Source” 示例；中文增加 “情况 5 SingleStore 源”。
SingleStore 专用说明（新建）
英文：docs/en/connectors/source/SingleStore.md、docs/en/connectors/sink/SingleStore.md
中文：docs/zh/connectors/source/SingleStore.md、docs/zh/connectors/sink/SingleStore.md
内容包含：简介、支持的 SingleStore 版本、驱动与 URL（含 jdbc:singlestore://、loadbalance、sequential）、依赖说明、关键选项、示例（table_path / query / properties 等）。

4. 使用方式
驱动类：com.singlestore.jdbc.Driver
URL 示例：jdbc:singlestore://localhost:3306/test（可选 ?user=root&password=xxx 等参数）
驱动 JAR：需自行下载 singlestore-jdbc-client 并放到 $SEATUNNEL_HOME/lib/（Zeta）或 $SEATUNNEL_HOME/plugins/（Spark/Flink）。
使用 jdbc:singlestore: 时无需再配 dialect；若用其它 URL 仍要走 SingleStore，可设置 dialect = "SingleStore"。