### PR TITLE
[Fix][Docs] Fix broken markdown links in zh connector sink docs

### DIFF
--- a/docs/zh/connectors/sink/Mysql.md
+++ b/docs/zh/connectors/sink/Mysql.md
@@ -101,7 +101,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 简单的例子
 
->此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在mysql中创建数据库测试表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel]（../../start-v2/local/deployment.md）中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎]（../../Start-v2/locale/Quick-Start SeaTunnel Engine.md）中的说明运行此作业。
+>此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在mysql中创建数据库测试表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel](../../getting-started/locally/deployment.md)中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎](../../getting-started/locally/quick-start-seatunnel-engine.md)中的说明运行此作业。
 
 ```
 # 定义运行时环境

--- a/docs/zh/connectors/sink/OceanBase.md
+++ b/docs/zh/connectors/sink/OceanBase.md
@@ -99,7 +99,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 简单示例
 
-> 此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在mysql中创建数据库测试和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel]（../../start-v2/local/deployment.md）中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎]（../../Start-v2/locale/Quick-Start-SeaTunnel-Engine.md）中的说明运行此作业。
+> 此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在mysql中创建数据库测试和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel](../../getting-started/locally/deployment.md)中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎](../../getting-started/locally/quick-start-seatunnel-engine.md)中的说明运行此作业。
 
 ```
 # 定义运行环境

--- a/docs/zh/connectors/sink/Oracle.md
+++ b/docs/zh/connectors/sink/Oracle.md
@@ -99,7 +99,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 简单的例子
 
->此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在Oracle中创建测试数据库和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel]（../../start-v2/local/deployment.md）中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎]（../../Start-v2/locale/Quick-Start-SeaTunnel-Engine.md）中的说明运行此作业。
+>此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在Oracle中创建测试数据库和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装SeaTunnel](../../getting-started/locally/deployment.md)中的说明安装和部署SeaTunnel。然后按照[快速启动SeaTunnel引擎](../../getting-started/locally/quick-start-seatunnel-engine.md)中的说明运行此作业。
 
 ```
 # 定义运行环境


### PR DESCRIPTION
### Purpose of this pull request

Fix broken markdown links in Chinese documentation for Oracle, Mysql, and OceanBase sink connectors.

The links were broken due to:
1. Using Chinese parentheses `（）` instead of English parentheses `()`, causing markdown link syntax to fail
2. Incorrect paths (`start-v2/local` and `Start-v2/locale`) instead of the correct `getting-started/locally`
3. Wrong filename casing (`Quick-Start-SeaTunnel-Engine.md`) instead of `quick-start-seatunnel-engine.md`

### Does this PR introduce _any_ user-facing change?

Yes. The documentation links for "Install SeaTunnel" and "Quick Start SeaTunnel Engine" in the Chinese sink docs for Oracle, Mysql, and OceanBase now work correctly.

### How was this patch tested?

Verified that the corrected paths match the actual file locations in the repository and are consistent with the English documentation.

### Check list

* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs