### PR TITLE
[Docs] Separate local and cluster guidance for SeaTunnel Engine quick start

### DIFF
--- a/docs/en/getting-started/locally/quick-start-seatunnel-engine.md
+++ b/docs/en/getting-started/locally/quick-start-seatunnel-engine.md
@@ -4,11 +4,22 @@ sidebar_position: 2
 
 # Quick Start With SeaTunnel Engine
 
-## Step 1: Deploy SeaTunnel And Connectors
+SeaTunnel Engine can be used either for a quick single-node trial or as a multi-node cluster. This page is organized around those two paths:
+
+| Path | Best for | Next step |
+| --- | --- | --- |
+| Single-node quick start | Validate configs, connectors, or pipelines on one machine | Continue with the single-node quick start section on this page |
+| Cluster deployment | Run SeaTunnel Engine across multiple nodes in test, staging, or production-like environments | Go to [SeaTunnel Engine(Zeta) Deployment](../../engines/zeta/deployment.md) |
+
+## Part 1: Single-node Quick Start (Local Mode)
+
+This path is intended for validating the installation, connectors, and job configuration on a single machine. The commands below all start SeaTunnel Engine with `-m local`.
+
+### Step 1: Deploy SeaTunnel And Connectors
 
 Before starting, make sure you have downloaded and deployed SeaTunnel as described in [Deployment](deployment.md)
 
-## Step 2: Add Job Config File To Define A Job
+### Step 2: Add Job Config File To Define A Job
 
 Edit `config/v2.batch.config.template`, which determines the way and logic of data input, processing, and output after seatunnel is started.
 The following is an example of the configuration file, which is the same as the example application mentioned above.
@@ -53,7 +64,7 @@ sink {
 
 More information can be found in [Config Concept](../../introduction/concepts/config.md)
 
-## Step 3: Run SeaTunnel Application
+### Step 3: Run SeaTunnel Application
 
 You could start the application by the following commands:
 
@@ -94,9 +105,9 @@ The SeaTunnel console will print some logs as below:
 2022-12-19 11:01:46,491 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=16: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: mIJDt, 995616438
 ```
 
-## Extended Example: Batch Mode from MySQL to Doris
+### Extended Example: Batch Mode from MySQL to Doris
 
-### Step 1: Download the Connector
+#### Step 1: Download the Connector
 
 First, you need to add the connector name to the `${SEATUNNEL_HOME}/config/plugin_config` file. Then, execute the command to install the connector (of course, you can also manually download the connector from the [Apache Maven Repository](https://repo.maven.apache.org/maven2/org/apache/seatunnel/) and move it to the `connectors/` directory). Finally, make sure that the `connector-jdbc` and `connector-doris` connectors are in the `${SEATUNNEL_HOME}/connectors/` directory.
 
@@ -113,11 +124,11 @@ connector-doris
 sh bin/install-plugin.sh
 ```
 
-### Step 2: Place the MySQL Driver
+#### Step 2: Place the MySQL Driver
 
 You need to download the [JDBC driver JAR package](https://mvnrepository.com/artifact/mysql/mysql-connector-java) and place it in the `${SEATUNNEL_HOME}/lib/` directory.
 
-### Step 3: Add Job Configuration File to Define the Job
+#### Step 3: Add Job Configuration File to Define the Job
 
 ```bash
 cd seatunnel/job/
@@ -159,7 +170,7 @@ sink {
 
 For more information about the configuration, please refer to [Basic Concepts of Configuration](../../introduction/concepts/config.md).
 
-### Step 4: Run the SeaTunnel Application
+#### Step 4: Run the SeaTunnel Application
 
 You can start the application using the following command:
 
@@ -192,9 +203,23 @@ If you want to optimize your job, refer to the connector documentation for [Sour
 
 :::
 
+## Part 2: Cluster Deployment
+
+If you have already validated your job locally and want to run SeaTunnel Engine across multiple nodes, continue with [SeaTunnel Engine(Zeta) Deployment](../../engines/zeta/deployment.md).
+
+The deployment guide covers:
+
+- deployment scenarios for local mode, hybrid cluster mode, and separated cluster mode
+- the deployment steps for hybrid and separated cluster modes
+- guidance on choosing the right deployment mode
+
+Recommendation:
+
+- Use the local mode on this page when you want to verify configs and job pipelines on a single machine.
+- Use the deployment guide when you need multi-node execution, resource isolation, or an environment closer to staging or production.
 
 ## What's More
 
-- Start write your own config file now, choose the [connector](../../connectors/source) you want to use, and configure the parameters according to the connector's documentation.
-- See [SeaTunnel Engine(Zeta)](../../engines/zeta/about.md) if you want to know more about SeaTunnel Engine. Here you will learn how to deploy SeaTunnel Engine and how to use it in cluster mode.
-
+- Start writing your own config file, choose the [connector](../../connectors/source) you want to use, and configure the parameters according to the connector documentation.
+- If you want to deploy a multi-node SeaTunnel Engine cluster, continue with [SeaTunnel Engine(Zeta) Deployment](../../engines/zeta/deployment.md).
+- See [SeaTunnel Engine(Zeta)](../../engines/zeta/about.md) if you want to learn more about SeaTunnel Engine.

--- a/docs/zh/getting-started/locally/quick-start-seatunnel-engine.md
+++ b/docs/zh/getting-started/locally/quick-start-seatunnel-engine.md
@@ -4,11 +4,22 @@ sidebar_position: 2
 
 # SeaTunnel 引擎快速开始
 
-## 步骤 1: 部署SeaTunnel及连接器
+SeaTunnel Engine 既可以用于单机快速体验，也可以部署为多节点集群。本页按照这两种使用方式组织：
+
+| 使用方式 | 适用场景 | 下一步 |
+| --- | --- | --- |
+| 单机快速开始 | 在一台机器上验证配置、连接器或处理链路 | 继续阅读本页的单机快速开始部分 |
+| 集群部署 | 在测试、预发或生产环境中运行多节点任务 | 跳转到 [SeaTunnel Engine(Zeta) 安装部署](../../engines/zeta/deployment.md) |
+
+## 第一部分：单机快速开始（Local 模式）
+
+这一部分适合在单台机器上快速验证安装、连接器和作业配置。下面的命令都使用 `-m local` 启动 SeaTunnel Engine。
+
+### 步骤 1: 部署SeaTunnel及连接器
 
 在开始前，请确保您已经按照[部署](deployment.md)中的描述下载并部署了SeaTunnel。
 
-## 步骤 2: 添加作业配置文件来定义作业
+### 步骤 2: 添加作业配置文件来定义作业
 
 编辑`config/v2.batch.config.template`，它决定了当seatunnel启动后数据输入、处理和输出的方式及逻辑。
 下面是配置文件的示例，它与上面提到的示例应用程序相同。
@@ -53,7 +64,7 @@ sink {
 
 关于配置的更多信息请查看[配置的基本概念](../../introduction/concepts/config.md)
 
-## 步骤 3: 运行SeaTunnel应用程序
+### 步骤 3: 运行SeaTunnel应用程序
 
 您可以通过以下命令启动应用程序：
 
@@ -93,9 +104,9 @@ SeaTunnel控制台将会打印一些如下日志信息:
 2022-12-19 11:01:46,491 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=16: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: mIJDt, 995616438
 ```
 
-## 扩展示例：从 MySQL 到 Doris 批处理模式
+### 扩展示例：从 MySQL 到 Doris 批处理模式
 
-### 步骤1：下载连接器
+#### 步骤1：下载连接器
 首先，您需要在`${SEATUNNEL_HOME}/config/plugin_config`文件中加入连接器名称，然后，执行命令来安装连接器(当然，您也可以从 [Apache Maven Repository](https://repo.maven.apache.org/maven2/org/apache/seatunnel/) 手动下载连接器，然后将其移动至`connectors/`目录下)，最后，确认连接器`connector-jdbc`、`connector-doris`在`${SEATUNNEL_HOME}/connectors/`目录下即可。
 
 ```bash
@@ -111,11 +122,11 @@ connector-doris
 sh bin/install-plugin.sh
 ```
 
-### 步骤2：放入 MySQL 驱动 
+#### 步骤2：放入 MySQL 驱动 
 
 您需要下载 [jdbc driver jar package](https://mvnrepository.com/artifact/mysql/mysql-connector-java) 驱动，并放置在 `${SEATUNNEL_HOME}/lib/`目录下
 
-### 步骤3：添加作业配置文件来定义作业
+#### 步骤3：添加作业配置文件来定义作业
 
 ```bash
 cd seatunnel/job/
@@ -157,7 +168,7 @@ sink {
 
 关于配置的更多信息请查看[配置的基本概念](../../introduction/concepts/config.md)
 
-### 步骤 4: 运行SeaTunnel应用程序
+#### 步骤 4: 运行SeaTunnel应用程序
 
 您可以通过以下命令启动应用程序：
 
@@ -190,9 +201,23 @@ Total Failed Count        :                   0
 
 :::
 
+## 第二部分：集群部署
 
-## 此外
+如果您已经完成单机验证，并希望在多节点环境中运行 SeaTunnel Engine，请继续阅读[SeaTunnel Engine(Zeta) 安装部署](../../engines/zeta/deployment.md)。
+
+集群部署文档集中说明了以下内容：
+
+- 不同部署模式的适用场景，包括 Local 模式、混合集群模式和分离集群模式
+- 混合集群模式与分离集群模式的部署步骤
+- 选择部署模式时的建议
+
+建议：
+
+- 如果您只是想在一台机器上快速验证配置和任务链路，使用本页中的 Local 模式即可。
+- 如果您需要多节点运行、资源隔离或更贴近测试和生产环境的部署方式，请进入集群部署文档继续操作。
+
+## 下一步
 
 - 开始编写您自己的配置文件，选择您想要使用的[连接器](../../connectors/source)，并根据连接器的文档配置参数。
-- 如果您想要了解更多关于信息，请参阅[SeaTunnel引擎](../../engines/zeta/about.md). 在这里你将了解如何部署SeaTunnel Engine的集群模式以及如何在集群模式下使用。
-
+- 如果您要部署多节点 SeaTunnel Engine 集群，请继续阅读[SeaTunnel Engine(Zeta) 安装部署](../../engines/zeta/deployment.md)。
+- 如果您想进一步了解 SeaTunnel Engine，请参阅[SeaTunnel引擎](../../engines/zeta/about.md)。


### PR DESCRIPTION
## What does this PR do?
- reorganize the SeaTunnel Engine quick start page into two clear paths: single-node local mode and cluster deployment
- keep the existing local runnable flow intact while adding a direct entry to the Zeta deployment guide for cluster users
- align the same structure in both Chinese and English docs

## Why is the change needed?
- the previous page only described the local `-m local` flow, which made it easy to miss the cluster deployment entry when reading the SeaTunnel Engine quick start
- this change makes the dev documentation clearer for both single-node trial users and readers preparing for cluster deployment

## Verify
- `mvn spotless:apply`
- `./mvnw -q -DskipTests verify -nsu -T 3C`