### PR TITLE
[Fix][Zeta] Fix job restore failure after master switch when IMap still loading from S3

### DIFF
--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/utils/ExceptionUtil.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/utils/ExceptionUtil.java
@@ -31,6 +31,7 @@ import com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import lombok.NonNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -155,6 +156,7 @@ public final class ExceptionUtil {
         Throwable exception = ExceptionUtils.getRootException(e);
         return exception instanceof HazelcastInstanceNotActiveException
                 || exception instanceof InterruptedException
-                || exception instanceof OperationTimeoutException;
+                || exception instanceof OperationTimeoutException
+                || exception instanceof RetryableHazelcastException;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/utils/ExceptionUtil.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/utils/ExceptionUtil.java
@@ -152,6 +152,28 @@ public final class ExceptionUtil {
         throw new RuntimeException("Never throw here.");
     }
 
+    /**
+     * Check if an exception indicates an operation that should be retried.
+     *
+     * <p>This method is used by {@link org.apache.seatunnel.common.utils.RetryUtils} to determine
+     * if a failed operation should be retried. It extracts the root cause of the exception chain
+     * and checks if it matches known transient exception types.
+     *
+     * <p>The following exception types are considered retryable:
+     *
+     * <ul>
+     *   <li>{@link HazelcastInstanceNotActiveException} - Hazelcast instance is shutting down
+     *   <li>{@link InterruptedException} - Operation was interrupted
+     *   <li>{@link OperationTimeoutException} - Operation timed out waiting for a response
+     *   <li>{@link RetryableHazelcastException} - Hazelcast explicitly marks the operation as
+     *       retryable, e.g., when an IMap partition is still loading data from external storage
+     *       (MapStore) during cluster startup or master switch
+     * </ul>
+     *
+     * @param e the exception to check (may be wrapped in CompletionException / ExecutionException)
+     * @return {@code true} if the root cause is a transient, retryable exception; {@code false}
+     *     otherwise
+     */
     public static boolean isOperationNeedRetryException(@NonNull Throwable e) {
         Throwable exception = ExceptionUtils.getRootException(e);
         return exception instanceof HazelcastInstanceNotActiveException

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/utils/ExceptionUtilTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/utils/ExceptionUtilTest.java
@@ -19,7 +19,11 @@ package org.apache.seatunnel.engine.common.utils;
 
 import org.junit.jupiter.api.Test;
 
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExceptionUtilTest {
 
@@ -44,5 +48,25 @@ public class ExceptionUtilTest {
     @Test
     void throwsNullPointerExceptionWhenNull() {
         assertThrows(NullPointerException.class, () -> ExceptionUtil.sneakyThrow(null));
+    }
+
+    @Test
+    void testIsOperationNeedRetryException_withRetryableHazelcastException() {
+        RetryableHazelcastException exception = new RetryableHazelcastException("IMap loading");
+        assertTrue(ExceptionUtil.isOperationNeedRetryException(exception));
+    }
+
+    @Test
+    void testIsOperationNeedRetryException_withWrappedRetryableHazelcastException() {
+        Throwable exception =
+                new Exception(
+                        new RuntimeException(new RetryableHazelcastException("IMap loading")));
+        assertTrue(ExceptionUtil.isOperationNeedRetryException(exception));
+    }
+
+    @Test
+    void testIsOperationNeedRetryException_withNonRetryableException() {
+        Exception exception = new Exception("Non-retryable error");
+        assertFalse(ExceptionUtil.isOperationNeedRetryException(exception));
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.api.event.EventProcessor;
 import org.apache.seatunnel.api.tracing.MDCExecutorService;
 import org.apache.seatunnel.api.tracing.MDCTracer;
 import org.apache.seatunnel.common.utils.ExceptionUtils;
+import org.apache.seatunnel.common.utils.RetryUtils;
 import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.common.utils.StringFormatUtils;
 import org.apache.seatunnel.engine.common.Constant;
@@ -39,6 +40,7 @@ import org.apache.seatunnel.engine.common.exception.SavePointFailedException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.job.JobResult;
 import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
@@ -504,7 +506,21 @@ public class CoordinatorService {
     }
 
     private void restoreJobFromMasterActiveSwitch(@NonNull Long jobId, @NonNull JobInfo jobInfo) {
-        if (runningJobStateIMap.get(jobId) == null) {
+        Object jobState;
+        try {
+            jobState =
+                    RetryUtils.retryWithException(
+                            () -> runningJobStateIMap.get(jobId),
+                            new RetryUtils.RetryMaterial(
+                                    Constant.OPERATION_RETRY_TIME,
+                                    true,
+                                    ExceptionUtil::isOperationNeedRetryException,
+                                    Constant.OPERATION_RETRY_SLEEP));
+        } catch (Exception e) {
+            throw new SeaTunnelEngineException(
+                    String.format("Job id %s restore failed, can not get job state", jobId), e);
+        }
+        if (jobState == null) {
             runningJobInfoIMap.remove(jobId);
             return;
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -449,10 +449,26 @@ public class CoordinatorService {
     }
 
     private void restoreAllRunningJobFromMasterNodeSwitch() {
-        List<Map.Entry<Long, JobInfo>> needRestoreFromMasterNodeSwitchJobs =
-                runningJobInfoIMap.entrySet().stream()
-                        .filter(entry -> !runningJobMasterMap.containsKey(entry.getKey()))
-                        .collect(Collectors.toList());
+        List<Map.Entry<Long, JobInfo>> needRestoreFromMasterNodeSwitchJobs;
+        try {
+            needRestoreFromMasterNodeSwitchJobs =
+                    RetryUtils.retryWithException(
+                            () ->
+                                    runningJobInfoIMap.entrySet().stream()
+                                            .filter(
+                                                    entry ->
+                                                            !runningJobMasterMap.containsKey(
+                                                                    entry.getKey()))
+                                            .collect(Collectors.toList()),
+                            new RetryUtils.RetryMaterial(
+                                    Constant.OPERATION_RETRY_TIME,
+                                    true,
+                                    ExceptionUtil::isOperationNeedRetryException,
+                                    Constant.OPERATION_RETRY_SLEEP));
+        } catch (Exception e) {
+            throw new SeaTunnelEngineException(
+                    "Failed to fetch running jobs from IMap during master switch restore", e);
+        }
         if (needRestoreFromMasterNodeSwitchJobs.isEmpty()) {
             return;
         }


### PR DESCRIPTION
- Add RetryableHazelcastException to ExceptionUtil.isOperationNeedRetryException so SeaTunnel's RetryUtils retries putIfAbsent calls when engine* IMap is still loading from S3 external store during EAGER loading on master startup
- Wrap runningJobStateIMap.get() in RetryUtils in restoreJobFromMasterActiveSwitch to handle RetryableHazelcastException from the null-check get() call

RetryableHazelcastException is explicitly designed by Hazelcast to be retried by callers but was missing from the retry condition list, causing SeaTunnel's own 30-retry window to be completely unused. Jobs would fail init silently after only Hazelcast's invocation retries were exhausted, leaving jobs invisible in UI.

Fixes #10560

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)