### PR TITLE
[Feature][Transform-V2] Support batched LLM and Embedding transforms with checkpoint state

### DIFF
--- a/docs/en/transforms/embedding.md
+++ b/docs/en/transforms/embedding.md
@@ -18,6 +18,7 @@ different API endpoints.
 | api_key                        | string | yes      | -             | The API key required to authenticate with the embedding service.                                                                                                        |
 | secret_key                     | string | yes      | -             | The secret key required for additional authentication with the embedding service.                                                                                       |
 | aws_region                     | string | no       |               | AWS Region. Required for use Amazon Bedrock model.                                                                                                                      |
+| process_batch_size             | int    | no       | 100           | The number of rows buffered before one embedding batch is processed. Unfinished buffered rows and binary chunks are checkpointed for recovery.                           |
 | single_vectorized_input_number | int    | no       | 1             | The number of inputs vectorized in one request. Default is 1.                                                                                                           |
 | vectorization_fields           | map    | yes      | -             | A mapping between input fields and their corresponding output vector fields.                                                                                            |
 | model                          | string | yes      | -             | The specific model to use for embedding (e.g: `text-embedding-3-small` for OPENAI).                                                                                     |
@@ -55,6 +56,12 @@ The secret key used for additional authentication. Some providers may require th
 Specifies how many inputs are processed in a single vectorization request. The default is 1. Adjust based on your
 processing
 capacity and the model provider's API limitations.
+
+### process_batch_size
+
+Specifies how many input rows are buffered by the transform before one batch is processed. This controls row-level
+batching, while `single_vectorized_input_number` controls how many embedding inputs are sent in one model request.
+Buffered rows and incomplete binary chunks are written into checkpoint state and can be restored after recovery.
 
 ### vectorization_fields
 

--- a/docs/en/transforms/llm.md
+++ b/docs/en/transforms/llm.md
@@ -20,6 +20,7 @@ more.
 | model                  | string | yes      |               |
 | api_key                | string | yes      |               |
 | api_path               | string | no       |               |
+| process_batch_size     | int    | no       | 100           |
 | custom_config          | map    | no       |               |
 | custom_response_parse  | string | no       |               |
 | custom_request_headers | map    | no       |               |
@@ -102,6 +103,11 @@ If you use OpenAI model, please refer https://platform.openai.com/docs/api-refer
 
 The API path to use for the model provider. In most cases, you do not need to change this configuration. If you
 are using an API agent's service, you may need to configure it to the agent's API address.
+
+### process_batch_size
+
+The number of rows buffered before one LLM inference request is triggered. The buffered rows are included in transform
+checkpoint state, so unfinished batches can be restored after recovery.
 
 ### custom_config
 

--- a/docs/zh/transforms/embedding.md
+++ b/docs/zh/transforms/embedding.md
@@ -16,6 +16,7 @@
 | api_key                        | string | 是    | -      | 用于验证embedding服务的API密钥。                                           |
 | secret_key                     | string | 是    | -      | 用于额外验证的密钥。一些提供商可能需要此密钥进行安全的API请求。                                |
 | aws_region                     | string | 否    |        | 用于使用Amazon Bedrock 模型，需要指定模型请求区域.                                |
+| process_batch_size             | int    | 否    | 100    | transform 在触发一次 embedding 批处理前先缓冲的行数。未完成的缓冲行和二进制分片都会写入 checkpoint。 |
 | single_vectorized_input_number | int    | 否    | 1      | 单次请求向量化的输入数量。默认值为1。                                              |
 | vectorization_fields           | map    | 是    | -      | 输入字段和相应的输出向量字段之间的映射。                                             |
 | model                          | string | 是    | -      | 要使用的具体embedding模型。例如，如果提供商为OPENAI，可以指定 `text-embedding-3-small`。 |
@@ -50,6 +51,12 @@
 ### single_vectorized_input_number
 
 指定单次请求向量化的输入数量。默认值为1。根据处理能力和模型提供商的API限制进行调整。
+
+### process_batch_size
+
+指定 transform 在触发一次批量处理前先缓冲多少输入行。它控制的是“行级批处理”，而 `single_vectorized_input_number`
+控制的是单次模型请求里发送多少个 embedding 输入。缓冲中的行以及未拼完的二进制分片会写入 checkpoint 状态，
+任务恢复后可以继续处理。
 
 ### vectorization_fields
 

--- a/docs/zh/transforms/llm.md
+++ b/docs/zh/transforms/llm.md
@@ -18,6 +18,7 @@
 | model                  | string | yes      |             |
 | api_key                | string | yes      |             |
 | api_path               | string | no       |             |
+| process_batch_size     | int    | no       | 100         |
 | custom_config          | map    | no       |             |
 | custom_response_parse  | string | no       |             |
 | custom_request_headers | map    | no       |             |
@@ -98,6 +99,10 @@ transform {
 ### api_path
 
 用于模型提供者的 API 路径。在大多数情况下，您不需要更改此配置。如果使用 API 代理的服务，您可能需要将其配置为代理的 API 地址。
+
+### process_batch_size
+
+在触发一次 LLM 推理请求之前，transform 会先缓冲的行数。未完成的缓冲批次会写入 checkpoint 状态，因此任务恢复后可以继续处理。
 
 ### custom_config
 

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/transform/SeaTunnelBatchTransform.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/transform/SeaTunnelBatchTransform.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.transform;
+
+import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.state.CheckpointListener;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Stateful transform that can buffer rows, emit batched results, and participate in checkpoint.
+ *
+ * @param <T> input/output record type
+ * @param <StateT> checkpoint state type
+ */
+public interface SeaTunnelBatchTransform<T, StateT>
+        extends SeaTunnelTransform<T>, CheckpointListener {
+
+    /** Collect one input record into the internal batch buffer. */
+    void collect(T row);
+
+    /**
+     * Drain results that are ready to be emitted without forcing the remaining buffered data to be
+     * processed.
+     */
+    default List<T> drainOutput() {
+        return Collections.emptyList();
+    }
+
+    /** Force flush buffered data and return all rows ready to be emitted. */
+    List<T> flush();
+
+    /** Snapshot buffered state for checkpoint. */
+    List<StateT> snapshotState(long checkpointId) throws Exception;
+
+    /** Restore buffered state after recovery. */
+    void restoreState(List<StateT> states) throws Exception;
+
+    /** Serializer for checkpoint state. */
+    Optional<Serializer<StateT>> getStateSerializer();
+
+    default boolean hasBufferedData() {
+        return false;
+    }
+
+    default int getBufferSize() {
+        return 0;
+    }
+
+    @Override
+    default void notifyCheckpointComplete(long checkpointId) throws Exception {}
+}

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -400,6 +400,7 @@ public class SeaTunnelContainer extends AbstractTestContainer {
         Pattern aqsThread = Pattern.compile("pool-[0-9]-thread-[0-9]");
         return s.startsWith("hz.main")
                 || s.startsWith("seatunnel-coordinator-service")
+                || s.startsWith("pending-job-schedule-runner")
                 || s.startsWith("GC task thread")
                 || s.contains("CompilerThread")
                 || s.startsWith("SeaTunnel-CompletableFuture-Thread-")

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/MockServerRequestUtils.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/MockServerRequestUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.transform;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+final class MockServerRequestUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private MockServerRequestUtils() {}
+
+    static ArrayNode retrieveRequests(
+            GenericContainer<?> mockserverContainer, String method, String path)
+            throws IOException {
+        String endpoint =
+                String.format(
+                        "http://%s:%d/mockserver/retrieve?type=REQUESTS",
+                        mockserverContainer.getHost(), mockserverContainer.getMappedPort(1080));
+
+        HttpPut request = new HttpPut(endpoint);
+        request.setHeader("Content-Type", "application/json");
+        request.setEntity(
+                new StringEntity(createMatcher(method, path).toString(), StandardCharsets.UTF_8));
+
+        try (CloseableHttpClient client = HttpClients.createDefault();
+                CloseableHttpResponse response = client.execute(request)) {
+            String responseBody =
+                    EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            Assertions.assertEquals(
+                    HttpStatus.SC_OK, response.getStatusLine().getStatusCode(), responseBody);
+            JsonNode requests = OBJECT_MAPPER.readTree(responseBody);
+            Assertions.assertTrue(requests.isArray(), responseBody);
+            return (ArrayNode) requests;
+        }
+    }
+
+    private static ObjectNode createMatcher(String method, String path) {
+        ObjectNode matcher = OBJECT_MAPPER.createObjectNode();
+        matcher.put("method", method);
+        matcher.put("path", path);
+        return matcher;
+    }
+}

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/MockServerRequestUtils.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/MockServerRequestUtils.java
@@ -42,6 +42,27 @@ final class MockServerRequestUtils {
 
     private MockServerRequestUtils() {}
 
+    static void clearRequests(GenericContainer<?> mockserverContainer, String method, String path)
+            throws IOException {
+        String endpoint =
+                String.format(
+                        "http://%s:%d/mockserver/clear?type=LOG",
+                        mockserverContainer.getHost(), mockserverContainer.getMappedPort(1080));
+
+        HttpPut request = new HttpPut(endpoint);
+        request.setHeader("Content-Type", "application/json");
+        request.setEntity(
+                new StringEntity(createMatcher(method, path).toString(), StandardCharsets.UTF_8));
+
+        try (CloseableHttpClient client = HttpClients.createDefault();
+                CloseableHttpResponse response = client.execute(request)) {
+            String responseBody =
+                    EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            Assertions.assertEquals(
+                    HttpStatus.SC_OK, response.getStatusLine().getStatusCode(), responseBody);
+        }
+    }
+
     static ArrayNode retrieveRequests(
             GenericContainer<?> mockserverContainer, String method, String path)
             throws IOException {

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestEmbeddingIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestEmbeddingIT.java
@@ -109,6 +109,8 @@ public class TestEmbeddingIT extends TestSuiteBase implements TestResource {
     @TestTemplate
     public void testEmbeddingBatch(TestContainer container)
             throws IOException, InterruptedException {
+        MockServerRequestUtils.clearRequests(
+                mockserverContainer, "POST", "/v1/qianfan/embedding-batch/bge_large_en");
         Container.ExecResult execResult = container.executeJob("/embedding_transform_batch.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
 

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestEmbeddingIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestEmbeddingIT.java
@@ -17,6 +17,9 @@
 
 package org.apache.seatunnel.e2e.transform;
 
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
+
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
 import org.apache.seatunnel.e2e.common.container.EngineType;
@@ -101,6 +104,32 @@ public class TestEmbeddingIT extends TestSuiteBase implements TestResource {
     public void testEmbedding(TestContainer container) throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeJob("/embedding_transform.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
+    }
+
+    @TestTemplate
+    public void testEmbeddingBatch(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult execResult = container.executeJob("/embedding_transform_batch.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        ArrayNode requests =
+                MockServerRequestUtils.retrieveRequests(
+                        mockserverContainer, "POST", "/v1/qianfan/embedding-batch/bge_large_en");
+        Assertions.assertEquals(3, requests.size());
+
+        int singleInputRequests = 0;
+        int batchInputRequests = 0;
+        for (JsonNode request : requests) {
+            JsonNode input = request.path("body").path("json").path("input");
+            Assertions.assertTrue(input.isArray());
+            if (input.size() == 1) {
+                singleInputRequests++;
+            } else if (input.size() == 2) {
+                batchInputRequests++;
+            }
+        }
+        Assertions.assertEquals(1, singleInputRequests);
+        Assertions.assertEquals(2, batchInputRequests);
     }
 
     @TestTemplate

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestLLMIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestLLMIT.java
@@ -96,6 +96,8 @@ public class TestLLMIT extends TestSuiteBase implements TestResource {
     @TestTemplate
     public void testLLMWithOpenAIBatch(TestContainer container)
             throws IOException, InterruptedException {
+        MockServerRequestUtils.clearRequests(
+                mockserverContainer, "POST", "/v1/chat/completions/batch");
         Container.ExecResult execResult = container.executeJob("/llm_openai_transform_batch.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
 

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestLLMIT.java
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/java/org/apache/seatunnel/e2e/transform/TestLLMIT.java
@@ -17,6 +17,10 @@
 
 package org.apache.seatunnel.e2e.transform;
 
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
+
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 
@@ -41,6 +45,7 @@ import java.util.stream.Stream;
 
 public class TestLLMIT extends TestSuiteBase implements TestResource {
     private static final String TMP_DIR = "/tmp";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private GenericContainer<?> mockserverContainer;
     private static final String IMAGE = "mockserver/mockserver:5.14.0";
 
@@ -86,6 +91,27 @@ public class TestLLMIT extends TestSuiteBase implements TestResource {
             throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeJob("/llm_openai_transform.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
+    }
+
+    @TestTemplate
+    public void testLLMWithOpenAIBatch(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult execResult = container.executeJob("/llm_openai_transform_batch.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+
+        ArrayNode requests =
+                MockServerRequestUtils.retrieveRequests(
+                        mockserverContainer, "POST", "/v1/chat/completions/batch");
+        Assertions.assertEquals(2, requests.size());
+
+        for (JsonNode request : requests) {
+            JsonNode requestBody = request.path("body").path("json");
+            JsonNode messages = requestBody.path("messages");
+            Assertions.assertEquals(2, messages.size());
+            JsonNode rows = OBJECT_MAPPER.readTree(messages.get(1).path("content").asText());
+            Assertions.assertTrue(rows.isArray());
+            Assertions.assertEquals(2, rows.size());
+        }
     }
 
     @TestTemplate

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/embedding_transform_batch.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/embedding_transform_batch.conf
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file validates batched embedding requests in seatunnel
+######
+
+env {
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 4
+    schema = {
+      fields {
+        book_id = "int"
+        book_intro = "string"
+      }
+    }
+    rows = [
+      {fields = [1, "Scout Finch learns empathy and justice in the American South."], kind = INSERT}
+      {fields = [2, "Winston Smith questions surveillance and totalitarian power."], kind = INSERT}
+      {fields = [3, "Elizabeth Bennet challenges class expectations and pride."], kind = INSERT}
+      {fields = [4, "Captain Ahab pursues obsession against the white whale."], kind = INSERT}
+    ]
+    plugin_output = "fake"
+  }
+}
+
+transform {
+  Embedding {
+    plugin_input = "fake"
+    model_provider = QIANFAN
+    model = bge_large_en
+    api_key = xxxxxxxx
+    secret_key = xxxxxxxx
+    api_path = "http://mockserver:1080/v1/qianfan/embedding-batch"
+    oauth_path = "http://mockserver:1080/v1/qianfan/token"
+    single_vectorized_input_number = 2
+    process_batch_size = 2
+    vectorization_fields {
+      book_intro_vector = book_intro
+    }
+    plugin_output = "embedding_output"
+  }
+}
+
+sink {
+  Assert {
+      plugin_input = "embedding_output"
+      rules =
+        {
+          field_rules = [
+            {
+              field_name = book_id
+              field_type = int
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = book_intro
+              field_type = string
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            },
+            {
+              field_name = book_intro_vector
+              field_type = float_vector
+              field_value = [
+                {
+                  rule_type = NOT_NULL
+                }
+              ]
+            }
+          ]
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/llm_openai_transform_batch.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/llm_openai_transform_batch.conf
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file validates batched LLM inference requests in seatunnel
+######
+
+env {
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 4
+    schema = {
+      fields {
+        id = "int"
+        name = "string"
+      }
+    }
+    rows = [
+      {fields = [1, "Jia Fan"], kind = INSERT}
+      {fields = [2, "Hailin Wang"], kind = INSERT}
+      {fields = [3, "Tomas"], kind = INSERT}
+      {fields = [4, "Eric"], kind = INSERT}
+    ]
+    plugin_output = "fake"
+  }
+}
+
+transform {
+  LLM {
+    plugin_input = "fake"
+    model_provider = OPENAI
+    model = gpt-4o-mini
+    api_key = sk-xxx
+    prompt = "Determine whether someone is Chinese or American by their name"
+    process_batch_size = 2
+    openai.api_path = "http://mockserver:1080/v1/chat/completions/batch"
+    plugin_output = "llm_output"
+  }
+}
+
+sink {
+  Assert {
+    plugin_input = "llm_output"
+    rules =
+      {
+        field_rules = [
+          {
+            field_name = llm_output
+            field_type = string
+            field_value = [
+              {
+                rule_type = NOT_NULL
+              }
+            ]
+          }
+        ]
+      }
+  }
+}

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mock-embedding.json
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mock-embedding.json
@@ -7,11 +7,49 @@
       "path": "/v1/qianfan/embedding-batch/.*",
       "queryStringParameters": {
         "access_token": ["^.*$"]
+      },
+      "body": {
+        "type": "JSON_SCHEMA",
+        "jsonSchema": "{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"array\",\"minItems\":1,\"maxItems\":1}},\"required\":[\"input\"]}"
       }
     },
     "httpResponse": {
       "body": {
-        "id": "batch-qianfan",
+        "id": "batch-qianfan-single",
+        "object": "embedding_list",
+        "created": 1724948271,
+        "data": [
+          {
+            "object": "embedding",
+            "embedding": [0.1, 0.2, 0.3, 0.4],
+            "index": 0
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 2,
+          "total_tokens": 2
+        }
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "POST",
+      "path": "/v1/qianfan/embedding-batch/.*",
+      "queryStringParameters": {
+        "access_token": ["^.*$"]
+      },
+      "body": {
+        "type": "JSON_SCHEMA",
+        "jsonSchema": "{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"array\",\"minItems\":2,\"maxItems\":2}},\"required\":[\"input\"]}"
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "batch-qianfan-double",
         "object": "embedding_list",
         "created": 1724948271,
         "data": [
@@ -161,5 +199,4 @@
     }
   }
 ]
-
 

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mock-embedding.json
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mock-embedding.json
@@ -4,6 +4,41 @@
   {
     "httpRequest": {
       "method": "POST",
+      "path": "/v1/qianfan/embedding-batch/.*",
+      "queryStringParameters": {
+        "access_token": ["^.*$"]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "batch-qianfan",
+        "object": "embedding_list",
+        "created": 1724948271,
+        "data": [
+          {
+            "object": "embedding",
+            "embedding": [0.1, 0.2, 0.3, 0.4],
+            "index": 0
+          },
+          {
+            "object": "embedding",
+            "embedding": [0.5, 0.6, 0.7, 0.8],
+            "index": 1
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 4,
+          "total_tokens": 4
+        }
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "POST",
       "path": "/v1/cohere/embedding/model/cohere.embed-english-v3/invoke"
     },
     "httpResponse": {
@@ -126,6 +161,5 @@
     }
   }
 ]
-
 
 

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mockserver-config.json
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-1/src/test/resources/mockserver-config.json
@@ -4,6 +4,42 @@
   {
     "httpRequest": {
       "method": "POST",
+      "path": "/v1/chat/completions/batch"
+    },
+    "httpResponse": {
+      "body": {
+        "id": "chatcmpl-batch-openai",
+        "object": "chat.completion",
+        "created": 1722674828,
+        "model": "gpt-4o-mini",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "[\"Chinese\", \"Chinese\"]"
+            },
+            "logprobs": null,
+            "finish_reason": "stop"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 107,
+          "completion_tokens": 4,
+          "total_tokens": 111
+        },
+        "system_fingerprint": "fp_0f03d4f0ee",
+        "code": 0,
+        "msg": "ok"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "POST",
       "path": "/v1/chat/completions"
     },
     "httpResponse": {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycle.java
@@ -17,13 +17,16 @@
 
 package org.apache.seatunnel.engine.server.task.flow;
 
+import org.apache.seatunnel.api.serialization.Serializer;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.Record;
 import org.apache.seatunnel.api.transform.Collector;
+import org.apache.seatunnel.api.transform.SeaTunnelBatchTransform;
 import org.apache.seatunnel.api.transform.SeaTunnelFlatMapTransform;
 import org.apache.seatunnel.api.transform.SeaTunnelMapTransform;
 import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.core.checkpoint.InternalCheckpointListener;
 import org.apache.seatunnel.engine.core.dag.actions.TransformChainAction;
 import org.apache.seatunnel.engine.server.checkpoint.ActionStateKey;
 import org.apache.seatunnel.engine.server.checkpoint.ActionSubtaskState;
@@ -35,20 +38,34 @@ import org.apache.commons.collections4.CollectionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
-        implements OneInputFlowLifeCycle<Record<?>> {
+        implements OneInputFlowLifeCycle<Record<?>>, InternalCheckpointListener {
+
+    private static final byte SERIALIZER_PRESENT = 1;
+
+    private static final byte SERIALIZER_ABSENT = 0;
 
     private final TransformChainAction<T> action;
 
     private final List<SeaTunnelTransform<T>> transform;
 
     private final Collector<Record<?>> collector;
+
+    private final List<BatchTransformHolder<T, ?>> batchTransforms;
 
     public TransformFlowLifeCycle(
             TransformChainAction<T> action,
@@ -59,6 +76,7 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
         this.action = action;
         this.transform = action.getTransforms();
         this.collector = collector;
+        this.batchTransforms = collectBatchTransforms(action.getTransforms());
     }
 
     @Override
@@ -85,7 +103,13 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
                 prepareClose = true;
             }
             if (barrier.snapshot()) {
-                runningTask.addState(barrier, ActionStateKey.of(action), Collections.emptyList());
+                emitBatchOutputs(true);
+                runningTask.addState(
+                        barrier,
+                        ActionStateKey.of(action),
+                        snapshotBatchTransformStates(barrier.getId()));
+            } else {
+                emitBatchOutputs(true);
             }
             // ack after #addState
             runningTask.ack(barrier);
@@ -130,16 +154,30 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
     }
 
     public List<T> transform(T inputData) {
+        return applyTransforms(0, Collections.singletonList(inputData));
+    }
+
+    private List<T> applyTransforms(int startIndex, List<T> inputDataList) {
         if (transform.isEmpty()) {
-            return Collections.singletonList(inputData);
+            return inputDataList;
         }
 
-        List<T> dataList = new ArrayList<>();
-        dataList.add(inputData);
+        List<T> dataList = inputDataList;
 
-        for (SeaTunnelTransform<T> transformer : transform) {
+        for (int i = startIndex; i < transform.size() && !dataList.isEmpty(); i++) {
+            SeaTunnelTransform<T> transformer = transform.get(i);
             List<T> nextInputDataList = new ArrayList<>();
-            if (transformer instanceof SeaTunnelFlatMapTransform) {
+            if (transformer instanceof SeaTunnelBatchTransform) {
+                SeaTunnelBatchTransform<T, ?> batchTransform =
+                        (SeaTunnelBatchTransform<T, ?>) transformer;
+                for (T data : dataList) {
+                    batchTransform.collect(data);
+                    List<T> readyOutputs = batchTransform.drainOutput();
+                    if (CollectionUtils.isNotEmpty(readyOutputs)) {
+                        nextInputDataList.addAll(readyOutputs);
+                    }
+                }
+            } else if (transformer instanceof SeaTunnelFlatMapTransform) {
                 SeaTunnelFlatMapTransform<T> transformDecorator =
                         (SeaTunnelFlatMapTransform<T>) transformer;
                 for (T data : dataList) {
@@ -179,11 +217,37 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
 
     @Override
     public void restoreState(List<ActionSubtaskState> actionStateList) throws Exception {
-        // nothing
+        if (actionStateList.isEmpty() || batchTransforms.isEmpty()) {
+            return;
+        }
+        List<byte[]> stateEnvelopes =
+                actionStateList.stream()
+                        .map(ActionSubtaskState::getState)
+                        .flatMap(Collection::stream)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        for (int i = 0; i < batchTransforms.size() && i < stateEnvelopes.size(); i++) {
+            restoreBatchTransformState(batchTransforms.get(i), stateEnvelopes.get(i));
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        for (BatchTransformHolder<T, ?> batchTransform : batchTransforms) {
+            batchTransform.transform.notifyCheckpointComplete(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        for (BatchTransformHolder<T, ?> batchTransform : batchTransforms) {
+            batchTransform.transform.notifyCheckpointAborted(checkpointId);
+        }
     }
 
     @Override
     public void close() throws IOException {
+        emitBatchOutputs(true);
         for (SeaTunnelTransform<T> t : transform) {
             try {
                 t.close();
@@ -196,5 +260,146 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
             }
         }
         super.close();
+    }
+
+    private void emitBatchOutputs(boolean forceFlush) {
+        for (BatchTransformHolder<T, ?> batchTransform : batchTransforms) {
+            List<T> outputs =
+                    forceFlush
+                            ? batchTransform.transform.flush()
+                            : batchTransform.transform.drainOutput();
+            emitOutputs(batchTransform.transformIndex + 1, outputs);
+        }
+    }
+
+    private void emitOutputs(int startIndex, List<T> outputs) {
+        if (CollectionUtils.isEmpty(outputs)) {
+            return;
+        }
+        List<T> transformedOutputs = applyTransforms(startIndex, outputs);
+        for (T output : transformedOutputs) {
+            collector.collect(new Record<>(output));
+        }
+    }
+
+    private List<byte[]> snapshotBatchTransformStates(long checkpointId) {
+        if (batchTransforms.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<byte[]> states = new ArrayList<>(batchTransforms.size());
+        for (BatchTransformHolder<T, ?> batchTransform : batchTransforms) {
+            states.add(snapshotBatchTransformState(batchTransform, checkpointId));
+        }
+        return states;
+    }
+
+    private <StateT> byte[] snapshotBatchTransformState(
+            BatchTransformHolder<T, StateT> batchTransform, long checkpointId) {
+        try {
+            List<StateT> states = batchTransform.transform.snapshotState(checkpointId);
+            return serializeStateEnvelope(batchTransform.serializer, states);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to snapshot state for batch transform [%s]",
+                            batchTransform.transform.getPluginName()),
+                    e);
+        }
+    }
+
+    private <StateT> byte[] serializeStateEnvelope(
+            Optional<Serializer<StateT>> serializerOptional, List<StateT> states)
+            throws IOException {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream)) {
+            if (!serializerOptional.isPresent()) {
+                if (CollectionUtils.isNotEmpty(states)) {
+                    throw new IllegalStateException(
+                            "Batch transform returned state but no serializer was provided");
+                }
+                outputStream.writeByte(SERIALIZER_ABSENT);
+                outputStream.writeInt(0);
+                return byteArrayOutputStream.toByteArray();
+            }
+            outputStream.writeByte(SERIALIZER_PRESENT);
+            outputStream.writeInt(states.size());
+            Serializer<StateT> serializer = serializerOptional.get();
+            for (StateT state : states) {
+                byte[] stateBytes = serializer.serialize(state);
+                if (stateBytes == null) {
+                    outputStream.writeInt(-1);
+                } else {
+                    outputStream.writeInt(stateBytes.length);
+                    outputStream.write(stateBytes);
+                }
+            }
+            return byteArrayOutputStream.toByteArray();
+        }
+    }
+
+    private <StateT> void restoreBatchTransformState(
+            BatchTransformHolder<T, StateT> batchTransform, byte[] stateEnvelope) throws Exception {
+        List<StateT> states = deserializeStateEnvelope(batchTransform.serializer, stateEnvelope);
+        if (!states.isEmpty()) {
+            batchTransform.transform.restoreState(states);
+        }
+    }
+
+    private <StateT> List<StateT> deserializeStateEnvelope(
+            Optional<Serializer<StateT>> serializerOptional, byte[] stateEnvelope)
+            throws Exception {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(stateEnvelope);
+                DataInputStream inputStream = new DataInputStream(byteArrayInputStream)) {
+            byte serializerFlag = inputStream.readByte();
+            int stateCount = inputStream.readInt();
+            if (serializerFlag == SERIALIZER_ABSENT) {
+                return Collections.emptyList();
+            }
+            if (!serializerOptional.isPresent()) {
+                throw new IllegalStateException(
+                        "Checkpoint envelope contains state but serializer is absent");
+            }
+            List<StateT> states = new ArrayList<>(stateCount);
+            Serializer<StateT> serializer = serializerOptional.get();
+            for (int i = 0; i < stateCount; i++) {
+                int length = inputStream.readInt();
+                if (length < 0) {
+                    states.add(null);
+                    continue;
+                }
+                byte[] stateBytes = new byte[length];
+                inputStream.readFully(stateBytes);
+                states.add(serializer.deserialize(stateBytes));
+            }
+            return states;
+        }
+    }
+
+    private List<BatchTransformHolder<T, ?>> collectBatchTransforms(
+            List<SeaTunnelTransform<T>> transforms) {
+        List<BatchTransformHolder<T, ?>> result = new ArrayList<>();
+        for (int i = 0; i < transforms.size(); i++) {
+            SeaTunnelTransform<T> transform = transforms.get(i);
+            if (transform instanceof SeaTunnelBatchTransform) {
+                result.add(
+                        new BatchTransformHolder<>(i, (SeaTunnelBatchTransform<T, ?>) transform));
+            }
+        }
+        return result;
+    }
+
+    private static final class BatchTransformHolder<T, StateT> {
+        private final int transformIndex;
+        private final SeaTunnelBatchTransform<T, StateT> transform;
+        private final Optional<Serializer<StateT>> serializer;
+
+        @SuppressWarnings("unchecked")
+        private BatchTransformHolder(int transformIndex, SeaTunnelBatchTransform<T, ?> transform) {
+            this.transformIndex = transformIndex;
+            this.transform = (SeaTunnelBatchTransform<T, StateT>) transform;
+            this.serializer =
+                    (Optional<Serializer<StateT>>)
+                            (Optional<?>) this.transform.getStateSerializer();
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/MultipleFieldOutputTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/MultipleFieldOutputTransform.java
@@ -164,4 +164,12 @@ public abstract class MultipleFieldOutputTransform extends AbstractCatalogSuppor
     }
 
     protected abstract Column[] getOutputColumns();
+
+    protected int[] getFieldsIndex() {
+        return fieldsIndex;
+    }
+
+    protected SeaTunnelRowContainerGenerator getRowContainerGenerator() {
+        return rowContainerGenerator;
+    }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingTransform.java
@@ -20,13 +20,17 @@ package org.apache.seatunnel.transform.nlpmodel.embedding;
 import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.serialization.DefaultSerializer;
+import org.apache.seatunnel.api.serialization.Serializer;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.type.MetadataUtil;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowAccessor;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.VectorType;
+import org.apache.seatunnel.api.transform.SeaTunnelBatchTransform;
 import org.apache.seatunnel.transform.common.MultipleFieldOutputTransform;
 import org.apache.seatunnel.transform.exception.TransformCommonError;
 import org.apache.seatunnel.transform.nlpmodel.ModelProvider;
@@ -48,34 +52,44 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
-public class EmbeddingTransform extends MultipleFieldOutputTransform {
+public class EmbeddingTransform extends MultipleFieldOutputTransform
+        implements SeaTunnelBatchTransform<SeaTunnelRow, EmbeddingTransform.EmbeddingBatchState> {
+
+    private static final Serializer<EmbeddingBatchState> STATE_SERIALIZER =
+            new DefaultSerializer<>();
 
     private final ReadonlyConfig config;
-    private List<Integer> fieldOriginalIndexes;
-    private transient Model model;
-    private Integer dimension;
-    private boolean isMultimodalFields = false;
-    private Map<Integer, FieldSpec> fieldSpecMap;
-    private List<String> fieldNames;
-
+    private final int processBatchSize;
+    private final List<BufferedInput> bufferedInputs = new ArrayList<>();
+    private final List<SeaTunnelRow> readyOutputs = new ArrayList<>();
     private final Map<String, TreeMap<Long, byte[]>> binaryFileCache = new ConcurrentHashMap<>();
     private final Map<String, Long> partIndexMap = new ConcurrentHashMap<>();
+
+    private transient Model model;
+    private Integer dimension;
+    private boolean multimodalFields;
+    private Map<Integer, FieldSpec> fieldSpecMap;
+    private List<String> fieldNames;
 
     public EmbeddingTransform(
             @NonNull ReadonlyConfig config, @NonNull CatalogTable inputCatalogTable) {
         super(inputCatalogTable);
         this.config = config;
+        this.processBatchSize = config.get(ModelTransformConfig.PROCESS_BATCH_SIZE);
         initOutputFields(inputCatalogTable.getTableSchema().toPhysicalRowDataType(), config);
     }
 
@@ -90,11 +104,10 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
         ModelProvider provider = config.get(ModelTransformConfig.MODEL_PROVIDER);
         String apiPath =
                 provider.usedEmbeddingPath(
-                        config.get(ModelTransformConfig.API_PATH), isMultimodalFields);
+                        config.get(ModelTransformConfig.API_PATH), multimodalFields);
         try {
             switch (provider) {
                 case CUSTOM:
-                    // load custom_config from the configuration
                     ReadonlyConfig customConfig =
                             config.getOptional(
                                             ModelTransformConfig.CustomRequestConfig.CUSTOM_CONFIG)
@@ -139,7 +152,7 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
                                     config.get(
                                             EmbeddingTransformConfig
                                                     .SINGLE_VECTORIZED_INPUT_NUMBER),
-                                    isMultimodalFields);
+                                    multimodalFields);
                     break;
                 case QIANFAN:
                     model =
@@ -152,7 +165,6 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
                                     config.get(
                                             EmbeddingTransformConfig
                                                     .SINGLE_VECTORIZED_INPUT_NUMBER));
-
                     break;
                 case ZHIPU:
                     model =
@@ -182,7 +194,7 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
                 default:
                     throw new IllegalArgumentException("Unsupported model provider: " + provider);
             }
-            if (isMultimodalFields && !(model instanceof MultimodalModel)) {
+            if (multimodalFields && !(model instanceof MultimodalModel)) {
                 throw new IllegalArgumentException(
                         String.format(
                                 "Model provider: %s does not support multimodal embedding",
@@ -197,8 +209,8 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
     }
 
     private void initOutputFields(SeaTunnelRowType inputRowType, ReadonlyConfig config) {
-        Map<Integer, FieldSpec> fieldSpecMap = new HashMap<>();
-        List<String> fieldNames = new ArrayList<>();
+        Map<Integer, FieldSpec> configuredFieldSpecMap = new LinkedHashMap<>();
+        List<String> configuredFieldNames = new ArrayList<>();
         Map<String, Object> fieldsConfig =
                 config.get(EmbeddingTransformConfig.VECTORIZATION_FIELDS);
         if (fieldsConfig == null || fieldsConfig.isEmpty()) {
@@ -207,7 +219,6 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
 
         for (Map.Entry<String, Object> field : fieldsConfig.entrySet()) {
             FieldSpec fieldSpec = new FieldSpec(field);
-            log.info("Field spec: {}", fieldSpec.toString());
             String srcField = fieldSpec.getFieldName();
             int srcFieldIndex;
             try {
@@ -216,13 +227,14 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
                 throw TransformCommonError.cannotFindInputFieldError(getPluginName(), srcField);
             }
             if (fieldSpec.isMultimodalField()) {
-                isMultimodalFields = true;
+                multimodalFields = true;
             }
-            fieldSpecMap.put(srcFieldIndex, fieldSpec);
-            fieldNames.add(field.getKey());
+            configuredFieldSpecMap.put(srcFieldIndex, fieldSpec);
+            configuredFieldNames.add(field.getKey());
+            log.info("Field spec: {}", fieldSpec);
         }
-        this.fieldSpecMap = fieldSpecMap;
-        this.fieldNames = fieldNames;
+        this.fieldSpecMap = configuredFieldSpecMap;
+        this.fieldNames = configuredFieldNames;
     }
 
     @Override
@@ -230,32 +242,91 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
         tryOpen();
         try {
             if (MetadataUtil.isBinaryFormat(inputRow)) {
-                return vectorizationBinaryRow(inputRow);
+                return vectorizePreparedFields(createBinaryFieldValues(processBinaryRow(inputRow)));
             }
-            Set<Integer> fieldOriginalIndexes = fieldSpecMap.keySet();
-            Object[] fieldValues = new Object[fieldOriginalIndexes.size()];
-            List<ByteBuffer> vectorization;
-            int i = 0;
-
-            for (Integer fieldOriginalIndex : fieldOriginalIndexes) {
-                FieldSpec fieldSpec = fieldSpecMap.get(fieldOriginalIndex);
-                Object value = inputRow.getField(fieldOriginalIndex);
-                fieldValues[i++] =
-                        isMultimodalFields ? new MultimodalFieldValue(fieldSpec, value) : value;
-            }
-
-            vectorization = model.vectorization(fieldValues);
-            return vectorization.toArray();
+            return vectorizePreparedFields(extractFieldValues(inputRow));
         } catch (Exception e) {
             throw new RuntimeException("Failed to data vectorization", e);
         }
     }
 
     @Override
+    public void collect(SeaTunnelRow row) {
+        SeaTunnelRow bufferedRow = row.copy();
+        try {
+            if (MetadataUtil.isBinaryFormat(bufferedRow)) {
+                byte[] completeData = processBinaryRow(new SeaTunnelRowAccessor(bufferedRow));
+                if (completeData != null) {
+                    bufferedInputs.add(new BufferedInput(bufferedRow, completeData));
+                }
+            } else {
+                bufferedInputs.add(new BufferedInput(bufferedRow, null));
+            }
+            processBufferedInputs(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to collect row for embedding batch transform", e);
+        }
+    }
+
+    @Override
+    public List<SeaTunnelRow> drainOutput() {
+        if (readyOutputs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<SeaTunnelRow> outputs = new ArrayList<>(readyOutputs);
+        readyOutputs.clear();
+        return outputs;
+    }
+
+    @Override
+    public List<SeaTunnelRow> flush() {
+        processBufferedInputs(true);
+        return drainOutput();
+    }
+
+    @Override
+    public List<EmbeddingBatchState> snapshotState(long checkpointId) {
+        if (bufferedInputs.isEmpty() && binaryFileCache.isEmpty() && partIndexMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(
+                new EmbeddingBatchState(
+                        copyBufferedInputs(bufferedInputs),
+                        copyBinaryFileCache(binaryFileCache),
+                        new LinkedHashMap<>(partIndexMap)));
+    }
+
+    @Override
+    public void restoreState(List<EmbeddingBatchState> states) {
+        bufferedInputs.clear();
+        binaryFileCache.clear();
+        partIndexMap.clear();
+        for (EmbeddingBatchState state : states) {
+            bufferedInputs.addAll(copyBufferedInputs(state.getBufferedInputs()));
+            mergeBinaryFileCache(binaryFileCache, state.getBinaryFileCache());
+            partIndexMap.putAll(state.getPartIndexMap());
+        }
+    }
+
+    @Override
+    public Optional<Serializer<EmbeddingBatchState>> getStateSerializer() {
+        return Optional.of(STATE_SERIALIZER);
+    }
+
+    @Override
+    public boolean hasBufferedData() {
+        return !bufferedInputs.isEmpty() || !binaryFileCache.isEmpty();
+    }
+
+    @Override
+    public int getBufferSize() {
+        return bufferedInputs.size();
+    }
+
+    @Override
     @VisibleForTesting
     public Column[] getOutputColumns() {
         tryOpen();
-        log.info("getOutputColumns: {}", fieldNames);
         Column[] columns = new Column[fieldNames.size()];
         for (int i = 0; i < fieldNames.size(); i++) {
             columns[i] =
@@ -277,22 +348,106 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
     }
 
     public boolean isMultimodalFields() {
-        return isMultimodalFields;
+        return multimodalFields;
     }
 
-    /** Process a row in binary format: [data, relativePath, partIndex] */
-    private Object[] vectorizationBinaryRow(SeaTunnelRowAccessor inputRow) throws Exception {
+    @SneakyThrows
+    @Override
+    public void close() {
+        if (model != null) {
+            model.close();
+        }
+        bufferedInputs.clear();
+        readyOutputs.clear();
+        binaryFileCache.clear();
+        partIndexMap.clear();
+    }
 
-        byte[] completeData = processBinaryRow(inputRow);
+    private void processBufferedInputs(boolean forceFlush) {
+        while (!bufferedInputs.isEmpty()
+                && (forceFlush || bufferedInputs.size() >= processBatchSize)) {
+            tryOpen();
+            getProducedCatalogTable();
+            int currentBatchSize =
+                    forceFlush
+                            ? Math.min(processBatchSize, bufferedInputs.size())
+                            : processBatchSize;
+            List<BufferedInput> batchInputs =
+                    new ArrayList<>(bufferedInputs.subList(0, currentBatchSize));
+            bufferedInputs.subList(0, currentBatchSize).clear();
+            readyOutputs.addAll(vectorizeBatch(batchInputs));
+        }
+    }
+
+    private List<SeaTunnelRow> vectorizeBatch(List<BufferedInput> batchInputs) {
+        List<Object[]> rowFieldValuesList = new ArrayList<>(batchInputs.size());
+        List<Object> mergedFieldValues = new ArrayList<>();
+        for (BufferedInput batchInput : batchInputs) {
+            Object[] rowFieldValues =
+                    batchInput.isBinary()
+                            ? createBinaryFieldValues(batchInput.getCompleteBinaryData())
+                            : extractFieldValues(new SeaTunnelRowAccessor(batchInput.getRow()));
+            rowFieldValuesList.add(rowFieldValues);
+            mergedFieldValues.addAll(Arrays.asList(rowFieldValues));
+        }
+
+        try {
+            List<ByteBuffer> embeddings = model.vectorization(mergedFieldValues.toArray());
+            if (embeddings.size() != mergedFieldValues.size()) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Expected %s vectors but model returned %s vectors",
+                                mergedFieldValues.size(), embeddings.size()));
+            }
+            List<SeaTunnelRow> outputs = new ArrayList<>(batchInputs.size());
+            int embeddingIndex = 0;
+            for (int i = 0; i < batchInputs.size(); i++) {
+                Object[] rowOutputValues = new Object[rowFieldValuesList.get(i).length];
+                for (int j = 0; j < rowOutputValues.length; j++) {
+                    rowOutputValues[j] = embeddings.get(embeddingIndex++);
+                }
+                outputs.add(buildOutputRow(batchInputs.get(i).getRow(), rowOutputValues));
+            }
+            return outputs;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to process embedding batch", e);
+        }
+    }
+
+    private SeaTunnelRow buildOutputRow(SeaTunnelRow inputRow, Object[] fieldValues) {
+        SeaTunnelRow outputRow = getRowContainerGenerator().apply(inputRow);
+        int[] fieldsIndex = getFieldsIndex();
+        for (int i = 0; i < fieldValues.length; i++) {
+            outputRow.setField(fieldsIndex[i], fieldValues[i]);
+        }
+        return outputRow;
+    }
+
+    private Object[] extractFieldValues(SeaTunnelRowAccessor inputRow) {
+        Object[] fieldValues = new Object[fieldSpecMap.size()];
+        int i = 0;
+        for (Map.Entry<Integer, FieldSpec> entry : fieldSpecMap.entrySet()) {
+            Object value = inputRow.getField(entry.getKey());
+            fieldValues[i++] =
+                    multimodalFields ? new MultimodalFieldValue(entry.getValue(), value) : value;
+        }
+        return fieldValues;
+    }
+
+    private Object[] vectorizePreparedFields(Object[] fieldValues) throws IOException {
+        if (fieldValues == null) {
+            return null;
+        }
+        return model.vectorization(fieldValues).toArray();
+    }
+
+    private Object[] createBinaryFieldValues(byte[] completeData) {
         if (completeData == null) {
             return null;
         }
-        Set<Integer> fieldOriginalIndexes = fieldSpecMap.keySet();
-        Object[] fieldValues = new Object[fieldOriginalIndexes.size()];
+        Object[] fieldValues = new Object[fieldSpecMap.size()];
         int i = 0;
-
-        for (Integer fieldOriginalIndex : fieldOriginalIndexes) {
-            FieldSpec fieldSpec = fieldSpecMap.get(fieldOriginalIndex);
+        for (FieldSpec fieldSpec : fieldSpecMap.values()) {
             if (fieldSpec.isBinary()) {
                 fieldValues[i++] = new MultimodalFieldValue(fieldSpec, completeData);
             } else {
@@ -302,13 +457,7 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
                 fieldValues[i++] = null;
             }
         }
-
-        try {
-            return model.vectorization(fieldValues).toArray();
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to vectorize binary data for file: " + inputRow.toString(), e);
-        }
+        return fieldValues;
     }
 
     private byte[] processBinaryRow(SeaTunnelRowAccessor inputRow) throws Exception {
@@ -316,23 +465,22 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
         String relativePath = (String) inputRow.getField(1);
         long partIndex = (long) inputRow.getField(2);
 
-        if (partIndex != -1) {
+        if (partIndex >= 0) {
             checkPartOrder(relativePath, partIndex);
+            cacheBinaryChunk(relativePath, partIndex, data);
         }
-        cacheBinaryChunk(relativePath, partIndex, data);
-        if (MetadataUtil.isComplete(inputRow)) {
-            byte[] completeFile = assembleCompleteFile(relativePath);
-            cleanupFileCache(relativePath);
-            log.info(
-                    "Assembled complete file: {}, size: {} bytes",
-                    relativePath,
-                    completeFile.length);
-            return completeFile;
+        if (!MetadataUtil.isComplete(inputRow)) {
+            return null;
         }
-        return null;
+        if (partIndex < 0) {
+            return data;
+        }
+        byte[] completeFile = assembleCompleteFile(relativePath);
+        cleanupFileCache(relativePath);
+        log.info("Assembled complete file: {}, size: {} bytes", relativePath, completeFile.length);
+        return completeFile;
     }
 
-    /** Validate that partIndex is in correct order for the given file */
     private void checkPartOrder(String relativePath, long partIndex) throws Exception {
         Long lastPartIndex = partIndexMap.getOrDefault(relativePath, -1L);
         if (partIndex - 1 != lastPartIndex) {
@@ -342,15 +490,14 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
     }
 
     private void cacheBinaryChunk(String relativePath, long partIndex, byte[] data) {
-        if (partIndex >= 0) {
-            binaryFileCache
-                    .computeIfAbsent(relativePath, k -> new TreeMap<>())
-                    .put(partIndex, data);
-        }
+        binaryFileCache.computeIfAbsent(relativePath, key -> new TreeMap<>()).put(partIndex, data);
     }
 
     private byte[] assembleCompleteFile(String relativePath) {
         TreeMap<Long, byte[]> chunks = binaryFileCache.get(relativePath);
+        if (chunks == null || chunks.isEmpty()) {
+            throw new IllegalStateException("Missing binary chunks for file: " + relativePath);
+        }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             for (Map.Entry<Long, byte[]> entry : chunks.entrySet()) {
                 byte[] chunk = entry.getValue();
@@ -370,13 +517,99 @@ public class EmbeddingTransform extends MultipleFieldOutputTransform {
         log.info("Cleaned up cache and partIndex tracking for file: {}", relativePath);
     }
 
-    @SneakyThrows
-    @Override
-    public void close() {
-        if (model != null) {
-            model.close();
+    private List<BufferedInput> copyBufferedInputs(List<BufferedInput> inputs) {
+        List<BufferedInput> copiedInputs = new ArrayList<>(inputs.size());
+        for (BufferedInput input : inputs) {
+            copiedInputs.add(input.copy());
         }
-        binaryFileCache.clear();
-        partIndexMap.clear();
+        return copiedInputs;
+    }
+
+    private Map<String, TreeMap<Long, byte[]>> copyBinaryFileCache(
+            Map<String, TreeMap<Long, byte[]>> source) {
+        Map<String, TreeMap<Long, byte[]>> copied = new LinkedHashMap<>();
+        mergeBinaryFileCache(copied, source);
+        return copied;
+    }
+
+    private void mergeBinaryFileCache(
+            Map<String, TreeMap<Long, byte[]>> target, Map<String, TreeMap<Long, byte[]>> source) {
+        for (Map.Entry<String, TreeMap<Long, byte[]>> entry : source.entrySet()) {
+            TreeMap<Long, byte[]> chunks =
+                    target.computeIfAbsent(entry.getKey(), key -> new TreeMap<>());
+            for (Map.Entry<Long, byte[]> chunkEntry : entry.getValue().entrySet()) {
+                chunks.put(chunkEntry.getKey(), copyBytes(chunkEntry.getValue()));
+            }
+        }
+    }
+
+    private byte[] copyBytes(byte[] value) {
+        return value == null ? null : Arrays.copyOf(value, value.length);
+    }
+
+    @VisibleForTesting
+    void setModel(Model model) {
+        this.model = model;
+    }
+
+    static final class BufferedInput implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final SeaTunnelRow row;
+        private final byte[] completeBinaryData;
+
+        private BufferedInput(SeaTunnelRow row, byte[] completeBinaryData) {
+            this.row = row;
+            this.completeBinaryData = completeBinaryData;
+        }
+
+        public SeaTunnelRow getRow() {
+            return row;
+        }
+
+        public byte[] getCompleteBinaryData() {
+            return completeBinaryData;
+        }
+
+        public boolean isBinary() {
+            return completeBinaryData != null;
+        }
+
+        public BufferedInput copy() {
+            return new BufferedInput(
+                    row.copy(),
+                    completeBinaryData == null
+                            ? null
+                            : Arrays.copyOf(completeBinaryData, completeBinaryData.length));
+        }
+    }
+
+    public static final class EmbeddingBatchState implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final List<BufferedInput> bufferedInputs;
+        private final Map<String, TreeMap<Long, byte[]>> binaryFileCache;
+        private final Map<String, Long> partIndexMap;
+
+        public EmbeddingBatchState(
+                List<BufferedInput> bufferedInputs,
+                Map<String, TreeMap<Long, byte[]>> binaryFileCache,
+                Map<String, Long> partIndexMap) {
+            this.bufferedInputs = bufferedInputs;
+            this.binaryFileCache = binaryFileCache;
+            this.partIndexMap = partIndexMap;
+        }
+
+        public List<BufferedInput> getBufferedInputs() {
+            return bufferedInputs;
+        }
+
+        public Map<String, TreeMap<Long, byte[]>> getBinaryFileCache() {
+            return binaryFileCache;
+        }
+
+        public Map<String, Long> getPartIndexMap() {
+            return partIndexMap;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMTransform.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.nlpmodel.llm;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.serialization.DefaultSerializer;
+import org.apache.seatunnel.api.serialization.Serializer;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -25,6 +29,7 @@ import org.apache.seatunnel.api.table.catalog.SeaTunnelDataTypeConvertorUtil;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowAccessor;
+import org.apache.seatunnel.api.transform.SeaTunnelBatchTransform;
 import org.apache.seatunnel.transform.common.SingleFieldOutputTransform;
 import org.apache.seatunnel.transform.nlpmodel.ModelProvider;
 import org.apache.seatunnel.transform.nlpmodel.ModelTransformConfig;
@@ -37,21 +42,34 @@ import org.apache.seatunnel.transform.nlpmodel.llm.remote.openai.OpenAIModel;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
-public class LLMTransform extends SingleFieldOutputTransform {
+public class LLMTransform extends SingleFieldOutputTransform
+        implements SeaTunnelBatchTransform<SeaTunnelRow, LLMTransform.LLMBatchState> {
+
+    private static final Serializer<LLMBatchState> STATE_SERIALIZER = new DefaultSerializer<>();
+
     private final ReadonlyConfig config;
     private final SeaTunnelDataType<?> outputDataType;
+    private final int processBatchSize;
+    private final List<SeaTunnelRow> bufferedRows = new ArrayList<>();
+    private final List<SeaTunnelRow> readyOutputs = new ArrayList<>();
+
     private Model model;
 
     public LLMTransform(@NonNull ReadonlyConfig config, @NonNull CatalogTable inputCatalogTable) {
         super(inputCatalogTable);
         this.config = config;
+        this.processBatchSize = config.get(ModelTransformConfig.PROCESS_BATCH_SIZE);
         this.outputDataType =
                 SeaTunnelDataTypeConvertorUtil.deserializeSeaTunnelDataType(
                         "output", config.get(LLMTransformConfig.OUTPUT_DATA_TYPE).toString());
+        getProducedCatalogTable();
     }
 
     private void tryOpen() {
@@ -70,7 +88,6 @@ public class LLMTransform extends SingleFieldOutputTransform {
         ModelProvider provider = config.get(ModelTransformConfig.MODEL_PROVIDER);
         switch (provider) {
             case CUSTOM:
-                // load custom_config from the configuration
                 ReadonlyConfig customConfig =
                         config.getOptional(ModelTransformConfig.CustomRequestConfig.CUSTOM_CONFIG)
                                 .map(ReadonlyConfig::fromMap)
@@ -143,25 +160,65 @@ public class LLMTransform extends SingleFieldOutputTransform {
         SeaTunnelRow seaTunnelRow = new SeaTunnelRow(inputRow.getFields());
         try {
             List<String> values = model.inference(Collections.singletonList(seaTunnelRow));
-            switch (outputDataType.getSqlType()) {
-                case STRING:
-                    return String.valueOf(values.get(0));
-                case INT:
-                    return Integer.parseInt(values.get(0));
-                case BIGINT:
-                    return Long.parseLong(values.get(0));
-                case DOUBLE:
-                    return Double.parseDouble(values.get(0));
-                case BOOLEAN:
-                    return Boolean.parseBoolean(values.get(0));
-                default:
-                    throw new IllegalArgumentException(
-                            "Unsupported output data type: " + outputDataType);
-            }
+            return convertOutputValue(values.get(0));
         } catch (Exception e) {
             throw new RuntimeException(
                     String.format("Failed to inference model with row %s", seaTunnelRow), e);
         }
+    }
+
+    @Override
+    public void collect(SeaTunnelRow row) {
+        tryOpen();
+        bufferedRows.add(row.copy());
+        processBufferedRows(false);
+    }
+
+    @Override
+    public List<SeaTunnelRow> drainOutput() {
+        if (readyOutputs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<SeaTunnelRow> outputs = new ArrayList<>(readyOutputs);
+        readyOutputs.clear();
+        return outputs;
+    }
+
+    @Override
+    public List<SeaTunnelRow> flush() {
+        processBufferedRows(true);
+        return drainOutput();
+    }
+
+    @Override
+    public List<LLMBatchState> snapshotState(long checkpointId) {
+        if (bufferedRows.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(new LLMBatchState(copyRows(bufferedRows)));
+    }
+
+    @Override
+    public void restoreState(List<LLMBatchState> states) {
+        bufferedRows.clear();
+        for (LLMBatchState state : states) {
+            bufferedRows.addAll(copyRows(state.getBufferedRows()));
+        }
+    }
+
+    @Override
+    public Optional<Serializer<LLMBatchState>> getStateSerializer() {
+        return Optional.of(STATE_SERIALIZER);
+    }
+
+    @Override
+    public boolean hasBufferedData() {
+        return !bufferedRows.isEmpty();
+    }
+
+    @Override
+    public int getBufferSize() {
+        return bufferedRows.size();
     }
 
     @Override
@@ -182,6 +239,89 @@ public class LLMTransform extends SingleFieldOutputTransform {
     public void close() {
         if (model != null) {
             model.close();
+        }
+        bufferedRows.clear();
+        readyOutputs.clear();
+    }
+
+    private void processBufferedRows(boolean forceFlush) {
+        while (!bufferedRows.isEmpty() && (forceFlush || bufferedRows.size() >= processBatchSize)) {
+            int currentBatchSize =
+                    forceFlush ? Math.min(processBatchSize, bufferedRows.size()) : processBatchSize;
+            List<SeaTunnelRow> batchRows =
+                    new ArrayList<>(bufferedRows.subList(0, currentBatchSize));
+            bufferedRows.subList(0, currentBatchSize).clear();
+            readyOutputs.addAll(inferenceBatch(batchRows));
+        }
+    }
+
+    private List<SeaTunnelRow> inferenceBatch(List<SeaTunnelRow> batchRows) {
+        try {
+            List<String> values = model.inference(batchRows);
+            if (values.size() != batchRows.size()) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Expected %s outputs but model returned %s outputs",
+                                batchRows.size(), values.size()));
+            }
+            List<SeaTunnelRow> outputs = new ArrayList<>(batchRows.size());
+            for (int i = 0; i < batchRows.size(); i++) {
+                outputs.add(buildOutputRow(batchRows.get(i), values.get(i)));
+            }
+            return outputs;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inference batch rows with LLM transform", e);
+        }
+    }
+
+    private SeaTunnelRow buildOutputRow(SeaTunnelRow inputRow, String value) {
+        SeaTunnelRow outputRow = getRowContainerGenerator().apply(inputRow);
+        outputRow.setField(getFieldIndex(), convertOutputValue(value));
+        return outputRow;
+    }
+
+    private Object convertOutputValue(String value) {
+        switch (outputDataType.getSqlType()) {
+            case STRING:
+                return String.valueOf(value);
+            case INT:
+                return Integer.parseInt(value);
+            case BIGINT:
+                return Long.parseLong(value);
+            case DOUBLE:
+                return Double.parseDouble(value);
+            case BOOLEAN:
+                return Boolean.parseBoolean(value);
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported output data type: " + outputDataType);
+        }
+    }
+
+    private List<SeaTunnelRow> copyRows(List<SeaTunnelRow> rows) {
+        List<SeaTunnelRow> copiedRows = new ArrayList<>(rows.size());
+        for (SeaTunnelRow row : rows) {
+            copiedRows.add(row.copy());
+        }
+        return copiedRows;
+    }
+
+    @VisibleForTesting
+    void setModel(Model model) {
+        this.model = model;
+    }
+
+    public static final class LLMBatchState implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final List<SeaTunnelRow> bufferedRows;
+
+        public LLMBatchState(List<SeaTunnelRow> bufferedRows) {
+            this.bufferedRows = bufferedRows;
+        }
+
+        public List<SeaTunnelRow> getBufferedRows() {
+            return bufferedRows;
         }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingBatchTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingBatchTransformTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.nlpmodel.embedding;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.MetadataUtil;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.transform.nlpmodel.embedding.remote.Model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class EmbeddingBatchTransformTest {
+
+    @Test
+    void shouldDrainEmbeddingBatchWhenProcessBatchSizeReached() {
+        EmbeddingTransform transform = new EmbeddingTransform(textConfig(2), textTable());
+        transform.setModel(new FakeEmbeddingModel());
+
+        transform.collect(textRow(1, "alpha"));
+        Assertions.assertTrue(transform.drainOutput().isEmpty());
+
+        transform.collect(textRow(2, "beta"));
+        List<SeaTunnelRow> outputs = transform.drainOutput();
+
+        Assertions.assertEquals(2, outputs.size());
+        Assertions.assertTrue(outputs.get(0).getField(2) instanceof ByteBuffer);
+        Assertions.assertTrue(outputs.get(1).getField(2) instanceof ByteBuffer);
+    }
+
+    @Test
+    void shouldRestoreTextBatchFromCheckpoint() throws Exception {
+        EmbeddingTransform transform = new EmbeddingTransform(textConfig(2), textTable());
+        transform.setModel(new FakeEmbeddingModel());
+        transform.collect(textRow(3, "gamma"));
+
+        List<EmbeddingTransform.EmbeddingBatchState> states = transform.snapshotState(1L);
+        Assertions.assertEquals(1, states.size());
+
+        EmbeddingTransform restored = new EmbeddingTransform(textConfig(2), textTable());
+        restored.setModel(new FakeEmbeddingModel());
+        restored.restoreState(states);
+
+        List<SeaTunnelRow> outputs = restored.flush();
+        Assertions.assertEquals(1, outputs.size());
+        Assertions.assertTrue(outputs.get(0).getField(2) instanceof ByteBuffer);
+    }
+
+    @Test
+    void shouldRestoreIncompleteBinaryChunksFromCheckpoint() throws Exception {
+        EmbeddingTransform transform = new EmbeddingTransform(binaryConfig(), binaryTable());
+        transform.setModel(new FakeEmbeddingModel());
+        transform.collect(binaryRow(new byte[] {1, 2}, "image.png", 0L, false));
+
+        List<EmbeddingTransform.EmbeddingBatchState> states = transform.snapshotState(1L);
+        Assertions.assertEquals(1, states.size());
+
+        EmbeddingTransform restored = new EmbeddingTransform(binaryConfig(), binaryTable());
+        restored.setModel(new FakeEmbeddingModel());
+        restored.restoreState(states);
+        restored.collect(binaryRow(new byte[] {3, 4}, "image.png", 1L, true));
+
+        List<SeaTunnelRow> outputs = restored.drainOutput();
+        Assertions.assertEquals(1, outputs.size());
+        Assertions.assertTrue(outputs.get(0).getField(3) instanceof ByteBuffer);
+    }
+
+    private ReadonlyConfig textConfig(int batchSize) {
+        Map<String, Object> vectorizationFields = new LinkedHashMap<>();
+        vectorizationFields.put("text_vector", "text");
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("model_provider", "OPENAI");
+        config.put("model", "text-embedding-3-small");
+        config.put("api_key", "sk-test");
+        config.put("process_batch_size", batchSize);
+        config.put("single_vectorized_input_number", 16);
+        config.put("vectorization_fields", vectorizationFields);
+        return ReadonlyConfig.fromMap(config);
+    }
+
+    private ReadonlyConfig binaryConfig() {
+        Map<String, Object> fieldConfig = new LinkedHashMap<>();
+        fieldConfig.put("field", "data");
+        fieldConfig.put("modality", "jpeg");
+        fieldConfig.put("format", "binary");
+
+        Map<String, Object> vectorizationFields = new LinkedHashMap<>();
+        vectorizationFields.put("image_vector", fieldConfig);
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("model_provider", "DOUBAO");
+        config.put("model", "doubao-embedding");
+        config.put("api_key", "sk-test");
+        config.put("process_batch_size", 1);
+        config.put("single_vectorized_input_number", 16);
+        config.put("vectorization_fields", vectorizationFields);
+        return ReadonlyConfig.fromMap(config);
+    }
+
+    private CatalogTable textTable() {
+        return CatalogTable.of(
+                TableIdentifier.of("test", "db", "schema", "text_table"),
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "id", BasicType.INT_TYPE, null, null, false, null, null))
+                        .column(
+                                PhysicalColumn.of(
+                                        "text",
+                                        BasicType.STRING_TYPE,
+                                        null,
+                                        null,
+                                        true,
+                                        null,
+                                        null))
+                        .build(),
+                new LinkedHashMap<>(),
+                new ArrayList<>(),
+                null);
+    }
+
+    private CatalogTable binaryTable() {
+        return CatalogTable.of(
+                TableIdentifier.of("test", "db", "schema", "binary_table"),
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "data",
+                                        PrimitiveByteArrayType.INSTANCE,
+                                        null,
+                                        null,
+                                        true,
+                                        null,
+                                        null))
+                        .column(
+                                PhysicalColumn.of(
+                                        "relative_path",
+                                        BasicType.STRING_TYPE,
+                                        null,
+                                        null,
+                                        true,
+                                        null,
+                                        null))
+                        .column(
+                                PhysicalColumn.of(
+                                        "part_index",
+                                        BasicType.LONG_TYPE,
+                                        null,
+                                        null,
+                                        true,
+                                        null,
+                                        null))
+                        .build(),
+                new LinkedHashMap<>(),
+                new ArrayList<>(),
+                null);
+    }
+
+    private SeaTunnelRow textRow(int id, String text) {
+        SeaTunnelRow row = new SeaTunnelRow(2);
+        row.setField(0, id);
+        row.setField(1, text);
+        return row;
+    }
+
+    private SeaTunnelRow binaryRow(
+            byte[] data, String relativePath, long partIndex, boolean complete) {
+        SeaTunnelRow row = new SeaTunnelRow(3);
+        row.setField(0, data);
+        row.setField(1, relativePath);
+        row.setField(2, partIndex);
+        MetadataUtil.setBinaryFormat(row);
+        if (complete) {
+            MetadataUtil.setBinaryRowComplete(row);
+        }
+        return row;
+    }
+
+    private static final class FakeEmbeddingModel implements Model {
+        @Override
+        public List<ByteBuffer> vectorization(Object[] fields) {
+            List<ByteBuffer> outputs = new ArrayList<>(fields.length);
+            for (int i = 0; i < fields.length; i++) {
+                outputs.add(ByteBuffer.wrap(new byte[] {(byte) (i + 1), (byte) (i + 2)}));
+            }
+            return outputs;
+        }
+
+        @Override
+        public Integer dimension() {
+            return 2;
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMBatchTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMBatchTransformTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.nlpmodel.llm;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.transform.nlpmodel.llm.remote.Model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class LLMBatchTransformTest {
+
+    @Test
+    void shouldDrainBatchWhenProcessBatchSizeReached() {
+        LLMTransform transform = new LLMTransform(batchConfig(2), defaultTable());
+        transform.setModel(new FakeLLMModel());
+
+        transform.collect(row(1, "alpha"));
+        Assertions.assertTrue(transform.drainOutput().isEmpty());
+
+        transform.collect(row(2, "beta"));
+        List<SeaTunnelRow> outputs = transform.drainOutput();
+
+        Assertions.assertEquals(2, outputs.size());
+        Assertions.assertEquals("result-1", outputs.get(0).getField(2));
+        Assertions.assertEquals("result-2", outputs.get(1).getField(2));
+    }
+
+    @Test
+    void shouldRestoreBufferedRowsFromCheckpoint() throws Exception {
+        LLMTransform transform = new LLMTransform(batchConfig(2), defaultTable());
+        transform.setModel(new FakeLLMModel());
+        transform.collect(row(3, "gamma"));
+
+        List<LLMTransform.LLMBatchState> states = transform.snapshotState(1L);
+        Assertions.assertEquals(1, states.size());
+
+        LLMTransform restored = new LLMTransform(batchConfig(2), defaultTable());
+        restored.setModel(new FakeLLMModel());
+        restored.restoreState(states);
+
+        List<SeaTunnelRow> outputs = restored.flush();
+        Assertions.assertEquals(1, outputs.size());
+        Assertions.assertEquals("result-3", outputs.get(0).getField(2));
+    }
+
+    private ReadonlyConfig batchConfig(int batchSize) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("model_provider", "OPENAI");
+        config.put("model", "gpt-4o-mini");
+        config.put("api_key", "sk-test");
+        config.put("prompt", "test");
+        config.put("process_batch_size", batchSize);
+        config.put("output_column_name", "llm_output");
+        config.put("output_data_type", "STRING");
+        return ReadonlyConfig.fromMap(config);
+    }
+
+    private CatalogTable defaultTable() {
+        return CatalogTable.of(
+                TableIdentifier.of("test", "db", "schema", "table"),
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "id", BasicType.INT_TYPE, null, null, false, null, null))
+                        .column(
+                                PhysicalColumn.of(
+                                        "name",
+                                        BasicType.STRING_TYPE,
+                                        null,
+                                        null,
+                                        true,
+                                        null,
+                                        null))
+                        .build(),
+                new LinkedHashMap<>(),
+                new ArrayList<>(),
+                null);
+    }
+
+    private SeaTunnelRow row(int id, String name) {
+        SeaTunnelRow row = new SeaTunnelRow(2);
+        row.setField(0, id);
+        row.setField(1, name);
+        return row;
+    }
+
+    private static final class FakeLLMModel implements Model {
+        @Override
+        public List<String> inference(List<SeaTunnelRow> rows) {
+            List<String> outputs = new ArrayList<>(rows.size());
+            for (SeaTunnelRow row : rows) {
+                outputs.add("result-" + row.getField(0));
+            }
+            return outputs;
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Support batched transform execution with checkpoint state for `LLM` and `Embedding`, and add E2E coverage that verifies the new batch request behavior.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can now configure `process_batch_size` for `LLM` and `Embedding` transforms in batch jobs, and the transform state is checkpointed and restored.

### How was this patch tested?

- `./mvnw spotless:apply`
- Unit tests for `LLMTransform` and `EmbeddingTransform`
- Added transform E2E tests that assert actual batched requests against MockServer for both `LLM` and `Embedding`
