### PR TITLE
[Fix][Zeta] Fix NPE in REST API job info response when jobDAGInfo or …

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -238,7 +238,7 @@ public abstract class BaseService {
                         startTimestamp, DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS);
             }
         }
-        return null;
+        return "";
     }
 
     protected JsonObject getJobInfoJson(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -202,7 +202,9 @@ public abstract class BaseService {
                                 jobImmutableInformation.getCreateTime(),
                                 DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
                 .add(RestConstant.START_TIME, getJobStartTime(jobId))
-                .add(RestConstant.JOB_DAG, jobDAGInfo.toJsonObject())
+                .add(
+                        RestConstant.JOB_DAG,
+                        jobDAGInfo != null ? jobDAGInfo.toJsonObject() : new JsonObject())
                 .add(
                         RestConstant.PLUGIN_JARS_URLS,
                         (JsonValue)
@@ -253,15 +255,21 @@ public abstract class BaseService {
                                 DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
                 .add(
                         RestConstant.START_TIME,
-                        DateTimeUtils.toString(
-                                jobState.getStartTime(),
-                                DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
+                        jobState.getStartTime() == null
+                                ? ""
+                                : DateTimeUtils.toString(
+                                        jobState.getStartTime(),
+                                        DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
                 .add(
                         RestConstant.FINISH_TIME,
-                        DateTimeUtils.toString(
-                                jobState.getFinishTime(),
-                                DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
-                .add(RestConstant.JOB_DAG, jobDAGInfo.toJsonObject())
+                        jobState.getFinishTime() == null
+                                ? ""
+                                : DateTimeUtils.toString(
+                                        jobState.getFinishTime(),
+                                        DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
+                .add(
+                        RestConstant.JOB_DAG,
+                        jobDAGInfo != null ? jobDAGInfo.toJsonObject() : new JsonObject())
                 .add(RestConstant.PLUGIN_JARS_URLS, new JsonArray())
                 .add(
                         RestConstant.METRICS,

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceNullSafetyTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceNullSafetyTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.JobDAGInfo;
+import org.apache.seatunnel.engine.server.master.JobHistoryService;
+import org.apache.seatunnel.engine.server.rest.RestConstant;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class BaseServiceNullSafetyTest {
+
+    private JobInfoService jobInfoService;
+
+    @BeforeEach
+    void setUp() {
+        NodeEngineImpl nodeEngine = mock(NodeEngineImpl.class);
+        jobInfoService = new JobInfoService(nodeEngine);
+    }
+
+    private JobHistoryService.JobState buildJobState(Long startTime, Long finishTime) {
+        return new JobHistoryService.JobState(
+                12345L,
+                "test-job",
+                JobStatus.FAILED,
+                System.currentTimeMillis(),
+                startTime,
+                finishTime,
+                Collections.emptyMap(),
+                null);
+    }
+
+    @Test
+    public void testGetJobInfoJsonWithNullDAGInfo() {
+        JobHistoryService.JobState jobState = buildJobState(1000L, 2000L);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", null);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(result.get(RestConstant.JOB_DAG));
+        Assertions.assertEquals("{}", result.get(RestConstant.JOB_DAG).toString());
+    }
+
+    @Test
+    public void testGetJobInfoJsonWithNonNullDAGInfo() {
+        JobHistoryService.JobState jobState = buildJobState(1000L, 2000L);
+        JobDAGInfo dagInfo = mock(JobDAGInfo.class);
+        com.hazelcast.internal.json.JsonObject dagJson = new JsonObject().add("key", "value");
+        org.mockito.Mockito.when(dagInfo.toJsonObject()).thenReturn(dagJson);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", dagInfo);
+
+        Assertions.assertEquals(dagJson.toString(), result.get(RestConstant.JOB_DAG).toString());
+    }
+
+    @Test
+    public void testGetJobInfoJsonWithNullStartTime() {
+        JobHistoryService.JobState jobState = buildJobState(null, 2000L);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", null);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("", result.getString(RestConstant.START_TIME, null));
+    }
+
+    @Test
+    public void testGetJobInfoJsonWithNullFinishTime() {
+        JobHistoryService.JobState jobState = buildJobState(1000L, null);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", null);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("", result.getString(RestConstant.FINISH_TIME, null));
+    }
+
+    @Test
+    public void testGetJobInfoJsonWithBothTimestampsNull() {
+        JobHistoryService.JobState jobState = buildJobState(null, null);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", null);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("", result.getString(RestConstant.START_TIME, null));
+        Assertions.assertEquals("", result.getString(RestConstant.FINISH_TIME, null));
+    }
+}


### PR DESCRIPTION
…job timestamps are null

jobDAGInfo returned by DAGUtils.getJobDAGInfo() can be null when the job DAG is not yet available. Calling jobDAGInfo.toJsonObject() without a null check in convertToJson() and getJobInfoJson() causes NPE and returns HTTP 500.

jobState.getStartTime() and getFinishTime() are nullable Long fields. If the job does not reach SCHEDULED state, these timestamps are never set. Passing null to DateTimeUtils.toString() throws NPE.

Fix: add null guard for jobDAGInfo, fall back to empty JsonObject.
Fix: add null guard for startTime and finishTime, fall back to empty string.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

 Fix two NPE scenarios in `BaseService` that cause HTTP 500 responses from the job info REST endpoints.

  **1. `jobDAGInfo` null in `convertToJson()` and `getJobInfoJson()`**
  `DAGUtils.getJobDAGInfo()` can return `null` when the job DAG is not yet available. Both `convertToJson()` (serving `/running-jobs`) and `getJobInfoJson()` (serving
  `/finished-jobs`) call `jobDAGInfo.toJsonObject()` without a null check, causing NPE.

  **2. `startTime` / `finishTime` null in `getJobInfoJson()`**
  `JobState.startTime` and `finishTime` are nullable `Long` fields. If a job does not reach `SCHEDULED` state, `startTime` is never set. Passing `null` to
  `DateTimeUtils.toString()` throws NPE.


### Does this PR introduce _any_ user-facing change?


Yes. Before this fix, querying `/running-jobs` or `/finished-jobs` returns HTTP 500 when any job has a null DAG or null timestamps. After this fix, those fields fall back to an empty `JsonObject` / empty string respectively, and the response succeeds.



### How was this patch tested?

Reproduced locally by querying the REST API immediately after job submission (before DAG is built) and for jobs that fail before reaching `SCHEDULED` state. Both returned HTTP 500 before the fix and correct JSON after.



### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)