### PR TITLE
[Improve][Zeta] Improve health metrics retrieval and parsing with enhanced logging

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/LocalModeIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/LocalModeIT.java
@@ -91,6 +91,7 @@ public class LocalModeIT {
             Map<String, String> clusterHealthMetrics = engineClient.getClusterHealthMetrics();
             Assertions.assertEquals(1, clusterHealthMetrics.size());
             Assertions.assertTrue(clusterHealthMetrics.containsKey("[localhost]:9999"));
+            Assertions.assertNotNull(engineClient.getHealthMetrics("[localhost]:9999"));
         } finally {
             if (engineClient != null) {
                 engineClient.close();

--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelClient.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelClient.java
@@ -191,10 +191,7 @@ public class SeaTunnelClient implements SeaTunnelClientInstance, AutoCloseable {
         Set<Member> members = hazelcastClient.getHazelcastInstance().getCluster().getMembers();
         Member member =
                 members.stream()
-                        .filter(
-                                m ->
-                                        (m.getAddress().getHost() + ":" + m.getAddress().getPort())
-                                                .equals(address))
+                        .filter(m -> m.getAddress().toString().equals(address))
                         .findFirst()
                         .orElseThrow(
                                 () ->

--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelClient.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/SeaTunnelClient.java
@@ -40,8 +40,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class SeaTunnelClient implements SeaTunnelClientInstance, AutoCloseable {
+    private static final int INVALID_METRICS_LOG_INTERVAL_MS = 60_000;
+    private static final int INVALID_METRICS_LOG_PREFIX_MAX_LEN = 512;
+    private static final int INVALID_METRICS_LOG_TOKEN_MAX_LEN = 128;
+    private static final int INVALID_METRICS_LOG_TOKEN_MAX_COUNT = 5;
+    private static final AtomicLong LAST_INVALID_METRICS_LOG_TIME_MS = new AtomicLong(0L);
     private final SeaTunnelHazelcastClient hazelcastClient;
     @Getter private final JobClient jobClient;
 
@@ -174,23 +181,128 @@ public class SeaTunnelClient implements SeaTunnelClientInstance, AutoCloseable {
         Map<String, String> healthMetricsMap = new HashMap<>();
         members.forEach(
                 member -> {
-                    String metrics =
-                            hazelcastClient.requestAndDecodeResponse(
-                                    member.getUuid(),
-                                    SeaTunnelGetClusterHealthMetricsCodec.encodeRequest(),
-                                    SeaTunnelGetClusterHealthMetricsCodec::decodeResponse);
-                    String[] split = metrics.split(",");
-                    Map<String, String> kvMap = new LinkedHashMap<>();
-                    Arrays.stream(split)
-                            .forEach(
-                                    kv -> {
-                                        String[] kvArr = kv.split("=");
-                                        kvMap.put(kvArr[0], kvArr[1]);
-                                    });
                     healthMetricsMap.put(
-                            member.getAddress().toString(), JsonUtils.toJsonString(kvMap));
+                            member.getAddress().toString(), getMetricsByMember(member));
                 });
-
         return healthMetricsMap;
+    }
+
+    public String getHealthMetrics(String address) {
+        Set<Member> members = hazelcastClient.getHazelcastInstance().getCluster().getMembers();
+        Member member =
+                members.stream()
+                        .filter(
+                                m ->
+                                        (m.getAddress().getHost() + ":" + m.getAddress().getPort())
+                                                .equals(address))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Member with address "
+                                                        + address
+                                                        + " not found in the cluster."));
+        return getMetricsByMember(member);
+    }
+
+    private String getMetricsByMember(Member member) {
+        String metrics =
+                hazelcastClient.requestAndDecodeResponse(
+                        member.getUuid(),
+                        SeaTunnelGetClusterHealthMetricsCodec.encodeRequest(),
+                        SeaTunnelGetClusterHealthMetricsCodec::decodeResponse);
+        return JsonUtils.toJsonString(
+                parseHealthMetricsString(metrics, member.getAddress().toString(), getLogger()));
+    }
+
+    static Map<String, String> parseHealthMetricsString(String metrics) {
+        return parseHealthMetricsString(metrics, null, null);
+    }
+
+    static Map<String, String> parseHealthMetricsString(
+            String metrics, String memberAddress, ILogger logger) {
+        Map<String, String> kvMap = new LinkedHashMap<>();
+        if (metrics == null || metrics.isEmpty()) {
+            return kvMap;
+        }
+
+        // SeaTunnelHealthMonitor#render uses ", " as pair separators. Splitting on ",\\s+" avoids
+        // breaking values which may contain commas (e.g. decimal separator under some locales).
+        String[] pairs = metrics.split(",\\s+");
+        List<String> invalidTokens =
+                Arrays.stream(pairs)
+                        .map(kv -> kv == null ? "" : kv.trim())
+                        .filter(trimmed -> !trimmed.isEmpty())
+                        .filter(trimmed -> trimmed.indexOf('=') <= 0)
+                        .limit(INVALID_METRICS_LOG_TOKEN_MAX_COUNT)
+                        .map(token -> truncateForLog(token, INVALID_METRICS_LOG_TOKEN_MAX_LEN))
+                        .collect(Collectors.toList());
+
+        Arrays.stream(pairs)
+                .forEach(
+                        kv -> {
+                            if (kv == null) {
+                                return;
+                            }
+                            String trimmed = kv.trim();
+                            if (trimmed.isEmpty()) {
+                                return;
+                            }
+                            int eqIndex = trimmed.indexOf('=');
+                            if (eqIndex <= 0) {
+                                return;
+                            }
+                            String key = trimmed.substring(0, eqIndex).trim();
+                            String value =
+                                    eqIndex == trimmed.length() - 1
+                                            ? ""
+                                            : trimmed.substring(eqIndex + 1).trim();
+                            if (!key.isEmpty()) {
+                                kvMap.put(key, value);
+                            }
+                        });
+
+        logInvalidHealthMetricsIfNeeded(metrics, memberAddress, invalidTokens, logger);
+        return kvMap;
+    }
+
+    private static void logInvalidHealthMetricsIfNeeded(
+            String metrics, String memberAddress, List<String> invalidTokens, ILogger logger) {
+        if (logger == null || invalidTokens == null || invalidTokens.isEmpty()) {
+            return;
+        }
+        if (!logger.isWarningEnabled()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long last = LAST_INVALID_METRICS_LOG_TIME_MS.get();
+        if (now - last < INVALID_METRICS_LOG_INTERVAL_MS) {
+            return;
+        }
+        if (!LAST_INVALID_METRICS_LOG_TIME_MS.compareAndSet(last, now)) {
+            return;
+        }
+
+        String address = memberAddress == null ? "unknown" : memberAddress;
+        String prefix =
+                truncateForLog(metrics == null ? "" : metrics, INVALID_METRICS_LOG_PREFIX_MAX_LEN);
+        logger.warning(
+                "Invalid zeta health metrics token(s) from member "
+                        + address
+                        + ", tokens="
+                        + invalidTokens
+                        + ", rawPrefix="
+                        + prefix);
+    }
+
+    private static String truncateForLog(String s, int maxLen) {
+        if (s == null) {
+            return "";
+        }
+        String normalized = s.replace('\n', ' ').replace('\r', ' ');
+        if (maxLen <= 0) {
+            return "";
+        }
+        return normalized.length() <= maxLen ? normalized : normalized.substring(0, maxLen) + "...";
     }
 }

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientHealthMetricsParsingTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/SeaTunnelClientHealthMetricsParsingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.engine.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.hazelcast.logging.ILogger;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SeaTunnelClientHealthMetricsParsingTest {
+
+    @Test
+    public void testParseHealthMetricsStringNormal() {
+        Map<String, String> parsed = SeaTunnelClient.parseHealthMetricsString("a=1, b=2, c=3");
+        Assertions.assertEquals("1", parsed.get("a"));
+        Assertions.assertEquals("2", parsed.get("b"));
+        Assertions.assertEquals("3", parsed.get("c"));
+    }
+
+    @Test
+    public void testParseHealthMetricsStringIgnoreMalformedPairs() {
+        Map<String, String> parsed =
+                SeaTunnelClient.parseHealthMetricsString("a=1, broken, b=2, =x, c=");
+        Assertions.assertEquals("1", parsed.get("a"));
+        Assertions.assertEquals("2", parsed.get("b"));
+        Assertions.assertEquals("", parsed.get("c"));
+        Assertions.assertFalse(parsed.containsKey(""));
+    }
+
+    @Test
+    public void testParseHealthMetricsStringKeepCommaInsideValue() {
+        Map<String, String> parsed =
+                SeaTunnelClient.parseHealthMetricsString(
+                        "load.process=12,34%, heap.memory.used=1,2GB, connection.count=10");
+        Assertions.assertEquals("12,34%", parsed.get("load.process"));
+        Assertions.assertEquals("1,2GB", parsed.get("heap.memory.used"));
+        Assertions.assertEquals("10", parsed.get("connection.count"));
+    }
+
+    @Test
+    public void testParseHealthMetricsStringNullOrEmpty() {
+        Assertions.assertTrue(SeaTunnelClient.parseHealthMetricsString(null).isEmpty());
+        Assertions.assertTrue(SeaTunnelClient.parseHealthMetricsString("").isEmpty());
+        Assertions.assertTrue(SeaTunnelClient.parseHealthMetricsString("   ").isEmpty());
+    }
+
+    @Test
+    public void testParseHealthMetricsStringKeepAdditionalEqualsInValue() {
+        Map<String, String> parsed =
+                SeaTunnelClient.parseHealthMetricsString("token=a=b=c, processors=8");
+        Assertions.assertEquals("a=b=c", parsed.get("token"));
+        Assertions.assertEquals("8", parsed.get("processors"));
+    }
+
+    @Test
+    public void testParseHealthMetricsStringLogMalformedTokenWhenLoggerEnabled() {
+        long originalLastLogTime = setLastInvalidMetricsLogTimeMs(0L);
+        ILogger logger = Mockito.mock(ILogger.class);
+        Mockito.when(logger.isWarningEnabled()).thenReturn(true);
+
+        try {
+            Map<String, String> parsed =
+                    SeaTunnelClient.parseHealthMetricsString(
+                            "load.process=12,34%, broken, processors=8", "127.0.0.1:5801", logger);
+
+            Assertions.assertEquals("12,34%", parsed.get("load.process"));
+            Assertions.assertEquals("8", parsed.get("processors"));
+            Mockito.verify(logger)
+                    .warning(Mockito.contains("Invalid zeta health metrics token(s) from member"));
+        } finally {
+            setLastInvalidMetricsLogTimeMs(originalLastLogTime);
+        }
+    }
+
+    @Test
+    public void testParseHealthMetricsStringWithNullLogger() {
+        Map<String, String> parsed =
+                SeaTunnelClient.parseHealthMetricsString("a=1, broken, c=", "127.0.0.1:5801", null);
+        Assertions.assertEquals("1", parsed.get("a"));
+        Assertions.assertEquals("", parsed.get("c"));
+    }
+
+    @Test
+    public void testParseHealthMetricsStringLogRateLimit() {
+        long originalLastLogTime = setLastInvalidMetricsLogTimeMs(0L);
+        ILogger logger = Mockito.mock(ILogger.class);
+        Mockito.when(logger.isWarningEnabled()).thenReturn(true);
+
+        try {
+            SeaTunnelClient.parseHealthMetricsString("broken1, broken2", "127.0.0.1:5801", logger);
+            SeaTunnelClient.parseHealthMetricsString("broken3, broken4", "127.0.0.1:5802", logger);
+            Mockito.verify(logger, Mockito.times(1)).warning(Mockito.anyString());
+        } finally {
+            setLastInvalidMetricsLogTimeMs(originalLastLogTime);
+        }
+    }
+
+    private static long setLastInvalidMetricsLogTimeMs(long value) {
+        try {
+            Field field =
+                    SeaTunnelClient.class.getDeclaredField("LAST_INVALID_METRICS_LOG_TIME_MS");
+            field.setAccessible(true);
+            AtomicLong lastInvalidMetricsLogTimeMs = (AtomicLong) field.get(null);
+            return lastInvalidMetricsLogTimeMs.getAndSet(value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set LAST_INVALID_METRICS_LOG_TIME_MS", e);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelHealthMonitor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelHealthMonitor.java
@@ -261,7 +261,7 @@ public class SeaTunnelHealthMonitor {
 
             double value = osSystemLoadAverage.read();
             if (value < 0) {
-                sb.append("load.systemAverage").append("=n/a ");
+                sb.append("load.systemAverage").append("=n/a, ");
             } else {
                 sb.append("load.systemAverage")
                         .append('=')

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -80,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -116,9 +117,11 @@ import static org.apache.seatunnel.engine.server.rest.RestConstant.TABLE_SOURCE_
 public abstract class BaseService {
 
     private static final int JOB_METRICS_LOG_TRUNCATE_LENGTH = 500;
+    private static final int INVALID_METRICS_LOG_INTERVAL_MS = 60_000;
     private static final int INVALID_METRICS_LOG_PREFIX_MAX_LEN = 512;
     private static final int INVALID_METRICS_LOG_TOKEN_MAX_LEN = 128;
     private static final int INVALID_METRICS_LOG_TOKEN_MAX_COUNT = 5;
+    private static final AtomicLong LAST_INVALID_METRICS_LOG_TIME_MS = new AtomicLong(0L);
     private static final Pattern VERTEX_IDENTIFIER_PATTERN =
             Pattern.compile("((?:Sink|Source|Transform)\\[(\\d+)\\])");
 
@@ -972,7 +975,7 @@ public abstract class BaseService {
             jobInfo.add(key, value);
         }
 
-        if (!invalidTokens.isEmpty()) {
+        if (!invalidTokens.isEmpty() && log.isWarnEnabled() && shouldLogInvalidMetrics()) {
             log.warn(
                     "Ignored malformed cluster health metrics token(s) from member {}, tokens={}, rawPrefix={}",
                     memberAddress == null ? "unknown" : memberAddress,
@@ -981,6 +984,15 @@ public abstract class BaseService {
         }
 
         return jobInfo;
+    }
+
+    private static boolean shouldLogInvalidMetrics() {
+        long now = System.currentTimeMillis();
+        long last = LAST_INVALID_METRICS_LOG_TIME_MS.get();
+        if (now - last < INVALID_METRICS_LOG_INTERVAL_MS) {
+            return false;
+        }
+        return LAST_INVALID_METRICS_LOG_TIME_MS.compareAndSet(last, now);
     }
 
     private static String truncateForLog(String input, int maxLen) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -116,6 +116,9 @@ import static org.apache.seatunnel.engine.server.rest.RestConstant.TABLE_SOURCE_
 public abstract class BaseService {
 
     private static final int JOB_METRICS_LOG_TRUNCATE_LENGTH = 500;
+    private static final int INVALID_METRICS_LOG_PREFIX_MAX_LEN = 512;
+    private static final int INVALID_METRICS_LOG_TOKEN_MAX_LEN = 128;
+    private static final int INVALID_METRICS_LOG_TOKEN_MAX_COUNT = 5;
     private static final Pattern VERTEX_IDENTIFIER_PATTERN =
             Pattern.compile("((?:Sink|Source|Transform)\\[(\\d+)\\])");
 
@@ -929,17 +932,62 @@ public abstract class BaseService {
 
                                         log.error("Failed to get cluster health metrics", e);
                                     }
-                                    String[] parts = input.split(", ");
-                                    JsonObject jobInfo = new JsonObject();
-                                    Arrays.stream(parts)
-                                            .forEach(
-                                                    part -> {
-                                                        String[] keyValue = part.split("=");
-                                                        jobInfo.add(keyValue[0], keyValue[1]);
-                                                    });
-                                    return jobInfo;
+                                    return parseSystemMonitoringMetrics(input, address);
                                 })
                         .collect(JsonArray::new, JsonArray::add, JsonArray::add);
         return jsonValues;
+    }
+
+    private JsonObject parseSystemMonitoringMetrics(String input, Address memberAddress) {
+        JsonObject jobInfo = new JsonObject();
+        if (input == null || input.isEmpty()) {
+            return jobInfo;
+        }
+
+        String[] parts = input.split(",\\s+");
+        List<String> invalidTokens = new ArrayList<>();
+        for (String part : parts) {
+            if (part == null) {
+                continue;
+            }
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int equalIndex = trimmed.indexOf('=');
+            if (equalIndex <= 0) {
+                if (invalidTokens.size() < INVALID_METRICS_LOG_TOKEN_MAX_COUNT) {
+                    invalidTokens.add(truncateForLog(trimmed, INVALID_METRICS_LOG_TOKEN_MAX_LEN));
+                }
+                continue;
+            }
+            String key = trimmed.substring(0, equalIndex).trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            String value =
+                    equalIndex == trimmed.length() - 1
+                            ? ""
+                            : trimmed.substring(equalIndex + 1).trim();
+            jobInfo.add(key, value);
+        }
+
+        if (!invalidTokens.isEmpty()) {
+            log.warn(
+                    "Ignored malformed cluster health metrics token(s) from member {}, tokens={}, rawPrefix={}",
+                    memberAddress == null ? "unknown" : memberAddress,
+                    invalidTokens,
+                    truncateForLog(input, INVALID_METRICS_LOG_PREFIX_MAX_LEN));
+        }
+
+        return jobInfo;
+    }
+
+    private static String truncateForLog(String input, int maxLen) {
+        if (input == null || maxLen <= 0) {
+            return "";
+        }
+        String normalized = input.replace('\n', ' ').replace('\r', ' ');
+        return normalized.length() <= maxLen ? normalized : normalized.substring(0, maxLen) + "...";
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceHealthMetricsParsingTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceHealthMetricsParsingTest.java
@@ -25,13 +25,16 @@ import com.hazelcast.cluster.Address;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class BaseServiceHealthMetricsParsingTest {
 
     private BaseService baseService;
     private Address memberAddress;
     private Method parseSystemMonitoringMetricsMethod;
+    private Method shouldLogInvalidMetricsMethod;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -41,6 +44,9 @@ public class BaseServiceHealthMetricsParsingTest {
                 BaseService.class.getDeclaredMethod(
                         "parseSystemMonitoringMetrics", String.class, Address.class);
         parseSystemMonitoringMetricsMethod.setAccessible(true);
+        shouldLogInvalidMetricsMethod =
+                BaseService.class.getDeclaredMethod("shouldLogInvalidMetrics");
+        shouldLogInvalidMetricsMethod.setAccessible(true);
     }
 
     @Test
@@ -74,5 +80,28 @@ public class BaseServiceHealthMetricsParsingTest {
         Assertions.assertEquals("12,34%", parsed.getString("load.process", null));
         Assertions.assertEquals("1,2GB", parsed.getString("heap.memory.used", null));
         Assertions.assertEquals("10", parsed.getString("connection.count", null));
+    }
+
+    @Test
+    void testMalformedMetricsWarningRateLimit() throws Exception {
+        long originalLastLogTime = setLastInvalidMetricsLogTimeMs(0L);
+
+        try {
+            Assertions.assertTrue((boolean) shouldLogInvalidMetricsMethod.invoke(null));
+            Assertions.assertFalse((boolean) shouldLogInvalidMetricsMethod.invoke(null));
+        } finally {
+            setLastInvalidMetricsLogTimeMs(originalLastLogTime);
+        }
+    }
+
+    private static long setLastInvalidMetricsLogTimeMs(long value) {
+        try {
+            Field field = BaseService.class.getDeclaredField("LAST_INVALID_METRICS_LOG_TIME_MS");
+            field.setAccessible(true);
+            AtomicLong lastInvalidMetricsLogTimeMs = (AtomicLong) field.get(null);
+            return lastInvalidMetricsLogTimeMs.getAndSet(value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set LAST_INVALID_METRICS_LOG_TIME_MS", e);
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceHealthMetricsParsingTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceHealthMetricsParsingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.lang.reflect.Method;
+
+public class BaseServiceHealthMetricsParsingTest {
+
+    private BaseService baseService;
+    private Address memberAddress;
+    private Method parseSystemMonitoringMetricsMethod;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        baseService = new JobInfoService(org.mockito.Mockito.mock(NodeEngineImpl.class));
+        memberAddress = new Address("127.0.0.1", 5801);
+        parseSystemMonitoringMetricsMethod =
+                BaseService.class.getDeclaredMethod(
+                        "parseSystemMonitoringMetrics", String.class, Address.class);
+        parseSystemMonitoringMetricsMethod.setAccessible(true);
+    }
+
+    @Test
+    void testParseSystemMonitoringMetricsNullInput() throws Exception {
+        JsonObject parsed =
+                (JsonObject)
+                        parseSystemMonitoringMetricsMethod.invoke(baseService, null, memberAddress);
+        Assertions.assertEquals(0, parsed.size());
+    }
+
+    @Test
+    void testParseSystemMonitoringMetricsIgnoreMalformedTokens() throws Exception {
+        JsonObject parsed =
+                (JsonObject)
+                        parseSystemMonitoringMetricsMethod.invoke(
+                                baseService, "a=1, broken, =x, c=", memberAddress);
+        Assertions.assertEquals("1", parsed.getString("a", null));
+        Assertions.assertEquals("", parsed.getString("c", null));
+        Assertions.assertNull(parsed.get("broken"));
+        Assertions.assertEquals(2, parsed.size());
+    }
+
+    @Test
+    void testParseSystemMonitoringMetricsKeepCommaInsideValue() throws Exception {
+        JsonObject parsed =
+                (JsonObject)
+                        parseSystemMonitoringMetricsMethod.invoke(
+                                baseService,
+                                "load.process=12,34%, heap.memory.used=1,2GB, connection.count=10",
+                                memberAddress);
+        Assertions.assertEquals("12,34%", parsed.getString("load.process", null));
+        Assertions.assertEquals("1,2GB", parsed.getString("heap.memory.used", null));
+        Assertions.assertEquals("10", parsed.getString("connection.count", null));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

This PR improves the parsing of health metrics strings to handle malformed tokens gracefully, with enhanced logging for invalid tokens to help diagnose issues while avoiding log flooding.

Key changes:
- **SeaTunnelClient**: Improved `parseHealthMetricsString` to handle malformed tokens, keep commas inside values (e.g., "12,34%"), and add rate-limited warning logs for invalid tokens
- **BaseService**: Similar parsing improvements for system monitoring metrics with better handling of malformed tokens
- **SeaTunnelHealthMonitor**: Fixed missing comma separator after "n/a" value in `load.systemAverage`
- Added unit tests for health metrics parsing in both `SeaTunnelClient` and `BaseService`

### Does this PR introduce _any_ user-facing change?

No user-facing behavior change. The health metrics API returns the same valid data, but now gracefully handles malformed tokens instead of potentially throwing errors or producing incomplete results.

### How was this patch tested?

- Added unit tests: `SeaTunnelClientHealthMetricsParsingTest` and `BaseServiceHealthMetricsParsingTest`
- Tests cover: normal parsing, malformed tokens handling, comma-in-value handling, rate-limited logging, null/empty input handling

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)