### PR TITLE
[Feature][Connector-V2][Pulsar] Support multi-table read for Pulsar source (#10425) 

### DIFF
--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -41,7 +41,7 @@ Source connector for Apache Pulsar.
 | cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
 | schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
 | format                   | String  | No       | json          | Data format. Default is json. **Multi-table mode only supports JSON and CANAL_JSON**                            |
-| common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../source-common-options.md) for details           |
+| common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md) for details           |
 
 ### topic [String]
 

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -75,7 +75,7 @@ Additional rules:
 - Only `JSON` and `CANAL_JSON` are supported in multi-table mode.
 - Explicit `topic` entries must not overlap with any `topic-pattern` entry.
 - If multiple `topic-pattern` items can match the same topic, the first matching item in `tables_configs` wins. Put more specific patterns before broader ones.
-- In batch mode, every table must be bounded. If any table uses `cursor.stop.mode = NEVER`, the source is unbounded and batch jobs are rejected.
+- In batch mode, multi-table configurations must be bounded. If more than one table is configured and any table uses `cursor.stop.mode = NEVER`, the source is unbounded and batch jobs are rejected. Single-table mode and single-entry `tables_configs` keep backward-compatible batch behavior.
 
 ### topic-discovery.interval [Long]
 

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -19,29 +19,29 @@ Source connector for Apache Pulsar.
 
 ## Options
 
-|           name           |  type   | required | default value |
-|--------------------------|---------|----------|---------------|
-| topic                    | String  | No       | -             |
-| topic-pattern            | String  | No       | -             |
-| table_path               | String  | No       | -             |
-| tables_configs           | Array   | No       | -             |
-| topic-discovery.interval | Long    | No       | -1            |
-| subscription.name        | String  | No       | -             |
-| client.service-url       | String  | Yes      | -             |
-| admin.service-url        | String  | Yes      | -             |
-| auth.plugin-class        | String  | No       | -             |
-| auth.params              | String  | No       | -             |
-| poll.timeout             | Integer | No       | 100           |
-| poll.interval            | Long    | No       | 50            |
-| poll.batch.size          | Integer | No       | 500           |
-| cursor.startup.mode      | Enum    | No       | LATEST        |
-| cursor.startup.timestamp | Long    | No       | -             |
-| cursor.reset.mode        | Enum    | No       | LATEST        |
-| cursor.stop.mode         | Enum    | No       | NEVER         |
-| cursor.stop.timestamp    | Long    | No       | -             |
-| schema                   | config  | No       | -             |
-| common-options           |         | no       | -             |
-| format                   | String  | no       | json          |
+| Name                     | Type    | Required | Default Value | Description                                                                                                      |
+|--------------------------|---------|----------|---------------|------------------------------------------------------------------------------------------------------------------|
+| topic                    | String  | No       | -             | Topic name(s) to read. Supports comma-separated list. **Note: only one of `topic`, `topic-pattern`, `tables_configs`** |
+| topic-pattern            | String  | No       | -             | Regular expression for topic names. **Note: only one of `topic`, `topic-pattern`, `tables_configs`**            |
+| table_path               | String  | No       | -             | Logical table identifier for multi-table mode                                                                    |
+| tables_configs           | Array   | No       | -             | Multi-table configuration. Each item can override global defaults. **Note: only one of `topic`, `topic-pattern`, `tables_configs`** |
+| topic-discovery.interval | Long    | No       | -1            | Interval (ms) to discover new partitions. Non-positive disables discovery. Only works with `topic-pattern`      |
+| subscription.name        | String  | No       | -             | Consumer subscription name. Can be defined globally or per item in multi-table mode                              |
+| client.service-url       | String  | Yes      | -             | Pulsar client service URL, e.g., `pulsar://localhost:6650`                                                      |
+| admin.service-url        | String  | Yes      | -             | Pulsar admin HTTP URL, e.g., `http://localhost:8080`                                                            |
+| auth.plugin-class        | String  | No       | -             | Pulsar client authentication plugin class name                                                                   |
+| auth.params              | String  | No       | -             | Pulsar client authentication parameters                                                                          |
+| poll.timeout             | Integer | No       | 100           | Timeout (ms) for polling messages from Pulsar                                                                    |
+| poll.interval            | Long    | No       | 50            | Interval (ms) between two polls                                                                                  |
+| poll.batch.size          | Integer | No       | 500           | Maximum number of messages to poll in a single batch                                                             |
+| cursor.startup.mode      | Enum    | No       | LATEST        | Startup position mode. Options: `EARLIEST`, `LATEST`, `SUBSCRIPTION`, `TIMESTAMP`                                |
+| cursor.startup.timestamp | Long    | No       | -             | Start timestamp (ms) when `cursor.startup.mode=TIMESTAMP`                                                        |
+| cursor.reset.mode        | Enum    | No       | LATEST        | Reset mode when `cursor.startup.mode=SUBSCRIPTION`. Options: `EARLIEST`, `LATEST`                               |
+| cursor.stop.mode         | Enum    | No       | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch)                         |
+| cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
+| schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
+| format                   | String  | No       | json          | Data format. Default is json. **Multi-table mode only supports JSON and CANAL_JSON**                            |
+| common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../source-common-options.md) for details           |
 
 ### topic [String]
 

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -73,6 +73,8 @@ Additional rules:
 - `table_path` is required when `topic-pattern` is used.
 - `subscription.name` must exist either globally or inside the item.
 - Only `JSON` and `CANAL_JSON` are supported in multi-table mode.
+- Explicit `topic` entries must not overlap with any `topic-pattern` entry.
+- If multiple `topic-pattern` items can match the same topic, the first matching item in `tables_configs` wins. Put more specific patterns before broader ones.
 - In batch mode, every table must be bounded. If any table uses `cursor.stop.mode = NEVER`, the source is unbounded and batch jobs are rejected.
 
 ### topic-discovery.interval [Long]

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -23,8 +23,10 @@ Source connector for Apache Pulsar.
 |--------------------------|---------|----------|---------------|
 | topic                    | String  | No       | -             |
 | topic-pattern            | String  | No       | -             |
+| table_path               | String  | No       | -             |
+| tables_configs           | Array   | No       | -             |
 | topic-discovery.interval | Long    | No       | -1            |
-| subscription.name        | String  | Yes      | -             |
+| subscription.name        | String  | No       | -             |
 | client.service-url       | String  | Yes      | -             |
 | admin.service-url        | String  | Yes      | -             |
 | auth.plugin-class        | String  | No       | -             |
@@ -43,15 +45,35 @@ Source connector for Apache Pulsar.
 
 ### topic [String]
 
-Topic name(s) to read data from when the table is used as source. It also supports topic list for source by separating topic by semicolon like 'topic-1;topic-2'.
+Topic name(s) to read data from when the table is used as source. It also supports topic lists by separating topics with commas like `'topic-1,topic-2'`.
 
-**Note, only one of "topic-pattern" and "topic" can be specified for sources.**
+**Note, only one of `topic`, `topic-pattern` and `tables_configs` can be specified for sources.**
 
 ### topic-pattern [String]
 
 The regular expression for a pattern of topic names to read from. All topics with names that match the specified regular expression will be subscribed by the consumer when the job starts running.
 
-**Note, only one of "topic-pattern" and "topic" can be specified for sources.**
+**Note, only one of `topic`, `topic-pattern` and `tables_configs` can be specified for sources.**
+
+### table_path [String]
+
+Logical table identifier for one `tables_configs` item. This option is mainly used in multi-table mode.
+
+### tables_configs [Array]
+
+Multi-table source configuration. Each item can override global defaults such as `format`, cursor options and `subscription.name`.
+
+Each item must configure exactly one of:
+
+- `topic`
+- `topic-pattern`
+
+Additional rules:
+
+- `table_path` is required when `topic-pattern` is used.
+- `subscription.name` must exist either globally or inside the item.
+- Only `JSON` and `CANAL_JSON` are supported in multi-table mode.
+- In batch mode, every table must be bounded. If any table uses `cursor.stop.mode = NEVER`, the source is unbounded and batch jobs are rejected.
 
 ### topic-discovery.interval [Long]
 
@@ -61,7 +83,7 @@ The interval (in ms) for the Pulsar source to discover the new topic partitions.
 
 ### subscription.name [String]
 
-Specify the subscription name for this consumer. This argument is required when constructing the consumer.
+Specify the subscription name for this consumer. This is required for each effective table configuration, but in multi-table mode it can be defined globally or overridden per `tables_configs` item.
 
 ### client.service-url [String]
 
@@ -142,17 +164,59 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
 
 ## Example
 
-```Jdbc {
+```hocon
 source {
   Pulsar {
-  	topic = "example"
-  	subscription.name = "seatunnel"
+    topic = "example"
+    subscription.name = "seatunnel"
     client.service-url = "pulsar://localhost:6650"
     admin.service-url = "http://my-broker.example.com:8080"
     plugin_output = "test"
   }
 }
 ```
+
+## Multi-table Example
+
+```hocon
+source {
+  Pulsar {
+    subscription.name = "seatunnel-sub"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "NEVER"
+    format = "json"
+
+    tables_configs = [
+      {
+        table_path = "default.orders"
+        topic = "persistent://public/default/orders"
+        schema = {
+          fields {
+            order_id = "bigint"
+            user_id = "int"
+          }
+        }
+      },
+      {
+        table_path = "default.users"
+        topic-pattern = "persistent://public/default/users-.*"
+        subscription.name = "users-sub"
+        format = "canal_json"
+        schema = {
+          fields {
+            user_id = "int"
+            name = "string"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+In batch mode, replace `cursor.stop.mode = "NEVER"` with a bounded mode such as `LATEST` or `TIMESTAMP`.
 
 ## Changelog
 

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -2,46 +2,46 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 # Apache Pulsar
 
-> Apache Pulsar Source 连接器
+> Apache Pulsar 源连接器
 
 ## 描述
 
-Apache Pulsar 的 Source 连接器。
+Apache Pulsar 的源连接器。
 
 ## 关键特性
 
-- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
-- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [批](../../introduction/concepts/connector-v2-features.md)
+- [x] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行读取](../../introduction/concepts/connector-v2-features.md)
 - [ ] [用户自定义 split](../../introduction/concepts/connector-v2-features.md)
 
 ## 参数
 
-| name                     | type    | required | default value |
-|--------------------------|---------|----------|---------------|
-| topic                    | String  | No       | -             |
-| topic-pattern            | String  | No       | -             |
-| table_path               | String  | No       | -             |
-| tables_configs           | Array   | No       | -             |
-| topic-discovery.interval | Long    | No       | -1            |
-| subscription.name        | String  | No       | -             |
-| client.service-url       | String  | Yes      | -             |
-| admin.service-url        | String  | Yes      | -             |
-| auth.plugin-class        | String  | No       | -             |
-| auth.params              | String  | No       | -             |
-| poll.timeout             | Integer | No       | 100           |
-| poll.interval            | Long    | No       | 50            |
-| poll.batch.size          | Integer | No       | 500           |
-| cursor.startup.mode      | Enum    | No       | LATEST        |
-| cursor.startup.timestamp | Long    | No       | -             |
-| cursor.reset.mode        | Enum    | No       | LATEST        |
-| cursor.stop.mode         | Enum    | No       | NEVER         |
-| cursor.stop.timestamp    | Long    | No       | -             |
-| schema                   | config  | No       | -             |
-| common-options           |         | No       | -             |
-| format                   | String  | No       | json          |
+| 名称                       | 类型      | 是否必填 | 默认值    | 描述                                                                                        |
+|--------------------------|---------|------|--------|-------------------------------------------------------------------------------------------|
+| topic                    | String  | 否    | -      | 单表读取的 topic 名称。支持逗号分隔多个 topic。**注意:只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种** |
+| topic-pattern            | String  | 否    | -      | 用于匹配 topic 名称的正则表达式。**注意:只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种**           |
+| table_path               | String  | 否    | -      | 多表模式中单个配置项对应的逻辑表标识                                                                        |
+| tables_configs           | Array   | 否    | -      | 多表读取配置。每个 item 可覆盖全局默认值。**注意:只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种**       |
+| topic-discovery.interval | Long    | 否    | -1     | 发现新 topic 分区的间隔(毫秒)。非正值禁用发现。仅在使用 `topic-pattern` 时生效                                      |
+| subscription.name        | String  | 否    | -      | 消费者订阅名。在多表模式下可定义在全局或 item 中                                                               |
+| client.service-url       | String  | 是    | -      | Pulsar 服务的客户端 URL,例如 `pulsar://localhost:6650`                                            |
+| admin.service-url        | String  | 是    | -      | Pulsar 管理端点的 HTTP URL,例如 `http://localhost:8080`                                          |
+| auth.plugin-class        | String  | 否    | -      | Pulsar 客户端认证插件类名                                                                          |
+| auth.params              | String  | 否    | -      | Pulsar 客户端认证参数                                                                            |
+| poll.timeout             | Integer | 否    | 100    | 从 Pulsar 拉取消息的超时时间(毫秒)                                                                    |
+| poll.interval            | Long    | 否    | 50     | 两次拉取之间的间隔时间(毫秒)                                                                           |
+| poll.batch.size          | Integer | 否    | 500    | 单次拉取的最大消息数                                                                                |
+| cursor.startup.mode      | Enum    | 否    | LATEST | 启动位置模式。可选值:`EARLIEST`、`LATEST`、`SUBSCRIPTION`、`TIMESTAMP`                                 |
+| cursor.startup.timestamp | Long    | 否    | -      | 当 `cursor.startup.mode=TIMESTAMP` 时的起始时间戳(毫秒)                                             |
+| cursor.reset.mode        | Enum    | 否    | LATEST | 当 `cursor.startup.mode=SUBSCRIPTION` 时的重置模式。可选值:`EARLIEST`、`LATEST`                       |
+| cursor.stop.mode         | Enum    | 否    | NEVER  | 停止位置模式。可选值:`NEVER`(流式)、`LATEST`(批式)、`TIMESTAMP`(批式)                                       |
+| cursor.stop.timestamp    | Long    | 否    | -      | 当 `cursor.stop.mode=TIMESTAMP` 时的停止时间戳(毫秒)                                                |
+| schema                   | Config  | 否    | -      | 数据结构,包括字段名称和字段类型                                                                          |
+| format                   | String  | 否    | json   | 数据格式。默认为 json。**多表模式仅支持 JSON 和 CANAL_JSON**                                               |
+| common-options           |         | 否    | -      | Source 插件通用参数,请参考 [Source Common Options](../source-common-options.md) 了解详情               |
 
 ### topic [String]
 
@@ -80,7 +80,7 @@ Apache Pulsar 的 Source 连接器。
 
 ### topic-discovery.interval [Long]
 
-Pulsar Source 发现新 topic 分区的时间间隔，单位为毫秒。小于等于 0 表示关闭动态发现。
+Pulsar 源发现新主题分区的间隔（毫秒）。非正值禁用主题分区发现。
 
 **注意，该参数只在使用 `topic-pattern` 时生效。**
 
@@ -90,13 +90,13 @@ Pulsar Source 发现新 topic 分区的时间间隔，单位为毫秒。小于�
 
 ### client.service-url [String]
 
-Pulsar 服务地址。
+Pulsar 服务的服务 URL 提供程序。要使用客户端库连接到 Pulsar，需要指定 Pulsar 协议 URL。
 
 例如：`pulsar://localhost:6650,localhost:6651`。
 
 ### admin.service-url [String]
 
-Pulsar Admin HTTP 地址。
+Pulsar 服务管理端点的 HTTP URL。
 
 例如：`http://my-broker.example.com:8080`，或开启 TLS 时使用 `https://my-broker.example.com:8443`。
 
@@ -120,11 +120,11 @@ Pulsar Admin HTTP 地址。
 
 ### poll.batch.size [Integer]
 
-单次 `pollNext` 最多处理的消息数。
+轮询时要获取的最大记录数。更长的时间会增加吞吐量但也会增加延迟。
 
 ### cursor.startup.mode [Enum]
 
-启动模式，可选值为 `'EARLIEST'`、`'LATEST'`、`'SUBSCRIPTION'`、`'TIMESTAMP'`。
+Pulsar 消费者的启动模式，有效值为 `'EARLIEST'`、`'LATEST'`、`'SUBSCRIPTION'`、`'TIMESTAMP'`。
 
 ### cursor.startup.timestamp [Long]
 

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -74,7 +74,7 @@ Apache Pulsar 的源连接器。
 - `subscription.name` 必须在全局或 item 内存在。
 - 多表模式当前只支持 `JSON` 和 `CANAL_JSON`。
 - 显式配置的 `topic` 不能与任何 `topic-pattern` 发生重叠。
-- 在 batch 模式下，所有表都必须是 bounded。只要有任意一个表使用 `cursor.stop.mode = NEVER`，整个 source 就会被视为 unbounded，并拒绝在 batch 作业中运行。
+- 在 batch 模式下，多表配置必须全部是 bounded。只有当配置了多于一张表且任意一张表使用 `cursor.stop.mode = NEVER` 时，整个 source 才会被视为 unbounded，并拒绝在 batch 作业中运行。单表模式和仅包含一个配置项的 `tables_configs` 保持向后兼容的 batch 行为。
 
 - 当多个 `topic-pattern` 同时匹配到同一个 topic 时，会按 `tables_configs` 的声明顺序选择第一个匹配项。请将更具体的 pattern 放在更通用的 pattern 之前。
 

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -2,148 +2,164 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 # Apache Pulsar
 
-> Apache Pulsar 源连接器
+> Apache Pulsar Source 连接器
 
 ## 描述
 
-Apache Pulsar 的源连接器。
+Apache Pulsar 的 Source 连接器。
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [x] [流](../../introduction/concepts/connector-v2-features.md)
-- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行读取](../../introduction/concepts/connector-v2-features.md)
+- [ ] [用户自定义 split](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 参数
 
-| 参数名                      | 类型      | 必须 | 默认值    | 描述                                                                                   |
-|--------------------------|---------|----|--------|--------------------------------------------------------------------------------------|
-| topic                    | String  | 否  | -      | 主题名称                                                                                 |
-| topic-pattern            | String  | 否  | -      | 主题名称的正则表达式模式                                                                         |
-| topic-discovery.interval | Long    | 否  | -1     | 发现新主题分区的间隔（毫秒）                                                                       |
-| subscription.name        | String  | 是  | -      | 订阅名称                                                                                 |
-| client.service-url       | String  | 是  | -      | Pulsar 服务 URL                                                                        |
-| admin.service-url        | String  | 是  | -      | Pulsar 管理端点的 HTTP URL                                                                |
-| auth.plugin-class        | String  | 否  | -      | 认证插件的名称                                                                              |
-| auth.params              | String  | 否  | -      | 认证插件的参数                                                                              |
-| poll.timeout             | Integer | 否  | 100    | 获取记录时的最大等待时间（毫秒）                                                                     |
-| poll.interval            | Long    | 否  | 50     | 获取记录时的间隔时间（毫秒）                                                                       |
-| poll.batch.size          | Integer | 否  | 500    | 轮询时要获取的最大记录数                                                                         |
-| cursor.startup.mode      | Enum    | 否  | LATEST | 启动模式                                                                                 |
-| cursor.startup.timestamp | Long    | 否  | -      | 启动时间戳（毫秒）                                                                            |
-| cursor.reset.mode        | Enum    | 否  | LATEST | 游标重置策略                                                                               |
-| cursor.stop.mode         | Enum    | 否  | NEVER  | 停止模式                                                                                 |
-| cursor.stop.timestamp    | Long    | 否  | -      | 停止时间戳（毫秒）                                                                            |
-| schema                   | config  | 否  | -      | 数据结构，包括字段名称和字段类型。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| common-options           |         | 否  | -      | 源插件通用参数                                                                              |
-| format                   | String  | 否  | json   | 数据格式                                                                                 |
+| name                     | type    | required | default value |
+|--------------------------|---------|----------|---------------|
+| topic                    | String  | No       | -             |
+| topic-pattern            | String  | No       | -             |
+| table_path               | String  | No       | -             |
+| tables_configs           | Array   | No       | -             |
+| topic-discovery.interval | Long    | No       | -1            |
+| subscription.name        | String  | No       | -             |
+| client.service-url       | String  | Yes      | -             |
+| admin.service-url        | String  | Yes      | -             |
+| auth.plugin-class        | String  | No       | -             |
+| auth.params              | String  | No       | -             |
+| poll.timeout             | Integer | No       | 100           |
+| poll.interval            | Long    | No       | 50            |
+| poll.batch.size          | Integer | No       | 500           |
+| cursor.startup.mode      | Enum    | No       | LATEST        |
+| cursor.startup.timestamp | Long    | No       | -             |
+| cursor.reset.mode        | Enum    | No       | LATEST        |
+| cursor.stop.mode         | Enum    | No       | NEVER         |
+| cursor.stop.timestamp    | Long    | No       | -             |
+| schema                   | config  | No       | -             |
+| common-options           |         | No       | -             |
+| format                   | String  | No       | json          |
 
 ### topic [String]
 
-当表用作源时要读取数据的主题名称。它也支持通过分号分隔的主题列表，如 'topic-1;topic-2'。
+单表读取的 topic 名称。也支持用逗号分隔多个 topic，例如 `'topic-1,topic-2'`。
 
-**注意，只能为源指定 "topic-pattern" 和 "topic" 中的一个。**
+**注意，只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种配置方式。**
 
 ### topic-pattern [String]
 
-主题名称模式的正则表达式。当作业开始运行时，所有名称与指定正则表达式匹配的主题都将被消费者订阅。
+用于匹配 topic 名称的正则表达式。作业启动时，所有匹配该正则的 topic 都会被订阅。
 
-**注意，只能为源指定 "topic-pattern" 和 "topic" 中的一个。**
+**注意，只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种配置方式。**
+
+### table_path [String]
+
+单个 `tables_configs` 配置项对应的逻辑表标识。该参数主要用于多表模式。
+
+### tables_configs [Array]
+
+多表读取配置。每个 item 都可以覆盖全局默认值，例如 `format`、cursor 相关参数和 `subscription.name`。
+
+每个 item 必须且只能配置以下其中一个参数：
+
+- `topic`
+- `topic-pattern`
+
+额外约束：
+
+- 当使用 `topic-pattern` 时，必须显式配置 `table_path`。
+- `subscription.name` 必须在全局或 item 内存在。
+- 多表模式当前只支持 `JSON` 和 `CANAL_JSON`。
+- 在 batch 模式下，所有表都必须是 bounded。只要有任意一个表使用 `cursor.stop.mode = NEVER`，整个 source 就会被视为 unbounded，并拒绝在 batch 作业中运行。
 
 ### topic-discovery.interval [Long]
 
-Pulsar 源发现新主题分区的间隔（毫秒）。非正值禁用主题分区发现。
+Pulsar Source 发现新 topic 分区的时间间隔，单位为毫秒。小于等于 0 表示关闭动态发现。
 
-**注意，此选项仅在使用 'topic-pattern' 选项时有效。**
+**注意，该参数只在使用 `topic-pattern` 时生效。**
 
 ### subscription.name [String]
 
-为此消费者指定订阅名称。构造消费者时需要此参数。
+消费者订阅名。对每个最终生效的表配置都是必需的；在多表模式下，可以定义在全局，也可以在 `tables_configs` 的 item 中单独覆盖。
 
 ### client.service-url [String]
 
-Pulsar 服务的服务 URL 提供程序。要使用客户端库连接到 Pulsar，需要指定 Pulsar 协议 URL。
+Pulsar 服务地址。
 
-例如，`localhost`: `pulsar://localhost:6650,localhost:6651`。
+例如：`pulsar://localhost:6650,localhost:6651`。
 
 ### admin.service-url [String]
 
-Pulsar 服务管理端点的 HTTP URL。
+Pulsar Admin HTTP 地址。
 
-例如，`http://my-broker.example.com:8080`，或 `https://my-broker.example.com:8443`（用于 TLS）。
+例如：`http://my-broker.example.com:8080`，或开启 TLS 时使用 `https://my-broker.example.com:8443`。
 
 ### auth.plugin-class [String]
 
-认证插件的名称。
+认证插件类名。
 
 ### auth.params [String]
 
-认证插件的参数。
+认证插件参数。
 
-例如，`key1:val1,key2:val2`
+例如：`key1:val1,key2:val2`
 
 ### poll.timeout [Integer]
 
-获取记录时的最大等待时间（毫秒）。更长的时间会增加吞吐量但也会增加延迟。
+单次拉取数据的最长等待时间，单位毫秒。值越大，吞吐通常越高，但延迟也会增加。
 
 ### poll.interval [Long]
 
-获取记录时的间隔时间（毫秒）。更短的时间会增加吞吐量，但也会增加 CPU 负载。
+轮询间隔时间，单位毫秒。值越小，吞吐通常越高，但 CPU 开销也会增加。
 
 ### poll.batch.size [Integer]
 
-轮询时要获取的最大记录数。更长的时间会增加吞吐量但也会增加延迟。
+单次 `pollNext` 最多处理的消息数。
 
 ### cursor.startup.mode [Enum]
 
-Pulsar 消费者的启动模式，有效值为 `'EARLIEST'`、`'LATEST'`、`'SUBSCRIPTION'`、`'TIMESTAMP'`。
+启动模式，可选值为 `'EARLIEST'`、`'LATEST'`、`'SUBSCRIPTION'`、`'TIMESTAMP'`。
 
 ### cursor.startup.timestamp [Long]
 
-从指定的纪元时间戳（毫秒）开始。
-
-**注意，当 "cursor.startup.mode" 选项使用 `'TIMESTAMP'` 时，此选项是必需的。**
+当 `cursor.startup.mode = TIMESTAMP` 时使用的起始时间戳，单位毫秒。
 
 ### cursor.reset.mode [Enum]
 
-Pulsar 消费者的游标重置策略，有效值为 `'EARLIEST'`、`'LATEST'`。
+当 `cursor.startup.mode = SUBSCRIPTION` 时使用的 cursor reset 策略，可选值为 `'EARLIEST'`、`'LATEST'`。
 
-**注意，此选项仅在 "cursor.startup.mode" 选项使用 `'SUBSCRIPTION'` 时有效。**
+### cursor.stop.mode [Enum]
 
-### cursor.stop.mode [String]
+停止模式，可选值为 `'NEVER'`、`'LATEST'`、`'TIMESTAMP'`。
 
-Pulsar 消费者的停止模式，有效值为 `'NEVER'`、`'LATEST'` 和 `'TIMESTAMP'`。
-
-**注意，当指定 `'NEVER'` 时，这是一个实时作业，其他模式是离线作业。**
+当值为 `'NEVER'` 时，作业是实时流式读取；其他模式表示有界读取。
 
 ### cursor.stop.timestamp [Long]
 
-从指定的纪元时间戳（毫秒）停止。
-
-**注意，当 "cursor.stop.mode" 选项使用 `'TIMESTAMP'` 时，此选项是必需的。**
+当 `cursor.stop.mode = TIMESTAMP` 时使用的停止时间戳，单位毫秒。
 
 ### schema [Config]
 
-数据的结构，包括字段名称和字段类型。参考 [Schema-Feature](../../introduction/concepts/schema-feature.md)
+数据结构定义，包括字段名和字段类型。参考 [Schema Feature](../../introduction/concepts/schema-feature.md)。
 
 ## format [String]
 
-数据格式。默认格式是 json，参考 [formats](../formats)。
+数据格式。默认值为 `json`。更多格式说明参考 [formats](../formats)。
 
-### 通用选项
+### 通用参数
 
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+Source 插件通用参数请参考 [Source Common Options](../common-options/source-common-options.md)。
 
 ## 示例
 
-```
+```hocon
 source {
   Pulsar {
-  	topic = "example"
-  	subscription.name = "seatunnel"
+    topic = "example"
+    subscription.name = "seatunnel"
     client.service-url = "pulsar://localhost:6650"
     admin.service-url = "http://my-broker.example.com:8080"
     plugin_output = "test"
@@ -151,7 +167,48 @@ source {
 }
 ```
 
+## 多表示例
+
+```hocon
+source {
+  Pulsar {
+    subscription.name = "seatunnel-sub"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "NEVER"
+    format = "json"
+
+    tables_configs = [
+      {
+        table_path = "default.orders"
+        topic = "persistent://public/default/orders"
+        schema = {
+          fields {
+            order_id = "bigint"
+            user_id = "int"
+          }
+        }
+      },
+      {
+        table_path = "default.users"
+        topic-pattern = "persistent://public/default/users-.*"
+        subscription.name = "users-sub"
+        format = "canal_json"
+        schema = {
+          fields {
+            user_id = "int"
+            name = "string"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+如果用于 batch 作业，请将 `cursor.stop.mode = "NEVER"` 改为有界模式，例如 `LATEST` 或 `TIMESTAMP`。
+
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -73,7 +73,10 @@ Apache Pulsar 的 Source 连接器。
 - 当使用 `topic-pattern` 时，必须显式配置 `table_path`。
 - `subscription.name` 必须在全局或 item 内存在。
 - 多表模式当前只支持 `JSON` 和 `CANAL_JSON`。
+- 显式配置的 `topic` 不能与任何 `topic-pattern` 发生重叠。
 - 在 batch 模式下，所有表都必须是 bounded。只要有任意一个表使用 `cursor.stop.mode = NEVER`，整个 source 就会被视为 unbounded，并拒绝在 batch 作业中运行。
+
+- 当多个 `topic-pattern` 同时匹配到同一个 topic 时，会按 `tables_configs` 的声明顺序选择第一个匹配项。请将更具体的 pattern 放在更通用的 pattern 之前。
 
 ### topic-discovery.interval [Long]
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarBaseOptions.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarBaseOptions.java
@@ -70,7 +70,9 @@ public class PulsarBaseOptions extends ConnectorCommonOptions {
                     .stringType()
                     .defaultValue(DEFAULT_FORMAT)
                     .withDescription(
-                            "Data format. The default format is json. Optional text format. The default field separator is \", \". "
+                            "Data format. The default format is json. Optional text format. "
+                                    + "For multi-table mode, only JSON and CANAL_JSON are supported. "
+                                    + "The default field separator is \", \". "
                                     + "If you customize the delimiter, add the \"field_delimiter\" option.");
 
     public static final Option<String> FIELD_DELIMITER =

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -40,26 +40,29 @@ import java.util.stream.Collectors;
 
 import static org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils.isBlank;
 
-@Getter
 /**
  * Normalized Pulsar source configuration that unifies single-table and multi-table options into a
  * consistent runtime model.
  */
+@Getter
 public class PulsarMultiTableConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final List<PulsarTableConfig> tableConfigs;
     private final ReadonlyConfig globalConfig;
     private final boolean isMultiTable;
+    private final boolean isTablesConfigs;
 
     /** Create the normalized config used by Pulsar source runtime components. */
     private PulsarMultiTableConfig(
             List<PulsarTableConfig> tableConfigs,
             ReadonlyConfig globalConfig,
-            boolean isMultiTable) {
+            boolean isMultiTable,
+            boolean isTablesConfigs) {
         this.tableConfigs = tableConfigs;
         this.globalConfig = globalConfig;
         this.isMultiTable = isMultiTable;
+        this.isTablesConfigs = isTablesConfigs;
     }
 
     /**
@@ -119,7 +122,7 @@ public class PulsarMultiTableConfig implements Serializable {
                         config);
 
         return new PulsarMultiTableConfig(
-                java.util.Collections.singletonList(tableConfig), config, false);
+                java.util.Collections.singletonList(tableConfig), config, false, false);
     }
 
     private static PulsarMultiTableConfig parseMultiTable(ReadonlyConfig config) {
@@ -239,7 +242,7 @@ public class PulsarMultiTableConfig implements Serializable {
             tableConfigs.add(pulsarTableConfig);
         }
 
-        return new PulsarMultiTableConfig(tableConfigs, config, true);
+        return new PulsarMultiTableConfig(tableConfigs, config, tableConfigs.size() > 1, true);
     }
 
     private static ReadonlyConfig mergeWithGlobal(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
+
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.table.TableSchemaOptions;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.StartMode;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.StopMode;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils.isBlank;
+
+@Getter
+/**
+ * Normalized Pulsar source configuration that unifies single-table and multi-table options into a
+ * consistent runtime model.
+ */
+public class PulsarMultiTableConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final List<PulsarTableConfig> tableConfigs;
+    private final ReadonlyConfig globalConfig;
+    private final boolean isMultiTable;
+
+    /** Create the normalized config used by Pulsar source runtime components. */
+    private PulsarMultiTableConfig(
+            List<PulsarTableConfig> tableConfigs,
+            ReadonlyConfig globalConfig,
+            boolean isMultiTable) {
+        this.tableConfigs = tableConfigs;
+        this.globalConfig = globalConfig;
+        this.isMultiTable = isMultiTable;
+    }
+
+    /**
+     * Parse source options into a normalized config model.
+     *
+     * <p>When {@code tables_configs} is absent, single-table options are converted into a one-item
+     * table config list so downstream runtime logic can use one unified code path.
+     */
+    public static PulsarMultiTableConfig of(ReadonlyConfig config) {
+        if (config.getOptional(TableSchemaOptions.TABLE_CONFIGS).isPresent()) {
+            return parseMultiTable(config);
+        } else {
+            return parseSingleTable(config);
+        }
+    }
+
+    private static PulsarMultiTableConfig parseSingleTable(ReadonlyConfig config) {
+        String topic = config.getOptional(PulsarSourceOptions.TOPIC).orElse(null);
+        String topicPattern = config.getOptional(PulsarSourceOptions.TOPIC_PATTERN).orElse(null);
+        String subscriptionName =
+                config.getOptional(PulsarSourceOptions.SUBSCRIPTION_NAME).orElse(null);
+        String format = config.get(PulsarSourceOptions.FORMAT);
+        StartMode startMode = config.get(PulsarSourceOptions.CURSOR_STARTUP_MODE);
+        StopMode stopMode = config.get(PulsarSourceOptions.CURSOR_STOP_MODE);
+        Long startTimestamp =
+                config.getOptional(PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP).orElse(null);
+        Long stopTimestamp =
+                config.getOptional(PulsarSourceOptions.CURSOR_STOP_TIMESTAMP).orElse(null);
+        PulsarSourceOptions.CursorResetStrategy resetMode =
+                config.getOptional(PulsarSourceOptions.CURSOR_RESET_MODE).orElse(null);
+
+        TablePath tablePath = TablePath.of("default", topic != null ? topic : "pulsar_table");
+        validateTableConfig(
+                -1,
+                tablePath,
+                topic,
+                topicPattern,
+                format,
+                startMode,
+                startTimestamp,
+                stopMode,
+                stopTimestamp,
+                resetMode,
+                subscriptionName);
+        PulsarTableConfig tableConfig =
+                new PulsarTableConfig(
+                        tablePath,
+                        topic,
+                        topicPattern != null ? Pattern.compile(topicPattern) : null,
+                        format,
+                        startMode,
+                        startTimestamp,
+                        stopMode,
+                        stopTimestamp,
+                        resetMode,
+                        subscriptionName,
+                        config);
+
+        return new PulsarMultiTableConfig(
+                java.util.Collections.singletonList(tableConfig), config, false);
+    }
+
+    private static PulsarMultiTableConfig parseMultiTable(ReadonlyConfig config) {
+        List<Map<String, Object>> tablesConfigs = config.get(TableSchemaOptions.TABLE_CONFIGS);
+        if (tablesConfigs.isEmpty()) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    "tables_configs cannot be empty");
+        }
+        List<PulsarTableConfig> tableConfigs = new ArrayList<>();
+        Map<String, Integer> tablePathIndexes = new LinkedHashMap<>();
+        Map<String, Integer> explicitTopicIndexes = new LinkedHashMap<>();
+        Map<String, Integer> topicPatternIndexes = new LinkedHashMap<>();
+        List<PatternEntry> knownPatterns = new ArrayList<>();
+
+        for (int i = 0; i < tablesConfigs.size(); i++) {
+            Map<String, Object> tableConfigMap = tablesConfigs.get(i);
+            ReadonlyConfig tableConfig = mergeWithGlobal(config, tableConfigMap);
+
+            String topic = tableConfig.getOptional(PulsarSourceOptions.TOPIC).orElse(null);
+            String topicPatternStr =
+                    tableConfig.getOptional(PulsarSourceOptions.TOPIC_PATTERN).orElse(null);
+
+            if ((topic == null && topicPatternStr == null)
+                    || (topic != null && topicPatternStr != null)) {
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "tables_configs[%d] must specify exactly one of 'topic' or 'topic-pattern'",
+                                i));
+            }
+
+            String tablePathStr =
+                    tableConfig.getOptional(PulsarSourceOptions.TABLE_PATH).orElse(topic);
+            if (topicPatternStr != null && tablePathStr == null) {
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "tables_configs[%d] uses 'topic-pattern' but missing required 'table_path'",
+                                i));
+            }
+
+            TablePath tablePath = TablePath.of(tablePathStr);
+            Integer duplicateTablePathIndex = tablePathIndexes.putIfAbsent(tablePath.toString(), i);
+            if (duplicateTablePathIndex != null) {
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "Duplicate table_path '%s' found in tables_configs[%d] and tables_configs[%d]",
+                                tablePath, duplicateTablePathIndex, i));
+            }
+
+            String format =
+                    tableConfig
+                            .getOptional(PulsarSourceOptions.FORMAT)
+                            .orElse(config.get(PulsarSourceOptions.FORMAT));
+            StartMode startMode =
+                    tableConfig
+                            .getOptional(PulsarSourceOptions.CURSOR_STARTUP_MODE)
+                            .orElse(config.get(PulsarSourceOptions.CURSOR_STARTUP_MODE));
+            StopMode stopMode =
+                    tableConfig
+                            .getOptional(PulsarSourceOptions.CURSOR_STOP_MODE)
+                            .orElse(config.get(PulsarSourceOptions.CURSOR_STOP_MODE));
+            PulsarSourceOptions.CursorResetStrategy resetMode =
+                    tableConfig.getOptional(PulsarSourceOptions.CURSOR_RESET_MODE).orElse(null);
+            String subscriptionName =
+                    tableConfig.getOptional(PulsarSourceOptions.SUBSCRIPTION_NAME).orElse(null);
+
+            Long startTimestamp =
+                    tableConfig
+                            .getOptional(PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP)
+                            .orElse(
+                                    config.getOptional(PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP)
+                                            .orElse(null));
+            Long stopTimestamp =
+                    tableConfig
+                            .getOptional(PulsarSourceOptions.CURSOR_STOP_TIMESTAMP)
+                            .orElse(
+                                    config.getOptional(PulsarSourceOptions.CURSOR_STOP_TIMESTAMP)
+                                            .orElse(null));
+
+            validateTableConfig(
+                    i,
+                    tablePath,
+                    topic,
+                    topicPatternStr,
+                    format,
+                    startMode,
+                    startTimestamp,
+                    stopMode,
+                    stopTimestamp,
+                    resetMode,
+                    subscriptionName);
+            validateTopicOverlap(
+                    i,
+                    topic,
+                    topicPatternStr,
+                    explicitTopicIndexes,
+                    topicPatternIndexes,
+                    knownPatterns);
+
+            PulsarTableConfig pulsarTableConfig =
+                    new PulsarTableConfig(
+                            tablePath,
+                            topic,
+                            topicPatternStr != null ? Pattern.compile(topicPatternStr) : null,
+                            format,
+                            startMode,
+                            startTimestamp,
+                            stopMode,
+                            stopTimestamp,
+                            resetMode,
+                            subscriptionName,
+                            tableConfig);
+
+            tableConfigs.add(pulsarTableConfig);
+        }
+
+        return new PulsarMultiTableConfig(tableConfigs, config, true);
+    }
+
+    private static ReadonlyConfig mergeWithGlobal(
+            ReadonlyConfig globalConfig, Map<String, Object> tableConfigMap) {
+        Map<String, Object> merged = new HashMap<>(globalConfig.getSourceMap());
+        merged.remove(TableSchemaOptions.TABLE_CONFIGS.key());
+        merged.putAll(tableConfigMap);
+        return ReadonlyConfig.fromMap(merged);
+    }
+
+    private static void validateTableConfig(
+            int index,
+            TablePath tablePath,
+            String topic,
+            String topicPattern,
+            String format,
+            StartMode startMode,
+            Long startTimestamp,
+            StopMode stopMode,
+            Long stopTimestamp,
+            PulsarSourceOptions.CursorResetStrategy resetMode,
+            String subscriptionName) {
+        String configPrefix =
+                index >= 0
+                        ? String.format("tables_configs[%d] ('%s')", index, tablePath)
+                        : "Pulsar source config";
+
+        if ((topic == null && topicPattern == null) || (topic != null && topicPattern != null)) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s must specify exactly one of 'topic' or 'topic-pattern'",
+                            configPrefix));
+        }
+
+        if (isBlank(subscriptionName)) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format("%s must configure 'subscription.name'", configPrefix));
+        }
+
+        validateFormat(format, index, tablePath);
+
+        if (startMode == StartMode.TIMESTAMP && startTimestamp == null) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s has cursor.startup.mode=TIMESTAMP but cursor.startup.timestamp is not set",
+                            configPrefix));
+        }
+        if (startMode == StartMode.SUBSCRIPTION && resetMode == null) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s has cursor.startup.mode=SUBSCRIPTION but cursor.reset.mode is not set",
+                            configPrefix));
+        }
+
+        if (stopMode == StopMode.TIMESTAMP && stopTimestamp == null) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s has cursor.stop.mode=TIMESTAMP but cursor.stop.timestamp is not set",
+                            configPrefix));
+        }
+    }
+
+    private static void validateFormat(String format, int index, TablePath tablePath) {
+        String configPrefix =
+                index >= 0
+                        ? String.format("tables_configs[%d] ('%s')", index, tablePath)
+                        : "Pulsar source config";
+        String normalized = format.toUpperCase();
+        if (!Objects.equals("JSON", normalized) && !Objects.equals("CANAL_JSON", normalized)) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s uses unsupported format '%s', only JSON and CANAL_JSON are supported",
+                            configPrefix, format));
+        }
+    }
+
+    private static void validateTopicOverlap(
+            int index,
+            String topic,
+            String topicPatternStr,
+            Map<String, Integer> explicitTopicIndexes,
+            Map<String, Integer> topicPatternIndexes,
+            List<PatternEntry> knownPatterns) {
+        if (topic != null) {
+            for (String topicName : splitTopics(topic)) {
+                Integer duplicateIndex = explicitTopicIndexes.putIfAbsent(topicName, index);
+                if (duplicateIndex != null) {
+                    throw new PulsarConnectorException(
+                            SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                            String.format(
+                                    "Duplicate topic '%s' found in tables_configs[%d] and tables_configs[%d]",
+                                    topicName, duplicateIndex, index));
+                }
+                for (PatternEntry knownPattern : knownPatterns) {
+                    if (knownPattern.pattern.matcher(topicName).matches()) {
+                        throw new PulsarConnectorException(
+                                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                                String.format(
+                                        "tables_configs[%d] topic '%s' overlaps with topic-pattern in tables_configs[%d]",
+                                        index, topicName, knownPattern.index));
+                    }
+                }
+            }
+            return;
+        }
+
+        Integer duplicatePatternIndex = topicPatternIndexes.putIfAbsent(topicPatternStr, index);
+        if (duplicatePatternIndex != null) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Duplicate topic-pattern '%s' found in tables_configs[%d] and tables_configs[%d]",
+                            topicPatternStr, duplicatePatternIndex, index));
+        }
+
+        Pattern pattern = Pattern.compile(topicPatternStr);
+        for (Map.Entry<String, Integer> explicitTopic : explicitTopicIndexes.entrySet()) {
+            if (pattern.matcher(explicitTopic.getKey()).matches()) {
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "tables_configs[%d] topic-pattern '%s' overlaps with topic '%s' in tables_configs[%d]",
+                                index,
+                                topicPatternStr,
+                                explicitTopic.getKey(),
+                                explicitTopic.getValue()));
+            }
+        }
+        knownPatterns.add(new PatternEntry(index, pattern));
+    }
+
+    private static List<String> splitTopics(String topic) {
+        return Arrays.stream(topic.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private static final class PatternEntry {
+        private final int index;
+        private final Pattern pattern;
+
+        private PatternEntry(int index, Pattern pattern) {
+            this.index = index;
+            this.pattern = pattern;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -374,6 +374,9 @@ public class PulsarMultiTableConfig implements Serializable {
                                 explicitTopic.getValue()));
             }
         }
+        // Different Java regex patterns may still overlap. We intentionally allow that and resolve
+        // ownership by tables_configs declaration order in MultiTablePartitionDiscoverer so future
+        // topics do not fail the job when they match more than one pattern.
         knownPatterns.add(new PatternEntry(index, pattern));
     }
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarSourceOptions.java
@@ -41,6 +41,12 @@ public class PulsarSourceOptions extends PulsarBaseOptions {
                     .withDescription(
                             "The regular expression for a pattern of topic names to read from. All topics with names that match the specified regular expression will be subscribed by the consumer when the job starts running. Note, only one of \"topic-pattern\" and \"topic\" can be specified for sources.");
 
+    public static final Option<String> TABLE_PATH =
+            Options.key("table_path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The table path for multi-table configuration.");
+
     public static final Option<Integer> POLL_TIMEOUT =
             Options.key("poll.timeout")
                     .intType()

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarTableConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.StartMode;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.StopMode;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.regex.Pattern;
+
+@Getter
+/** Immutable table-level Pulsar source configuration after global defaults are merged. */
+public class PulsarTableConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final String topic;
+    private final Pattern topicPattern;
+    private final String format;
+    private final StartMode startMode;
+    private final Long startTimestamp;
+    private final StopMode stopMode;
+    private final Long stopTimestamp;
+    private final PulsarSourceOptions.CursorResetStrategy resetMode;
+    private final String subscriptionName;
+    private final ReadonlyConfig schemaConfig;
+
+    /**
+     * Create one effective table config for source initialization.
+     *
+     * <p>The values in this object already reflect the final result after applying global defaults
+     * and per-table overrides.
+     */
+    public PulsarTableConfig(
+            TablePath tablePath,
+            String topic,
+            Pattern topicPattern,
+            String format,
+            StartMode startMode,
+            Long startTimestamp,
+            StopMode stopMode,
+            Long stopTimestamp,
+            PulsarSourceOptions.CursorResetStrategy resetMode,
+            String subscriptionName,
+            ReadonlyConfig schemaConfig) {
+        this.tablePath = tablePath;
+        this.topic = topic;
+        this.topicPattern = topicPattern;
+        this.format = format;
+        this.startMode = startMode;
+        this.startTimestamp = startTimestamp;
+        this.stopMode = stopMode;
+        this.stopTimestamp = stopTimestamp;
+        this.resetMode = resetMode;
+        this.subscriptionName = subscriptionName;
+        this.schemaConfig = schemaConfig;
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/exception/PulsarConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/exception/PulsarConnectorErrorCode.java
@@ -29,7 +29,8 @@ public enum PulsarConnectorErrorCode implements SeaTunnelErrorCode {
     ACK_CUMULATE_FAILED("PULSAR-07", "Pulsar consumer acknowledgeCumulative failed"),
     CREATE_PRODUCER_FAILED("PULSAR-08", "create producer failed"),
     CREATE_TRANSACTION_FAILED("PULSAR-09", "create transaction failed"),
-    SEND_MESSAGE_FAILED("PULSAR-10", "send message failed");
+    SEND_MESSAGE_FAILED("PULSAR-10", "send message failed"),
+    DESERIALIZATION_SCHEMA_NOT_FOUND("PULSAR-11", "Deserialization schema not found for table");
 
     private final String code;
     private final String description;

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
@@ -28,15 +28,61 @@ import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discov
 
 import java.io.Serializable;
 
+/**
+ * Runtime metadata container for each table in a Pulsar source configuration.
+ *
+ * <p>This class is different from {@code PulsarTableConfig}:
+ *
+ * <ul>
+ *   <li>{@code PulsarTableConfig} is used during configuration parsing and validation
+ *   <li>{@code PulsarConsumerMetadata} is used during runtime and includes constructed objects like
+ *       {@link DeserializationSchema}
+ * </ul>
+ *
+ * <p><b>Thread-safety:</b> This class is immutable and thread-safe. All fields are final and can be
+ * safely accessed by multiple threads.
+ *
+ * <p><b>Serialization:</b> This class is {@link Serializable} and can be transferred between
+ * enumerator and reader. However, {@link DeserializationSchema} implementations must also be
+ * serializable.
+ *
+ * <p><b>Lifecycle:</b>
+ *
+ * <ol>
+ *   <li>Created by {@link PulsarSource#createConsumerMetadata}
+ *   <li>Stored in {@code Map<TablePath, PulsarConsumerMetadata>} in {@link PulsarSource}
+ *   <li>Passed to {@code PulsarSourceReader} and {@code PulsarSplitEnumerator}
+ *   <li>Used to resolve table-specific deserializers, cursors, and discoverers
+ * </ol>
+ */
 public class PulsarConsumerMetadata implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /** Logical table identifier (e.g., "db.orders"). Never null. */
     private final TablePath tablePath;
+
+    /** Catalog table including schema information. */
     private final CatalogTable catalogTable;
+
+    /**
+     * Deserialization schema for this table's data format. Different tables may use different
+     * formats (e.g., JSON vs CANAL_JSON).
+     */
     private final DeserializationSchema<SeaTunnelRow> deserializationSchema;
+
+    /** Partition discoverer for this table (topic or topic-pattern). */
     private final PulsarDiscoverer discoverer;
+
+    /** Start cursor (initial position) for this table's subscription. */
     private final StartCursor startCursor;
+
+    /**
+     * Stop cursor (end position) for this table's subscription. Determines if the table is bounded
+     * or unbounded.
+     */
     private final StopCursor stopCursor;
+
+    /** Consumer configuration including subscription name. */
     private final PulsarConsumerConfig consumerConfig;
 
     public PulsarConsumerMetadata(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
+
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConsumerConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.StartCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.PulsarDiscoverer;
+
+import java.io.Serializable;
+
+public class PulsarConsumerMetadata implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final DeserializationSchema<SeaTunnelRow> deserializationSchema;
+    private final PulsarDiscoverer discoverer;
+    private final StartCursor startCursor;
+    private final StopCursor stopCursor;
+    private final PulsarConsumerConfig consumerConfig;
+
+    public PulsarConsumerMetadata(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            DeserializationSchema<SeaTunnelRow> deserializationSchema,
+            PulsarDiscoverer discoverer,
+            StartCursor startCursor,
+            StopCursor stopCursor,
+            PulsarConsumerConfig consumerConfig) {
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.deserializationSchema = deserializationSchema;
+        this.discoverer = discoverer;
+        this.startCursor = startCursor;
+        this.stopCursor = stopCursor;
+        this.consumerConfig = consumerConfig;
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public CatalogTable getCatalogTable() {
+        return catalogTable;
+    }
+
+    public DeserializationSchema<SeaTunnelRow> getDeserializationSchema() {
+        return deserializationSchema;
+    }
+
+    public PulsarDiscoverer getDiscoverer() {
+        return discoverer;
+    }
+
+    public StartCursor getStartCursor() {
+        return startCursor;
+    }
+
+    public StopCursor getStopCursor() {
+        return stopCursor;
+    }
+
+    public PulsarConsumerConfig getConsumerConfig() {
+        return consumerConfig;
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarConsumerMetadata.java
@@ -26,6 +26,8 @@ import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.PulsarDiscoverer;
 
+import lombok.Getter;
+
 import java.io.Serializable;
 
 /**
@@ -55,6 +57,7 @@ import java.io.Serializable;
  *   <li>Used to resolve table-specific deserializers, cursors, and discoverers
  * </ol>
  */
+@Getter
 public class PulsarConsumerMetadata implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -100,33 +103,5 @@ public class PulsarConsumerMetadata implements Serializable {
         this.startCursor = startCursor;
         this.stopCursor = stopCursor;
         this.consumerConfig = consumerConfig;
-    }
-
-    public TablePath getTablePath() {
-        return tablePath;
-    }
-
-    public CatalogTable getCatalogTable() {
-        return catalogTable;
-    }
-
-    public DeserializationSchema<SeaTunnelRow> getDeserializationSchema() {
-        return deserializationSchema;
-    }
-
-    public PulsarDiscoverer getDiscoverer() {
-        return discoverer;
-    }
-
-    public StartCursor getStartCursor() {
-        return startCursor;
-    }
-
-    public StopCursor getStopCursor() {
-        return stopCursor;
-    }
-
-    public PulsarConsumerConfig getConsumerConfig() {
-        return consumerConfig;
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -160,7 +160,8 @@ public class PulsarSource
 
     @Override
     public void setJobContext(JobContext jobContext) {
-        if (JobMode.BATCH.equals(jobContext.getJobMode())
+        if (multiTableConfig.isMultiTable()
+                && JobMode.BATCH.equals(jobContext.getJobMode())
                 && getBoundedness() == Boundedness.UNBOUNDED) {
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
@@ -200,6 +201,8 @@ public class PulsarSource
             return consumerMetadataMap.values().iterator().next().getDiscoverer();
         }
 
+        // Preserve tables_configs order so multi-table topic-pattern overlaps are resolved
+        // deterministically by MultiTablePartitionDiscoverer.
         List<MultiTablePartitionDiscoverer.TableDiscovererPair> discovererPairs = new ArrayList<>();
         for (PulsarConsumerMetadata metadata : consumerMetadataMap.values()) {
             discovererPairs.add(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -125,6 +125,7 @@ public class PulsarSource
                 readerContext,
                 clientConfig,
                 consumerMetadataMap,
+                multiTableConfig.isTablesConfigs(),
                 pollTimeout,
                 pollInterval,
                 batchSize);
@@ -184,7 +185,7 @@ public class PulsarSource
         Map<TablePath, PulsarConsumerMetadata> metadataMap = new LinkedHashMap<>();
         for (PulsarTableConfig tableConfig : multiTableConfig.getTableConfigs()) {
             CatalogTable catalogTable =
-                    multiTableConfig.isMultiTable()
+                    multiTableConfig.isTablesConfigs()
                             ? buildCatalogTable(tableConfig)
                             : CatalogTable.of(
                                     TableIdentifier.of(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
 
+import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.serialization.DeserializationSchema;
@@ -26,18 +27,25 @@ import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.source.SupportParallelism;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.exception.CommonErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarAdminConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarClientConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConsumerConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarMultiTableConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarTableConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.PulsarSplitEnumerator;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.PulsarSplitEnumeratorState;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.StartCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.NeverStopCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.MultiTablePartitionDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.PulsarDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.TopicListDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.TopicPatternDiscoverer;
@@ -50,76 +58,49 @@ import org.apache.seatunnel.format.json.exception.SeaTunnelJsonFormatException;
 
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.regex.Pattern;
-
-import static org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.CURSOR_STARTUP_MODE;
-import static org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions.CURSOR_STOP_MODE;
+import java.util.Map;
 
 public class PulsarSource
         implements SeaTunnelSource<SeaTunnelRow, PulsarPartitionSplit, PulsarSplitEnumeratorState>,
                 SupportParallelism {
 
-    private DeserializationSchema<SeaTunnelRow> deserializationSchema;
-    private CatalogTable catalogTable;
+    private final PulsarMultiTableConfig multiTableConfig;
+    private final Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap;
+    private final PulsarAdminConfig adminConfig;
+    private final PulsarClientConfig clientConfig;
+    private final PulsarDiscoverer partitionDiscoverer;
 
-    private PulsarAdminConfig adminConfig;
-    private PulsarClientConfig clientConfig;
-    private PulsarConsumerConfig consumerConfig;
-    private PulsarDiscoverer partitionDiscoverer;
-    private long partitionDiscoveryIntervalMs;
-    private StartCursor startCursor;
-    private StopCursor stopCursor;
-
-    protected int pollTimeout;
-    protected long pollInterval;
-    protected int batchSize;
+    private final long partitionDiscoveryIntervalMs;
+    protected final int pollTimeout;
+    protected final long pollInterval;
+    protected final int batchSize;
 
     public PulsarSource(ReadonlyConfig config, CatalogTable catalogTable) {
-        this.catalogTable = catalogTable;
-        // admin config
-        PulsarAdminConfig.Builder adminConfigBuilder =
-                PulsarAdminConfig.builder()
-                        .adminUrl(config.get(PulsarSourceOptions.ADMIN_SERVICE_URL));
-        adminConfigBuilder.authPluginClassName(config.get(PulsarSourceOptions.AUTH_PLUGIN_CLASS));
-        adminConfigBuilder.authParams(config.get(PulsarSourceOptions.AUTH_PARAMS));
-        this.adminConfig = adminConfigBuilder.build();
-
-        // client config
-        PulsarClientConfig.Builder clientConfigBuilder =
-                PulsarClientConfig.builder()
-                        .serviceUrl(config.get(PulsarSourceOptions.CLIENT_SERVICE_URL));
-        clientConfigBuilder.authPluginClassName(config.get(PulsarSourceOptions.AUTH_PLUGIN_CLASS));
-        clientConfigBuilder.authParams(config.get(PulsarSourceOptions.AUTH_PARAMS));
-        this.clientConfig = clientConfigBuilder.build();
-
-        // consumer config
-        PulsarConsumerConfig.Builder consumerConfigBuilder =
-                PulsarConsumerConfig.builder()
-                        .subscriptionName(config.get(PulsarSourceOptions.SUBSCRIPTION_NAME));
-        this.consumerConfig = consumerConfigBuilder.build();
-
-        // source properties
+        this.multiTableConfig = PulsarMultiTableConfig.of(config);
         this.partitionDiscoveryIntervalMs =
                 config.get(PulsarSourceOptions.TOPIC_DISCOVERY_INTERVAL);
+        this.adminConfig = buildAdminConfig(config);
+        this.clientConfig = buildClientConfig(config);
+        this.consumerMetadataMap = createConsumerMetadata(catalogTable);
+        this.partitionDiscoverer = createPartitionDiscoverer();
         this.pollTimeout = config.get(PulsarSourceOptions.POLL_TIMEOUT);
         this.pollInterval = config.get(PulsarSourceOptions.POLL_INTERVAL);
         this.batchSize = config.get(PulsarSourceOptions.POLL_BATCH_SIZE);
 
-        setStartCursor(config);
-        setStopCursor(config);
-        setPartitionDiscoverer(config);
-        setDeserialization(config);
+        validateBoundedDiscovery();
+    }
 
-        if (partitionDiscoverer instanceof TopicPatternDiscoverer
-                && partitionDiscoveryIntervalMs > 0
-                && Boundedness.BOUNDED == stopCursor.getBoundedness()) {
-            throw new PulsarConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    "Bounded streams do not support dynamic partition discovery.");
-        }
+    @Override
+    public Boundedness getBoundedness() {
+        return consumerMetadataMap.values().stream()
+                        .map(PulsarConsumerMetadata::getStopCursor)
+                        .anyMatch(stopCursor -> stopCursor instanceof NeverStopCursor)
+                ? Boundedness.UNBOUNDED
+                : Boundedness.BOUNDED;
     }
 
     @Override
@@ -127,125 +108,13 @@ public class PulsarSource
         return PulsarSourceOptions.IDENTIFIER;
     }
 
-    private void setStartCursor(ReadonlyConfig config) {
-        PulsarSourceOptions.StartMode startMode = config.get(CURSOR_STARTUP_MODE);
-        switch (startMode) {
-            case EARLIEST:
-                this.startCursor = StartCursor.earliest();
-                break;
-            case LATEST:
-                this.startCursor = StartCursor.latest();
-                break;
-            case SUBSCRIPTION:
-                PulsarSourceOptions.CursorResetStrategy resetStrategy =
-                        config.get(PulsarSourceOptions.CURSOR_RESET_MODE);
-                this.startCursor = StartCursor.subscription(resetStrategy);
-                break;
-            case TIMESTAMP:
-                if (!config.getOptional(PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP).isPresent()) {
-                    throw new PulsarConnectorException(
-                            SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
-                            String.format(
-                                    "The '%s' property is required when the '%s' is 'timestamp'.",
-                                    PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP.key(),
-                                    CURSOR_STARTUP_MODE.key()));
-                }
-                this.startCursor =
-                        StartCursor.timestamp(
-                                config.get(PulsarSourceOptions.CURSOR_STARTUP_TIMESTAMP));
-                break;
-            default:
-                throw new PulsarConnectorException(
-                        SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
-                        String.format("The %s mode is not supported.", startMode));
-        }
-    }
-
-    private void setStopCursor(ReadonlyConfig config) {
-        PulsarSourceOptions.StopMode stopMode = config.get(CURSOR_STOP_MODE);
-        switch (stopMode) {
-            case LATEST:
-                this.stopCursor = StopCursor.latest();
-                break;
-            case NEVER:
-                this.stopCursor = StopCursor.never();
-                break;
-            case TIMESTAMP:
-                if (!config.getOptional(PulsarSourceOptions.CURSOR_STOP_TIMESTAMP).isPresent()) {
-                    throw new PulsarConnectorException(
-                            SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
-                            String.format(
-                                    "The '%s' property is required when the '%s' is 'timestamp'.",
-                                    PulsarSourceOptions.CURSOR_STOP_TIMESTAMP.key(),
-                                    CURSOR_STOP_MODE.key()));
-                }
-                this.stopCursor =
-                        StopCursor.timestamp(config.get(PulsarSourceOptions.CURSOR_STOP_TIMESTAMP));
-                break;
-            default:
-                throw new PulsarConnectorException(
-                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                        String.format("The %s mode is not supported.", stopMode));
-        }
-    }
-
-    private void setPartitionDiscoverer(ReadonlyConfig config) {
-        if (config.getOptional(PulsarSourceOptions.TOPIC).isPresent()) {
-            String topic = config.get(PulsarSourceOptions.TOPIC);
-            if (StringUtils.isNotBlank(topic)) {
-                this.partitionDiscoverer =
-                        new TopicListDiscoverer(Arrays.asList(StringUtils.split(topic, ",")));
-            }
-        }
-        if (config.getOptional(PulsarSourceOptions.TOPIC_PATTERN).isPresent()) {
-            String topicPattern = config.get(PulsarSourceOptions.TOPIC_PATTERN);
-            if (StringUtils.isNotBlank(topicPattern)) {
-                this.partitionDiscoverer =
-                        new TopicPatternDiscoverer(Pattern.compile(topicPattern));
-            }
-        }
-        if (this.partitionDiscoverer == null) {
-            throw new PulsarConnectorException(
-                    SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
-                    String.format(
-                            "The properties '%s' or '%s' is required.",
-                            PulsarSourceOptions.TOPIC.key(),
-                            PulsarSourceOptions.TOPIC_PATTERN.key()));
-        }
-    }
-
-    private void setDeserialization(ReadonlyConfig config) {
-        String format = config.get(PulsarSourceOptions.FORMAT);
-        switch (format.toUpperCase()) {
-            case "JSON":
-                this.deserializationSchema =
-                        new JsonDeserializationSchema(
-                                false, false, catalogTable.getSeaTunnelRowType());
-                break;
-            case "CANAL_JSON":
-                this.deserializationSchema =
-                        new PulsarCanalDecorator(
-                                CanalJsonDeserializationSchema.builder(catalogTable)
-                                        .setIgnoreParseErrors(true)
-                                        .build());
-                break;
-            default:
-                throw new SeaTunnelJsonFormatException(
-                        CommonErrorCodeDeprecated.UNSUPPORTED_DATA_TYPE,
-                        "Unsupported format: " + format);
-        }
-    }
-
-    @Override
-    public Boundedness getBoundedness() {
-        return this.stopCursor instanceof NeverStopCursor
-                ? Boundedness.UNBOUNDED
-                : Boundedness.BOUNDED;
-    }
-
     @Override
     public List<CatalogTable> getProducedCatalogTables() {
-        return Collections.singletonList(catalogTable);
+        List<CatalogTable> catalogTables = new ArrayList<>();
+        consumerMetadataMap
+                .values()
+                .forEach(metadata -> catalogTables.add(metadata.getCatalogTable()));
+        return catalogTables;
     }
 
     @Override
@@ -254,9 +123,7 @@ public class PulsarSource
         return new PulsarSourceReader<>(
                 readerContext,
                 clientConfig,
-                consumerConfig,
-                startCursor,
-                deserializationSchema,
+                consumerMetadataMap,
                 pollTimeout,
                 pollInterval,
                 batchSize);
@@ -271,9 +138,8 @@ public class PulsarSource
                 adminConfig,
                 partitionDiscoverer,
                 partitionDiscoveryIntervalMs,
-                startCursor,
-                stopCursor,
-                consumerConfig.getSubscriptionName());
+                consumerMetadataMap,
+                getBoundedness());
     }
 
     @Override
@@ -287,9 +153,182 @@ public class PulsarSource
                 adminConfig,
                 partitionDiscoverer,
                 partitionDiscoveryIntervalMs,
-                startCursor,
-                stopCursor,
-                consumerConfig.getSubscriptionName(),
+                consumerMetadataMap,
+                getBoundedness(),
                 checkpointState.getAssignedPartitions());
+    }
+
+    @Override
+    public void setJobContext(JobContext jobContext) {
+        if (JobMode.BATCH.equals(jobContext.getJobMode())
+                && getBoundedness() == Boundedness.UNBOUNDED) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    "Pulsar source does not support unbounded multi-table configuration in batch mode.");
+        }
+    }
+
+    private Map<TablePath, PulsarConsumerMetadata> createConsumerMetadata(
+            CatalogTable singleCatalogTable) {
+        Map<TablePath, PulsarConsumerMetadata> metadataMap = new LinkedHashMap<>();
+        for (PulsarTableConfig tableConfig : multiTableConfig.getTableConfigs()) {
+            CatalogTable catalogTable =
+                    multiTableConfig.isMultiTable()
+                            ? buildCatalogTable(tableConfig)
+                            : CatalogTable.of(
+                                    TableIdentifier.of(
+                                            PulsarSourceOptions.IDENTIFIER,
+                                            singleCatalogTable.getTableId().toTablePath()),
+                                    singleCatalogTable);
+            TablePath tablePath = catalogTable.getTableId().toTablePath();
+            metadataMap.put(
+                    tablePath,
+                    new PulsarConsumerMetadata(
+                            tablePath,
+                            catalogTable,
+                            createDeserialization(tableConfig.getFormat(), catalogTable),
+                            createDiscoverer(tableConfig),
+                            createStartCursor(tableConfig),
+                            createStopCursor(tableConfig),
+                            buildConsumerConfig(tableConfig.getSubscriptionName())));
+        }
+        return metadataMap;
+    }
+
+    private PulsarDiscoverer createPartitionDiscoverer() {
+        if (consumerMetadataMap.size() == 1) {
+            return consumerMetadataMap.values().iterator().next().getDiscoverer();
+        }
+
+        List<MultiTablePartitionDiscoverer.TableDiscovererPair> discovererPairs = new ArrayList<>();
+        for (PulsarConsumerMetadata metadata : consumerMetadataMap.values()) {
+            discovererPairs.add(
+                    new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                            metadata.getTablePath(),
+                            metadata.getDiscoverer(),
+                            metadata.getDiscoverer() instanceof TopicPatternDiscoverer));
+        }
+        return new MultiTablePartitionDiscoverer(discovererPairs);
+    }
+
+    private CatalogTable buildCatalogTable(PulsarTableConfig tableConfig) {
+        CatalogTable catalogTable;
+        if (tableConfig.getSchemaConfig().getOptional(PulsarSourceOptions.SCHEMA).isPresent()) {
+            catalogTable = CatalogTableUtil.buildWithConfig(tableConfig.getSchemaConfig());
+        } else {
+            catalogTable = CatalogTableUtil.buildSimpleTextTable();
+        }
+
+        return CatalogTable.of(
+                TableIdentifier.of(PulsarSourceOptions.IDENTIFIER, tableConfig.getTablePath()),
+                catalogTable);
+    }
+
+    private PulsarAdminConfig buildAdminConfig(ReadonlyConfig config) {
+        PulsarAdminConfig.Builder builder =
+                PulsarAdminConfig.builder()
+                        .adminUrl(config.get(PulsarSourceOptions.ADMIN_SERVICE_URL));
+        builder.authPluginClassName(config.get(PulsarSourceOptions.AUTH_PLUGIN_CLASS));
+        builder.authParams(config.get(PulsarSourceOptions.AUTH_PARAMS));
+        return builder.build();
+    }
+
+    private PulsarClientConfig buildClientConfig(ReadonlyConfig config) {
+        PulsarClientConfig.Builder builder =
+                PulsarClientConfig.builder()
+                        .serviceUrl(config.get(PulsarSourceOptions.CLIENT_SERVICE_URL));
+        builder.authPluginClassName(config.get(PulsarSourceOptions.AUTH_PLUGIN_CLASS));
+        builder.authParams(config.get(PulsarSourceOptions.AUTH_PARAMS));
+        return builder.build();
+    }
+
+    private PulsarConsumerConfig buildConsumerConfig(String subscriptionName) {
+        return PulsarConsumerConfig.builder().subscriptionName(subscriptionName).build();
+    }
+
+    private DeserializationSchema<SeaTunnelRow> createDeserialization(
+            String format, CatalogTable catalogTable) {
+        switch (format.toUpperCase()) {
+            case "JSON":
+                return new JsonDeserializationSchema(
+                        false, false, catalogTable.getSeaTunnelRowType());
+            case "CANAL_JSON":
+                return new PulsarCanalDecorator(
+                        CanalJsonDeserializationSchema.builder(catalogTable)
+                                .setIgnoreParseErrors(true)
+                                .build());
+            default:
+                throw new SeaTunnelJsonFormatException(
+                        CommonErrorCode.UNSUPPORTED_DATA_TYPE, "Unsupported format: " + format);
+        }
+    }
+
+    private void validateBoundedDiscovery() {
+        boolean hasTopicPattern;
+        if (partitionDiscoverer instanceof TopicPatternDiscoverer) {
+            hasTopicPattern = true;
+        } else if (partitionDiscoverer instanceof MultiTablePartitionDiscoverer) {
+            hasTopicPattern =
+                    ((MultiTablePartitionDiscoverer) partitionDiscoverer).hasTopicPattern();
+        } else {
+            hasTopicPattern = false;
+        }
+
+        if (hasTopicPattern
+                && partitionDiscoveryIntervalMs > 0
+                && Boundedness.BOUNDED == getBoundedness()) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    "Bounded streams do not support dynamic partition discovery.");
+        }
+    }
+
+    private StartCursor createStartCursor(PulsarTableConfig tableConfig) {
+        PulsarSourceOptions.StartMode startMode = tableConfig.getStartMode();
+        switch (startMode) {
+            case EARLIEST:
+                return StartCursor.earliest();
+            case LATEST:
+                return StartCursor.latest();
+            case SUBSCRIPTION:
+                return StartCursor.subscription(tableConfig.getResetMode());
+            case TIMESTAMP:
+                return StartCursor.timestamp(tableConfig.getStartTimestamp());
+            default:
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
+                        "Unsupported start mode: " + startMode);
+        }
+    }
+
+    private StopCursor createStopCursor(PulsarTableConfig tableConfig) {
+        PulsarSourceOptions.StopMode stopMode = tableConfig.getStopMode();
+        switch (stopMode) {
+            case LATEST:
+                return StopCursor.latest();
+            case NEVER:
+                return StopCursor.never();
+            case TIMESTAMP:
+                return StopCursor.timestamp(tableConfig.getStopTimestamp());
+            default:
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        "Unsupported stop mode: " + stopMode);
+        }
+    }
+
+    private PulsarDiscoverer createDiscoverer(PulsarTableConfig tableConfig) {
+        if (StringUtils.isNotBlank(tableConfig.getTopic())) {
+            return new TopicListDiscoverer(
+                    Arrays.asList(StringUtils.split(tableConfig.getTopic(), ",")));
+        }
+        if (tableConfig.getTopicPattern() != null) {
+            return new TopicPatternDiscoverer(tableConfig.getTopicPattern());
+        }
+        throw new PulsarConnectorException(
+                SeaTunnelAPIErrorCode.OPTION_VALIDATION_FAILED,
+                String.format(
+                        "The properties '%s' or '%s' is required.",
+                        PulsarSourceOptions.TOPIC.key(), PulsarSourceOptions.TOPIC_PATTERN.key()));
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -63,6 +63,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PulsarSource
         implements SeaTunnelSource<SeaTunnelRow, PulsarPartitionSplit, PulsarSplitEnumeratorState>,
@@ -163,9 +164,18 @@ public class PulsarSource
         if (multiTableConfig.isMultiTable()
                 && JobMode.BATCH.equals(jobContext.getJobMode())
                 && getBoundedness() == Boundedness.UNBOUNDED) {
+            List<String> unboundedTables =
+                    consumerMetadataMap.entrySet().stream()
+                            .filter(e -> e.getValue().getStopCursor() instanceof NeverStopCursor)
+                            .map(e -> e.getKey().toString())
+                            .collect(Collectors.toList());
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    "Pulsar source does not support unbounded multi-table configuration in batch mode.");
+                    String.format(
+                            "Pulsar source does not support unbounded multi-table configuration in batch mode. "
+                                    + "The following tables use cursor.stop.mode=NEVER (unbounded): %s. "
+                                    + "Either change them to a bounded mode (LATEST or TIMESTAMP) or use STREAMING mode.",
+                            String.join(", ", unboundedTables)));
         }
     }
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.table.TableSchemaOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
@@ -28,6 +30,7 @@ import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 
 import com.google.auto.service.AutoService;
 
@@ -88,6 +91,7 @@ public class PulsarSourceFactory implements TableSourceFactory {
     @Override
     public <T, SplitT extends SourceSplit, StateT extends Serializable>
             TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        validateSourceOptions(context.getOptions());
         CatalogTable catalogTable;
         if (context.getOptions().getOptional(PulsarSourceOptions.SCHEMA).isPresent()) {
             catalogTable = CatalogTableUtil.buildWithConfig(context.getOptions());
@@ -97,5 +101,16 @@ public class PulsarSourceFactory implements TableSourceFactory {
         return () ->
                 (SeaTunnelSource<T, SplitT, StateT>)
                         new PulsarSource(context.getOptions(), catalogTable);
+    }
+
+    private void validateSourceOptions(ReadonlyConfig config) {
+        if (!config.getOptional(TableSchemaOptions.TABLE_CONFIGS).isPresent()
+                && !config.getOptional(PulsarSourceOptions.SUBSCRIPTION_NAME).isPresent()) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Single-table Pulsar source must configure '%s'.",
+                            PulsarSourceOptions.SUBSCRIPTION_NAME.key()));
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
 
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.table.TableSchemaOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -43,10 +44,10 @@ public class PulsarSourceFactory implements TableSourceFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .required(
-                        PulsarSourceOptions.SUBSCRIPTION_NAME,
                         PulsarSourceOptions.CLIENT_SERVICE_URL,
                         PulsarSourceOptions.ADMIN_SERVICE_URL)
                 .optional(
+                        PulsarSourceOptions.SUBSCRIPTION_NAME,
                         PulsarSourceOptions.CURSOR_STARTUP_MODE,
                         PulsarSourceOptions.CURSOR_STOP_MODE,
                         PulsarSourceOptions.TOPIC_DISCOVERY_INTERVAL,
@@ -55,7 +56,10 @@ public class PulsarSourceFactory implements TableSourceFactory {
                         PulsarSourceOptions.POLL_BATCH_SIZE,
                         PulsarSourceOptions.FORMAT,
                         PulsarSourceOptions.SCHEMA)
-                .exclusive(PulsarSourceOptions.TOPIC, PulsarSourceOptions.TOPIC_PATTERN)
+                .exclusive(
+                        PulsarSourceOptions.TOPIC,
+                        PulsarSourceOptions.TOPIC_PATTERN,
+                        TableSchemaOptions.TABLE_CONFIGS)
                 .conditional(
                         PulsarSourceOptions.FORMAT,
                         PulsarSourceOptions.TEXT_FORMAT,

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -106,13 +106,6 @@ public class PulsarSplitEnumerator
             Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap,
             Boundedness boundedness,
             Set<TopicPartition> assignedPartitions) {
-        if (hasTopicPattern(partitionDiscoverer)
-                && partitionDiscoveryIntervalMs > 0
-                && Boundedness.BOUNDED == boundedness) {
-            throw new PulsarConnectorException(
-                    CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
-                    "Bounded streams do not support dynamic partition discovery.");
-        }
         this.context = context;
         this.adminConfig = adminConfig;
         this.partitionDiscoverer = partitionDiscoverer;

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -77,6 +77,7 @@ public class PulsarSplitEnumerator
     // This flag will be marked as true if periodically partition discovery is disabled AND the
     // initializing partition discovery has finished.
     private boolean noMoreNewPartitionSplits = false;
+    private volatile boolean initialized = false;
 
     private ScheduledThreadPoolExecutor executor = null;
 
@@ -125,10 +126,6 @@ public class PulsarSplitEnumerator
     @Override
     public void open() {
         this.pulsarAdmin = PulsarConfigUtil.createAdmin(adminConfig);
-    }
-
-    @Override
-    public void run() throws Exception {
         if (partitionDiscoveryIntervalMs > 0) {
             executor =
                     new ScheduledThreadPoolExecutor(
@@ -140,10 +137,28 @@ public class PulsarSplitEnumerator
                                 return thread;
                             });
             executor.scheduleAtFixedRate(
-                    this::discoverySplits, 0, partitionDiscoveryIntervalMs, TimeUnit.MILLISECONDS);
-        } else {
-            discoverySplits();
+                    () -> {
+                        if (!initialized) {
+                            return;
+                        }
+                        try {
+                            discoverySplits();
+                        } catch (Exception e) {
+                            LOG.error("Dynamic discovery failure:", e);
+                        }
+                    },
+                    partitionDiscoveryIntervalMs,
+                    partitionDiscoveryIntervalMs,
+                    TimeUnit.MILLISECONDS);
         }
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Run one discovery synchronously so topic-pattern conflicts and initial splits are
+        // resolved on the runtime side before periodic discovery begins.
+        discoverySplits();
+        initialized = true;
     }
 
     private void discoverySplits() {

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -19,14 +19,16 @@ package org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator;
 
 import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarAdminConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConfigUtil;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
-import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.StartCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.PulsarConsumerMetadata;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.SubscriptionStartCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.LatestMessageStopCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.MultiTablePartitionDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.PulsarDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.TopicPatternDiscoverer;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
@@ -59,14 +61,10 @@ public class PulsarSplitEnumerator
     private final PulsarAdminConfig adminConfig;
     private final PulsarDiscoverer partitionDiscoverer;
     private final long partitionDiscoveryIntervalMs;
-    private final StartCursor startCursor;
-    private final StopCursor stopCursor;
+    private final Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap;
+    private final Boundedness boundedness;
     private final Object stateLock = new Object();
 
-    /** The consumer group id used for this PulsarSource. */
-    private final String subscriptionName;
-
-    /** Partitions that have been assigned to readers. */
     private final Set<TopicPartition> assignedPartitions;
     /**
      * The discovered and initialized partition splits that are waiting for owner reader to be
@@ -87,17 +85,15 @@ public class PulsarSplitEnumerator
             PulsarAdminConfig adminConfig,
             PulsarDiscoverer partitionDiscoverer,
             long partitionDiscoveryIntervalMs,
-            StartCursor startCursor,
-            StopCursor stopCursor,
-            String subscriptionName) {
+            Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap,
+            Boundedness boundedness) {
         this(
                 context,
                 adminConfig,
                 partitionDiscoverer,
                 partitionDiscoveryIntervalMs,
-                startCursor,
-                stopCursor,
-                subscriptionName,
+                consumerMetadataMap,
+                boundedness,
                 Collections.emptySet());
     }
 
@@ -106,13 +102,12 @@ public class PulsarSplitEnumerator
             PulsarAdminConfig adminConfig,
             PulsarDiscoverer partitionDiscoverer,
             long partitionDiscoveryIntervalMs,
-            StartCursor startCursor,
-            StopCursor stopCursor,
-            String subscriptionName,
+            Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap,
+            Boundedness boundedness,
             Set<TopicPartition> assignedPartitions) {
-        if (partitionDiscoverer instanceof TopicPatternDiscoverer
+        if (hasTopicPattern(partitionDiscoverer)
                 && partitionDiscoveryIntervalMs > 0
-                && Boundedness.BOUNDED == stopCursor.getBoundedness()) {
+                && Boundedness.BOUNDED == boundedness) {
             throw new PulsarConnectorException(
                     CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
                     "Bounded streams do not support dynamic partition discovery.");
@@ -121,9 +116,8 @@ public class PulsarSplitEnumerator
         this.adminConfig = adminConfig;
         this.partitionDiscoverer = partitionDiscoverer;
         this.partitionDiscoveryIntervalMs = partitionDiscoveryIntervalMs;
-        this.startCursor = startCursor;
-        this.stopCursor = stopCursor;
-        this.subscriptionName = subscriptionName;
+        this.consumerMetadataMap = consumerMetadataMap;
+        this.boundedness = boundedness;
         this.assignedPartitions = new HashSet<>(assignedPartitions);
         this.pendingPartitionSplits = new HashMap<>();
     }
@@ -161,8 +155,7 @@ public class PulsarSplitEnumerator
     }
 
     private void checkPartitionChanges(Set<TopicPartition> fetchedPartitions) {
-        // Append the partitions into current assignment state.
-        final Set<TopicPartition> newPartitions = getNewPartitions(fetchedPartitions);
+        Set<TopicPartition> newPartitions = getNewPartitions(fetchedPartitions);
         if (partitionDiscoveryIntervalMs <= 0 && !noMoreNewPartitionSplits) {
             LOG.debug("Partition discovery is disabled.");
             noMoreNewPartitionSplits = true;
@@ -179,14 +172,25 @@ public class PulsarSplitEnumerator
     }
 
     private PulsarPartitionSplit createPulsarPartitionSplit(TopicPartition partition) {
-        StopCursor partitionStopCursor = stopCursor.copy();
-        PulsarPartitionSplit split = new PulsarPartitionSplit(partition, partitionStopCursor);
+        TablePath tablePath = resolveTablePath(partition);
+        PulsarConsumerMetadata consumerMetadata = consumerMetadataMap.get(tablePath);
+        if (consumerMetadata == null) {
+            throw new PulsarConnectorException(
+                    CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION,
+                    String.format("No consumer metadata found for table path '%s'", tablePath));
+        }
+        StopCursor partitionStopCursor = consumerMetadata.getStopCursor().copy();
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(partition, partitionStopCursor, null, tablePath);
         if (partitionStopCursor instanceof LatestMessageStopCursor) {
             ((LatestMessageStopCursor) partitionStopCursor).prepare(pulsarAdmin, partition);
         }
-        if (startCursor instanceof SubscriptionStartCursor) {
-            ((SubscriptionStartCursor) startCursor)
-                    .ensureSubscription(subscriptionName, partition, pulsarAdmin);
+        if (consumerMetadata.getStartCursor() instanceof SubscriptionStartCursor) {
+            ((SubscriptionStartCursor) consumerMetadata.getStartCursor())
+                    .ensureSubscription(
+                            consumerMetadata.getConsumerConfig().getSubscriptionName(),
+                            partition,
+                            pulsarAdmin);
         }
         return split;
     }
@@ -213,11 +217,7 @@ public class PulsarSplitEnumerator
             int ownerReader = getSplitOwner(split.getPartition(), numReaders);
             pendingPartitionSplits.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
         }
-        LOG.debug(
-                "Assigned {} to {} readers of subscription {}.",
-                newPartitionSplits,
-                numReaders,
-                subscriptionName);
+        LOG.debug("Assigned {} to {} readers.", newPartitionSplits, numReaders);
     }
 
     static int getSplitOwner(TopicPartition tp, int numReaders) {
@@ -232,9 +232,7 @@ public class PulsarSplitEnumerator
     private void assignPendingPartitionSplits(Set<Integer> pendingReaders) {
         // Check if there's any pending splits for given readers
         for (int pendingReader : pendingReaders) {
-
-            // Remove pending assignment for the reader
-            final Set<PulsarPartitionSplit> pendingAssignmentForReader =
+            Set<PulsarPartitionSplit> pendingAssignmentForReader =
                     pendingPartitionSplits.remove(pendingReader);
 
             if (pendingAssignmentForReader != null && !pendingAssignmentForReader.isEmpty()) {
@@ -251,12 +249,10 @@ public class PulsarSplitEnumerator
 
         // If periodically partition discovery is disabled and the initializing discovery has done,
         // signal NoMoreSplitsEvent to pending readers
-        if (noMoreNewPartitionSplits && stopCursor.getBoundedness() == Boundedness.BOUNDED) {
+        if (noMoreNewPartitionSplits && boundedness == Boundedness.BOUNDED) {
             LOG.debug(
-                    "No more PulsarPartitionSplits to assign. Sending NoMoreSplitsEvent to reader {}"
-                            + " in subscription {}.",
-                    pendingReaders,
-                    subscriptionName);
+                    "No more PulsarPartitionSplits to assign. Sending NoMoreSplitsEvent to reader {}.",
+                    pendingReaders);
             pendingReaders.forEach(context::signalNoMoreSplits);
         }
     }
@@ -293,10 +289,7 @@ public class PulsarSplitEnumerator
 
     @Override
     public void registerReader(int subtaskId) {
-        LOG.debug(
-                "Adding reader {} to PulsarSourceEnumerator for subscription {}.",
-                subtaskId,
-                subscriptionName);
+        LOG.debug("Adding reader {} to PulsarSourceEnumerator.", subtaskId);
         assignPendingPartitionSplits(Collections.singleton(subtaskId));
     }
 
@@ -310,5 +303,20 @@ public class PulsarSplitEnumerator
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         // nothing
+    }
+
+    private boolean hasTopicPattern(PulsarDiscoverer discoverer) {
+        if (discoverer instanceof TopicPatternDiscoverer) {
+            return true;
+        }
+        return discoverer instanceof MultiTablePartitionDiscoverer
+                && ((MultiTablePartitionDiscoverer) discoverer).hasTopicPattern();
+    }
+
+    private TablePath resolveTablePath(TopicPartition partition) {
+        if (partitionDiscoverer instanceof MultiTablePartitionDiscoverer) {
+            return ((MultiTablePartitionDiscoverer) partitionDiscoverer).getTablePath(partition);
+        }
+        return consumerMetadataMap.keySet().iterator().next();
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
@@ -17,12 +17,13 @@
 
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer;
 
-import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.TablePath;
-import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import lombok.Getter;
 
@@ -32,9 +33,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Resolves multi-table topic ownership for Pulsar source.
+ *
+ * <p>The discoverer pairs are evaluated in {@code tables_configs} declaration order. If multiple
+ * {@code topic-pattern} entries match the same topic, the first matching table keeps ownership and
+ * later matches are ignored. This makes topic routing deterministic even when new topics appear
+ * after the job has started.
+ */
 public class MultiTablePartitionDiscoverer implements PulsarDiscoverer {
 
     private static final long serialVersionUID = 7777745279743885587L;
+    private static final Logger LOG = LoggerFactory.getLogger(MultiTablePartitionDiscoverer.class);
 
     private final List<TableDiscovererPair> discovererPairs;
     private final Map<TopicPartition, TablePath> partitionToTablePath = new HashMap<>();
@@ -51,13 +61,13 @@ public class MultiTablePartitionDiscoverer implements PulsarDiscoverer {
         for (TableDiscovererPair pair : discovererPairs) {
             Set<TopicPartition> partitions = pair.discoverer.getSubscribedTopicPartitions(admin);
             for (TopicPartition tp : partitions) {
-                TablePath existing = partitionToTablePath.put(tp, pair.tablePath);
+                TablePath existing = partitionToTablePath.putIfAbsent(tp, pair.tablePath);
                 if (existing != null && !existing.equals(pair.tablePath)) {
-                    throw new PulsarConnectorException(
-                            SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                            String.format(
-                                    "TopicPartition '%s' matched by both '%s' and '%s'",
-                                    tp, existing, pair.tablePath));
+                    LOG.debug(
+                            "TopicPartition '{}' matched by multiple table configs. Keeping '{}' and ignoring '{}'.",
+                            tp,
+                            existing,
+                            pair.tablePath);
                 }
             }
             allPartitions.addAll(partitions);

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
@@ -63,7 +63,7 @@ public class MultiTablePartitionDiscoverer implements PulsarDiscoverer {
             for (TopicPartition tp : partitions) {
                 TablePath existing = partitionToTablePath.putIfAbsent(tp, pair.tablePath);
                 if (existing != null && !existing.equals(pair.tablePath)) {
-                    LOG.debug(
+                    LOG.warn(
                             "TopicPartition '{}' matched by multiple table configs. Keeping '{}' and ignoring '{}'.",
                             tp,
                             existing,

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -83,7 +84,9 @@ public class MultiTablePartitionDiscoverer implements PulsarDiscoverer {
         return discovererPairs.stream().anyMatch(TableDiscovererPair::isTopicPattern);
     }
 
-    public static class TableDiscovererPair {
+    public static class TableDiscovererPair implements Serializable {
+        private static final long serialVersionUID = -7486130997031326385L;
+
         public final TablePath tablePath;
         public final PulsarDiscoverer discoverer;
         @Getter public final boolean topicPattern;

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscoverer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer;
+
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MultiTablePartitionDiscoverer implements PulsarDiscoverer {
+
+    private static final long serialVersionUID = 7777745279743885587L;
+
+    private final List<TableDiscovererPair> discovererPairs;
+    private final Map<TopicPartition, TablePath> partitionToTablePath = new HashMap<>();
+
+    public MultiTablePartitionDiscoverer(List<TableDiscovererPair> discovererPairs) {
+        this.discovererPairs = discovererPairs;
+    }
+
+    @Override
+    public Set<TopicPartition> getSubscribedTopicPartitions(PulsarAdmin admin) {
+        Set<TopicPartition> allPartitions = new HashSet<>();
+        partitionToTablePath.clear();
+
+        for (TableDiscovererPair pair : discovererPairs) {
+            Set<TopicPartition> partitions = pair.discoverer.getSubscribedTopicPartitions(admin);
+            for (TopicPartition tp : partitions) {
+                TablePath existing = partitionToTablePath.put(tp, pair.tablePath);
+                if (existing != null && !existing.equals(pair.tablePath)) {
+                    throw new PulsarConnectorException(
+                            SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                            String.format(
+                                    "TopicPartition '%s' matched by both '%s' and '%s'",
+                                    tp, existing, pair.tablePath));
+                }
+            }
+            allPartitions.addAll(partitions);
+        }
+        return allPartitions;
+    }
+
+    public TablePath getTablePath(TopicPartition partition) {
+        return partitionToTablePath.get(partition);
+    }
+
+    public boolean hasTopicPattern() {
+        return discovererPairs.stream().anyMatch(TableDiscovererPair::isTopicPattern);
+    }
+
+    public static class TableDiscovererPair {
+        public final TablePath tablePath;
+        public final PulsarDiscoverer discoverer;
+        @Getter public final boolean topicPattern;
+
+        public TableDiscovererPair(
+                TablePath tablePath, PulsarDiscoverer discoverer, boolean topicPattern) {
+            this.tablePath = tablePath;
+            this.discoverer = discoverer;
+            this.topicPattern = topicPattern;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/TopicPatternDiscoverer.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/TopicPatternDiscoverer.java
@@ -65,7 +65,7 @@ public class TopicPatternDiscoverer implements PulsarDiscoverer {
                     .getTopics(namespace)
                     .parallelStream()
                     .filter(this::matchesSubscriptionMode)
-                    .filter(topic -> topicPattern.matcher(topic).find())
+                    .filter(topic -> topicPattern.matcher(topic).matches())
                     .map(
                             topicName -> {
                                 String completeTopicName =

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -129,6 +129,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
 
     @Override
     public void pollNext(Collector<T> output) throws Exception {
+        Map<TablePath, Collector<T>> collectorCache = new HashMap<>();
         for (int i = 0; i < batchSize; i++) {
             Optional<RecordWithSplitId> recordWithSplitId = handover.pollNext();
             if (recordWithSplitId.isPresent()) {
@@ -139,10 +140,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
                     TablePath tablePath = resolveTablePath(splitId);
                     DeserializationSchema<T> deserializationSchema =
                             resolveDeserializationSchema(tablePath);
-                    Collector<T> collector =
-                            tablePath == null
-                                    ? output
-                                    : new TableIdInjectingCollector<>(output, tablePath);
+                    Collector<T> collector = resolveCollector(tablePath, output, collectorCache);
                     deserializationSchema.deserialize(message.getData(), collector);
                 }
             }
@@ -295,5 +293,15 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     private DeserializationSchema<T> resolveDeserializationSchema(TablePath tablePath) {
         return (DeserializationSchema<T>)
                 resolveConsumerMetadata(tablePath).getDeserializationSchema();
+    }
+
+    private Collector<T> resolveCollector(
+            TablePath tablePath, Collector<T> output, Map<TablePath, Collector<T>> collectorCache) {
+        if (tablePath == null) {
+            return output;
+        }
+        // Reuse wrappers inside the current poll batch to avoid per-record allocations on hot path.
+        return collectorCache.computeIfAbsent(
+                tablePath, path -> new TableIdInjectingCollector<>(output, path));
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -60,6 +60,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     protected final PulsarClientConfig clientConfig;
     protected final Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap;
     protected final TablePath defaultTablePath;
+    protected final boolean injectTableIdForRouting;
     protected final Handover<RecordWithSplitId> handover;
 
     protected final Map<String, PulsarPartitionSplit> splitStates;
@@ -93,6 +94,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
                 consumerMetadataMap.size() == 1
                         ? consumerMetadataMap.keySet().iterator().next()
                         : null;
+        this.injectTableIdForRouting = consumerMetadataMap.size() > 1;
         this.pollTimeout = pollTimeout;
         this.pollInterval = pollInterval;
         this.batchSize = batchSize;
@@ -297,7 +299,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
 
     private Collector<T> resolveCollector(
             TablePath tablePath, Collector<T> output, Map<TablePath, Collector<T>> collectorCache) {
-        if (tablePath == null) {
+        if (!injectTableIdForRouting || tablePath == null) {
             return output;
         }
         // Reuse wrappers inside the current poll batch to avoid per-record allocations on hot path.

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -84,6 +84,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
             SourceReader.Context context,
             PulsarClientConfig clientConfig,
             Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap,
+            boolean injectTableId,
             int pollTimeout,
             long pollInterval,
             int batchSize) {
@@ -94,7 +95,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
                 consumerMetadataMap.size() == 1
                         ? consumerMetadataMap.keySet().iterator().next()
                         : null;
-        this.injectTableIdForRouting = consumerMetadataMap.size() > 1;
+        this.injectTableIdForRouting = injectTableId;
         this.pollTimeout = pollTimeout;
         this.pollInterval = pollInterval;
         this.batchSize = batchSize;

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -284,9 +284,21 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
             metadata = consumerMetadataMap.get(defaultTablePath);
         }
         if (metadata == null) {
+            String tablePathStr = tablePath != null ? tablePath.toString() : "null";
+            String defaultTablePathStr =
+                    defaultTablePath != null ? defaultTablePath.toString() : "null";
+            String availableTables =
+                    consumerMetadataMap.keySet().stream()
+                            .map(TablePath::toString)
+                            .collect(Collectors.joining(", "));
             throw new PulsarConnectorException(
                     PulsarConnectorErrorCode.DESERIALIZATION_SCHEMA_NOT_FOUND,
-                    String.format("No consumer metadata found for table '%s'", tablePath));
+                    String.format(
+                            "No consumer metadata found for table '%s'. "
+                                    + "Default table path: '%s'. "
+                                    + "Available tables: [%s]. "
+                                    + "This is likely a bug in the multi-table routing logic.",
+                            tablePathStr, defaultTablePathStr, availableTables));
         }
         return metadata;
     }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -80,6 +80,8 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     /** Indicating whether the SourceReader will be assigned more splits or not. */
     private boolean noMoreSplitsAssignment = false;
 
+    private boolean noMoreElementSignaled = false;
+
     public PulsarSourceReader(
             SourceReader.Context context,
             PulsarClientConfig clientConfig,
@@ -147,11 +149,8 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
                     deserializationSchema.deserialize(message.getData(), collector);
                 }
             }
-            if (noMoreSplitsAssignment && finishedSplits.size() == splitStates.size()) {
-                context.signalNoMoreElement();
-                break;
-            }
         }
+        signalNoMoreElementIfFinished();
     }
 
     @Override
@@ -318,5 +317,15 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
         // Reuse wrappers inside the current poll batch to avoid per-record allocations on hot path.
         return collectorCache.computeIfAbsent(
                 tablePath, path -> new TableIdInjectingCollector<>(output, path));
+    }
+
+    private void signalNoMoreElementIfFinished() throws Exception {
+        if (!noMoreElementSignaled
+                && noMoreSplitsAssignment
+                && finishedSplits.size() == splitStates.size()
+                && handover.isEmpty()) {
+            noMoreElementSignaled = true;
+            context.signalNoMoreElement();
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -21,15 +21,15 @@ import org.apache.seatunnel.api.serialization.DeserializationSchema;
 import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.common.Handover;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarClientConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConfigUtil;
-import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConsumerConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSemantics;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
-import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.StartCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.PulsarConsumerMetadata;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.split.PulsarPartitionSplit;
 
 import org.apache.pulsar.client.api.Message;
@@ -50,14 +50,16 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarSourceReader.class);
+
     protected final SourceReader.Context context;
     protected final PulsarClientConfig clientConfig;
-    protected final PulsarConsumerConfig consumerConfig;
-    protected final StartCursor startCursor;
+    protected final Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap;
+    protected final TablePath defaultTablePath;
     protected final Handover<RecordWithSplitId> handover;
 
     protected final Map<String, PulsarPartitionSplit> splitStates;
@@ -65,8 +67,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     protected final SortedMap<Long, Map<String, MessageId>> pendingCursorsToCommit;
     protected final Map<String, MessageId> pendingCursorsToFinish;
     protected final Set<String> finishedSplits;
-
-    protected final DeserializationSchema<T> deserialization;
+    protected final ConcurrentHashMap<String, TablePath> splitIdToTablePath;
 
     /** The maximum number of milliseconds to wait for a fetch batch. */
     protected final int pollTimeout;
@@ -81,17 +82,17 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     public PulsarSourceReader(
             SourceReader.Context context,
             PulsarClientConfig clientConfig,
-            PulsarConsumerConfig consumerConfig,
-            StartCursor startCursor,
-            DeserializationSchema<T> deserialization,
+            Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap,
             int pollTimeout,
             long pollInterval,
             int batchSize) {
         this.context = context;
         this.clientConfig = clientConfig;
-        this.consumerConfig = consumerConfig;
-        this.startCursor = startCursor;
-        this.deserialization = deserialization;
+        this.consumerMetadataMap = consumerMetadataMap;
+        this.defaultTablePath =
+                consumerMetadataMap.size() == 1
+                        ? consumerMetadataMap.keySet().iterator().next()
+                        : null;
         this.pollTimeout = pollTimeout;
         this.pollInterval = pollInterval;
         this.batchSize = batchSize;
@@ -100,6 +101,7 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
         this.pendingCursorsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
         this.pendingCursorsToFinish = Collections.synchronizedSortedMap(new TreeMap<>());
         this.finishedSplits = new TreeSet<>();
+        this.splitIdToTablePath = new ConcurrentHashMap<>();
         this.handover = new Handover<>();
     }
 
@@ -130,11 +132,18 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
         for (int i = 0; i < batchSize; i++) {
             Optional<RecordWithSplitId> recordWithSplitId = handover.pollNext();
             if (recordWithSplitId.isPresent()) {
-                final String splitId = recordWithSplitId.get().getSplitId();
-                final Message<byte[]> message = recordWithSplitId.get().getMessage();
+                String splitId = recordWithSplitId.get().getSplitId();
+                Message<byte[]> message = recordWithSplitId.get().getMessage();
                 synchronized (output.getCheckpointLock()) {
                     splitStates.get(splitId).setLatestConsumedId(message.getMessageId());
-                    deserialization.deserialize(message.getData(), output);
+                    TablePath tablePath = resolveTablePath(splitId);
+                    DeserializationSchema<T> deserializationSchema =
+                            resolveDeserializationSchema(tablePath);
+                    Collector<T> collector =
+                            tablePath == null
+                                    ? output
+                                    : new TableIdInjectingCollector<>(output, tablePath);
+                    deserializationSchema.deserialize(message.getData(), collector);
                 }
             }
             if (noMoreSplitsAssignment && finishedSplits.size() == splitStates.size()) {
@@ -168,6 +177,10 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     public void addSplits(List<PulsarPartitionSplit> splits) {
         for (PulsarPartitionSplit split : splits) {
             splitStates.put(split.splitId(), split);
+            TablePath tablePath = resolveTablePath(split);
+            if (tablePath != null) {
+                splitIdToTablePath.put(split.splitId(), tablePath);
+            }
             PulsarSplitReaderThread splitReaderThread = createPulsarSplitReaderThread(split);
             try {
                 splitReaderThread.setName(
@@ -186,14 +199,15 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     }
 
     protected PulsarSplitReaderThread createPulsarSplitReaderThread(PulsarPartitionSplit split) {
+        PulsarConsumerMetadata metadata = resolveConsumerMetadata(resolveTablePath(split));
         return new PulsarSplitReaderThread(
                 this,
                 split,
                 pulsarClient,
-                consumerConfig,
+                metadata.getConsumerConfig(),
                 pollTimeout,
                 pollInterval,
-                startCursor,
+                metadata.getStartCursor(),
                 handover);
     }
 
@@ -252,5 +266,34 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
                     "pulsar consumer acknowledgeCumulative failed.",
                     e);
         }
+    }
+
+    private TablePath resolveTablePath(String splitId) {
+        TablePath tablePath = splitIdToTablePath.get(splitId);
+        return tablePath != null ? tablePath : defaultTablePath;
+    }
+
+    private TablePath resolveTablePath(PulsarPartitionSplit split) {
+        return split.getTablePath() != null ? split.getTablePath() : defaultTablePath;
+    }
+
+    private PulsarConsumerMetadata resolveConsumerMetadata(TablePath tablePath) {
+        PulsarConsumerMetadata metadata =
+                tablePath == null ? null : consumerMetadataMap.get(tablePath);
+        if (metadata == null && defaultTablePath != null) {
+            metadata = consumerMetadataMap.get(defaultTablePath);
+        }
+        if (metadata == null) {
+            throw new PulsarConnectorException(
+                    PulsarConnectorErrorCode.DESERIALIZATION_SCHEMA_NOT_FOUND,
+                    String.format("No consumer metadata found for table '%s'", tablePath));
+        }
+        return metadata;
+    }
+
+    @SuppressWarnings("unchecked")
+    private DeserializationSchema<T> resolveDeserializationSchema(TablePath tablePath) {
+        return (DeserializationSchema<T>)
+                resolveConsumerMetadata(tablePath).getDeserializationSchema();
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/TableIdInjectingCollector.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/TableIdInjectingCollector.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source.reader;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+public class TableIdInjectingCollector<T> implements Collector<T> {
+    private final Collector<T> delegate;
+    private final String tableId;
+
+    public TableIdInjectingCollector(Collector<T> delegate, TablePath tablePath) {
+        this.delegate = delegate;
+        this.tableId = tablePath.toString();
+    }
+
+    @Override
+    public void collect(T record) {
+        if (record instanceof SeaTunnelRow) {
+            ((SeaTunnelRow) record).setTableId(tableId);
+        }
+        delegate.collect(record);
+    }
+
+    @Override
+    public Object getCheckpointLock() {
+        return delegate.getCheckpointLock();
+    }
+
+    @Override
+    public void collect(SchemaChangeEvent event) {
+        delegate.collect(event);
+    }
+
+    @Override
+    public void markSchemaChangeBeforeCheckpoint() {
+        delegate.markSchemaChangeBeforeCheckpoint();
+    }
+
+    @Override
+    public void markSchemaChangeAfterCheckpoint() {
+        delegate.markSchemaChangeAfterCheckpoint();
+    }
+
+    @Override
+    public boolean isEmptyThisPollNext() {
+        return delegate.isEmptyThisPollNext();
+    }
+
+    @Override
+    public void resetEmptyThisPollNext() {
+        delegate.resetEmptyThisPollNext();
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/split/PulsarPartitionSplit.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/split/PulsarPartitionSplit.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source.split;
 
 import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
 
@@ -36,15 +37,26 @@ public class PulsarPartitionSplit implements SourceSplit {
 
     @Nullable private MessageId latestConsumedId;
 
+    @Nullable private final TablePath tablePath;
+
     public PulsarPartitionSplit(TopicPartition partition, StopCursor stopCursor) {
-        this(partition, stopCursor, null);
+        this(partition, stopCursor, null, null);
     }
 
     public PulsarPartitionSplit(
             TopicPartition partition, StopCursor stopCursor, MessageId latestConsumedId) {
+        this(partition, stopCursor, latestConsumedId, null);
+    }
+
+    public PulsarPartitionSplit(
+            TopicPartition partition,
+            StopCursor stopCursor,
+            MessageId latestConsumedId,
+            @Nullable TablePath tablePath) {
         this.partition = Preconditions.checkNotNull(partition);
         this.stopCursor = Preconditions.checkNotNull(stopCursor);
         this.latestConsumedId = latestConsumedId;
+        this.tablePath = tablePath;
     }
 
     public TopicPartition getPartition() {
@@ -85,7 +97,11 @@ public class PulsarPartitionSplit implements SourceSplit {
         this.latestConsumedId = latestConsumedId;
     }
 
+    @Nullable public TablePath getTablePath() {
+        return tablePath;
+    }
+
     public PulsarPartitionSplit copy() {
-        return new PulsarPartitionSplit(partition, stopCursor, latestConsumedId);
+        return new PulsarPartitionSplit(partition, stopCursor, latestConsumedId, tablePath);
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/state/PulsarAggregatedCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/state/PulsarAggregatedCommitInfo.java
@@ -27,5 +27,5 @@ import java.util.List;
 @AllArgsConstructor
 public class PulsarAggregatedCommitInfo implements Serializable {
     private static final long serialVersionUID = -1365922376470598498L;
-    List<PulsarCommitInfo> commitInfos;
+    private final List<PulsarCommitInfo> commitInfos;
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
+
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class PulsarMultiTableConfigTest {
+
+    @Test
+    void shouldParseTablesConfigsWithGlobalFallbacks() {
+        Map<String, Object> config = createBaseConfig();
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders", null),
+                        createTableConfig(
+                                "db.users",
+                                null,
+                                "persistent://public/default/users-.*",
+                                "CANAL_JSON")));
+
+        PulsarMultiTableConfig multiTableConfig =
+                PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertTrue(multiTableConfig.isMultiTable());
+        Assertions.assertEquals(2, multiTableConfig.getTableConfigs().size());
+        Assertions.assertEquals(
+                "seatunnel-sub", multiTableConfig.getTableConfigs().get(0).getSubscriptionName());
+        Assertions.assertEquals(
+                PulsarSourceOptions.StartMode.EARLIEST,
+                multiTableConfig.getTableConfigs().get(0).getStartMode());
+        Assertions.assertEquals(
+                "CANAL_JSON", multiTableConfig.getTableConfigs().get(1).getFormat());
+    }
+
+    @Test
+    void shouldRejectOverlappingTopicDeclarations() {
+        Map<String, Object> config = createBaseConfig();
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig(
+                                "db.orders",
+                                "persistent://public/default/a,persistent://public/default/b",
+                                null),
+                        createTableConfig("db.users", "persistent://public/default/b", null)));
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertEquals(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED, exception.getSeaTunnelErrorCode());
+    }
+
+    @Test
+    void shouldRejectSubscriptionStartModeWithoutResetMode() {
+        Map<String, Object> config = createBaseConfig();
+        config.put("cursor.startup.mode", "SUBSCRIPTION");
+        config.remove("cursor.reset.mode");
+        config.put(
+                "tables_configs",
+                Collections.singletonList(
+                        createTableConfig(
+                                "db.orders", "persistent://public/default/orders", null)));
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertEquals(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED, exception.getSeaTunnelErrorCode());
+    }
+
+    @Test
+    void shouldAllowPerTableSubscriptionNameWithoutGlobalSubscription() {
+        Map<String, Object> config = createBaseConfig();
+        config.remove("subscription.name");
+        Map<String, Object> orders =
+                createTableConfig("db.orders", "persistent://public/default/orders", null);
+        orders.put("subscription.name", "orders-sub");
+        config.put("tables_configs", Collections.singletonList(orders));
+
+        PulsarMultiTableConfig multiTableConfig =
+                PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertEquals(
+                "orders-sub", multiTableConfig.getTableConfigs().get(0).getSubscriptionName());
+    }
+
+    @Test
+    void shouldRejectSingleTableWithoutSubscriptionName() {
+        Map<String, Object> config = createBaseConfig();
+        config.remove("subscription.name");
+        config.put("topic", "persistent://public/default/orders");
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertEquals(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED, exception.getSeaTunnelErrorCode());
+    }
+
+    private Map<String, Object> createBaseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("subscription.name", "seatunnel-sub");
+        config.put("client.service-url", "pulsar://localhost:6650");
+        config.put("admin.service-url", "http://localhost:8080");
+        config.put("format", "JSON");
+        config.put("cursor.startup.mode", "EARLIEST");
+        config.put("cursor.stop.mode", "NEVER");
+        config.put("cursor.reset.mode", "EARLIEST");
+        return config;
+    }
+
+    private Map<String, Object> createTableConfig(
+            String tablePath, String topic, String topicPattern) {
+        return createTableConfig(tablePath, topic, topicPattern, null);
+    }
+
+    private Map<String, Object> createTableConfig(
+            String tablePath, String topic, String topicPattern, String format) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("table_path", tablePath);
+        if (topic != null) {
+            config.put("topic", topic);
+        }
+        if (topicPattern != null) {
+            config.put("topic-pattern", topicPattern);
+        }
+        if (format != null) {
+            config.put("format", format);
+        }
+        Map<String, Object> schema = new HashMap<>();
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "bigint");
+        schema.put("fields", fields);
+        config.put("schema", schema);
+        return config;
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
@@ -100,6 +100,47 @@ class PulsarMultiTableConfigTest {
     }
 
     @Test
+    void shouldAllowOverlappingTopicPatternsForDeterministicRuntimeRouting() {
+        Map<String, Object> config = createBaseConfig();
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig(
+                                "db.orders_general", null, "persistent://public/default/orders-.*"),
+                        createTableConfig(
+                                "db.orders_vip",
+                                null,
+                                "persistent://public/default/orders-vip-.*")));
+
+        PulsarMultiTableConfig multiTableConfig =
+                PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertEquals(2, multiTableConfig.getTableConfigs().size());
+    }
+
+    @Test
+    void shouldRejectDuplicateTopicPatterns() {
+        Map<String, Object> config = createBaseConfig();
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig(
+                                "db.orders_general", null, "persistent://public/default/orders-.*"),
+                        createTableConfig(
+                                "db.orders_duplicate",
+                                null,
+                                "persistent://public/default/orders-.*")));
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertEquals(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED, exception.getSeaTunnelErrorCode());
+    }
+
+    @Test
     void shouldAllowPerTableSubscriptionNameWithoutGlobalSubscription() {
         Map<String, Object> config = createBaseConfig();
         config.remove("subscription.name");

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarCanalDecoratorTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarCanalDecoratorTest.java
@@ -30,8 +30,6 @@ import org.apache.seatunnel.format.json.canal.CanalJsonDeserializationSchema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import lombok.Getter;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -66,7 +64,7 @@ public class PulsarCanalDecoratorTest {
 
         SimpleCollector simpleCollector = new SimpleCollector();
         pulsarCanalDecorator.deserialize(json.getBytes(StandardCharsets.UTF_8), simpleCollector);
-        Assertions.assertFalse(simpleCollector.getList().isEmpty());
+        Assertions.assertFalse(simpleCollector.list.isEmpty());
         for (SeaTunnelRow seaTunnelRow : simpleCollector.list) {
             for (Object field : seaTunnelRow.getFields()) {
                 Assertions.assertNotNull(field);
@@ -75,7 +73,7 @@ public class PulsarCanalDecoratorTest {
     }
 
     private static class SimpleCollector implements Collector<SeaTunnelRow> {
-        @Getter private List<SeaTunnelRow> list = new ArrayList<>();
+        private final List<SeaTunnelRow> list = new ArrayList<>();
 
         @Override
         public void collect(SeaTunnelRow record) {

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -105,6 +105,22 @@ class PulsarSourceTest {
     }
 
     @Test
+    void shouldKeepSingleTableTablesConfigsBatchCompatibilityForUnboundedSource() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders")));
+
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertDoesNotThrow(
+                () -> source.setJobContext(new JobContext().setJobMode(JobMode.BATCH)));
+    }
+
+    @Test
     void shouldRejectSingleTableWithoutSubscriptionNameInFactory() {
         Map<String, Object> config = createBaseConfig("NEVER");
         config.remove("subscription.name");

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.utils.SerializationUtils;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 
 import org.junit.jupiter.api.Assertions;
@@ -172,6 +173,21 @@ class PulsarSourceTest {
                         new PulsarSource(
                                 ReadonlyConfig.fromMap(config),
                                 CatalogTableUtil.buildSimpleTextTable()));
+    }
+
+    @Test
+    void shouldSerializeMultiTableSourceForSparkExecution() {
+        Map<String, Object> config = createBaseConfig("LATEST");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders"),
+                        createTableConfig("db.users", "persistent://public/default/users")));
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertDoesNotThrow(() -> SerializationUtils.serialize(source));
     }
 
     private Map<String, Object> createBaseConfig(String stopMode) {

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 
@@ -90,6 +91,73 @@ class PulsarSourceTest {
                 () -> source.setJobContext(new JobContext().setJobMode(JobMode.BATCH)));
     }
 
+    @Test
+    void shouldKeepSingleTableBatchCompatibilityForUnboundedSource() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put("topic", "persistent://public/default/orders");
+
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertDoesNotThrow(
+                () -> source.setJobContext(new JobContext().setJobMode(JobMode.BATCH)));
+    }
+
+    @Test
+    void shouldRejectSingleTableWithoutSubscriptionNameInFactory() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.remove("subscription.name");
+        config.put("topic", "persistent://public/default/orders");
+
+        PulsarSourceFactory factory = new PulsarSourceFactory();
+
+        Assertions.assertThrows(
+                PulsarConnectorException.class,
+                () ->
+                        factory.createSource(
+                                new TableSourceFactoryContext(
+                                        ReadonlyConfig.fromMap(config),
+                                        Thread.currentThread().getContextClassLoader())));
+    }
+
+    @Test
+    void shouldAllowPerTableSubscriptionNameInFactoryForTablesConfigs() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.remove("subscription.name");
+        Map<String, Object> tableConfig =
+                createTableConfig("db.orders", "persistent://public/default/orders");
+        tableConfig.put("subscription.name", "orders-sub");
+        config.put("tables_configs", Arrays.asList(tableConfig));
+
+        PulsarSourceFactory factory = new PulsarSourceFactory();
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        factory.createSource(
+                                        new TableSourceFactoryContext(
+                                                ReadonlyConfig.fromMap(config),
+                                                Thread.currentThread().getContextClassLoader()))
+                                .createSource());
+    }
+
+    @Test
+    void shouldNotTouchPulsarAdminDuringSourceConstructionForTopicPatternTables() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put("admin.service-url", "invalid-admin-url");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createPatternTableConfig(
+                                "db.orders_pattern", "persistent://public/default/orders.*")));
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        new PulsarSource(
+                                ReadonlyConfig.fromMap(config),
+                                CatalogTableUtil.buildSimpleTextTable()));
+    }
+
     private Map<String, Object> createBaseConfig(String stopMode) {
         Map<String, Object> config = new HashMap<>();
         config.put("subscription.name", "seatunnel-sub");
@@ -106,11 +174,13 @@ class PulsarSourceTest {
         Map<String, Object> config = new HashMap<>();
         config.put("table_path", tablePath);
         config.put("topic", topic);
-        Map<String, Object> schema = new HashMap<>();
-        Map<String, Object> fields = new HashMap<>();
-        fields.put("id", "bigint");
-        schema.put("fields", fields);
-        config.put("schema", schema);
+        return config;
+    }
+
+    private Map<String, Object> createPatternTableConfig(String tablePath, String topicPattern) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("table_path", tablePath);
+        config.put("topic-pattern", topicPattern);
         return config;
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+class PulsarSourceTest {
+
+    @Test
+    void shouldExposeProducedCatalogTablesForTablesConfigs() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders"),
+                        createTableConfig("db.users", "persistent://public/default/users")));
+
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertEquals(2, source.getProducedCatalogTables().size());
+        Assertions.assertEquals(
+                "db.orders",
+                source.getProducedCatalogTables().get(0).getTableId().toTablePath().toString());
+        Assertions.assertEquals(
+                "db.users",
+                source.getProducedCatalogTables().get(1).getTableId().toTablePath().toString());
+        Assertions.assertEquals(Boundedness.UNBOUNDED, source.getBoundedness());
+    }
+
+    @Test
+    void shouldUseBoundednessOfAllTables() {
+        Map<String, Object> config = createBaseConfig("LATEST");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders"),
+                        createTableConfig("db.users", "persistent://public/default/users")));
+
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertEquals(Boundedness.BOUNDED, source.getBoundedness());
+    }
+
+    @Test
+    void shouldRejectBatchModeForUnboundedMultiTableSource() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put(
+                "tables_configs",
+                Arrays.asList(
+                        createTableConfig("db.orders", "persistent://public/default/orders"),
+                        createTableConfig("db.users", "persistent://public/default/users")));
+
+        PulsarSource source =
+                new PulsarSource(
+                        ReadonlyConfig.fromMap(config), CatalogTableUtil.buildSimpleTextTable());
+
+        Assertions.assertThrows(
+                PulsarConnectorException.class,
+                () -> source.setJobContext(new JobContext().setJobMode(JobMode.BATCH)));
+    }
+
+    private Map<String, Object> createBaseConfig(String stopMode) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("subscription.name", "seatunnel-sub");
+        config.put("client.service-url", "pulsar://localhost:6650");
+        config.put("admin.service-url", "http://localhost:8080");
+        config.put("format", "JSON");
+        config.put("cursor.startup.mode", "EARLIEST");
+        config.put("cursor.stop.mode", stopMode);
+        config.put("cursor.reset.mode", "EARLIEST");
+        return config;
+    }
+
+    private Map<String, Object> createTableConfig(String tablePath, String topic) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("table_path", tablePath);
+        config.put("topic", topic);
+        Map<String, Object> schema = new HashMap<>();
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "bigint");
+        schema.put("fields", fields);
+        config.put("schema", schema);
+        return config;
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscovererTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscovererTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+class MultiTablePartitionDiscovererTest {
+
+    @Test
+    void shouldKeepFirstMatchingPatternWhenTopicMatchesMultipleTables() {
+        TopicPartition sharedTopic =
+                new TopicPartition("persistent://public/default/orders-vip", 0);
+        TopicPartition generalTopic =
+                new TopicPartition("persistent://public/default/orders-standard", 0);
+
+        MultiTablePartitionDiscoverer discoverer =
+                new MultiTablePartitionDiscoverer(
+                        Arrays.asList(
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.orders_general"),
+                                        new TestingDiscoverer(sharedTopic, generalTopic),
+                                        true),
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.orders_vip"),
+                                        new TestingDiscoverer(sharedTopic),
+                                        true)));
+
+        Set<TopicPartition> partitions = discoverer.getSubscribedTopicPartitions(null);
+
+        Assertions.assertEquals(2, partitions.size());
+        Assertions.assertEquals(
+                TablePath.of("db.orders_general"), discoverer.getTablePath(sharedTopic));
+        Assertions.assertEquals(
+                TablePath.of("db.orders_general"), discoverer.getTablePath(generalTopic));
+    }
+
+    @Test
+    void shouldAssignNonOverlappingTopicsToLaterPatterns() {
+        TopicPartition generalTopic =
+                new TopicPartition("persistent://public/default/orders-standard", 0);
+        TopicPartition vipTopic = new TopicPartition("persistent://public/default/orders-vip", 0);
+
+        MultiTablePartitionDiscoverer discoverer =
+                new MultiTablePartitionDiscoverer(
+                        Arrays.asList(
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.orders_general"),
+                                        new TestingDiscoverer(generalTopic),
+                                        true),
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.orders_vip"),
+                                        new TestingDiscoverer(vipTopic),
+                                        true)));
+
+        discoverer.getSubscribedTopicPartitions(null);
+
+        Assertions.assertEquals(
+                TablePath.of("db.orders_general"), discoverer.getTablePath(generalTopic));
+        Assertions.assertEquals(TablePath.of("db.orders_vip"), discoverer.getTablePath(vipTopic));
+    }
+
+    private static final class TestingDiscoverer implements PulsarDiscoverer {
+        private static final long serialVersionUID = 1L;
+
+        private final Set<TopicPartition> partitions;
+
+        private TestingDiscoverer(TopicPartition... partitions) {
+            this.partitions =
+                    Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(partitions)));
+        }
+
+        @Override
+        public Set<TopicPartition> getSubscribedTopicPartitions(PulsarAdmin pulsarAdmin) {
+            return partitions;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscovererTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/discoverer/MultiTablePartitionDiscovererTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer;
 
 import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.common.utils.SerializationUtils;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -83,6 +84,27 @@ class MultiTablePartitionDiscovererTest {
         Assertions.assertEquals(
                 TablePath.of("db.orders_general"), discoverer.getTablePath(generalTopic));
         Assertions.assertEquals(TablePath.of("db.orders_vip"), discoverer.getTablePath(vipTopic));
+    }
+
+    @Test
+    void shouldSerializeMultiTableDiscovererForSparkExecution() {
+        MultiTablePartitionDiscoverer discoverer =
+                new MultiTablePartitionDiscoverer(
+                        Arrays.asList(
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.orders"),
+                                        new TestingDiscoverer(
+                                                new TopicPartition(
+                                                        "persistent://public/default/orders", 0)),
+                                        false),
+                                new MultiTablePartitionDiscoverer.TableDiscovererPair(
+                                        TablePath.of("db.users"),
+                                        new TestingDiscoverer(
+                                                new TopicPartition(
+                                                        "persistent://public/default/users", 0)),
+                                        false)));
+
+        Assertions.assertDoesNotThrow(() -> SerializationUtils.serialize(discoverer));
     }
 
     private static final class TestingDiscoverer implements PulsarDiscoverer {

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -174,6 +175,59 @@ class PulsarSourceReaderRestoreTest {
 
         Assertions.assertEquals(1, collector.records.size());
         Assertions.assertEquals(tablePath.toString(), collector.records.get(0).getTableId());
+    }
+
+    @Test
+    void shouldDrainBufferedRecordsBeforeSignalingNoMoreElements() throws Exception {
+        TablePath ordersPath = TablePath.of("db.orders");
+        TablePath usersPath = TablePath.of("db.users");
+        Map<TablePath, PulsarConsumerMetadata> metadataMap = new LinkedHashMap<>();
+        metadataMap.put(ordersPath, createMetadata(ordersPath));
+        metadataMap.put(usersPath, createMetadata(usersPath));
+
+        TestingReaderContext context = new TestingReaderContext();
+        TestingPulsarSourceReader reader = new TestingPulsarSourceReader(context, metadataMap);
+        PulsarPartitionSplit ordersSplit =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        ordersPath);
+        PulsarPartitionSplit usersSplit =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/users", 0),
+                        StopCursor.never(),
+                        null,
+                        usersPath);
+        reader.addSplits(Arrays.asList(ordersSplit, usersSplit));
+        reader.handleNoMoreSplits();
+        reader.handover.produce(
+                new RecordWithSplitId(
+                        testingMessage(
+                                "order".getBytes(StandardCharsets.UTF_8), MessageId.earliest),
+                        ordersSplit.splitId()));
+        reader.handleNoMoreElements(ordersSplit.splitId(), MessageId.earliest);
+        reader.handover.produce(
+                new RecordWithSplitId(
+                        testingMessage("user".getBytes(StandardCharsets.UTF_8), MessageId.earliest),
+                        usersSplit.splitId()));
+        reader.handleNoMoreElements(usersSplit.splitId(), MessageId.earliest);
+
+        TestingCollector collector = new TestingCollector();
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(1, collector.records.size());
+        Assertions.assertEquals(0, context.noMoreElementSignals);
+
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(2, collector.records.size());
+        Assertions.assertEquals(1, context.noMoreElementSignals);
+        Assertions.assertEquals(
+                Arrays.asList(ordersPath.toString(), usersPath.toString()),
+                Arrays.asList(
+                        collector.records.get(0).getTableId(),
+                        collector.records.get(1).getTableId()));
     }
 
     private static PulsarConsumerMetadata createMetadata(TablePath tablePath) {
@@ -320,6 +374,8 @@ class PulsarSourceReaderRestoreTest {
 
     private static final class TestingReaderContext implements SourceReader.Context {
 
+        private int noMoreElementSignals;
+
         @Override
         public int getIndexOfSubtask() {
             return 0;
@@ -327,11 +383,13 @@ class PulsarSourceReaderRestoreTest {
 
         @Override
         public Boundedness getBoundedness() {
-            return Boundedness.UNBOUNDED;
+            return Boundedness.BOUNDED;
         }
 
         @Override
-        public void signalNoMoreElement() {}
+        public void signalNoMoreElement() {
+            noMoreElementSignals++;
+        }
 
         @Override
         public void sendSplitRequest() {}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
@@ -60,12 +60,16 @@ import java.util.Optional;
 class PulsarSourceReaderRestoreTest {
 
     @Test
-    void shouldFallbackToSingleTableMetadataForLegacySplit() throws Exception {
+    void shouldFallbackToSingleTableMetadataForLegacySplitWithoutOverridingRowTableId()
+            throws Exception {
         TablePath tablePath = TablePath.of("db.orders");
         TestingPulsarSourceReader reader =
                 new TestingPulsarSourceReader(
                         new TestingReaderContext(),
-                        Collections.singletonMap(tablePath, createMetadata(tablePath)));
+                        Collections.singletonMap(
+                                tablePath,
+                                createMetadata(
+                                        tablePath, new TableIdAwareDeserializationSchema())));
 
         PulsarPartitionSplit split =
                 new PulsarPartitionSplit(
@@ -85,7 +89,7 @@ class PulsarSourceReaderRestoreTest {
         reader.pollNext(collector);
 
         Assertions.assertEquals(1, collector.records.size());
-        Assertions.assertEquals(tablePath.toString(), collector.records.get(0).getTableId());
+        Assertions.assertEquals("deserializer.table", collector.records.get(0).getTableId());
     }
 
     @Test
@@ -110,11 +114,47 @@ class PulsarSourceReaderRestoreTest {
                 () -> reader.addSplits(Collections.singletonList(legacySplit)));
     }
 
+    @Test
+    void shouldInjectTableIdForMultiTableRouting() throws Exception {
+        TablePath ordersPath = TablePath.of("db.orders");
+        TablePath usersPath = TablePath.of("db.users");
+        Map<TablePath, PulsarConsumerMetadata> metadataMap = new LinkedHashMap<>();
+        metadataMap.put(ordersPath, createMetadata(ordersPath));
+        metadataMap.put(usersPath, createMetadata(usersPath));
+
+        TestingPulsarSourceReader reader =
+                new TestingPulsarSourceReader(new TestingReaderContext(), metadataMap);
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        ordersPath);
+        reader.addSplits(Collections.singletonList(split));
+
+        reader.handover.produce(
+                new RecordWithSplitId(
+                        testingMessage(
+                                "value".getBytes(StandardCharsets.UTF_8), MessageId.earliest),
+                        split.splitId()));
+
+        TestingCollector collector = new TestingCollector();
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(1, collector.records.size());
+        Assertions.assertEquals(ordersPath.toString(), collector.records.get(0).getTableId());
+    }
+
     private static PulsarConsumerMetadata createMetadata(TablePath tablePath) {
+        return createMetadata(tablePath, new TestingDeserializationSchema());
+    }
+
+    private static PulsarConsumerMetadata createMetadata(
+            TablePath tablePath, DeserializationSchema<SeaTunnelRow> deserializationSchema) {
         return new PulsarConsumerMetadata(
                 tablePath,
                 CatalogTableUtil.buildSimpleTextTable(),
-                new TestingDeserializationSchema(),
+                deserializationSchema,
                 new TopicListDiscoverer(Collections.singletonList(tablePath.toString())),
                 StartCursor.earliest(),
                 StopCursor.never(),
@@ -286,7 +326,7 @@ class PulsarSourceReaderRestoreTest {
         }
     }
 
-    private static final class TestingDeserializationSchema
+    private static class TestingDeserializationSchema
             implements DeserializationSchema<SeaTunnelRow> {
 
         private static final SeaTunnelRowType ROW_TYPE =
@@ -301,6 +341,17 @@ class PulsarSourceReaderRestoreTest {
         @Override
         public SeaTunnelDataType<SeaTunnelRow> getProducedType() {
             return ROW_TYPE;
+        }
+    }
+
+    private static final class TableIdAwareDeserializationSchema
+            extends TestingDeserializationSchema {
+
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) {
+            SeaTunnelRow row = super.deserialize(message);
+            row.setTableId("deserializer.table");
+            return row;
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.source.reader;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarClientConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConsumerConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.PulsarConsumerMetadata;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.start.StartCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.cursor.stop.StopCursor;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.discoverer.TopicListDiscoverer;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class PulsarSourceReaderRestoreTest {
+
+    @Test
+    void shouldFallbackToSingleTableMetadataForLegacySplit() throws Exception {
+        TablePath tablePath = TablePath.of("db.orders");
+        TestingPulsarSourceReader reader =
+                new TestingPulsarSourceReader(
+                        new TestingReaderContext(),
+                        Collections.singletonMap(tablePath, createMetadata(tablePath)));
+
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        null);
+        reader.addSplits(Collections.singletonList(split));
+
+        reader.handover.produce(
+                new RecordWithSplitId(
+                        testingMessage(
+                                "value".getBytes(StandardCharsets.UTF_8), MessageId.earliest),
+                        split.splitId()));
+
+        TestingCollector collector = new TestingCollector();
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(1, collector.records.size());
+        Assertions.assertEquals(tablePath.toString(), collector.records.get(0).getTableId());
+    }
+
+    @Test
+    void shouldRejectLegacySplitRestoreForMultiTableReader() {
+        TablePath ordersPath = TablePath.of("db.orders");
+        TablePath usersPath = TablePath.of("db.users");
+        Map<TablePath, PulsarConsumerMetadata> metadataMap = new LinkedHashMap<>();
+        metadataMap.put(ordersPath, createMetadata(ordersPath));
+        metadataMap.put(usersPath, createMetadata(usersPath));
+
+        TestingPulsarSourceReader reader =
+                new TestingPulsarSourceReader(new TestingReaderContext(), metadataMap);
+        PulsarPartitionSplit legacySplit =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        null);
+
+        Assertions.assertThrows(
+                PulsarConnectorException.class,
+                () -> reader.addSplits(Collections.singletonList(legacySplit)));
+    }
+
+    private static PulsarConsumerMetadata createMetadata(TablePath tablePath) {
+        return new PulsarConsumerMetadata(
+                tablePath,
+                CatalogTableUtil.buildSimpleTextTable(),
+                new TestingDeserializationSchema(),
+                new TopicListDiscoverer(Collections.singletonList(tablePath.toString())),
+                StartCursor.earliest(),
+                StopCursor.never(),
+                PulsarConsumerConfig.builder().subscriptionName("seatunnel-sub").build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Message<byte[]> testingMessage(byte[] value, MessageId messageId) {
+        return (Message<byte[]>)
+                Proxy.newProxyInstance(
+                        Message.class.getClassLoader(),
+                        new Class<?>[] {Message.class},
+                        (proxy, method, args) -> {
+                            switch (method.getName()) {
+                                case "getData":
+                                case "getValue":
+                                    return value;
+                                case "getMessageId":
+                                    return messageId;
+                                case "size":
+                                    return value.length;
+                                case "hasKey":
+                                case "hasOrderingKey":
+                                case "hasBase64EncodedKey":
+                                case "isReplicated":
+                                case "hasBrokerPublishTime":
+                                case "hasIndex":
+                                    return false;
+                                case "getProperties":
+                                    return Collections.emptyMap();
+                                case "getProperty":
+                                case "getTopicName":
+                                case "getProducerName":
+                                case "getReplicatedFrom":
+                                case "getKey":
+                                case "getSchemaInternal":
+                                case "getEncryptionCtx":
+                                    return null;
+                                case "getPublishTime":
+                                case "getEventTime":
+                                case "getSequenceId":
+                                    return 0L;
+                                case "getRedeliveryCount":
+                                    return 0;
+                                case "getSchemaVersion":
+                                case "getKeyBytes":
+                                case "getOrderingKey":
+                                    return new byte[0];
+                                case "getReaderSchema":
+                                case "getBrokerPublishTime":
+                                case "getIndex":
+                                    return Optional.empty();
+                                case "equals":
+                                    return proxy == args[0];
+                                case "hashCode":
+                                    return System.identityHashCode(proxy);
+                                case "toString":
+                                    return "TestingMessage";
+                                default:
+                                    throw new UnsupportedOperationException(
+                                            "Unsupported method: " + method.getName());
+                            }
+                        });
+    }
+
+    private static final class TestingPulsarSourceReader extends PulsarSourceReader<SeaTunnelRow> {
+
+        private TestingPulsarSourceReader(
+                SourceReader.Context context, Map<TablePath, PulsarConsumerMetadata> metadataMap) {
+            super(
+                    context,
+                    PulsarClientConfig.builder().serviceUrl("pulsar://localhost:6650").build(),
+                    metadataMap,
+                    100,
+                    50L,
+                    1);
+        }
+
+        @Override
+        protected PulsarSplitReaderThread createPulsarSplitReaderThread(
+                PulsarPartitionSplit split) {
+            TablePath tablePath =
+                    split.getTablePath() != null ? split.getTablePath() : defaultTablePath;
+            PulsarConsumerMetadata metadata =
+                    tablePath == null ? null : consumerMetadataMap.get(tablePath);
+            if (metadata == null && defaultTablePath != null) {
+                metadata = consumerMetadataMap.get(defaultTablePath);
+            }
+            if (metadata == null) {
+                throw new PulsarConnectorException(
+                        PulsarConnectorErrorCode.DESERIALIZATION_SCHEMA_NOT_FOUND,
+                        String.format("No consumer metadata found for table '%s'", tablePath));
+            }
+            return new NoopSplitReaderThread(this, split, handover);
+        }
+    }
+
+    private static final class NoopSplitReaderThread extends PulsarSplitReaderThread {
+
+        private NoopSplitReaderThread(
+                PulsarSourceReader sourceReader,
+                PulsarPartitionSplit split,
+                org.apache.seatunnel.common.Handover<RecordWithSplitId> handover) {
+            super(
+                    sourceReader,
+                    split,
+                    null,
+                    PulsarConsumerConfig.builder().subscriptionName("seatunnel-sub").build(),
+                    100,
+                    50L,
+                    StartCursor.earliest(),
+                    handover);
+        }
+
+        @Override
+        public void open() {}
+
+        @Override
+        public synchronized void start() {}
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    private static final class TestingReaderContext implements SourceReader.Context {
+
+        @Override
+        public int getIndexOfSubtask() {
+            return 0;
+        }
+
+        @Override
+        public Boundedness getBoundedness() {
+            return Boundedness.UNBOUNDED;
+        }
+
+        @Override
+        public void signalNoMoreElement() {}
+
+        @Override
+        public void sendSplitRequest() {}
+
+        @Override
+        public void sendSourceEventToEnumerator(SourceEvent sourceEvent) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+
+    private static final class TestingCollector implements Collector<SeaTunnelRow> {
+        private final Object checkpointLock = new Object();
+        private final List<SeaTunnelRow> records = new ArrayList<>();
+
+        @Override
+        public void collect(SeaTunnelRow record) {
+            records.add(record);
+        }
+
+        @Override
+        public Object getCheckpointLock() {
+            return checkpointLock;
+        }
+    }
+
+    private static final class TestingDeserializationSchema
+            implements DeserializationSchema<SeaTunnelRow> {
+
+        private static final SeaTunnelRowType ROW_TYPE =
+                new SeaTunnelRowType(
+                        new String[] {"content"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) {
+            return new SeaTunnelRow(new Object[] {new String(message, StandardCharsets.UTF_8)});
+        }
+
+        @Override
+        public SeaTunnelDataType<SeaTunnelRow> getProducedType() {
+            return ROW_TYPE;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
@@ -145,6 +145,37 @@ class PulsarSourceReaderRestoreTest {
         Assertions.assertEquals(ordersPath.toString(), collector.records.get(0).getTableId());
     }
 
+    @Test
+    void shouldInjectConfiguredTableIdForSingleTableTablesConfigs() throws Exception {
+        TablePath tablePath = TablePath.of("db.orders");
+        TestingPulsarSourceReader reader =
+                new TestingPulsarSourceReader(
+                        new TestingReaderContext(),
+                        Collections.singletonMap(
+                                tablePath,
+                                createMetadata(tablePath, new TableIdAwareDeserializationSchema())),
+                        true);
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        tablePath);
+        reader.addSplits(Collections.singletonList(split));
+
+        reader.handover.produce(
+                new RecordWithSplitId(
+                        testingMessage(
+                                "value".getBytes(StandardCharsets.UTF_8), MessageId.earliest),
+                        split.splitId()));
+
+        TestingCollector collector = new TestingCollector();
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(1, collector.records.size());
+        Assertions.assertEquals(tablePath.toString(), collector.records.get(0).getTableId());
+    }
+
     private static PulsarConsumerMetadata createMetadata(TablePath tablePath) {
         return createMetadata(tablePath, new TestingDeserializationSchema());
     }
@@ -224,10 +255,18 @@ class PulsarSourceReaderRestoreTest {
 
         private TestingPulsarSourceReader(
                 SourceReader.Context context, Map<TablePath, PulsarConsumerMetadata> metadataMap) {
+            this(context, metadataMap, metadataMap.size() > 1);
+        }
+
+        private TestingPulsarSourceReader(
+                SourceReader.Context context,
+                Map<TablePath, PulsarConsumerMetadata> metadataMap,
+                boolean injectTableId) {
             super(
                     context,
                     PulsarClientConfig.builder().serviceUrl("pulsar://localhost:6650").build(),
                     metadataMap,
+                    injectTableId,
                     100,
                     50L,
                     1);

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarMultiTableIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarMultiTableIT.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.pulsar;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+@Slf4j
+public class PulsarMultiTableIT extends TestSuiteBase implements TestResource {
+
+    private static final String PULSAR_IMAGE_NAME = "apachepulsar/pulsar:2.3.1";
+    public static final String PULSAR_HOST = "pulsar.multitable.e2e";
+    private static final String TOPIC_ORDERS = "persistent://public/default/topic-orders";
+    private static final String TOPIC_USERS = "persistent://public/default/topic-users-json";
+
+    private PulsarContainer pulsarContainer;
+    private PulsarClient client;
+
+    @Override
+    @BeforeAll
+    public void startUp() throws Exception {
+        pulsarContainer =
+                new PulsarContainer(DockerImageName.parse(PULSAR_IMAGE_NAME))
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(PULSAR_HOST)
+                        .withStartupTimeout(Duration.ofMinutes(3))
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(PULSAR_IMAGE_NAME)));
+        Startables.deepStart(Stream.of(pulsarContainer)).join();
+        Awaitility.given()
+                .ignoreExceptions()
+                .atLeast(100, TimeUnit.MILLISECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(180, TimeUnit.SECONDS)
+                .untilAsserted(this::produceTestData);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        pulsarContainer.close();
+    }
+
+    private void produceTestData() throws PulsarClientException {
+        client = PulsarClient.builder().serviceUrl(pulsarContainer.getPulsarBrokerUrl()).build();
+        try (Producer<byte[]> ordersProducer =
+                        client.newProducer(Schema.BYTES).topic(TOPIC_ORDERS).create();
+                Producer<byte[]> usersProducer =
+                        client.newProducer(Schema.BYTES).topic(TOPIC_USERS).create()) {
+            ordersProducer.send(
+                    "{\"order_id\":1,\"amount\":99.9}".getBytes(StandardCharsets.UTF_8));
+            usersProducer.send(
+                    "{\"user_id\":2,\"name\":\"bob\"}".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @TestTemplate
+    void testMultiTableBatch(TestContainer container) throws IOException, InterruptedException {
+        Container.ExecResult result =
+                container.executeJob("/multi_table_pulsar_to_assert.conf");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarMultiTableIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarMultiTableIT.java
@@ -92,15 +92,13 @@ public class PulsarMultiTableIT extends TestSuiteBase implements TestResource {
                         client.newProducer(Schema.BYTES).topic(TOPIC_USERS).create()) {
             ordersProducer.send(
                     "{\"order_id\":1,\"amount\":99.9}".getBytes(StandardCharsets.UTF_8));
-            usersProducer.send(
-                    "{\"user_id\":2,\"name\":\"bob\"}".getBytes(StandardCharsets.UTF_8));
+            usersProducer.send("{\"user_id\":2,\"name\":\"bob\"}".getBytes(StandardCharsets.UTF_8));
         }
     }
 
     @TestTemplate
     void testMultiTableBatch(TestContainer container) throws IOException, InterruptedException {
-        Container.ExecResult result =
-                container.executeJob("/multi_table_pulsar_to_assert.conf");
+        Container.ExecResult result = container.executeJob("/multi_table_pulsar_to_assert.conf");
         Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/multi_table_pulsar_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/multi_table_pulsar_to_assert.conf
@@ -1,0 +1,131 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Pulsar {
+    client.service-url = "pulsar://pulsar.multitable.e2e:6650"
+    admin.service-url = "http://pulsar.multitable.e2e:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = json
+    tables_configs = [
+      {
+        table_path = "db.orders"
+        topic = "persistent://public/default/topic-orders"
+        subscription.name = "sub-orders"
+        schema = {
+          fields {
+            order_id = int
+            amount = double
+          }
+        }
+      },
+      {
+        table_path = "db.users"
+        topic-pattern = "persistent://public/default/topic-users-.*"
+        subscription.name = "sub-users"
+        schema = {
+          fields {
+            user_id = int
+            name = string
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Assert {
+    rules = {
+      table-names = ["db.orders", "db.users"]
+      tables_configs = [
+        {
+          table_path = "db.orders"
+          row_rules = [
+            {
+              rule_type = MAX_ROW
+              rule_value = 1
+            },
+            {
+              rule_type = MIN_ROW
+              rule_value = 1
+            }
+          ]
+          field_rules = [
+            {
+              field_name = order_id
+              field_type = int
+              field_value = [
+                {
+                  equals_to = 1
+                }
+              ]
+            },
+            {
+              field_name = amount
+              field_type = double
+              field_value = [
+                {
+                  equals_to = 99.9
+                }
+              ]
+            }
+          ]
+        },
+        {
+          table_path = "db.users"
+          row_rules = [
+            {
+              rule_type = MAX_ROW
+              rule_value = 1
+            },
+            {
+              rule_type = MIN_ROW
+              rule_value = 1
+            }
+          ]
+          field_rules = [
+            {
+              field_name = user_id
+              field_type = int
+              field_value = [
+                {
+                  equals_to = 2
+                }
+              ]
+            },
+            {
+              field_name = name
+              field_type = string
+              field_value = [
+                {
+                  equals_to = "bob"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request

This PR completes Pulsar source support for [#10425](https://github.com/apache/seatunnel/issues/10425) and fixes related compatibility issues.

Main updates:
1. Support multi-table source config (`tables_configs`) with unified single-table/multi-table runtime path.
2. Make overlapping `topic-pattern` routing deterministic by `tables_configs` order (first match wins).
3. Preserve single-table compatibility and fix Canal pipeline regression (avoid unintended `tableId` override in single-table reader path).
4. Refactor `PulsarSource` config/build logic for better maintainability.
5. Update Pulsar source docs in both EN/ZH.

### Does this PR introduce _any_ user-facing change?

Yes.

- New capability: Pulsar source supports multi-table configuration (`tables_configs`).
- Behavior clarification: overlapping `topic-pattern` in multi-table mode is resolved deterministically by declaration order.
- Compatibility fix: single-table Canal -> Pulsar -> JDBC path is restored (no silent data loss caused by `tableId` override).
- Docs updated:
  - `docs/en/connectors/source/Pulsar.md`
  - `docs/zh/connectors/source/Pulsar.md`

### How was this patch tested?

- `./mvnw -pl seatunnel-connectors-v2/connector-pulsar -am spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-pulsar -am -DskipTests verify`

Added/updated tests:
- `PulsarSourceTest`
- `PulsarMultiTableConfigTest`
- `MultiTablePartitionDiscovererTest`
- `PulsarSourceReaderRestoreTest`

Note: local surefire test runtime may hit existing shaded classpath `NoClassDefFoundError` issues unrelated to this patch.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md) (N/A)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR. (N/A)
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) (N/A)
  2. Update [seatunnel-dist/pom.xml](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml) (N/A)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml) (N/A)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/) (covered by existing Pulsar E2E)
  5. Update [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config) (N/A)
