### PR TITLE
[Fix][Zeta] Prevent NPE by lazy initializing overviewMap

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/monitor/CheckpointMonitorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/monitor/CheckpointMonitorService.java
@@ -47,13 +47,27 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CheckpointMonitorService {
 
-    private final IMap<Long, CheckpointOverview> overviewMap;
+    private final NodeEngine nodeEngine;
+    private volatile IMap<Long, CheckpointOverview> overviewMap;
     private final int maxHistorySize;
 
     public CheckpointMonitorService(NodeEngine nodeEngine, int maxHistorySize) {
-        this.overviewMap =
-                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_CHECKPOINT_MONITOR);
+        this.nodeEngine = nodeEngine;
         this.maxHistorySize = maxHistorySize;
+    }
+
+    private IMap<Long, CheckpointOverview> getOverviewMap() {
+        if (overviewMap == null) {
+            synchronized (this) {
+                if (overviewMap == null) {
+                    overviewMap =
+                            nodeEngine
+                                    .getHazelcastInstance()
+                                    .getMap(Constant.IMAP_CHECKPOINT_MONITOR);
+                }
+            }
+        }
+        return overviewMap;
     }
 
     public void onCheckpointTriggered(
@@ -177,17 +191,17 @@ public class CheckpointMonitorService {
     }
 
     public void cleanupJob(long jobId) {
-        overviewMap.remove(jobId);
+        getOverviewMap().remove(jobId);
     }
 
     public Optional<CheckpointOverview> getOverview(long jobId) {
-        CheckpointOverview overview = overviewMap.get(jobId);
+        CheckpointOverview overview = getOverviewMap().get(jobId);
         return Optional.ofNullable(overview);
     }
 
     public List<CheckpointHistoryEntry> getHistory(
             long jobId, Integer pipelineId, int limit, CheckpointStatus status) {
-        CheckpointOverview overview = overviewMap.get(jobId);
+        CheckpointOverview overview = getOverviewMap().get(jobId);
         if (overview == null) {
             return Collections.emptyList();
         }
@@ -224,16 +238,18 @@ public class CheckpointMonitorService {
 
     private void updateOverview(
             long jobId, int pipelineId, Consumer<PipelineCheckpointOverview> consumer) {
-        overviewMap.compute(
-                jobId,
-                (id, overview) -> {
-                    CheckpointOverview snapshot =
-                            overview == null ? new CheckpointOverview(jobId) : overview;
-                    PipelineCheckpointOverview pipeline = snapshot.getOrCreatePipeline(pipelineId);
-                    consumer.accept(pipeline);
-                    snapshot.setUpdatedAt(System.currentTimeMillis());
-                    return snapshot;
-                });
+        getOverviewMap()
+                .compute(
+                        jobId,
+                        (id, overview) -> {
+                            CheckpointOverview snapshot =
+                                    overview == null ? new CheckpointOverview(jobId) : overview;
+                            PipelineCheckpointOverview pipeline =
+                                    snapshot.getOrCreatePipeline(pipelineId);
+                            consumer.accept(pipeline);
+                            snapshot.setUpdatedAt(System.currentTimeMillis());
+                            return snapshot;
+                        });
     }
 
     private void removeInProgressIfExists(PipelineCheckpointOverview pipeline, long checkpointId) {


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/10570

### Purpose of this pull request

Prevent potential NPE caused by early initialization of `overviewMap`.

`overviewMap` was previously initialized in the constructor, which may be invoked before `PartitionService` is fully ready. This change lazily initializes the map to ensure it is accessed only when needed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)