### PR TITLE
[Improve] Update apache SeaTunnel collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,7 +33,7 @@ github:
     - apache
     - elt
   collaborators:
-    - dybyte
+    - ricky2129
     - chl-wxp
     - LiJie20190102
     - yzeng1618
@@ -42,7 +42,7 @@ github:
     - silenceland
     - SEZ9
     - boy-xiaozhang
-    - ZmmBigdata
+    - nzw921rx
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
Because dybyte has already become a Committer, I haven't seen any review records from ZmmBigdata, and at the same time, I found 2 very promising collaborators.

## What
- replace `dybyte` with `ricky2129` in `.asf.yaml`
- replace `ZmmBigdata` with `nzw921rx` in `.asf.yaml`

## Verification
- `./mvnw spotless:apply -nsu -T 3C`