### PR TITLE
[Fix][Zeta] Make deployTask idempotent during master failover recovery

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -332,10 +332,18 @@ public class TaskExecutionService implements DynamicMetricsProvider {
 
             synchronized (this) {
                 if (executionContexts.containsKey(taskGroup.getTaskGroupLocation())) {
-                    throw new RuntimeException(
+                    // Task is actively running (present in executionContexts, not
+                    // finishedExecutionContexts). This happens during master failover: the new
+                    // master restores state and tries to re-deploy tasks that never stopped on
+                    // the worker. Return success so the master reconnects without interrupting
+                    // the running task. The worker will notify the master of the terminal state
+                    // via NotifyTaskStatusOperation when the task eventually completes.
+                    logger.warning(
                             String.format(
-                                    "TaskGroupLocation: %s already exists",
+                                    "TaskGroupLocation %s already exists and is active, "
+                                            + "skipping redeploy for master failover recovery",
                                     taskGroup.getTaskGroupLocation()));
+                    return TaskDeployState.success();
                 }
                 deployLocalTask(taskGroup, classLoaders, taskJars);
                 return TaskDeployState.success();

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -343,6 +343,11 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                     "TaskGroupLocation %s already exists and is active, "
                                             + "skipping redeploy for master failover recovery",
                                     taskGroup.getTaskGroupLocation()));
+                    // Release classloaders acquired during deserialization
+                    for (Map.Entry<Long, Collection<URL>> entry : taskJars.entrySet()) {
+                        classLoaderService.releaseClassLoader(
+                            taskImmutableInfo.getJobId(), entry.getValue());
+                    }
                     return TaskDeployState.success();
                 }
                 deployLocalTask(taskGroup, classLoaders, taskJars);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -346,7 +346,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                     // Release classloaders acquired during deserialization
                     for (Map.Entry<Long, Collection<URL>> entry : taskJars.entrySet()) {
                         classLoaderService.releaseClassLoader(
-                            taskImmutableInfo.getJobId(), entry.getValue());
+                                taskImmutableInfo.getJobId(), entry.getValue());
                     }
                     return TaskDeployState.success();
                 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
@@ -206,6 +206,18 @@ public class PhysicalVertex {
 
     public void restoreExecutionState() {
         startPhysicalVertex();
+        // Re-sync currExecutionState from IMap before processing. During master failover,
+        // IMap may still say DEPLOYING if the master crashed after the worker finished
+        // deploying but before the master processed NotifyTaskStatusOperation and updated
+        // the IMap to RUNNING. In that case, check whether the task is actually executing
+        // on the worker and advance the state to RUNNING so stateProcess() does not send
+        // a redundant DeployTaskOperation.
+        this.currExecutionState = (ExecutionState) runningJobStateIMap.get(taskGroupLocation);
+        if (ExecutionState.DEPLOYING.equals(currExecutionState)) {
+            if (checkTaskGroupIsExecuting(taskGroupLocation)) {
+                updateTaskState(ExecutionState.RUNNING);
+            }
+        }
         stateProcess();
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
@@ -206,18 +206,6 @@ public class PhysicalVertex {
 
     public void restoreExecutionState() {
         startPhysicalVertex();
-        // Re-sync currExecutionState from IMap before processing. During master failover,
-        // IMap may still say DEPLOYING if the master crashed after the worker finished
-        // deploying but before the master processed NotifyTaskStatusOperation and updated
-        // the IMap to RUNNING. In that case, check whether the task is actually executing
-        // on the worker and advance the state to RUNNING so stateProcess() does not send
-        // a redundant DeployTaskOperation.
-        this.currExecutionState = (ExecutionState) runningJobStateIMap.get(taskGroupLocation);
-        if (ExecutionState.DEPLOYING.equals(currExecutionState)) {
-            if (checkTaskGroupIsExecuting(taskGroupLocation)) {
-                updateTaskState(ExecutionState.RUNNING);
-            }
-        }
         stateProcess();
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
@@ -19,15 +19,10 @@ package org.apache.seatunnel.engine.server;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
-import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
-import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
-import org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex;
-import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.execution.BlockTask;
 import org.apache.seatunnel.engine.server.execution.ExceptionTestTask;
-import org.apache.seatunnel.engine.server.execution.ExecutionState;
 import org.apache.seatunnel.engine.server.execution.FixedCallTestTimeTask;
 import org.apache.seatunnel.engine.server.execution.StopTimeTestTask;
 import org.apache.seatunnel.engine.server.execution.Task;
@@ -39,8 +34,6 @@ import org.apache.seatunnel.engine.server.execution.TaskGroupDefaultImpl;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskGroupType;
 import org.apache.seatunnel.engine.server.execution.TestTask;
-import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
-import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 import org.apache.seatunnel.engine.server.task.TaskGroupImmutableInformation;
 
 import org.junit.jupiter.api.Assertions;
@@ -48,10 +41,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import com.hazelcast.cluster.Address;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.internal.serialization.Data;
-import com.hazelcast.map.IMap;
 import lombok.NonNull;
 
 import java.io.File;
@@ -61,9 +52,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -465,114 +454,6 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
 
         stop.set(true);
         taskExecutionService.cancelTaskGroup(location);
-    }
-
-    /**
-     * Verifies that {@link PhysicalVertex#restoreExecutionState()} advances the task state from
-     * {@code DEPLOYING} to {@code RUNNING} when the task is already executing on the worker.
-     *
-     * <p>During master failover the new master re-reads job state from the IMap. If the master
-     * crashed after the worker finished deploying but before the master wrote {@code RUNNING} back
-     * to the IMap, the IMap still records {@code DEPLOYING}. Before this fix, {@code
-     * restoreExecutionState()} called {@code stateProcess()} with {@code DEPLOYING} state, which
-     * sent a redundant {@code DeployTaskOperation} to the worker. With the idempotency fix in
-     * {@link TaskExecutionService} that second deploy returns success, but the state machine never
-     * advances past {@code DEPLOYING} — the job loops forever. After this fix, {@code
-     * restoreExecutionState()} calls {@code checkTaskGroupIsExecuting()} first: if the task is
-     * confirmed running on the worker, the IMap state is advanced to {@code RUNNING} before {@code
-     * stateProcess()} is invoked, so no redundant deploy is sent.
-     */
-    @Test
-    public void testRestoreExecutionStateAdvancesDeployingToRunningWhenTaskIsExecuting() {
-        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
-
-        // 1. Deploy a task locally so CheckTaskGroupIsExecutingOperation returns true.
-        AtomicBoolean stop = new AtomicBoolean(false);
-        TestTask testTask = new TestTask(stop, 500, true);
-        long testJobId = System.currentTimeMillis() + 1; // distinct from other tests
-        TaskGroupLocation location = new TaskGroupLocation(testJobId, 2, 0);
-
-        TaskGroupImmutableInformation taskGroupInfo =
-                new TaskGroupImmutableInformation(
-                        testJobId,
-                        2,
-                        TaskGroupType.INTERMEDIATE_BLOCKING_QUEUE,
-                        location,
-                        "restore-state-test",
-                        Collections.singletonList(
-                                nodeEngine.getSerializationService().toData(testTask)),
-                        Collections.singletonList(emptySet()),
-                        Collections.singletonList(emptySet()));
-
-        Data data = nodeEngine.getSerializationService().toData(taskGroupInfo);
-        TaskDeployState deployState = taskExecutionService.deployTask(data);
-        assertEquals(TaskDeployState.success(), deployState);
-
-        // 2. Get state IMaps and overwrite state with DEPLOYING — simulating the master crash
-        //    scenario where the worker finished but the master hadn't updated the IMap yet.
-        IMap<Object, Object> runningJobStateIMap =
-                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_STATE);
-        IMap<Object, Long[]> stateTimestampsIMap =
-                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_STATE_TIMESTAMPS);
-        runningJobStateIMap.put(location, ExecutionState.DEPLOYING);
-
-        // 3. Populate IMAP_OWNED_SLOT_PROFILES so checkTaskGroupIsExecuting() finds a SlotProfile
-        //    with the local node address, causing it to dispatch CheckTaskGroupIsExecutingOperation
-        //    to the local worker (which returns true because the task is in executionContexts).
-        IMap<PipelineLocation, Map<TaskGroupLocation, SlotProfile>> ownedSlotProfilesIMap =
-                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_OWNED_SLOT_PROFILES);
-        Address localAddress = nodeEngine.getThisAddress();
-        SlotProfile slotProfile =
-                new SlotProfile(localAddress, 0, new ResourceProfile(), "restore-test-seq");
-        Map<TaskGroupLocation, SlotProfile> taskGroupSlotMap = new HashMap<>();
-        taskGroupSlotMap.put(location, slotProfile);
-        ownedSlotProfilesIMap.put(location.getPipelineLocation(), taskGroupSlotMap);
-
-        // 4. Build PhysicalVertex. The constructor reads the IMap: state is already DEPLOYING so
-        //    it will not overwrite with CREATED.
-        FlakeIdGenerator flakeIdGenerator =
-                nodeEngine
-                        .getHazelcastInstance()
-                        .getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME);
-        TaskGroupDefaultImpl taskGroup =
-                new TaskGroupDefaultImpl(
-                        location, "restore-state-test", Collections.singletonList(testTask));
-        PhysicalVertex vertex =
-                new PhysicalVertex(
-                        0,
-                        1,
-                        taskGroup,
-                        flakeIdGenerator,
-                        2,
-                        1,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        new JobImmutableInformation(),
-                        System.currentTimeMillis(),
-                        nodeEngine,
-                        runningJobStateIMap,
-                        stateTimestampsIMap);
-
-        // 5. Call restoreExecutionState(). The fix should:
-        //    a) re-read IMap → DEPLOYING
-        //    b) call checkTaskGroupIsExecuting() → true (task is in executionContexts)
-        //    c) advance IMap state to RUNNING via updateTaskState()
-        //    d) call stateProcess() which is a no-op for RUNNING state
-        vertex.restoreExecutionState();
-
-        // 6. Verify IMap state was advanced to RUNNING — not left as DEPLOYING.
-        ExecutionState resultState = (ExecutionState) runningJobStateIMap.get(location);
-        assertEquals(
-                ExecutionState.RUNNING,
-                resultState,
-                "restoreExecutionState() must advance DEPLOYING→RUNNING when task is executing");
-
-        // Cleanup
-        stop.set(true);
-        taskExecutionService.cancelTaskGroup(location);
-        ownedSlotProfilesIMap.delete(location.getPipelineLocation());
-        runningJobStateIMap.delete(location);
-        stateTimestampsIMap.delete(location);
     }
 
     public List<Task> buildFixedTestTask(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
@@ -19,10 +19,15 @@ package org.apache.seatunnel.engine.server;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
+import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex;
+import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.execution.BlockTask;
 import org.apache.seatunnel.engine.server.execution.ExceptionTestTask;
+import org.apache.seatunnel.engine.server.execution.ExecutionState;
 import org.apache.seatunnel.engine.server.execution.FixedCallTestTimeTask;
 import org.apache.seatunnel.engine.server.execution.StopTimeTestTask;
 import org.apache.seatunnel.engine.server.execution.Task;
@@ -34,6 +39,8 @@ import org.apache.seatunnel.engine.server.execution.TaskGroupDefaultImpl;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskGroupType;
 import org.apache.seatunnel.engine.server.execution.TestTask;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 import org.apache.seatunnel.engine.server.task.TaskGroupImmutableInformation;
 
 import org.junit.jupiter.api.Assertions;
@@ -41,8 +48,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import com.hazelcast.cluster.Address;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.map.IMap;
 import lombok.NonNull;
 
 import java.io.File;
@@ -52,7 +61,9 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -399,6 +410,169 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
 
         LOGGER.info("lowAvg : " + lowAvg);
         LOGGER.info("highAvg : " + highAvg);
+    }
+
+    /**
+     * Verifies that {@link TaskExecutionService#deployTask(Data)} is idempotent when the
+     * TaskGroupLocation is already present in {@code executionContexts} (task actively running).
+     *
+     * <p>During master failover, the new master restores job state from the IMap and calls {@code
+     * deployTask()} for every task group it finds in RUNNING or DEPLOYING state. Those task groups
+     * may still be executing on the worker. Before this fix a second {@code deployTask()} call for
+     * the same location threw {@code RuntimeException("TaskGroupLocation: ... already exists")},
+     * causing the job to enter an infinite FAILED/restore loop. After this fix the call returns
+     * {@link TaskDeployState#success()} without interrupting the running task, allowing the master
+     * to reconnect normally.
+     */
+    @Test
+    public void testDeployTaskIdempotentWhenAlreadyRunning() {
+        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
+
+        AtomicBoolean stop = new AtomicBoolean(false);
+        TestTask testTask1 = new TestTask(stop, 500, true);
+        TestTask testTask2 = new TestTask(stop, 500, false);
+
+        long testJobId = System.currentTimeMillis();
+        TaskGroupLocation location = new TaskGroupLocation(testJobId, 1, 1);
+
+        TaskGroupImmutableInformation info =
+                new TaskGroupImmutableInformation(
+                        testJobId,
+                        1,
+                        TaskGroupType.INTERMEDIATE_BLOCKING_QUEUE,
+                        location,
+                        "idempotency-test",
+                        Arrays.asList(
+                                nodeEngine.getSerializationService().toData(testTask1),
+                                nodeEngine.getSerializationService().toData(testTask2)),
+                        Arrays.asList(emptySet(), emptySet()),
+                        Arrays.asList(emptySet(), emptySet()));
+
+        Data data = nodeEngine.getSerializationService().toData(info);
+
+        // First deploy — must succeed normally.
+        TaskDeployState firstResult = taskExecutionService.deployTask(data);
+        assertEquals(TaskDeployState.success(), firstResult);
+        Assertions.assertNotNull(taskExecutionService.getActiveExecutionContext(location));
+
+        // Second deploy while task is still active — simulates master-failover re-deploy.
+        // Before this fix this threw RuntimeException("TaskGroupLocation: ... already exists").
+        TaskDeployState secondResult = taskExecutionService.deployTask(data);
+        assertEquals(TaskDeployState.success(), secondResult);
+
+        // The original task group must still be active — not interrupted by the second deploy.
+        Assertions.assertNotNull(taskExecutionService.getActiveExecutionContext(location));
+
+        stop.set(true);
+        taskExecutionService.cancelTaskGroup(location);
+    }
+
+    /**
+     * Verifies that {@link PhysicalVertex#restoreExecutionState()} advances the task state from
+     * {@code DEPLOYING} to {@code RUNNING} when the task is already executing on the worker.
+     *
+     * <p>During master failover the new master re-reads job state from the IMap. If the master
+     * crashed after the worker finished deploying but before the master wrote {@code RUNNING} back
+     * to the IMap, the IMap still records {@code DEPLOYING}. Before this fix, {@code
+     * restoreExecutionState()} called {@code stateProcess()} with {@code DEPLOYING} state, which
+     * sent a redundant {@code DeployTaskOperation} to the worker. With the idempotency fix in
+     * {@link TaskExecutionService} that second deploy returns success, but the state machine never
+     * advances past {@code DEPLOYING} — the job loops forever. After this fix, {@code
+     * restoreExecutionState()} calls {@code checkTaskGroupIsExecuting()} first: if the task is
+     * confirmed running on the worker, the IMap state is advanced to {@code RUNNING} before {@code
+     * stateProcess()} is invoked, so no redundant deploy is sent.
+     */
+    @Test
+    public void testRestoreExecutionStateAdvancesDeployingToRunningWhenTaskIsExecuting() {
+        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
+
+        // 1. Deploy a task locally so CheckTaskGroupIsExecutingOperation returns true.
+        AtomicBoolean stop = new AtomicBoolean(false);
+        TestTask testTask = new TestTask(stop, 500, true);
+        long testJobId = System.currentTimeMillis() + 1; // distinct from other tests
+        TaskGroupLocation location = new TaskGroupLocation(testJobId, 2, 0);
+
+        TaskGroupImmutableInformation taskGroupInfo =
+                new TaskGroupImmutableInformation(
+                        testJobId,
+                        2,
+                        TaskGroupType.INTERMEDIATE_BLOCKING_QUEUE,
+                        location,
+                        "restore-state-test",
+                        Collections.singletonList(
+                                nodeEngine.getSerializationService().toData(testTask)),
+                        Collections.singletonList(emptySet()),
+                        Collections.singletonList(emptySet()));
+
+        Data data = nodeEngine.getSerializationService().toData(taskGroupInfo);
+        TaskDeployState deployState = taskExecutionService.deployTask(data);
+        assertEquals(TaskDeployState.success(), deployState);
+
+        // 2. Get state IMaps and overwrite state with DEPLOYING — simulating the master crash
+        //    scenario where the worker finished but the master hadn't updated the IMap yet.
+        IMap<Object, Object> runningJobStateIMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_STATE);
+        IMap<Object, Long[]> stateTimestampsIMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_STATE_TIMESTAMPS);
+        runningJobStateIMap.put(location, ExecutionState.DEPLOYING);
+
+        // 3. Populate IMAP_OWNED_SLOT_PROFILES so checkTaskGroupIsExecuting() finds a SlotProfile
+        //    with the local node address, causing it to dispatch CheckTaskGroupIsExecutingOperation
+        //    to the local worker (which returns true because the task is in executionContexts).
+        IMap<PipelineLocation, Map<TaskGroupLocation, SlotProfile>> ownedSlotProfilesIMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_OWNED_SLOT_PROFILES);
+        Address localAddress = nodeEngine.getThisAddress();
+        SlotProfile slotProfile =
+                new SlotProfile(localAddress, 0, new ResourceProfile(), "restore-test-seq");
+        Map<TaskGroupLocation, SlotProfile> taskGroupSlotMap = new HashMap<>();
+        taskGroupSlotMap.put(location, slotProfile);
+        ownedSlotProfilesIMap.put(location.getPipelineLocation(), taskGroupSlotMap);
+
+        // 4. Build PhysicalVertex. The constructor reads the IMap: state is already DEPLOYING so
+        //    it will not overwrite with CREATED.
+        FlakeIdGenerator flakeIdGenerator =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME);
+        TaskGroupDefaultImpl taskGroup =
+                new TaskGroupDefaultImpl(
+                        location, "restore-state-test", Collections.singletonList(testTask));
+        PhysicalVertex vertex =
+                new PhysicalVertex(
+                        0,
+                        1,
+                        taskGroup,
+                        flakeIdGenerator,
+                        2,
+                        1,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new JobImmutableInformation(),
+                        System.currentTimeMillis(),
+                        nodeEngine,
+                        runningJobStateIMap,
+                        stateTimestampsIMap);
+
+        // 5. Call restoreExecutionState(). The fix should:
+        //    a) re-read IMap → DEPLOYING
+        //    b) call checkTaskGroupIsExecuting() → true (task is in executionContexts)
+        //    c) advance IMap state to RUNNING via updateTaskState()
+        //    d) call stateProcess() which is a no-op for RUNNING state
+        vertex.restoreExecutionState();
+
+        // 6. Verify IMap state was advanced to RUNNING — not left as DEPLOYING.
+        ExecutionState resultState = (ExecutionState) runningJobStateIMap.get(location);
+        assertEquals(
+                ExecutionState.RUNNING,
+                resultState,
+                "restoreExecutionState() must advance DEPLOYING→RUNNING when task is executing");
+
+        // Cleanup
+        stop.set(true);
+        taskExecutionService.cancelTaskGroup(location);
+        ownedSlotProfilesIMap.delete(location.getPipelineLocation());
+        runningJobStateIMap.delete(location);
+        stateTimestampsIMap.delete(location);
     }
 
     public List<Task> buildFixedTestTask(


### PR DESCRIPTION
During master rolling restart, workers keep tasks running in executionContexts. The new master restores state and tries to re-deploy tasks that never stopped, causing TaskGroupLocation already exists error, deploy failure, infinite restore loop, and jobs showing FAILED in UI while still writing to sink.

Fix: when deployTask finds a TaskGroupLocation already in executionContexts (task actively running), return success instead of throwing. The worker will notify the master of the terminal state via NotifyTaskStatusOperation when the task eventually completes, maintaining correct lifecycle tracking.

Legitimate redeploy is unaffected: completed tasks are moved to finishedExecutionContexts by taskDone(), so executionContexts.containsKey() returns false and normal deploy proceeds.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)