### PR TITLE
[Fix][Doc] Fix broken links in Chinese about.md

### DIFF
--- a/docs/zh/introduction/about.md
+++ b/docs/zh/introduction/about.md
@@ -47,11 +47,11 @@ SeaTunnel 使用的默认引擎是 [SeaTunnel Zeta Engine](../engines/zeta/about
 
 ## 连接器
 
-- **源连接器** SeaTunnel 支持从各种关系、图形、NoSQL、文档和内存数据库读取数据； 分布式文件系统，例如HDFS； 以及各种云存储解决方案，例如S3和OSS。 我们还支持很多常见SaaS服务的数据读取。 您可以在[此处] 访问详细列表。 如果您愿意，您可以开发自己的源连接器并将其轻松集成到 SeaTunnel 中。
+- **源连接器** SeaTunnel 支持从各种关系、图形、NoSQL、文档和内存数据库读取数据； 分布式文件系统，例如HDFS； 以及各种云存储解决方案，例如S3和OSS。 我们还支持很多常见SaaS服务的数据读取。 您可以在[此处](../connectors/source) 访问详细列表。 如果您愿意，您可以开发自己的源连接器并将其轻松集成到 SeaTunnel 中。
 
 - **转换连接器** 如果源和接收器之间的架构不同，您可以使用转换连接器更改从源读取的架构，使其与接收器架构相同。
 
-- **Sink Connector** SeaTunnel 支持将数据写入各种关系型、图形、NoSQL、文档和内存数据库； 分布式文件系统，例如HDFS； 以及各种云存储解决方案，例如S3和OSS。 我们还支持将数据写入许多常见的 SaaS 服务。 您可以在[此处]访问详细列表。 如果您愿意，您可以开发自己的 Sink 连接器并轻松将其集成到 SeaTunnel 中。
+- **Sink Connector** SeaTunnel 支持将数据写入各种关系型、图形、NoSQL、文档和内存数据库； 分布式文件系统，例如HDFS； 以及各种云存储解决方案，例如S3和OSS。 我们还支持将数据写入许多常见的 SaaS 服务。 您可以在[此处](../connectors/sink)访问详细列表。 如果您愿意，您可以开发自己的 Sink 连接器并轻松将其集成到 SeaTunnel 中。
 
 ## 谁在使用 SeaTunnel
 


### PR DESCRIPTION
### Purpose of this pull request
Fix broken Markdown links in Chinese documentation (`docs/zh/introduction/about.md`). The `[此处]` placeholders were missing the URL part, making the links non-clickable.

### Does this PR introduce _any_ user-facing change?
Yes, fixes two broken links in the Chinese documentation:
- Source connector list link now correctly points to `../connectors/source`
- Sink connector list link now correctly points to `../connectors/sink`

### How was this patch tested?
Verified the Markdown link syntax is correct by comparing with the English version (`docs/en/introduction/about.md`).

