### PR TITLE
[Docs][Core] Add Javadoc to MultiTableSink

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
@@ -45,6 +45,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/**
+ * Central sink adapter that wraps multiple per-table {@link SeaTunnelSink} instances into a single
+ * unified sink. Each table's sink is created from the {@link MultiTableFactoryContext} and managed
+ * independently for writing, committing, and state snapshotting.
+ *
+ * <p>This class multiplies writers per subtask using {@code replicaNum} to fill blocking write
+ * queues in {@link MultiTableSinkWriter}, improving throughput for multi-table workloads.
+ */
 public class MultiTableSink
         implements SeaTunnelSink<
                         SeaTunnelRow,
@@ -56,6 +64,16 @@ public class MultiTableSink
     @Getter private final Map<TablePath, SeaTunnelSink> sinks;
     private final int replicaNum;
 
+    /**
+     * Constructs a MultiTableSink from the given factory context.
+     *
+     * <p>The {@code sinks} map is populated directly from {@link
+     * MultiTableFactoryContext#getSinks()}, keyed by {@link TablePath}. The {@code replicaNum}
+     * controls how many writers are created per table per subtask. Each subtask creates {@code
+     * replicaNum} writers to fill the blocking queues in {@link MultiTableSinkWriter}.
+     *
+     * @param context the factory context containing per-table sinks and configuration options
+     */
     public MultiTableSink(MultiTableFactoryContext context) {
         this.sinks = context.getSinks();
         this.replicaNum =
@@ -67,6 +85,18 @@ public class MultiTableSink
         return "MultiTableSink";
     }
 
+    /**
+     * Creates a new {@link MultiTableSinkWriter} with freshly initialized per-table writers.
+     *
+     * <p>For each table and each replica, a writer is created with a computed index using the
+     * formula {@code index = subtaskIndex * replicaNum + i}. This scatters writers across the
+     * blocking queues inside {@link MultiTableSinkWriter}, ensuring even distribution of write
+     * load.
+     *
+     * @param context the sink writer context providing subtask index and parallelism info
+     * @return a new {@link MultiTableSinkWriter} wrapping all per-table writers
+     * @throws IOException if any per-table writer creation fails
+     */
     @Override
     public SinkWriter<SeaTunnelRow, MultiTableCommitInfo, MultiTableState> createWriter(
             SinkWriter.Context context) throws IOException {
@@ -86,6 +116,19 @@ public class MultiTableSink
         return new MultiTableSinkWriter(writers, replicaNum, sinkWritersContext);
     }
 
+    /**
+     * Restores a {@link MultiTableSinkWriter} from previously checkpointed states.
+     *
+     * <p>Checkpoint states are matched back to per-table writers using {@link SinkIdentifier}
+     * (composed of table identifier and computed index). If no matching state is found for a given
+     * table and replica, a fresh writer is created instead via {@link
+     * SeaTunnelSink#createWriter(SinkWriter.Context)}.
+     *
+     * @param context the sink writer context providing subtask index and parallelism info
+     * @param states the list of checkpoint states from a previous snapshot
+     * @return a restored {@link MultiTableSinkWriter} with per-table writers rebuilt from state
+     * @throws IOException if any per-table writer restoration fails
+     */
     @Override
     public SinkWriter<SeaTunnelRow, MultiTableCommitInfo, MultiTableState> restoreWriter(
             SinkWriter.Context context, List<MultiTableState> states) throws IOException {
@@ -126,6 +169,16 @@ public class MultiTableSink
         return Optional.of(new DefaultSerializer<>());
     }
 
+    /**
+     * Creates a {@link MultiTableSinkCommitter} that aggregates per-table {@link SinkCommitter}
+     * instances.
+     *
+     * <p>Iterates over all registered sinks and collects their committers. If none of the sub-sinks
+     * provide a committer, returns {@link Optional#empty()}.
+     *
+     * @return an optional containing the aggregated committer, or empty if no sub-sink has one
+     * @throws IOException if any per-table committer creation fails
+     */
     @Override
     public Optional<SinkCommitter<MultiTableCommitInfo>> createCommitter() throws IOException {
         Map<String, SinkCommitter<?>> committers = new HashMap<>();
@@ -148,6 +201,16 @@ public class MultiTableSink
         return Optional.of(new DefaultSerializer<>());
     }
 
+    /**
+     * Creates a {@link MultiTableSinkAggregatedCommitter} that aggregates per-table {@link
+     * SinkAggregatedCommitter} instances across all sub-sinks.
+     *
+     * <p>If none of the sub-sinks provide an aggregated committer, returns {@link
+     * Optional#empty()}.
+     *
+     * @return an optional containing the aggregated committer, or empty if no sub-sink has one
+     * @throws IOException if any per-table aggregated committer creation fails
+     */
     @Override
     public Optional<SinkAggregatedCommitter<MultiTableCommitInfo, MultiTableAggregatedCommitInfo>>
             createAggregatedCommitter() throws IOException {
@@ -165,6 +228,15 @@ public class MultiTableSink
         return Optional.of(new MultiTableSinkAggregatedCommitter(aggCommitters));
     }
 
+    /**
+     * Returns the list of {@link TablePath}s for all tables managed by this sink.
+     *
+     * <p>For each sub-sink, tries {@link SeaTunnelSink#getWriteCatalogTable()} first to extract the
+     * table path from the catalog table. If that is not present, falls back to using the {@link
+     * TablePath} key from the original sinks map.
+     *
+     * @return the list of table paths for all managed tables
+     */
     public List<TablePath> getSinkTables() {
 
         List<TablePath> tablePaths = new ArrayList<>();
@@ -191,11 +263,29 @@ public class MultiTableSink
         sinks.values().forEach(sink -> sink.setJobContext(jobContext));
     }
 
+    /**
+     * Always returns empty in multi-table context.
+     *
+     * <p>In a multi-table sink, catalog tables are managed individually by each sub-sink rather
+     * than at the top level. This method delegates to the parent interface default, which returns
+     * {@link Optional#empty()}.
+     *
+     * @return {@link Optional#empty()}, always
+     */
     @Override
     public Optional<CatalogTable> getWriteCatalogTable() {
         return SeaTunnelSink.super.getWriteCatalogTable();
     }
 
+    /**
+     * Delegates schema evolution support to the first sub-sink.
+     *
+     * <p>If the first sub-sink implements {@link SupportSchemaEvolutionSink}, returns its supported
+     * {@link SchemaChangeType} list. Otherwise returns an empty list, indicating no schema
+     * evolution support.
+     *
+     * @return the list of supported schema change types, or empty if not supported
+     */
     @Override
     public List<SchemaChangeType> supports() {
         SeaTunnelSink firstSink = sinks.entrySet().iterator().next().getValue();

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
@@ -280,6 +280,8 @@ public class MultiTableSink
     /**
      * Delegates schema evolution support to the first sub-sink.
      *
+     * <p>Precondition: the sinks map must contain at least one entry.
+     *
      * <p>If the first sub-sink implements {@link SupportSchemaEvolutionSink}, returns its supported
      * {@link SchemaChangeType} list. Otherwise returns an empty list, indicating no schema
      * evolution support.


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
 Add method-level Javadoc to `MultiTableSink.java` as described in #10536 (sub-issue of #10533)

This class had 207 lines and zero method-level Javadoc. Added Javadoc to the class level and 8 key methods:
- Constructor — sinks map population and replicaNum role
- `createWriter()` — index formula and writer distribution
- `restoreWriter()` — checkpoint state matching via SinkIdentifier
- `createCommitter()` — per-table committer aggregation
- `createAggregatedCommitter()` — per-table aggregated committer aggregation
- `getSinkTables()` — fallback logic for table path resolution
- `getWriteCatalogTable()` — always empty in multi-table context
- `supports()` — schema evolution delegation to first sub-sink

Closes #10536

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
- `./mvnw spotless:apply` — formatting verified
- `./mvnw -q -DskipTests verify` — build verified
- No test needed as this is a documentation-only change (no code logic modified)

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)