### PR TITLE
Fix DM NVARCHAR2 type mapping in JDBC connector

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -67,6 +67,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
+    public static final String DM_NVARCHAR2 = "NVARCHAR2";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
     public static final String DM_TEXT = "TEXT";
@@ -204,7 +205,8 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case DM_NVARCHAR:
-                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
+            case DM_NVARCHAR2:
+                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR2, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;


### PR DESCRIPTION
## Problem

When synchronizing data from Dameng Database to MySQL via the JDBC connector, NVARCHAR2 data type is not supported. The JDBC connector fails to map NVARCHAR2 columns during table synchronization.

## Solution

Added NVARCHAR2 type mapping to the Dameng JDBC dialect:
- Added NVARCHAR2 to DmDbTypes mapping
- Maps to equivalent Java/String type for proper data transfer

## Validation

```yaml
# Source table with NVARCHAR2 column
source:
  plugin_name: Jdbc
  driver: dm.jdbc.driver.DmDriver
  table_list:
    - table_path: sfsjzt.test_nvarchar2

# NVARCHAR2 columns now sync correctly
```

Fixes #10635