### PR TITLE
[Fix][Zeta] Fix path traversal vulnerability in log file REST API endpoints

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogIT.java
@@ -112,7 +112,7 @@ public class JobLogIT extends SeaTunnelEngineContainer {
                 server.execInContainer(
                         "sh",
                         "-c",
-                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../etc/passwd'");
+                        "curl --path-as-is -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../etc/passwd'");
         Assertions.assertEquals(
                 "400",
                 result.getStdout().trim(),
@@ -123,7 +123,7 @@ public class JobLogIT extends SeaTunnelEngineContainer {
                 server.execInContainer(
                         "sh",
                         "-c",
-                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../../etc/shadow'");
+                        "curl --path-as-is -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../../etc/shadow'");
         Assertions.assertEquals(
                 "400",
                 result.getStdout().trim(),
@@ -134,7 +134,7 @@ public class JobLogIT extends SeaTunnelEngineContainer {
                 server.execInContainer(
                         "sh",
                         "-c",
-                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/logs/../../etc/passwd'");
+                        "curl --path-as-is -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/logs/../../etc/passwd'");
         Assertions.assertEquals(
                 "400",
                 result.getStdout().trim(),

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogIT.java
@@ -106,6 +106,42 @@ public class JobLogIT extends SeaTunnelEngineContainer {
     }
 
     @Test
+    public void testPathTraversalAttackPrevention() throws IOException, InterruptedException {
+        // Test path traversal with Unix-style relative path
+        Container.ExecResult result =
+                server.execInContainer(
+                        "sh",
+                        "-c",
+                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../etc/passwd'");
+        Assertions.assertEquals(
+                "400",
+                result.getStdout().trim(),
+                "Path traversal attack with ../../etc/passwd should be blocked with HTTP 400");
+
+        // Test path traversal with deeper relative path
+        result =
+                server.execInContainer(
+                        "sh",
+                        "-c",
+                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/log/../../../etc/shadow'");
+        Assertions.assertEquals(
+                "400",
+                result.getStdout().trim(),
+                "Path traversal attack with ../../../etc/shadow should be blocked with HTTP 400");
+
+        // Test path traversal via /logs endpoint (all node log)
+        result =
+                server.execInContainer(
+                        "sh",
+                        "-c",
+                        "curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8080/logs/../../etc/passwd'");
+        Assertions.assertEquals(
+                "400",
+                result.getStdout().trim(),
+                "Path traversal attack on /logs endpoint should be blocked with HTTP 400");
+    }
+
+    @Test
     public void testJobLogFile() throws Exception {
         submitJobAndAssertResponse(
                 server, JobMode.BATCH.name(), false, CUSTOM_JOB_NAME, CUSTOM_JOB_ID);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
@@ -346,19 +346,28 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
 
     // Prepare log response with path traversal protection
     private void prepareLogResponse(HttpGetCommand httpGetCommand, String logPath, String logName) {
-        String logFilePath = logPath + "/" + logName;
+        String logFilePath = new File(logPath, logName).getPath();
         try {
             String canonicalLogDir = new File(logPath).getCanonicalPath();
             String canonicalFilePath = new File(logFilePath).getCanonicalPath();
             if (!canonicalFilePath.startsWith(canonicalLogDir + File.separator)
                     && !canonicalFilePath.equals(canonicalLogDir)) {
                 httpGetCommand.send400();
-                logger.warning(String.format("Illegal log file path detected: %s", logName));
+                logger.warning(
+                        String.format(
+                                "Path traversal attempt blocked - Requested: %s, Resolved: %s, LogDir: %s",
+                                logName, canonicalFilePath, canonicalLogDir));
                 return;
             }
             String logContent = FileUtils.readFileToStr(new File(canonicalFilePath).toPath());
             this.prepareResponse(httpGetCommand, logContent);
-        } catch (SeaTunnelRuntimeException | IOException e) {
+        } catch (IOException e) {
+            httpGetCommand.send400();
+            logger.warning(
+                    String.format(
+                            "Failed to resolve log file path: %s, error: %s",
+                            logFilePath, e.getMessage()));
+        } catch (SeaTunnelRuntimeException e) {
             httpGetCommand.send400();
             logger.warning(
                     String.format("Log file content is empty, get log path : %s", logFilePath));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
@@ -344,7 +344,16 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
         }
     }
 
-    // Prepare log response with path traversal protection
+    /**
+     * Prepares the current-node log response after enforcing the configured log directory boundary.
+     *
+     * <p>The requested log file is resolved to its canonical path before reading so that relative
+     * segments and symbolic links cannot escape the canonical log directory.
+     *
+     * @param httpGetCommand command used to send the HTTP response
+     * @param logPath configured log directory
+     * @param logName requested log file name from the request URI
+     */
     private void prepareLogResponse(HttpGetCommand httpGetCommand, String logPath, String logName) {
         String logFilePath = new File(logPath, logName).getPath();
         try {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
@@ -344,14 +344,21 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
         }
     }
 
-    /** Prepare Log Response */
+    // Prepare log response with path traversal protection
     private void prepareLogResponse(HttpGetCommand httpGetCommand, String logPath, String logName) {
         String logFilePath = logPath + "/" + logName;
         try {
-            String logContent = FileUtils.readFileToStr(new File(logFilePath).toPath());
+            String canonicalLogDir = new File(logPath).getCanonicalPath();
+            String canonicalFilePath = new File(logFilePath).getCanonicalPath();
+            if (!canonicalFilePath.startsWith(canonicalLogDir + File.separator)
+                    && !canonicalFilePath.equals(canonicalLogDir)) {
+                httpGetCommand.send400();
+                logger.warning(String.format("Illegal log file path detected: %s", logName));
+                return;
+            }
+            String logContent = FileUtils.readFileToStr(new File(canonicalFilePath).toPath());
             this.prepareResponse(httpGetCommand, logContent);
-        } catch (SeaTunnelRuntimeException e) {
-            // If the log file does not exist, return 400
+        } catch (SeaTunnelRuntimeException | IOException e) {
             httpGetCommand.send400();
             logger.warning(
                     String.format("Log file content is empty, get log path : %s", logFilePath));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
@@ -36,7 +36,17 @@ public class LogBaseServlet extends BaseServlet {
     public LogBaseServlet(NodeEngineImpl nodeEngine) {
         super(nodeEngine);
     }
-    // Prepare log response with path traversal protection
+
+    /**
+     * Prepares the servlet log response after enforcing the configured log directory boundary.
+     *
+     * <p>The requested log file is resolved to its canonical path before reading so that relative
+     * segments and symbolic links cannot escape the canonical log directory.
+     *
+     * @param resp response used to return status and log content
+     * @param logPath configured log directory
+     * @param logName requested log file name from the request URI
+     */
     protected void prepareLogResponse(HttpServletResponse resp, String logPath, String logName) {
         if (StringUtils.isBlank(logPath)) {
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
@@ -36,7 +36,7 @@ public class LogBaseServlet extends BaseServlet {
     public LogBaseServlet(NodeEngineImpl nodeEngine) {
         super(nodeEngine);
     }
-    /** Prepare Log Response */
+    // Prepare log response with path traversal protection
     protected void prepareLogResponse(HttpServletResponse resp, String logPath, String logName) {
         if (StringUtils.isBlank(logPath)) {
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -46,10 +46,17 @@ public class LogBaseServlet extends BaseServlet {
         }
         String logFilePath = logPath + "/" + logName;
         try {
-            String logContent = FileUtils.readFileToStr(new File(logFilePath).toPath());
+            String canonicalLogDir = new File(logPath).getCanonicalPath();
+            String canonicalFilePath = new File(logFilePath).getCanonicalPath();
+            if (!canonicalFilePath.startsWith(canonicalLogDir + File.separator)
+                    && !canonicalFilePath.equals(canonicalLogDir)) {
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                log.warn("Illegal log file path detected: {}", logName);
+                return;
+            }
+            String logContent = FileUtils.readFileToStr(new File(canonicalFilePath).toPath());
             write(resp, logContent);
         } catch (SeaTunnelRuntimeException | IOException e) {
-            // If the log file does not exist, return 400
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             log.warn(String.format("Log file content is empty, get log path : %s", logFilePath));
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/LogBaseServlet.java
@@ -44,19 +44,26 @@ public class LogBaseServlet extends BaseServlet {
                     "Log file path is empty, no log file path configured in the current configuration file");
             return;
         }
-        String logFilePath = logPath + "/" + logName;
+        String logFilePath = new File(logPath, logName).getPath();
         try {
             String canonicalLogDir = new File(logPath).getCanonicalPath();
             String canonicalFilePath = new File(logFilePath).getCanonicalPath();
             if (!canonicalFilePath.startsWith(canonicalLogDir + File.separator)
                     && !canonicalFilePath.equals(canonicalLogDir)) {
                 resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-                log.warn("Illegal log file path detected: {}", logName);
+                log.warn(
+                        "Path traversal attempt blocked - Requested: {}, Resolved: {}, LogDir: {}",
+                        logName,
+                        canonicalFilePath,
+                        canonicalLogDir);
                 return;
             }
             String logContent = FileUtils.readFileToStr(new File(canonicalFilePath).toPath());
             write(resp, logContent);
-        } catch (SeaTunnelRuntimeException | IOException e) {
+        } catch (IOException e) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            log.warn("Failed to resolve log file path: {}, error: {}", logFilePath, e.getMessage());
+        } catch (SeaTunnelRuntimeException e) {
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             log.warn(String.format("Log file content is empty, get log path : %s", logFilePath));
         }


### PR DESCRIPTION
## Purpose

Fix a path traversal vulnerability (CWE-22) in the log file REST API endpoints that allows arbitrary file read outside the configured log directory.

## Affected Endpoints

- `/hazelcast/rest/maps/log/<path>` (current node log)
- `/hazelcast/rest/maps/logs/<path>` (all node log)

Both the legacy Hazelcast REST handler and the Jetty servlet code paths are affected.

## Root Cause

The `logName` parameter extracted from the request URI is concatenated directly into a file path without any sanitization. An attacker can use path traversal sequences (e.g., `../../etc/passwd`) to read arbitrary files on the server.

## Fix

Add canonical path validation in `prepareLogResponse()` for both code paths:
1. `RestHttpGetCommandProcessor` (legacy Hazelcast handler)
2. `LogBaseServlet` (Jetty servlet base class)

The fix resolves the constructed file path to its canonical form via `File.getCanonicalPath()` and verifies it remains within the configured log directory boundary. Requests attempting to escape the log directory are rejected with HTTP 400.

## Changed Files

- `seatunnel-engine/seatunnel-engine-server/.../rest/RestHttpGetCommandProcessor.java`
- `seatunnel-engine/seatunnel-engine-server/.../rest/servlet/LogBaseServlet.java`

CVE-2026-40119