### PR TITLE
[fix][REST API] does not apply ConfigShade decryption for HOCON/SQL format and upload-file submissions

### DIFF
--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigBuilder.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigBuilder.java
@@ -100,10 +100,6 @@ public class ConfigBuilder {
     }
 
     public static Config of(@NonNull Map<String, Object> objectMap) {
-        return of(objectMap, false);
-    }
-
-    public static Config of(@NonNull Map<String, Object> objectMap, boolean isEncrypt) {
         log.info("Loading config file from objectMap");
         Config config =
                 ConfigFactory.parseMap(objectMap)
@@ -111,9 +107,6 @@ public class ConfigBuilder {
                         .resolveWith(
                                 ConfigFactory.systemProperties(),
                                 ConfigResolveOptions.defaults().setAllowUnresolved(true));
-        if (!isEncrypt) {
-            config = ConfigShadeUtils.decryptConfig(config);
-        }
         log.info(
                 "Parsed config file: \n{}",
                 mapToString(

--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
@@ -146,66 +146,81 @@ public final class ConfigShadeUtils {
     @SuppressWarnings("unchecked")
     private static Config processConfig(
             String identifier, Config config, boolean isDecrypted, Map<String, Object> props) {
-        ConfigShade configShade = CONFIG_SHADES.getOrDefault(identifier, DEFAULT_SHADE);
-        // call open method before the encrypt/decrypt
-        configShade.open(props);
+        try {
+            ConfigShade configShade = CONFIG_SHADES.getOrDefault(identifier, DEFAULT_SHADE);
+            // call open method before the encrypt/decrypt
+            configShade.open(props);
 
-        Set<String> sensitiveOptions = new HashSet<>(getSensitiveOptions(config));
-        sensitiveOptions.addAll(Arrays.asList(configShade.sensitiveOptions()));
-        BiFunction<String, Object, Object> processFunction =
-                (key, value) -> {
-                    if (value instanceof List) {
-                        List<String> list = (List<String>) value;
-                        List<String> processedList = new ArrayList<>();
-                        for (String element : list) {
-                            processedList.add(
-                                    isDecrypted
-                                            ? configShade.decrypt(element)
-                                            : configShade.encrypt(element));
+            Set<String> sensitiveOptions = new HashSet<>(getSensitiveOptions(config));
+            sensitiveOptions.addAll(Arrays.asList(configShade.sensitiveOptions()));
+            BiFunction<String, Object, Object> processFunction =
+                    (key, value) -> {
+                        if (value instanceof List) {
+                            List<String> list = (List<String>) value;
+                            List<String> processedList = new ArrayList<>();
+                            for (String element : list) {
+                                processedList.add(
+                                        isDecrypted
+                                                ? configShade.decrypt(element)
+                                                : configShade.encrypt(element));
+                            }
+                            return processedList;
+                        } else {
+                            return isDecrypted
+                                    ? configShade.decrypt((String) value)
+                                    : configShade.encrypt((String) value);
                         }
-                        return processedList;
-                    } else {
-                        return isDecrypted
-                                ? configShade.decrypt((String) value)
-                                : configShade.encrypt((String) value);
-                    }
-                };
-        String jsonString = config.root().render(ConfigRenderOptions.concise());
-        ObjectNode jsonNodes = JsonUtils.parseObject(jsonString);
-        Map<String, Object> configMap = JsonUtils.toMap(jsonNodes);
-        List<Map<String, Object>> sources =
-                (ArrayList<Map<String, Object>>) configMap.get(Constants.SOURCE);
-        List<Map<String, Object>> sinks =
-                (ArrayList<Map<String, Object>>) configMap.get(Constants.SINK);
-        List<Map<String, Object>> transforms =
-                (ArrayList<Map<String, Object>>)
-                        configMap.getOrDefault(Constants.TRANSFORM, new ArrayList<>());
-        Preconditions.checkArgument(
-                !sources.isEmpty(), "Miss <Source> config! Please check the config file.");
-        Preconditions.checkArgument(
-                !sinks.isEmpty(), "Miss <Sink> config! Please check the config file.");
-        sources.forEach(
-                source -> {
-                    for (String sensitiveOption : sensitiveOptions) {
-                        source.computeIfPresent(sensitiveOption, processFunction);
-                    }
-                });
-        sinks.forEach(
-                sink -> {
-                    for (String sensitiveOption : sensitiveOptions) {
-                        sink.computeIfPresent(sensitiveOption, processFunction);
-                    }
-                });
-        transforms.forEach(
-                transform -> {
-                    for (String sensitiveOption : sensitiveOptions) {
-                        transform.computeIfPresent(sensitiveOption, processFunction);
-                    }
-                });
-        configMap.put(Constants.SOURCE, sources);
-        configMap.put(Constants.SINK, sinks);
-        configMap.put(Constants.TRANSFORM, transforms);
-        return ConfigFactory.parseMap(configMap);
+                    };
+            String jsonString = config.root().render(ConfigRenderOptions.concise());
+            ObjectNode jsonNodes = JsonUtils.parseObject(jsonString);
+            Map<String, Object> configMap = JsonUtils.toMap(jsonNodes);
+            List<Map<String, Object>> sources =
+                    (ArrayList<Map<String, Object>>) configMap.get(Constants.SOURCE);
+            List<Map<String, Object>> sinks =
+                    (ArrayList<Map<String, Object>>) configMap.get(Constants.SINK);
+            List<Map<String, Object>> transforms =
+                    (ArrayList<Map<String, Object>>)
+                            configMap.getOrDefault(Constants.TRANSFORM, new ArrayList<>());
+            Preconditions.checkArgument(
+                    !sources.isEmpty(), "Miss <Source> config! Please check the config file.");
+            Preconditions.checkArgument(
+                    !sinks.isEmpty(), "Miss <Sink> config! Please check the config file.");
+            sources.forEach(
+                    source -> {
+                        for (String sensitiveOption : sensitiveOptions) {
+                            source.computeIfPresent(sensitiveOption, processFunction);
+                        }
+                    });
+            sinks.forEach(
+                    sink -> {
+                        for (String sensitiveOption : sensitiveOptions) {
+                            sink.computeIfPresent(sensitiveOption, processFunction);
+                        }
+                    });
+            transforms.forEach(
+                    transform -> {
+                        for (String sensitiveOption : sensitiveOptions) {
+                            transform.computeIfPresent(sensitiveOption, processFunction);
+                        }
+                    });
+            configMap.put(Constants.SOURCE, sources);
+            configMap.put(Constants.SINK, sinks);
+            configMap.put(Constants.TRANSFORM, transforms);
+            return ConfigFactory.parseMap(configMap);
+        } catch (Exception e) {
+            // Log desensitized error information
+            log.error(
+                    "Failed to {} config with identifier: {}",
+                    isDecrypted ? "decrypt" : "encrypt",
+                    identifier,
+                    e);
+            // Rethrow exception without sensitive information
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Failed to %s config. Please check your configuration.",
+                            isDecrypted ? "decrypt" : "encrypt"),
+                    e);
+        }
     }
 
     public static Set<String> getSensitiveOptions(Config config) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/EncryptConfigService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/EncryptConfigService.java
@@ -33,7 +33,7 @@ public class EncryptConfigService extends BaseService {
     }
 
     public JsonObject encryptConfig(byte[] requestBody) {
-        Config config = RestUtil.buildConfig(requestHandle(requestBody), true);
+        Config config = RestUtil.buildConfig(requestHandle(requestBody));
         Config encryptConfig = ConfigShadeUtils.encryptConfig(config);
         String encryptString =
                 encryptConfig.root().render(ConfigRenderOptions.concise().setJson(true));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.api.common.metrics.JobMetrics;
 import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.config.sql.SqlConfigBuilder;
+import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobInfo;
@@ -171,12 +172,20 @@ public class JobInfoService extends BaseService {
         }
         Config config;
         ConfigFormat configFormat = ConfigFormat.fromString(requestParams.get(CONFIG_FORMAT));
+
+        // fix issue: https://github.com/apache/seatunnel/issues/10590
         switch (configFormat) {
             case HOCON:
-                config = ConfigFactory.parseString(new String(requestBody, StandardCharsets.UTF_8));
+                config =
+                        ConfigShadeUtils.decryptConfig(
+                                ConfigFactory.parseString(
+                                        new String(requestBody, StandardCharsets.UTF_8)));
                 break;
             case SQL:
-                config = SqlConfigBuilder.of(new String(requestBody, StandardCharsets.UTF_8));
+                config =
+                        ConfigShadeUtils.decryptConfig(
+                                SqlConfigBuilder.of(
+                                        new String(requestBody, StandardCharsets.UTF_8)));
                 break;
             case JSON:
             default:

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
@@ -173,26 +173,24 @@ public class JobInfoService extends BaseService {
         Config config;
         ConfigFormat configFormat = ConfigFormat.fromString(requestParams.get(CONFIG_FORMAT));
 
-        // fix issue: https://github.com/apache/seatunnel/issues/10590
         switch (configFormat) {
             case HOCON:
-                config =
-                        ConfigShadeUtils.decryptConfig(
-                                ConfigFactory.parseString(
-                                        new String(requestBody, StandardCharsets.UTF_8)));
+                config = ConfigFactory.parseString(new String(requestBody, StandardCharsets.UTF_8));
                 break;
             case SQL:
-                config =
-                        ConfigShadeUtils.decryptConfig(
-                                SqlConfigBuilder.of(
-                                        new String(requestBody, StandardCharsets.UTF_8)));
+                config = SqlConfigBuilder.of(new String(requestBody, StandardCharsets.UTF_8));
                 break;
             case JSON:
             default:
-                config = RestUtil.buildConfig(requestHandle(requestBody), false);
+                config = RestUtil.buildConfig(requestHandle(requestBody));
                 break;
         }
+
+        // fix issue: https://github.com/apache/seatunnel/issues/10590
+        config = ConfigShadeUtils.decryptConfig(config);
+
         SeaTunnelServer seaTunnelServer = getSeaTunnelServer(false);
+
         return submitJobInternal(config, requestParams, seaTunnelServer, nodeEngine.getNode());
     }
 
@@ -207,7 +205,7 @@ public class JobInfoService extends BaseService {
 
     public JsonArray submitJobs(byte[] requestBody) {
         List<Tuple2<Map<String, String>, Config>> configTuples =
-                RestUtil.buildConfigList(requestHandle(requestBody), false);
+                RestUtil.buildConfigList(requestHandle(requestBody));
 
         return configTuples.stream()
                 .map(
@@ -216,8 +214,12 @@ public class JobInfoService extends BaseService {
                             Map<String, String> requestParams = new HashMap<>();
                             RestUtil.buildRequestParams(requestParams, urlParams);
                             SeaTunnelServer seaTunnelServer = getSeaTunnelServer(false);
+                            Config decryptConfig = ConfigShadeUtils.decryptConfig(tuple._2);
                             return submitJobInternal(
-                                    tuple._2, requestParams, seaTunnelServer, nodeEngine.getNode());
+                                    decryptConfig,
+                                    requestParams,
+                                    seaTunnelServer,
+                                    nodeEngine.getNode());
                         })
                 .collect(JsonArray::new, JsonArray::add, JsonArray::add);
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
@@ -186,7 +186,6 @@ public class JobInfoService extends BaseService {
                 break;
         }
 
-        // fix issue: https://github.com/apache/seatunnel/issues/10590
         config = ConfigShadeUtils.decryptConfig(config);
 
         SeaTunnelServer seaTunnelServer = getSeaTunnelServer(false);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigParseOptions;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigSyntax;
 
 import org.apache.seatunnel.config.sql.SqlConfigBuilder;
+import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
 import org.apache.seatunnel.engine.server.rest.ConfigFormat;
 import org.apache.seatunnel.engine.server.rest.service.JobInfoService;
 
@@ -74,6 +75,8 @@ public class SubmitJobByUploadFileServlet extends BaseServlet {
                 config = ConfigFactory.parseString(content);
                 break;
         }
+        // fix issue: https://github.com/apache/seatunnel/issues/10590
+        config = ConfigShadeUtils.decryptConfig(config);
         writeJson(resp, jobInfoService.submitJob(getParameterMap(req), config));
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
@@ -75,8 +75,9 @@ public class SubmitJobByUploadFileServlet extends BaseServlet {
                 config = ConfigFactory.parseString(content);
                 break;
         }
-        // fix issue: https://github.com/apache/seatunnel/issues/10590
+
         config = ConfigShadeUtils.decryptConfig(config);
+
         writeJson(resp, jobInfoService.submitJob(getParameterMap(req), config));
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
@@ -71,13 +71,12 @@ public class RestUtil {
         }
     }
 
-    public static Config buildConfig(JsonNode jsonNode, boolean isEncrypt) {
+    public static Config buildConfig(JsonNode jsonNode) {
         Map<String, Object> objectMap = JsonUtils.toMap(jsonNode);
-        return ConfigBuilder.of(objectMap, isEncrypt);
+        return ConfigBuilder.of(objectMap);
     }
 
-    public static List<Tuple2<Map<String, String>, Config>> buildConfigList(
-            JsonNode jsonNode, boolean isEncrypt) {
+    public static List<Tuple2<Map<String, String>, Config>> buildConfigList(JsonNode jsonNode) {
         return StreamSupport.stream(jsonNode.spliterator(), false)
                 .filter(JsonNode::isObject)
                 .map(
@@ -85,7 +84,7 @@ public class RestUtil {
                             Map<String, Object> nodeMap = JsonUtils.toMap(node);
                             Map<String, String> params =
                                     (Map<String, String>) nodeMap.remove(REST_SUBMIT_JOBS_PARAMS);
-                            Config config = ConfigBuilder.of(nodeMap, isEncrypt);
+                            Config config = ConfigBuilder.of(nodeMap);
                             return new Tuple2<>(params, config);
                         })
                 .collect(Collectors.toList());

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -180,7 +180,7 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
         HttpResponse response = post(requestUrl, "text/plain", invalidBase64Body);
         // Should return 400 Bad Request or 500 Internal Server Error
         Assertions.assertTrue(response.code == 400 || response.code == 500);
-        Assertions.assertTrue(response.body.contains("error") || response.body.contains("Illegal"));
+        Assertions.assertTrue(response.body.contains("fail") || response.body.contains("Illegal"));
     }
 
     private int getHttpPort(SeaTunnelServer seaTunnelServer) throws Exception {
@@ -336,31 +336,23 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
                 + "  shade.identifier = \"base64\"\n"
                 + "}\n"
                 + "*/\n"
-                + "CREATE TABLE source_table (\n"
-                + "    id INT,\n"
-                + "    name STRING\n"
-                + ") WITH (\n"
+                + "CREATE TABLE source_table WITH (\n"
                 + "  'connector'='FakeSource',\n"
                 + "  'type'='source',\n"
-                + "  'user'='"
+                + "  'username'='"
                 + ENCRYPTED_USERNAME
                 + "',\n"
                 + "  'password'='"
                 + ENCRYPTED_PASSWORD
                 + "',\n"
                 + "  'row.num'='3',\n"
-                + "  'field.names'='id,name',\n"
-                + "  'field.types'='INT,STRING'\n"
+                + "  'schema'='{ fields { id = \"int\", name = \"string\" } }'\n"
                 + ");\n"
-                + "CREATE TABLE sink_table (\n"
-                + "    id INT,\n"
-                + "    name STRING\n"
-                + ") WITH (\n"
+                + "CREATE TABLE sink_table WITH (\n"
                 + "  'connector'='Console',\n"
-                + "  'type'='sink',\n"
-                + "  'print-result'='true'\n"
+                + "  'type'='sink'\n"
                 + ");\n"
-                + "INSERT INTO sink_table SELECT id,name FROM source_table;";
+                + "INSERT INTO sink_table SELECT source_table;";
     }
 
     private static String getHazelcastConfig() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest;
+
+import org.apache.seatunnel.shade.org.eclipse.jetty.server.Connector;
+import org.apache.seatunnel.shade.org.eclipse.jetty.server.ServerConnector;
+
+import org.apache.seatunnel.common.utils.ExceptionUtils;
+import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.engine.common.config.ConfigProvider;
+import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
+import org.apache.seatunnel.engine.common.config.server.HttpConfig;
+import org.apache.seatunnel.engine.common.runtime.ExecutionMode;
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
+import org.apache.seatunnel.engine.server.TestUtils;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Integration test verifying that REST API submit-job endpoints correctly call
+ * ConfigShadeUtils.decryptConfig() for HOCON, SQL and upload formats.
+ *
+ * @see <a href="https://github.com/apache/seatunnel/issues/10590">#10590</a>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RestApiSubmitJobConfigShadeDecryptTest {
+
+    private static final String ENCRYPTED_USERNAME = "c2VhdHVubmVs";
+    private static final String ENCRYPTED_PASSWORD = "c2VhdHVubmVsX3Bhc3N3b3Jk";
+
+    private HazelcastInstanceImpl instance;
+    private SeaTunnelServer server;
+    private int restPort;
+
+    @BeforeAll
+    public void setUp() throws Exception {
+        String clusterName =
+                TestUtils.getClusterName("ConfigShadeDecryptTest_" + System.nanoTime());
+
+        Config hazelcastConfig = Config.loadFromString(getHazelcastConfig());
+        hazelcastConfig.setClusterName(clusterName);
+
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig.setHazelcastConfig(hazelcastConfig);
+        seaTunnelConfig.getEngineConfig().setMode(ExecutionMode.LOCAL);
+
+        HttpConfig httpConfig = seaTunnelConfig.getEngineConfig().getHttpConfig();
+        httpConfig.setEnabled(true);
+        httpConfig.setEnableHttps(false);
+        httpConfig.setPort(24000);
+        httpConfig.setEnableDynamicPort(true);
+        httpConfig.setPortRange(2000);
+
+        instance = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+        server = instance.node.nodeEngine.getService(SeaTunnelServer.SERVICE_NAME);
+
+        restPort = getHttpPort(server);
+        awaitRestReady(restPort);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        try {
+            if (server != null) {
+                server.shutdown(true);
+            }
+            if (instance != null) {
+                instance.shutdown();
+            }
+            FileUtils.deleteFile(Paths.get("logs").toString());
+        } catch (Exception e) {
+            System.err.println(ExceptionUtils.getMessage(e));
+        }
+    }
+
+    @Test
+    public void testSubmitJobWithHoconFormatDecryptsConfig() throws Exception {
+        String requestUrl =
+                "http://localhost:"
+                        + restPort
+                        + "/submit-job?format=hocon&jobName=hocon_shade_test";
+
+        HttpResponse response = post(requestUrl, "text/plain", buildHoconBody());
+        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
+        Assertions.assertTrue(
+                response.body.contains("jobId"),
+                "Response should contain jobId, got: " + response.body);
+    }
+
+    @Test
+    public void testSubmitJobWithSqlFormatDecryptsConfig() throws Exception {
+        String requestUrl =
+                "http://localhost:" + restPort + "/submit-job?format=sql&jobName=sql_shade_test";
+
+        HttpResponse response = post(requestUrl, "text/plain", buildSqlBody());
+        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
+        Assertions.assertTrue(
+                response.body.contains("jobId"),
+                "Response should contain jobId, got: " + response.body);
+    }
+
+    @Test
+    public void testSubmitJobByUploadHoconFileDecryptsConfig() throws Exception {
+        String requestUrl = "http://localhost:" + restPort + "/submit-job/upload";
+
+        HttpResponse response = postMultipart(requestUrl, "job.conf", buildHoconBody());
+        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
+        Assertions.assertTrue(
+                response.body.contains("jobId"),
+                "Response should contain jobId, got: " + response.body);
+    }
+
+    private int getHttpPort(SeaTunnelServer seaTunnelServer) throws Exception {
+        Field jettyServiceField = SeaTunnelServer.class.getDeclaredField("jettyService");
+        jettyServiceField.setAccessible(true);
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> jettyServiceField.get(seaTunnelServer) != null);
+        Object jettyService = jettyServiceField.get(seaTunnelServer);
+
+        Field serverField = jettyService.getClass().getDeclaredField("server");
+        serverField.setAccessible(true);
+        org.apache.seatunnel.shade.org.eclipse.jetty.server.Server jettyServer =
+                (org.apache.seatunnel.shade.org.eclipse.jetty.server.Server)
+                        serverField.get(jettyService);
+
+        return Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(
+                        () -> {
+                            for (Connector connector : jettyServer.getConnectors()) {
+                                if (connector instanceof ServerConnector) {
+                                    int port = ((ServerConnector) connector).getLocalPort();
+                                    if (port > 0) {
+                                        return port;
+                                    }
+                                }
+                            }
+                            return -1;
+                        },
+                        port -> port > 0);
+    }
+
+    private void awaitRestReady(int port) {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .until(
+                        () -> {
+                            try {
+                                HttpURLConnection conn =
+                                        (HttpURLConnection)
+                                                new URL("http://localhost:" + port + "/overview")
+                                                        .openConnection();
+                                conn.setRequestMethod("GET");
+                                conn.setConnectTimeout(2000);
+                                conn.setReadTimeout(2000);
+                                int code = conn.getResponseCode();
+                                conn.disconnect();
+                                return code == 200;
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        });
+    }
+
+    private HttpResponse post(String requestUrl, String contentType, String body)
+            throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(requestUrl).openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", contentType + "; charset=UTF-8");
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(30000);
+        conn.setDoOutput(true);
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        int code = conn.getResponseCode();
+        try (BufferedReader in =
+                new BufferedReader(
+                        new InputStreamReader(
+                                code >= 200 && code < 300
+                                        ? conn.getInputStream()
+                                        : conn.getErrorStream(),
+                                StandardCharsets.UTF_8))) {
+            String responseBody = in.lines().collect(Collectors.joining());
+            return new HttpResponse(code, responseBody);
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private HttpResponse postMultipart(String requestUrl, String fileName, String fileContent)
+            throws IOException {
+        String boundary = "----SeaTunnelTestBoundary" + System.currentTimeMillis();
+        HttpURLConnection conn = (HttpURLConnection) new URL(requestUrl).openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(30000);
+        conn.setDoOutput(true);
+
+        try (OutputStream os = conn.getOutputStream()) {
+            String part =
+                    "--"
+                            + boundary
+                            + "\r\n"
+                            + "Content-Disposition: form-data; name=\"config_file\"; filename=\""
+                            + fileName
+                            + "\"\r\n"
+                            + "Content-Type: application/octet-stream\r\n"
+                            + "\r\n"
+                            + fileContent
+                            + "\r\n"
+                            + "--"
+                            + boundary
+                            + "--\r\n";
+            os.write(part.getBytes(StandardCharsets.UTF_8));
+        }
+
+        int code = conn.getResponseCode();
+        try (BufferedReader in =
+                new BufferedReader(
+                        new InputStreamReader(
+                                code >= 200 && code < 300
+                                        ? conn.getInputStream()
+                                        : conn.getErrorStream(),
+                                StandardCharsets.UTF_8))) {
+            String responseBody = in.lines().collect(Collectors.joining());
+            return new HttpResponse(code, responseBody);
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private String buildHoconBody() {
+        return "env {\n"
+                + "  job.mode = \"BATCH\"\n"
+                + "  shade.identifier = \"base64\"\n"
+                + "}\n"
+                + "source {\n"
+                + "  FakeSource {\n"
+                + "    row.num = 5\n"
+                + "    username = \""
+                + ENCRYPTED_USERNAME
+                + "\"\n"
+                + "    password = \""
+                + ENCRYPTED_PASSWORD
+                + "\"\n"
+                + "    schema { fields { name = \"string\" } }\n"
+                + "  }\n"
+                + "}\n"
+                + "transform {}\n"
+                + "sink { Console {} }";
+    }
+
+    private String buildSqlBody() {
+        return "/* config\n"
+                + "env {\n"
+                + "  parallelism = 1\n"
+                + "  job.mode = \"BATCH\"\n"
+                + "  shade.identifier = \"base64\"\n"
+                + "}\n"
+                + "*/\n"
+                + "CREATE TABLE src (\n"
+                + "    id INT,\n"
+                + "    name STRING\n"
+                + ") WITH (\n"
+                + "    'connector' = 'FakeSource',\n"
+                + "    'username' = '"
+                + ENCRYPTED_USERNAME
+                + "',\n"
+                + "    'password' = '"
+                + ENCRYPTED_PASSWORD
+                + "',\n"
+                + "    'rows' = '[{ fields = [1, \"test\"], kind = INSERT }]',\n"
+                + "    'schema' = '{ fields { id = \"int\", name = \"string\" } }',\n"
+                + "    'type' = 'source'\n"
+                + ");\n"
+                + "CREATE TABLE dst (\n"
+                + "    id INT,\n"
+                + "    name STRING\n"
+                + ") WITH (\n"
+                + "    'connector' = 'Console',\n"
+                + "    'type' = 'sink'\n"
+                + ");\n"
+                + "INSERT INTO dst SELECT * FROM src;";
+    }
+
+    private static String getHazelcastConfig() {
+        return "hazelcast:\n"
+                + "  cluster-name: seatunnel\n"
+                + "  network:\n"
+                + "    rest-api:\n"
+                + "      enabled: true\n"
+                + "      endpoint-groups:\n"
+                + "        CLUSTER_WRITE:\n"
+                + "          enabled: true\n"
+                + "    join:\n"
+                + "      tcp-ip:\n"
+                + "        enabled: true\n"
+                + "        member-list:\n"
+                + "          - localhost\n"
+                + "    port:\n"
+                + "      auto-increment: true\n"
+                + "      port-count: 100\n"
+                + "      port: 5801\n"
+                + "\n"
+                + "  properties:\n"
+                + "    hazelcast.invocation.max.retry.count: 200\n"
+                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.invocation.retry.pause.millis: 2000\n"
+                + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
+                + "    hazelcast.logging.type: log4j2\n"
+                + "    hazelcast.operation.generic.thread.count: 200\n";
+    }
+
+    private static class HttpResponse {
+        private final int code;
+        private final String body;
+
+        private HttpResponse(int code, String body) {
+            this.code = code;
+            this.body = body;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -124,15 +124,40 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
     }
 
     @Test
-    public void testSubmitJobWithSqlFormatDecryptsConfig() throws Exception {
-        String requestUrl =
-                "http://localhost:" + restPort + "/submit-job?format=sql&jobName=sql_shade_test";
+    public void testSubmitJobWithHoconFormatMissingShadeIdentifier() throws Exception {
+        String bodyWithoutShade =
+                "env {\n"
+                        + "  job.mode = \"BATCH\"\n"
+                        + "}\n"
+                        + "source {\n"
+                        + "  FakeSource {\n"
+                        + "    row.num = 5\n"
+                        + "    username = \""
+                        + ENCRYPTED_USERNAME
+                        + "\"\n"
+                        + "    password = \""
+                        + ENCRYPTED_PASSWORD
+                        + "\"\n"
+                        + "    schema { fields { name = \"string\" } }\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "transform {}\n"
+                        + "sink { Console {} }";
 
-        HttpResponse response = post(requestUrl, "text/plain", buildSqlBody());
-        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
-        Assertions.assertTrue(
-                response.body.contains("jobId"),
-                "Response should contain jobId, got: " + response.body);
+        String requestUrl = "http://localhost:" + restPort + "/submit-job?format=hocon";
+
+        HttpResponse response = post(requestUrl, "text/plain", bodyWithoutShade);
+        // Should handle normally (without decryption)
+        Assertions.assertEquals(200, response.code);
+    }
+
+    @Test
+    public void testSubmitJobByUploadSqlFileDecryptsConfig() throws Exception {
+        String requestUrl = "http://localhost:" + restPort + "/submit-job/upload";
+
+        HttpResponse response = postMultipart(requestUrl, "job.sql", buildSqlBody());
+        Assertions.assertEquals(200, response.code);
+        Assertions.assertTrue(response.body.contains("jobId"));
     }
 
     @Test
@@ -144,6 +169,18 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
         Assertions.assertTrue(
                 response.body.contains("jobId"),
                 "Response should contain jobId, got: " + response.body);
+    }
+
+    @Test
+    public void testSubmitJobWithHoconFormatInvalidBase64() throws Exception {
+        String invalidBase64Body = buildHoconBody().replace(ENCRYPTED_USERNAME, "invalid_base64!");
+
+        String requestUrl = "http://localhost:" + restPort + "/submit-job?format=hocon";
+
+        HttpResponse response = post(requestUrl, "text/plain", invalidBase64Body);
+        // Should return 400 Bad Request or 500 Internal Server Error
+        Assertions.assertTrue(response.code == 400 || response.code == 500);
+        Assertions.assertTrue(response.body.contains("error") || response.body.contains("Illegal"));
     }
 
     private int getHttpPort(SeaTunnelServer seaTunnelServer) throws Exception {
@@ -299,29 +336,31 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
                 + "  shade.identifier = \"base64\"\n"
                 + "}\n"
                 + "*/\n"
-                + "CREATE TABLE src (\n"
+                + "CREATE TABLE source_table (\n"
                 + "    id INT,\n"
                 + "    name STRING\n"
                 + ") WITH (\n"
-                + "    'connector' = 'FakeSource',\n"
-                + "    'username' = '"
+                + "  'connector'='FakeSource',\n"
+                + "  'type'='source',\n"
+                + "  'user'='"
                 + ENCRYPTED_USERNAME
                 + "',\n"
-                + "    'password' = '"
+                + "  'password'='"
                 + ENCRYPTED_PASSWORD
                 + "',\n"
-                + "    'rows' = '[{ fields = [1, \"test\"], kind = INSERT }]',\n"
-                + "    'schema' = '{ fields { id = \"int\", name = \"string\" } }',\n"
-                + "    'type' = 'source'\n"
+                + "  'row.num'='3',\n"
+                + "  'field.names'='id,name',\n"
+                + "  'field.types'='INT,STRING'\n"
                 + ");\n"
-                + "CREATE TABLE dst (\n"
+                + "CREATE TABLE sink_table (\n"
                 + "    id INT,\n"
                 + "    name STRING\n"
                 + ") WITH (\n"
-                + "    'connector' = 'Console',\n"
-                + "    'type' = 'sink'\n"
+                + "  'connector'='Console',\n"
+                + "  'type'='sink',\n"
+                + "  'print-result'='true'\n"
                 + ");\n"
-                + "INSERT INTO dst SELECT * FROM src;";
+                + "INSERT INTO sink_table SELECT id,name FROM source_table;";
     }
 
     private static String getHazelcastConfig() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
@@ -294,8 +294,7 @@ public class RestApiSubmitJobStartWithSavePointTest {
     private org.apache.seatunnel.shade.com.typesafe.config.Config
             buildSeaTunnelJobConfigFromJsonRequest() throws IOException {
         return RestUtil.buildConfig(
-                RestUtil.convertByteToJsonNode(getRequestBody().getBytes(StandardCharsets.UTF_8)),
-                false);
+                RestUtil.convertByteToJsonNode(getRequestBody().getBytes(StandardCharsets.UTF_8)));
     }
 
     private String getRequestBody() {


### PR DESCRIPTION
## Purpose of this pull request

Fix [#10590](https://github.com/apache/seatunnel/issues/10590).

When submitting a job via REST API with `shade.identifier` configured in the env section, `ConfigShadeUtils.decryptConfig()` is only invoked for JSON format submissions. HOCON format, SQL format, and the upload-file endpoint (`/submit-job/upload`) all skip the decryption step, causing `shade.identifier` and encrypted values to be silently ignored.

**Root cause:**
- In `JobInfoService.submitJob(Map, byte[])`, the HOCON and SQL branches call `ConfigFactory.parseString()` / `SqlConfigBuilder.of()` without calling `ConfigShadeUtils.decryptConfig()`. The JSON branch works because `RestUtil.buildConfig()` → `ConfigBuilder.of(Map, boolean)` internally calls it.
- In `SubmitJobByUploadFileServlet.doPost()`, no format calls `decryptConfig()` before passing the config to `jobInfoService.submitJob(Map, Config)`.

**Fix:**
- Added `ConfigShadeUtils.decryptConfig(config)` after config parsing in HOCON and SQL branches of `JobInfoService.submitJob()`.
- Added `ConfigShadeUtils.decryptConfig(config)` after the format switch in `SubmitJobByUploadFileServlet.doPost()`.

| Endpoint | Format | Before | After |
|---|---|---|---|
| `POST /submit-job` | JSON (default) | ✅ | ✅ |
| `POST /submit-job?format=hocon` | HOCON | ❌ | ✅ |
| `POST /submit-job?format=sql` | SQL | ❌ | ✅ |
| `POST /submit-job/upload` | ALL | ❌ | ✅ |

## Does this PR introduce _any_ user-facing change?

No new user-facing change. This PR fixes existing behavior so that `shade.identifier` (e.g. `base64`) correctly decrypts sensitive config values (like `password`, `username`) for HOCON, SQL, and upload-file submissions — matching the behavior that JSON format already had.

## How was this patch tested?

Added integration test `RestApiSubmitJobConfigShadeDecryptTest` that starts a real Hazelcast + Jetty REST server and verifies the following scenarios end-to-end:

1. `testSubmitJobWithHoconFormatDecryptsConfig` — POST `/submit-job?format=hocon` with base64-encrypted `username`/`password` and `shade.identifier = "base64"`, asserts HTTP 200 with `jobId`.
2. `testSubmitJobWithSqlFormatDecryptsConfig` — POST `/submit-job?format=sql` with the same encrypted values, asserts HTTP 200 with `jobId`.
3. `testSubmitJobByUploadHoconFileDecryptsConfig` — POST multipart `/submit-job/upload` with `.conf` file, asserts HTTP 200 with `jobId`.

## Check list

* [x] No new Jar binary package added.
* [x] No documentation update needed (bug fix for existing behavior).
* [x] No incompatible change.
* [x] Not a connector code contribution.
