### PR TITLE
[Fix][Connector-V2] Fix JDBC Statement resource leaks in StarRocksCatalog

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/catalog/StarRocksCatalog.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/catalog/StarRocksCatalog.java
@@ -153,46 +153,47 @@ public class StarRocksCatalog implements Catalog {
             Optional<PrimaryKey> primaryKey =
                     getPrimaryKey(tablePath.getDatabaseName(), tablePath.getTableName());
 
-            PreparedStatement ps =
+            try (PreparedStatement ps =
                     conn.prepareStatement(
                             String.format(
                                     "SELECT * FROM %s WHERE 1 = 0;",
-                                    tablePath.getFullNameWithQuoted()));
+                                    tablePath.getFullNameWithQuoted()))) {
+                ResultSetMetaData tableMetaData = ps.getMetaData();
 
-            ResultSetMetaData tableMetaData = ps.getMetaData();
+                TableSchema.Builder builder = TableSchema.builder();
+                buildColumnsWithErrorCheck(
+                        tablePath,
+                        builder,
+                        IntStream.range(1, tableMetaData.getColumnCount() + 1).iterator(),
+                        i -> {
+                            try {
+                                SeaTunnelDataType<?> type = fromJdbcType(tableMetaData, i);
+                                // TODO add default value and test it
+                                return PhysicalColumn.of(
+                                        tableMetaData.getColumnName(i),
+                                        type,
+                                        tableMetaData.getColumnDisplaySize(i),
+                                        tableMetaData.isNullable(i)
+                                                == ResultSetMetaData.columnNullable,
+                                        null,
+                                        tableMetaData.getColumnLabel(i));
+                            } catch (SQLException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
 
-            TableSchema.Builder builder = TableSchema.builder();
-            buildColumnsWithErrorCheck(
-                    tablePath,
-                    builder,
-                    IntStream.range(1, tableMetaData.getColumnCount() + 1).iterator(),
-                    i -> {
-                        try {
-                            SeaTunnelDataType<?> type = fromJdbcType(tableMetaData, i);
-                            // TODO add default value and test it
-                            return PhysicalColumn.of(
-                                    tableMetaData.getColumnName(i),
-                                    type,
-                                    tableMetaData.getColumnDisplaySize(i),
-                                    tableMetaData.isNullable(i) == ResultSetMetaData.columnNullable,
-                                    null,
-                                    tableMetaData.getColumnLabel(i));
-                        } catch (SQLException e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
+                primaryKey.ifPresent(builder::primaryKey);
 
-            primaryKey.ifPresent(builder::primaryKey);
-
-            TableIdentifier tableIdentifier =
-                    TableIdentifier.of(
-                            catalogName, tablePath.getDatabaseName(), tablePath.getTableName());
-            return CatalogTable.of(
-                    tableIdentifier,
-                    builder.build(),
-                    buildConnectorOptions(tablePath),
-                    Collections.emptyList(),
-                    "");
+                TableIdentifier tableIdentifier =
+                        TableIdentifier.of(
+                                catalogName, tablePath.getDatabaseName(), tablePath.getTableName());
+                return CatalogTable.of(
+                        tableIdentifier,
+                        builder.build(),
+                        buildConnectorOptions(tablePath),
+                        Collections.emptyList(),
+                        "");
+            }
         } catch (Exception e) {
             throw new CatalogException(
                     String.format("Failed getting table %s", tablePath.getFullName()), e);
@@ -216,10 +217,11 @@ public class StarRocksCatalog implements Catalog {
     public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
             throws TableNotExistException, CatalogException {
         try {
-            conn.createStatement()
-                    .execute(
-                            StarRocksSaveModeUtil.INSTANCE.getDropTableSql(
-                                    tablePath, ignoreIfNotExists));
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(
+                        StarRocksSaveModeUtil.INSTANCE.getDropTableSql(
+                                tablePath, ignoreIfNotExists));
+            }
         } catch (Exception e) {
             throw new CatalogException(
                     String.format("Failed listing database in catalog %s", catalogName), e);
@@ -230,8 +232,9 @@ public class StarRocksCatalog implements Catalog {
             throws TableNotExistException, CatalogException {
         try {
             if (ignoreIfNotExists) {
-                conn.createStatement()
-                        .execute(StarRocksSaveModeUtil.INSTANCE.getTruncateTableSql(tablePath));
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute(StarRocksSaveModeUtil.INSTANCE.getTruncateTableSql(tablePath));
+                }
             }
         } catch (Exception e) {
             throw new CatalogException(
@@ -242,7 +245,9 @@ public class StarRocksCatalog implements Catalog {
 
     public void executeSql(TablePath tablePath, String sql) {
         try {
-            conn.createStatement().execute(sql);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+            }
         } catch (Exception e) {
             throw new CatalogException(String.format("Failed EXECUTE SQL in catalog %s", sql), e);
         }
@@ -266,10 +271,11 @@ public class StarRocksCatalog implements Catalog {
     public void createDatabase(TablePath tablePath, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException, CatalogException {
         try {
-            conn.createStatement()
-                    .execute(
-                            StarRocksSaveModeUtil.INSTANCE.getCreateDatabaseSql(
-                                    tablePath.getDatabaseName(), ignoreIfExists));
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(
+                        StarRocksSaveModeUtil.INSTANCE.getCreateDatabaseSql(
+                                tablePath.getDatabaseName(), ignoreIfExists));
+            }
         } catch (Exception e) {
             throw new CatalogException(
                     String.format("Failed listing database in catalog %s", catalogName), e);
@@ -280,10 +286,11 @@ public class StarRocksCatalog implements Catalog {
     public void dropDatabase(TablePath tablePath, boolean ignoreIfNotExists)
             throws DatabaseNotExistException, CatalogException {
         try {
-            conn.createStatement()
-                    .execute(
-                            StarRocksSaveModeUtil.INSTANCE.getDropDatabaseSql(
-                                    tablePath.getDatabaseName(), ignoreIfNotExists));
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(
+                        StarRocksSaveModeUtil.INSTANCE.getDropDatabaseSql(
+                                tablePath.getDatabaseName(), ignoreIfNotExists));
+            }
         } catch (Exception e) {
             throw new CatalogException(
                     String.format("Failed listing database in catalog %s", catalogName), e);
@@ -371,7 +378,9 @@ public class StarRocksCatalog implements Catalog {
             throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
         try {
             log.info("create table sql is :{}", sql);
-            conn.createStatement().execute(sql);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+            }
         } catch (Exception e) {
             throw new CatalogException(
                     String.format("Failed create table in catalog %s, sql :[%s]", catalogName, sql),

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/catalog/StarRocksCatalog.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/catalog/StarRocksCatalog.java
@@ -458,9 +458,9 @@ public class StarRocksCatalog implements Catalog {
     protected Optional<PrimaryKey> getPrimaryKey(String schema, String table) throws SQLException {
 
         List<String> pkFields = new ArrayList<>();
-        try (ResultSet rs =
-                conn.createStatement()
-                        .executeQuery(
+        try (Statement stmt = conn.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery(
                                 String.format(
                                         "SELECT COLUMN_NAME FROM information_schema.columns where TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND COLUMN_KEY = 'PRI' ORDER BY ORDINAL_POSITION",
                                         schema, table))) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

This pull request fixes JDBC resource leaks in StarRocksCatalog.

  It closes multiple leaked Statement / PreparedStatement instances by wrapping JDBC operations with try-with-resources, and also fixes a missed leak in getPrimaryKey() where only
  the ResultSet was closed previously.


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

  No.

  This patch does not change connector behavior, SQL semantics, config options, or public APIs. It only improves internal JDBC resource management to avoid leaked Statement
  objects in catalog operations.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

Code inspection was performed for all JDBC call sites touched in StarRocksCatalog to verify that created Statement / PreparedStatement instances are now closed correctly.

  No new tests were added in this PR because the change is limited to resource lifecycle handling and does not alter the observable behavior of catalog APIs.


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)