### PR TITLE
[Bug][Connect-V2][Jdbc][Sqlserver] Fix JDBC sink null binding for SQLServer binary-like columns (e.g. IMAGE)

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
@@ -210,14 +210,16 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                 SeaTunnelDataType<?> seaTunnelDataType = rowType.getFieldType(fieldIndex);
                 String fieldName = rowType.getFieldName(fieldIndex);
                 int statementIndex = fieldIndex + 1;
-                Object fieldValue = row.getField(fieldIndex);
-                if (fieldValue == null) {
-                    statement.setObject(statementIndex, null);
-                    continue;
-                }
                 String sourceType = null;
                 if (databaseTableSchema != null && databaseTableSchema.contains(fieldName)) {
                     sourceType = databaseTableSchema.getColumn(fieldName).getSourceType();
+                }
+                Object fieldValue = row.getField(fieldIndex);
+                if (fieldValue == null) {
+                    setNullToStatementByDataType(
+                            statement, seaTunnelDataType, statementIndex, sourceType);
+                    statement.setObject(statementIndex, null);
+                    continue;
                 }
                 setValueToStatementByDataType(
                         row.getField(fieldIndex),
@@ -233,6 +235,15 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
             }
         }
         return statement;
+    }
+
+    protected void setNullToStatementByDataType(
+            PreparedStatement statement,
+            SeaTunnelDataType<?> seaTunnelDataType,
+            int statementIndex,
+            @Nullable String sourceType)
+            throws SQLException {
+        statement.setObject(statementIndex, null);
     }
 
     protected void setValueToStatementByDataType(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/converter/AbstractJdbcRowConverter.java
@@ -218,7 +218,6 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                 if (fieldValue == null) {
                     setNullToStatementByDataType(
                             statement, seaTunnelDataType, statementIndex, sourceType);
-                    statement.setObject(statementIndex, null);
                     continue;
                 }
                 setValueToStatementByDataType(
@@ -236,7 +235,24 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
         }
         return statement;
     }
-
+    /**
+     * Bind a null value to the PreparedStatement parameter.
+     *
+     * <p>Default implementation uses {@link PreparedStatement#setObject(int, Object)}, which works
+     * for most databases. However, some databases (e.g., SQL Server) require explicit type
+     * information for null values in certain column types (e.g., IMAGE, BLOB).
+     *
+     * <p>Subclasses can override this method to provide database-specific null handling. For
+     * example, SQL Server uses {@link PreparedStatement#setNull(int, int)} with the appropriate
+     * JDBC type (e.g., {@link java.sql.Types#LONGVARBINARY} for IMAGE columns).
+     *
+     * @param statement the PreparedStatement to bind the parameter to
+     * @param seaTunnelDataType the SeaTunnel data type of the field
+     * @param statementIndex the 1-based parameter index in the PreparedStatement
+     * @param sourceType the source database column type (if available), used to determine the
+     *     appropriate JDBC type for null values
+     * @throws SQLException if a database access error occurs
+     */
     protected void setNullToStatementByDataType(
             PreparedStatement statement,
             SeaTunnelDataType<?> seaTunnelDataType,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverter.java
@@ -18,27 +18,23 @@
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.sqlserver;
 
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
-import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.api.table.type.SqlType;
-import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.AbstractJdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.JdbcFieldTypeUtils;
 
+import lombok.extern.slf4j.Slf4j;
+
 import javax.annotation.Nullable;
 
-import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Optional;
 
+@Slf4j
 public class SqlserverJdbcRowConverter extends AbstractJdbcRowConverter {
 
     @Override
@@ -53,7 +49,20 @@ public class SqlserverJdbcRowConverter extends AbstractJdbcRowConverter {
                 .map(e -> e.toLocalDateTime().toLocalTime())
                 .orElse(null);
     }
-
+    /**
+     * {@inheritDoc}
+     *
+     * <p>SQL Server requires explicit type information for null values in binary columns (IMAGE,
+     * VARBINARY, BINARY). Using {@code setObject(index, null)} causes the driver to infer the type
+     * as NVARCHAR, which leads to conversion errors:
+     *
+     * <pre>
+     * Implicit conversion from data type nvarchar to image is not allowed
+     * </pre>
+     *
+     * <p>This method uses {@code setNull(index, sqlType)} with the appropriate JDBC type based on
+     * the source column type.
+     */
     @Override
     protected void setNullToStatementByDataType(
             PreparedStatement statement,
@@ -70,8 +79,27 @@ public class SqlserverJdbcRowConverter extends AbstractJdbcRowConverter {
         statement.setObject(statementIndex, null);
     }
 
+    /**
+     * Resolves the appropriate JDBC type for SQL Server binary columns when the value is null.
+     *
+     * <p>SQL Server has multiple binary types, each mapping to a different JDBC type:
+     *
+     * <ul>
+     *   <li>IMAGE → LONGVARBINARY (legacy large binary type)
+     *   <li>VARBINARY(*) → VARBINARY
+     *   <li>VARBINARY(MAX) → VARBINARY
+     *   <li>BINARY(*) → BINARY (fixed-length)
+     *   <li>other → VARBINARY
+     * </ul>
+     *
+     * @param sourceType the SQL Server column type (e.g., "IMAGE", "VARBINARY", "BINARY")
+     * @return the JDBC type constant from {@link java.sql.Types}
+     */
     private int resolveSqlServerBytesNullType(@Nullable String sourceType) {
         if (sourceType == null) {
+            log.warn(
+                    "Cannot determine source type for BYTES field, defaulting to VARBINARY. "
+                            + "If this causes errors, please provide databaseTableSchema.");
             return java.sql.Types.VARBINARY;
         }
 
@@ -85,81 +113,11 @@ public class SqlserverJdbcRowConverter extends AbstractJdbcRowConverter {
             return java.sql.Types.BINARY;
         }
 
+        // Unknown type, log warning and use conservative LONGVARBINARY
+        log.warn(
+                "Unknown SQLServer binary type: {}, defaulting to LONGVARBINARY. "
+                        + "This may cause issues if the target column is not a large binary type.",
+                sourceType);
         return java.sql.Types.VARBINARY;
-    }
-
-    public PreparedStatement toExternal(
-            SeaTunnelRowType rowType, SeaTunnelRow row, PreparedStatement statement)
-            throws SQLException {
-        for (int fieldIndex = 0; fieldIndex < rowType.getTotalFields(); fieldIndex++) {
-            SeaTunnelDataType<?> seaTunnelDataType = rowType.getFieldType(fieldIndex);
-            int statementIndex = fieldIndex + 1;
-            Object fieldValue = row.getField(fieldIndex);
-            if (fieldValue == null && seaTunnelDataType.getSqlType() != SqlType.BYTES) {
-                statement.setObject(statementIndex, null);
-                continue;
-            }
-
-            switch (seaTunnelDataType.getSqlType()) {
-                case STRING:
-                    statement.setString(statementIndex, (String) row.getField(fieldIndex));
-                    break;
-                case BOOLEAN:
-                    statement.setBoolean(statementIndex, (Boolean) row.getField(fieldIndex));
-                    break;
-                case TINYINT:
-                    statement.setByte(statementIndex, (Byte) row.getField(fieldIndex));
-                    break;
-                case SMALLINT:
-                    statement.setShort(statementIndex, (Short) row.getField(fieldIndex));
-                    break;
-                case INT:
-                    statement.setInt(statementIndex, (Integer) row.getField(fieldIndex));
-                    break;
-                case BIGINT:
-                    statement.setLong(statementIndex, (Long) row.getField(fieldIndex));
-                    break;
-                case FLOAT:
-                    statement.setFloat(statementIndex, (Float) row.getField(fieldIndex));
-                    break;
-                case DOUBLE:
-                    statement.setDouble(statementIndex, (Double) row.getField(fieldIndex));
-                    break;
-                case DECIMAL:
-                    statement.setBigDecimal(statementIndex, (BigDecimal) row.getField(fieldIndex));
-                    break;
-                case DATE:
-                    LocalDate localDate = (LocalDate) row.getField(fieldIndex);
-                    statement.setDate(statementIndex, java.sql.Date.valueOf(localDate));
-                    break;
-                case TIME:
-                    LocalTime localTime = (LocalTime) row.getField(fieldIndex);
-                    statement.setTime(statementIndex, java.sql.Time.valueOf(localTime));
-                    break;
-                case TIMESTAMP:
-                    LocalDateTime localDateTime = (LocalDateTime) row.getField(fieldIndex);
-                    statement.setTimestamp(
-                            statementIndex, java.sql.Timestamp.valueOf(localDateTime));
-                    break;
-                case BYTES:
-                    if (row.getField(fieldIndex) == null) {
-                        statement.setBytes(statementIndex, new byte[0]);
-                        break;
-                    }
-                    statement.setBytes(statementIndex, (byte[]) row.getField(fieldIndex));
-                    break;
-                case NULL:
-                    statement.setNull(statementIndex, java.sql.Types.NULL);
-                    break;
-                case MAP:
-                case ARRAY:
-                case ROW:
-                default:
-                    throw new JdbcConnectorException(
-                            CommonErrorCodeDeprecated.UNSUPPORTED_DATA_TYPE,
-                            "Unexpected value: " + seaTunnelDataType);
-            }
-        }
-        return statement;
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverter.java
@@ -27,6 +27,8 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.Abstrac
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.JdbcFieldTypeUtils;
 
+import javax.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -50,6 +52,40 @@ public class SqlserverJdbcRowConverter extends AbstractJdbcRowConverter {
         return Optional.ofNullable(sqlTime)
                 .map(e -> e.toLocalDateTime().toLocalTime())
                 .orElse(null);
+    }
+
+    @Override
+    protected void setNullToStatementByDataType(
+            PreparedStatement statement,
+            SeaTunnelDataType<?> seaTunnelDataType,
+            int statementIndex,
+            @Nullable String sourceType)
+            throws SQLException {
+
+        if (seaTunnelDataType.getSqlType() == SqlType.BYTES) {
+            statement.setNull(statementIndex, resolveSqlServerBytesNullType(sourceType));
+            return;
+        }
+
+        statement.setObject(statementIndex, null);
+    }
+
+    private int resolveSqlServerBytesNullType(@Nullable String sourceType) {
+        if (sourceType == null) {
+            return java.sql.Types.VARBINARY;
+        }
+
+        if (SqlServerTypeConverter.SQLSERVER_IMAGE.equals(sourceType)) {
+            return java.sql.Types.LONGVARBINARY;
+        }
+        if (sourceType.startsWith(SqlServerTypeConverter.SQLSERVER_VARBINARY)) {
+            return java.sql.Types.VARBINARY;
+        }
+        if (sourceType.startsWith(SqlServerTypeConverter.SQLSERVER_BINARY)) {
+            return java.sql.Types.BINARY;
+        }
+
+        return java.sql.Types.VARBINARY;
     }
 
     public PreparedStatement toExternal(

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.sqlserver;
+
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.Types;
+
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+public class SqlserverJdbcRowConverterTest {
+
+    @Test
+    void testSetNullToStatementByDataTypeForImage() throws Exception {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(
+                statement, bytesType, 1, SqlServerTypeConverter.SQLSERVER_IMAGE);
+
+        verify(statement).setNull(1, Types.LONGVARBINARY);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForVarbinary() throws Exception {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(
+                statement, bytesType, 1, SqlServerTypeConverter.SQLSERVER_VARBINARY);
+
+        verify(statement).setNull(1, Types.VARBINARY);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForBinary() throws Exception {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(
+                statement, bytesType, 1, SqlServerTypeConverter.SQLSERVER_BINARY);
+
+        verify(statement).setNull(1, Types.BINARY);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForMaxVarbinary() throws Exception {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(
+                statement, bytesType, 1, SqlServerTypeConverter.MAX_VARBINARY);
+
+        verify(statement).setNull(1, Types.VARBINARY);
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlserverJdbcRowConverterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.sqlserver;
 
+import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 
@@ -75,6 +76,42 @@ public class SqlserverJdbcRowConverterTest {
 
         converter.setNullToStatementByDataType(
                 statement, bytesType, 1, SqlServerTypeConverter.MAX_VARBINARY);
+
+        verify(statement).setNull(1, Types.VARBINARY);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForNullSourceType() throws Exception {
+        // Test when sourceType is null, use default VARBINARY
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(statement, bytesType, 1, null);
+
+        verify(statement).setNull(1, Types.VARBINARY);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForNonBytesType() throws Exception {
+        // Test null values of non-BYTES type should use setObject
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> stringType = BasicType.STRING_TYPE;
+
+        converter.setNullToStatementByDataType(statement, stringType, 1, null);
+
+        verify(statement).setObject(1, null);
+    }
+
+    @Test
+    void testSetNullToStatementByDataTypeForUnknownSourceType() throws Exception {
+        // Test unknown sourceType should use default type
+        PreparedStatement statement = mock(PreparedStatement.class);
+        SqlserverJdbcRowConverter converter = new SqlserverJdbcRowConverter();
+        SeaTunnelDataType<?> bytesType = PrimitiveByteArrayType.INSTANCE;
+
+        converter.setNullToStatementByDataType(statement, bytesType, 1, "UNKNOWN_BINARY_TYPE");
 
         verify(statement).setNull(1, Types.VARBINARY);
     }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
fix #10613 

Previously, when a field value was null, `AbstractJdbcRowConverter` used:
    statement.setObject(index, null)

On SQLServer, this may cause the driver to infer `nvarchar` type for null values,
which leads to errors like:
    "Implicit conversion from data type nvarchar to image is not allowed"

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
No.

This is a bug fix that corrects null handling for SQLServer binary columns.
Existing jobs will continue to work as before, except that previously failing
cases (e.g. writing null to IMAGE column) will now succeed.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
1. Added unit tests in `SqlserverJdbcRowConverterTest`

2. Verified logic through code path`

3. Manually verified with SQLServer

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)