### PR TITLE
[Docs]: Replace deprecated openjdk:8 with seatunnelhub/openjdk:8u342

### DIFF
--- a/docs/en/getting-started/docker/docker.md
+++ b/docs/en/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 The Dockerfile is like this:
 ```dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -70,7 +70,7 @@ minikube image load seatunnel:3.0.0-flink-1.13
 <TabItem value="Zeta (local-mode)">
 
 ```Dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ENV SEATUNNEL_VERSION="3.0.0"
 ENV SEATUNNEL_HOME="/opt/seatunnel"
@@ -98,7 +98,7 @@ minikube image load seatunnel:3.0.0
 <TabItem value="Zeta (cluster-mode)">
 
 ```Dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ENV SEATUNNEL_VERSION="3.0.0"
 ENV SEATUNNEL_HOME="/opt/seatunnel"

--- a/docs/zh/getting-started/docker/docker.md
+++ b/docs/zh/getting-started/docker/docker.md
@@ -64,7 +64,7 @@ docker images | grep apache/seatunnel
 
 Dockerfile文件内容为：
 ```dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ARG VERSION
 # Build from Source Code And Copy it into image

--- a/docs/zh/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/zh/getting-started/kubernetes/kubernetes.mdx
@@ -70,7 +70,7 @@ minikube image load seatunnel:3.0.0-flink-1.13
 <TabItem value="Zeta (local-mode)">
 
 ```Dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ENV SEATUNNEL_VERSION="3.0.0"
 ENV SEATUNNEL_HOME="/opt/seatunnel"
@@ -98,7 +98,7 @@ minikube image load seatunnel:3.0.0
 <TabItem value="Zeta (cluster-mode)">
 
 ```Dockerfile
-FROM openjdk:8
+FROM seatunnelhub/openjdk:8u342
 
 ENV SEATUNNEL_VERSION="3.0.0"
 ENV SEATUNNEL_HOME="/opt/seatunnel"


### PR DESCRIPTION
## Purpose
Updates documentation to use a maintained and secure base image.

Closes #10642

## Changes
Replaced deprecated `FROM openjdk:8` with `FROM seatunnelhub/openjdk:8u342` in all four affected doc files (EN + ZH, Kubernetes + Docker):

- docs/en/getting-started/kubernetes/kubernetes.mdx (lines 73, 101)
- docs/zh/getting-started/kubernetes/kubernetes.mdx (lines 73, 101)
- docs/en/getting-started/docker/docker.md (line 67)
- docs/zh/getting-started/docker/docker.md (line 67)

## Verification
- Ran `grep -r "FROM openjdk:8" docs/` — no remaining occurrences