### PR TITLE
[Fix] [E2e] Ignore pending coordinator scheduler thread during container cleanup

### DIFF
--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -400,6 +400,7 @@ public class SeaTunnelContainer extends AbstractTestContainer {
         Pattern aqsThread = Pattern.compile("pool-[0-9]-thread-[0-9]");
         return s.startsWith("hz.main")
                 || s.startsWith("seatunnel-coordinator-service")
+                || s.startsWith("pending-job-schedule-runner")
                 || s.startsWith("GC task thread")
                 || s.contains("CompilerThread")
                 || s.startsWith("SeaTunnel-CompletableFuture-Thread-")


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes a false negative in E2E container cleanup. `CoordinatorService` starts a long-lived scheduler thread named `pending-job-schedule-runner`. The E2E cleanup logic in `SeaTunnelContainer` already ignores `seatunnel-coordinator-service-*` worker threads, but this renamed scheduler thread is not classified as a system thread, so tests can time out during post-job thread cleanup even when the job itself has finished successfully.

This patch adds `pending-job-schedule-runner` to the E2E system-thread allowlist so the cleanup check no longer treats this coordinator background thread as a leaked test thread.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)