### PR TITLE
feat(helm): Add support for existing ConfigMap

### DIFF
--- a/deploy/kubernetes/seatunnel/templates/_helpers.tpl
+++ b/deploy/kubernetes/seatunnel/templates/_helpers.tpl
@@ -63,3 +63,14 @@ app.kubernetes.io/name: {{ include "seatunnel.fullname" . }}-worker
 app.kubernetes.io/component: worker
 {{ include "seatunnel.common.labels" . }}
 {{- end -}}
+
+{{/*
+Get the ConfigMap name - either existing or the one to be created.
+*/}}
+{{- define "seatunnel.configMapName" -}}
+{{- if .Values.configMap.create -}}
+{{- include "seatunnel.fullname" . }}-configs
+{{- else -}}
+{{- .Values.configMap.existingConfigMapName }}
+{{- end -}}
+{{- end -}}

--- a/deploy/kubernetes/seatunnel/templates/configmap.yaml
+++ b/deploy/kubernetes/seatunnel/templates/configmap.yaml
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+{{- if .Values.configMap.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,4 +27,5 @@ data:
     {{- base $path | nindent 2 }}: |-
       {{- tpl ($.Files.Get $path) $ | nindent 4 -}}
   {{- end }}
+{{- end }}
 

--- a/deploy/kubernetes/seatunnel/templates/deployment-seatunnel-master.yaml
+++ b/deploy/kubernetes/seatunnel/templates/deployment-seatunnel-master.yaml
@@ -92,5 +92,5 @@ spec:
       volumes:
         - name: seatunnel-configs
           configMap:
-            name: {{ include "seatunnel.fullname" . }}-configs
+            name: {{ include "seatunnel.configMapName" . }}
 

--- a/deploy/kubernetes/seatunnel/templates/deployment-seatunnel-worker.yaml
+++ b/deploy/kubernetes/seatunnel/templates/deployment-seatunnel-worker.yaml
@@ -90,4 +90,4 @@ spec:
       volumes:
         - name: seatunnel-configs
           configMap:
-            name: {{ include "seatunnel.fullname" . }}-configs
+            name: {{ include "seatunnel.configMapName" . }}

--- a/deploy/kubernetes/seatunnel/values.yaml
+++ b/deploy/kubernetes/seatunnel/values.yaml
@@ -25,6 +25,16 @@ image:
   pullPolicy: "IfNotPresent"
   pullSecret: ""
 
+# ConfigMap settings
+configMap:
+  # If true, create a new ConfigMap. If false, use existingConfigMapName
+  create: true
+  # Name of existing ConfigMap to use (only used when create=false)
+  # The ConfigMap should contain all config files: hazelcast-client.yaml, hazelcast-master.yaml,
+  # hazelcast-worker.yaml, jvm_client_options, jvm_master_options, jvm_worker_options,
+  # log4j2.properties, seatunnel.yaml
+  existingConfigMapName: ""
+
 # The env for pod
 env:
   - name: TZ


### PR DESCRIPTION
Allows users to use pre-existing ConfigMaps instead of always creating new ones. This resolves "configmap already exists" errors when:
- Users manage ConfigMaps separately (GitOps workflows)
- ConfigMaps are pre-created by other tools or processes
- Users want to share ConfigMaps across multiple releases

Changes:
- Added configMap.create and configMap.existingConfigMapName options in values.yaml
- Made ConfigMap creation conditional in templates/configmap.yaml
- Added seatunnel.configMapName helper function in templates/_helpers.tpl
- Updated deployment templates to use dynamic ConfigMap name

Usage:
  helm install seatunnel apache/seatunnel \ --set configMap.create=false \ --set configMap.existingConfigMapName=my-configmap

Note: Configuration values in conf/ directory are currently hardcoded and not exposed in values.yaml. Users must manage these values in their ConfigMaps. Future improvements could expose these values for better customization.

Backward compatible: Default behavior unchanged (configMap.create: true)

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)