### PR TITLE
[Fix][Zeta] Stabilize flaky CI tests for unit-test and jdbc-connectors-it-part-7

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.e2e.common.TestSuiteBase;
 import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -195,6 +196,7 @@ public class JdbcMySqlSaveModeCatalogIT extends TestSuiteBase implements TestRes
     }
 
     @Override
+    @AfterAll
     public void tearDown() throws Exception {
         if (mysql_container != null) {
             mysql_container.close();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
@@ -38,6 +38,7 @@ import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -549,6 +550,7 @@ public class JdbcMysqlSplitIT extends TestSuiteBase implements TestResource {
     }
 
     @Override
+    @AfterAll
     public void tearDown() throws Exception {
         if (mysql_container != null) {
             mysql_container.close();

--- a/seatunnel-e2e/seatunnel-core-e2e/seatunnel-starter-e2e/src/test/java/org/apache/seatunnel/core/starter/seatunnel/SeaTunnelConnectorTest.java
+++ b/seatunnel-e2e/seatunnel-core-e2e/seatunnel-starter-e2e/src/test/java/org/apache/seatunnel/core/starter/seatunnel/SeaTunnelConnectorTest.java
@@ -269,7 +269,14 @@ public class SeaTunnelConnectorTest extends TestSuiteBase implements TestResourc
             throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeConnectorCheck(case1);
         Assertions.assertEquals(0, execResult.getExitCode());
-        Assertions.assertTrue(StringUtils.isBlank(execResult.getStderr()));
+        String stderrWithoutSlf4jNoise =
+                Arrays.stream(StringUtils.defaultString(execResult.getStderr()).split("\\R"))
+                        .map(String::trim)
+                        .filter(StringUtils::isNotBlank)
+                        .filter(line -> !line.startsWith("SLF4J:"))
+                        .collect(Collectors.joining(System.lineSeparator()));
+        Assertions.assertTrue(
+                StringUtils.isBlank(stderrWithoutSlf4jNoise), stderrWithoutSlf4jNoise);
         log.info(execResult.getStdout());
         return execResult;
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -64,19 +64,27 @@ import static org.awaitility.Awaitility.await;
 public class CoordinatorServiceTest {
     @Test
     public void testMasterNodeActive() {
+        String clusterName =
+                TestUtils.getClusterName("CoordinatorServiceTest_testMasterNodeActive");
         HazelcastInstanceImpl instance1 =
-                SeaTunnelServerStarter.createHazelcastInstance(
-                        TestUtils.getClusterName("CoordinatorServiceTest_testMasterNodeActive"));
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
         HazelcastInstanceImpl instance2 =
-                SeaTunnelServerStarter.createHazelcastInstance(
-                        TestUtils.getClusterName("CoordinatorServiceTest_testMasterNodeActive"));
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
 
         SeaTunnelServer server1 =
                 instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
         SeaTunnelServer server2 =
                 instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
 
-        Assertions.assertTrue(server1.isMasterNode());
+        await().atMost(20000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertEquals(2, instance1.getCluster().getMembers().size());
+                            Assertions.assertEquals(2, instance2.getCluster().getMembers().size());
+                            Assertions.assertTrue(server1.isMasterNode());
+                            Assertions.assertFalse(server2.isMasterNode());
+                        });
+
         CoordinatorService coordinatorService1 = server1.getCoordinatorService();
         Assertions.assertTrue(coordinatorService1.isCoordinatorActive());
 
@@ -98,6 +106,16 @@ public class CoordinatorServiceTest {
                             }
                         });
         instance2.shutdown();
+    }
+
+    private HazelcastInstanceImpl createHazelcastInstanceWithJoinPortTryCount(
+            String clusterName, int joinPortTryCount) {
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig.getHazelcastConfig().setClusterName(clusterName);
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setProperty("hazelcast.tcp.join.port.try.count", String.valueOf(joinPortTryCount));
+        return SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
     }
 
     @Test


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
fix  ci 
<img width="2511" height="1045" alt="59ff16489df2ebd6b60a73a6486897cc" src="https://github.com/user-attachments/assets/cfdac419-5079-49b1-967c-13ac4232bb56" />

1. `CoordinatorServiceTest#testMasterNodeActive` is race-prone.

   - In failed runs, both nodes stayed at `cluster size is 1` (did not form a 2-node cluster in time), so `server2` could become active master and `assertThrows(SeaTunnelEngineException, server2.getCoordinatorService)` became non-deterministic.
   - This is not a production logic regression; it is a flaky test condition under CI contention/port occupancy.
  
<img width="2494" height="660" alt="33c26315a8a0fe0ca539463367f99c5a" src="https://github.com/user-attachments/assets/ebbab964-3687-4dec-92f5-b808010c98bc" />

2.  JDBC part-7 tests had cleanup hooks without `@AfterAll`, so MySQL container cleanup could be skipped, increasing resource/port interference across jobs.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

3. testExecCheck assert that the content of stderr must be empty: Assertions.assertTrue(StringUtils.isBlank(execResult.getStderr())); however, there is actually relevant slf4j output.

### Does this PR introduce _any_ user-facing change?

1. `CoordinatorServiceTest`:

  - Create instances with higher `hazelcast.tcp.join.port.try.count` for better join robustness under occupied low ports.
  - Wait until both nodes form a stable 2-member cluster before asserting master/non-master behavior.

2. `JdbcMySqlSaveModeCatalogIT` and `JdbcMysqlSplitIT`:
  - Add `@AfterAll` to `tearDown()` to guarantee container cleanup.

3、`SeaTunnelConnectorTest` Loosen the assertion: ignore lines starting with SLF4J:, but fail on any other stderr output.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)