### PR TITLE
[Fix][E2E] Fix flaky CI failure in `KingbaseDialectContainerTest`

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/AbstractKingbaseContainerTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/AbstractKingbaseContainerTest.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.kingbase.KingbaseC
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.containers.GenericContainer;
@@ -44,6 +45,7 @@ import java.time.Duration;
  * errors, please replace the image with a newly built one that contains a valid license.
  */
 @DisabledOnOs(OS.WINDOWS)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractKingbaseContainerTest {
 
     protected static final String KINGBASE_IMAGE = "liangyaobo/kingbase:v8r6-license";
@@ -53,12 +55,12 @@ public abstract class AbstractKingbaseContainerTest {
     protected static final String SCHEMA = "public";
     protected static final int KINGBASE_PORT = 54321;
 
-    protected static GenericContainer<?> kingbaseContainer;
-    protected static Connection connection;
-    protected static KingbaseCatalog catalog;
+    protected GenericContainer<?> kingbaseContainer;
+    protected String jdbcUrl;
+    protected KingbaseCatalog catalog;
 
     @BeforeAll
-    public static void startContainer() throws SQLException {
+    public void startContainer() throws SQLException {
         DockerImageName imageName = DockerImageName.parse(KINGBASE_IMAGE);
 
         kingbaseContainer =
@@ -73,9 +75,9 @@ public abstract class AbstractKingbaseContainerTest {
 
         String host = kingbaseContainer.getHost();
         Integer mappedPort = kingbaseContainer.getMappedPort(KINGBASE_PORT);
-        String jdbcUrl = String.format("jdbc:kingbase8://%s:%d/%s", host, mappedPort, DATABASE);
+        jdbcUrl = String.format("jdbc:kingbase8://%s:%d/%s", host, mappedPort, DATABASE);
 
-        connection = connectWithRetry(jdbcUrl, USERNAME, PASSWORD);
+        waitUntilSqlReady();
 
         catalog =
                 new KingbaseCatalog(
@@ -89,12 +91,9 @@ public abstract class AbstractKingbaseContainerTest {
     }
 
     @AfterAll
-    public static void stopContainer() throws SQLException {
+    public void stopContainer() {
         if (catalog != null) {
             catalog.close();
-        }
-        if (connection != null && !connection.isClosed()) {
-            connection.close();
         }
         if (kingbaseContainer != null) {
             kingbaseContainer.stop();
@@ -102,8 +101,36 @@ public abstract class AbstractKingbaseContainerTest {
     }
 
     protected void executeSql(String sql) throws SQLException {
-        try (Statement stmt = connection.createStatement()) {
+        try (Connection connection = getConnection();
+                Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
+        }
+    }
+
+    protected Connection getConnection() throws SQLException {
+        return connectWithRetry(jdbcUrl, USERNAME, PASSWORD);
+    }
+
+    private void waitUntilSqlReady() throws SQLException {
+        RetryUtils.RetryMaterial retryMaterial =
+                new RetryUtils.RetryMaterial(30, true, exception -> true, 2000);
+
+        try {
+            RetryUtils.retryWithException(
+                    () -> {
+                        try (Connection connection =
+                                        DriverManager.getConnection(jdbcUrl, USERNAME, PASSWORD);
+                                Statement stmt = connection.createStatement()) {
+                            stmt.execute("SELECT 1");
+                        }
+                        return null;
+                    },
+                    retryMaterial);
+        } catch (Exception e) {
+            if (e instanceof SQLException) {
+                throw (SQLException) e;
+            }
+            throw new SQLException("Kingbase is not ready to execute SQL", e);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/KingbaseCatalogContainerTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/KingbaseCatalogContainerTest.java
@@ -95,7 +95,7 @@ public class KingbaseCatalogContainerTest extends AbstractKingbaseContainerTest 
     }
 
     @Test
-    public void testCreateTableViaAPI() throws SQLException {
+    public void testCreateTableViaAPI() {
         String testTableName = "test_api_create_table";
         TablePath tablePath = TablePath.of(DATABASE, SCHEMA, testTableName);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/KingbaseDialectContainerTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/container/KingbaseDialectContainerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,36 +42,37 @@ import java.util.Optional;
 @DisabledOnOs(OS.WINDOWS)
 public class KingbaseDialectContainerTest extends AbstractKingbaseContainerTest {
 
-    private static KingbaseDialect dialect;
     private static final String TEST_TABLE = "dialect_test_table";
+    private KingbaseDialect dialect;
 
     @BeforeAll
-    public static void setupDialect() throws SQLException {
+    public void setupDialect() throws SQLException {
         dialect = new KingbaseDialect();
 
-        String createTableSql =
-                String.format(
-                        "CREATE TABLE %s.%s ("
-                                + "id INT8 PRIMARY KEY, "
-                                + "name VARCHAR(100), "
-                                + "value NUMERIC(10,2), "
-                                + "created_at TIMESTAMP"
-                                + ")",
-                        quoteIdentifier(SCHEMA), quoteIdentifier(TEST_TABLE));
+        String qualifiedTable =
+                String.format("%s.%s", quoteIdentifier(SCHEMA), quoteIdentifier(TEST_TABLE));
 
-        try (Statement stmt = connection.createStatement()) {
-            stmt.execute(createTableSql);
-        }
+        String createTableSql =
+                "CREATE TABLE IF NOT EXISTS "
+                        + qualifiedTable
+                        + " ("
+                        + "id BIGINT PRIMARY KEY, "
+                        + "name VARCHAR(100), "
+                        + "value NUMERIC(10,2), "
+                        + "created_at TIMESTAMP"
+                        + ")";
+        executeSql(createTableSql);
+
+        String truncateSql = "TRUNCATE TABLE " + qualifiedTable;
+        executeSql(truncateSql);
 
         // Insert test data
         String insertSql =
-                String.format(
-                        "INSERT INTO %s.%s (id, name, value, created_at) "
-                                + "VALUES (1, 'test1', 100.50, CURRENT_TIMESTAMP)",
-                        quoteIdentifier(SCHEMA), quoteIdentifier(TEST_TABLE));
-        try (Statement stmt = connection.createStatement()) {
-            stmt.execute(insertSql);
-        }
+                "INSERT INTO "
+                        + qualifiedTable
+                        + " (id, name, value, created_at) "
+                        + "VALUES (1, 'test1', 100.50, CURRENT_TIMESTAMP)";
+        executeSql(insertSql);
     }
 
     @Test
@@ -221,7 +223,8 @@ public class KingbaseDialectContainerTest extends AbstractKingbaseContainerTest 
             executeSql(insertSql);
 
             // Verify insert
-            try (Statement stmt = connection.createStatement();
+            try (Connection connection = getConnection();
+                    Statement stmt = connection.createStatement();
                     ResultSet rs =
                             stmt.executeQuery(
                                     String.format(
@@ -290,20 +293,15 @@ public class KingbaseDialectContainerTest extends AbstractKingbaseContainerTest 
 
     @Test
     public void testCreatPreparedStatement() throws SQLException {
-        PreparedStatement ps = null;
-        try {
-            String sql =
-                    String.format(
-                            "SELECT * FROM %s.%s",
-                            quoteIdentifier(SCHEMA), quoteIdentifier(TEST_TABLE));
-            ps = dialect.creatPreparedStatement(connection, sql, 100);
+        String sql =
+                String.format(
+                        "SELECT * FROM %s.%s",
+                        quoteIdentifier(SCHEMA), quoteIdentifier(TEST_TABLE));
 
+        try (Connection connection = getConnection();
+                PreparedStatement ps = dialect.creatPreparedStatement(connection, sql, 100)) {
             Assertions.assertNotNull(ps);
             Assertions.assertEquals(100, ps.getFetchSize());
-        } finally {
-            if (ps != null) {
-                ps.close();
-            }
         }
     }
 


### PR DESCRIPTION
### Purpose of this pull request

`KingbaseDialectContainerTest` were occasionally failing with `NullPointerException` in CI.

The previous test structure relied on shared static state and reused JDBC connections across test execution, which made the tests sensitive to lifecycle ordering and shared resource state.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)