### PR TITLE
[Improve][API] Avoid relying on index alignment between keySet and values in getSinkTables()

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
@@ -240,13 +240,13 @@ public class MultiTableSink
     public List<TablePath> getSinkTables() {
 
         List<TablePath> tablePaths = new ArrayList<>();
-        List<SeaTunnelSink> values = new ArrayList<>(sinks.values());
-        for (int i = 0; i < values.size(); i++) {
-            if (values.get(i).getWriteCatalogTable().isPresent()) {
+        for (Map.Entry<TablePath, SeaTunnelSink> entry : sinks.entrySet()) {
+            if (entry.getValue().getWriteCatalogTable().isPresent()) {
                 tablePaths.add(
-                        ((CatalogTable) values.get(i).getWriteCatalogTable().get()).getTablePath());
+                        ((CatalogTable) entry.getValue().getWriteCatalogTable().get())
+                                .getTablePath());
             } else {
-                tablePaths.add(sinks.keySet().toArray(new TablePath[0])[i]);
+                tablePaths.add(entry.getKey());
             }
         }
         return tablePaths;

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSink.java
@@ -229,27 +229,37 @@ public class MultiTableSink
     }
 
     /**
-     * Returns the list of {@link TablePath}s for all tables managed by this sink.
+     * Returns the list of resolved sink {@link TablePath}s for all tables managed by this sink.
      *
-     * <p>For each sub-sink, tries {@link SeaTunnelSink#getWriteCatalogTable()} first to extract the
-     * table path from the catalog table. If that is not present, falls back to using the {@link
-     * TablePath} key from the original sinks map.
+     * <p>Delegates to {@link #getSinkTableMapping()} and returns its values as a list.
      *
-     * @return the list of table paths for all managed tables
+     * @return the list of resolved sink table paths
      */
     public List<TablePath> getSinkTables() {
+        return new ArrayList<>(getSinkTableMapping().values());
+    }
 
-        List<TablePath> tablePaths = new ArrayList<>();
+    /**
+     * Returns a mapping from upstream {@link TablePath} keys to their resolved sink table paths.
+     *
+     * <p>For each sub-sink, if {@link SeaTunnelSink#getWriteCatalogTable()} is present, the
+     * resolved path comes from the catalog table. Otherwise, the upstream key is used as-is.
+     *
+     * @return a map of upstream table paths to resolved sink table paths
+     */
+    public Map<TablePath, TablePath> getSinkTableMapping() {
+        Map<TablePath, TablePath> mapping = new HashMap<>();
         for (Map.Entry<TablePath, SeaTunnelSink> entry : sinks.entrySet()) {
             if (entry.getValue().getWriteCatalogTable().isPresent()) {
-                tablePaths.add(
+                mapping.put(
+                        entry.getKey(),
                         ((CatalogTable) entry.getValue().getWriteCatalogTable().get())
                                 .getTablePath());
             } else {
-                tablePaths.add(entry.getKey());
+                mapping.put(entry.getKey(), entry.getKey());
             }
         }
-        return tablePaths;
+        return mapping;
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -123,14 +123,8 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         boolean isMulti = sinkAction.getSink() instanceof MultiTableSink;
         if (isMulti) {
             sinkTables = ((MultiTableSink) sinkAction.getSink()).getSinkTables();
-            TablePath[] upstreamTablePaths =
-                    ((MultiTableSink) sinkAction.getSink())
-                            .getSinks()
-                            .keySet()
-                            .toArray(new TablePath[0]);
-            for (int i = 0; i < ((MultiTableSink) sinkAction.getSink()).getSinks().size(); i++) {
-                tablesMaps.put(upstreamTablePaths[i], sinkTables.get(i));
-            }
+            tablesMaps.putAll(
+                    ((MultiTableSink) sinkAction.getSink()).getSinkTableMapping());
         } else {
             Optional<CatalogTable> catalogTable = sinkAction.getSink().getWriteCatalogTable();
             if (catalogTable.isPresent()) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -123,8 +123,7 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         boolean isMulti = sinkAction.getSink() instanceof MultiTableSink;
         if (isMulti) {
             sinkTables = ((MultiTableSink) sinkAction.getSink()).getSinkTables();
-            tablesMaps.putAll(
-                    ((MultiTableSink) sinkAction.getSink()).getSinkTableMapping());
+            tablesMaps.putAll(((MultiTableSink) sinkAction.getSink()).getSinkTableMapping());
         } else {
             Optional<CatalogTable> catalogTable = sinkAction.getSink().getWriteCatalogTable();
             if (catalogTable.isPresent()) {


### PR DESCRIPTION
### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Refactor `getSinkTables()` in `MultiTableSink` to iterate over `entrySet()` instead of relying on index alignment between `keySet()` and `values()`.

Closes #10658  

### Does this PR introduce _any_ user-facing change?

No. The logic remains the same — only the iteration approach is changed for safety and clarity.

### How was this patch tested?

- `./mvnw spotless:apply` — formatting verified                                              
- `./mvnw -q -DskipTests verify` — build verified

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)