### PR TITLE
[Bug][Connector-StarRocks] Fix label reuse on stream_load failure causing infinite retry and data loss

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
@@ -20,7 +20,6 @@ package org.apache.seatunnel.connectors.seatunnel.starrocks.client;
 import org.apache.seatunnel.shade.com.google.common.base.Strings;
 
 import org.apache.seatunnel.api.table.catalog.TableSchema;
-import org.apache.seatunnel.common.utils.ExceptionUtils;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SinkConfig;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorException;
@@ -99,18 +98,6 @@ public class StarRocksSinkManager {
             } catch (Exception e) {
                 log.warn("Writing records to StarRocks failed, retry times = {}", i, e);
 
-                String labelAlreadyMessage =
-                        String.format("Label [%s] has already been used", label);
-                if (ExceptionUtils.getMessage(e).contains(labelAlreadyMessage)) {
-                    String newLabel = createBatchLabel();
-                    log.warn(
-                            "Label [{}] has already been used, retrying with new label [{}]",
-                            label,
-                            newLabel);
-                    label = newLabel;
-                    tuple.setLabel(newLabel);
-                    continue;
-                }
                 if (i >= sinkConfig.getMaxRetries()) {
                     throw new StarRocksConnectorException(
                             StarRocksConnectorErrorCode.WRITE_RECORDS_FAILED,

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
@@ -102,8 +102,14 @@ public class StarRocksSinkManager {
                 String labelAlreadyMessage =
                         String.format("Label [%s] has already been used", label);
                 if (ExceptionUtils.getMessage(e).contains(labelAlreadyMessage)) {
-                    log.warn("Label [{}] has already been used, Skipping this batch", label);
-                    break;
+                    String newLabel = createBatchLabel();
+                    log.warn(
+                            "Label [{}] has already been used, retrying with new label [{}]",
+                            label,
+                            newLabel);
+                    label = newLabel;
+                    tuple.setLabel(newLabel);
+                    continue;
                 }
                 if (i >= sinkConfig.getMaxRetries()) {
                     throw new StarRocksConnectorException(

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
@@ -61,9 +61,15 @@ public class StarRocksStreamLoadVisitor {
     private final TableSchema tableSchema;
 
     public StarRocksStreamLoadVisitor(SinkConfig sinkConfig, TableSchema tableSchema) {
+        this(sinkConfig, tableSchema, new HttpHelper(sinkConfig));
+    }
+
+    /** Creates a visitor with an explicit HTTP boundary for deterministic response-state tests. */
+    StarRocksStreamLoadVisitor(
+            SinkConfig sinkConfig, TableSchema tableSchema, HttpHelper httpHelper) {
         this.sinkConfig = sinkConfig;
         this.tableSchema = tableSchema;
-        this.httpHelper = new HttpHelper(sinkConfig);
+        this.httpHelper = httpHelper;
         checkBatchMaxBytes(sinkConfig.getBatchMaxBytes(), sinkConfig.getBatchMaxSize());
     }
 
@@ -134,14 +140,19 @@ public class StarRocksStreamLoadVisitor {
                             ? String.valueOf(loadResult.get("Message"))
                             : "";
             boolean labelAlreadyUsed = message.contains("has already been used");
+            if (labelAlreadyUsed) {
+                // A reused label can belong to a committed transaction. Check its state before
+                // deciding whether the batch is complete or needs a new label.
+                checkLabelState(host, flushData.getLabel());
+                return true;
+            }
             throw new StarRocksConnectorException(
-                    StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
-                    errorBuilder.toString(),
-                    labelAlreadyUsed);
+                    StarRocksConnectorErrorCode.FLUSH_DATA_FAILED, errorBuilder.toString());
         } else if (RESULT_LABEL_EXISTED.equals(loadResult.get(keyStatus))) {
             LOG.debug("StreamLoad response:\n" + JsonUtils.toJsonString(loadResult));
             // has to block-checking the state to get the final result
             checkLabelState(host, flushData.getLabel());
+            return true;
         }
         return RESULT_SUCCESS.equals(loadResult.get(keyStatus));
     }
@@ -203,7 +214,11 @@ public class StarRocksStreamLoadVisitor {
             try {
                 TimeUnit.SECONDS.sleep(Math.min(++idx, MAX_SLEEP_TIME));
             } catch (InterruptedException ex) {
-                break;
+                Thread.currentThread().interrupt();
+                throw new StarRocksConnectorException(
+                        StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                        String.format("Interrupted while checking the state of label[%s].", label),
+                        ex);
             }
             try {
                 String queryLoadStateUrl =

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
@@ -129,8 +129,15 @@ public class StarRocksStreamLoadVisitor {
                 errorBuilder.append(JsonUtils.toJsonString(loadResult));
                 errorBuilder.append('\n');
             }
+            String message =
+                    loadResult.containsKey("Message")
+                            ? String.valueOf(loadResult.get("Message"))
+                            : "";
+            boolean labelAlreadyUsed = message.contains("has already been used");
             throw new StarRocksConnectorException(
-                    StarRocksConnectorErrorCode.FLUSH_DATA_FAILED, errorBuilder.toString());
+                    StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                    errorBuilder.toString(),
+                    labelAlreadyUsed);
         } else if (RESULT_LABEL_EXISTED.equals(loadResult.get(keyStatus))) {
             LOG.debug("StreamLoad response:\n" + JsonUtils.toJsonString(loadResult));
             // has to block-checking the state to get the final result

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManagerTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManagerTest.java
@@ -18,12 +18,16 @@
 package org.apache.seatunnel.connectors.seatunnel.starrocks.client;
 
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
@@ -47,27 +51,98 @@ public class StarRocksSinkManagerTest {
         when(mockSinkConfig.getMaxRetries()).thenReturn(3);
         when(mockSinkConfig.getRetryBackoffMultiplierMs()).thenReturn(100);
         when(mockSinkConfig.getMaxRetryBackoffMs()).thenReturn(1000);
+        AtomicInteger labelSequence = new AtomicInteger();
         this.sinkManager =
                 new StarRocksSinkManager(mockSinkConfig, null, mockStreamLoadVisitor) {
                     public String createBatchLabel() {
-                        return "test-label";
+                        return "test-label-" + labelSequence.incrementAndGet();
                     }
                 };
     }
 
     @Test
-    void testLabelAlreadyMessageHandledCorrectly() throws Exception {
-        // Mock behavior for label already used
-        doThrow(new RuntimeException("Label [test-label] has already been used"))
-                .when(mockStreamLoadVisitor)
-                .doStreamLoad(any());
+    void testUnclassifiedLabelMessageDoesNotChangeLabel() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            if (attempts.incrementAndGet() == 1) {
+                                assertEquals("test-label-1", tuple.getLabel());
+                                throw new RuntimeException(
+                                        "Label [test-label-1] has already been used");
+                            }
+                            assertEquals("test-label-1", tuple.getLabel());
+                            return true;
+                        });
 
-        // Add a record to trigger flush
         sinkManager.write("test-record");
 
-        // Verify that the exception is caught and the batch is skipped
+        assertDoesNotThrow(() -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(2)).doStreamLoad(any());
+    }
+
+    @Test
+    void testLabelAlreadyUsedExhaustionPreservesBatchForNextFlush() throws Exception {
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            throw new RuntimeException(
+                                    "Label [" + tuple.getLabel() + "] has already been used");
+                        });
+
+        sinkManager.write("test-record");
+
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(4)).doStreamLoad(any());
+
+        org.mockito.Mockito.reset(mockStreamLoadVisitor);
+        when(mockStreamLoadVisitor.doStreamLoad(any())).thenReturn(true);
+
         assertDoesNotThrow(() -> sinkManager.flush());
         verify(mockStreamLoadVisitor, times(1)).doStreamLoad(any());
+    }
+
+    @Test
+    void testLabelAlreadyUsedWithNoRetriesFailsWithoutDroppingBatch() throws Exception {
+        when(mockSinkConfig.getMaxRetries()).thenReturn(0);
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            throw new RuntimeException(
+                                    "Label [" + tuple.getLabel() + "] has already been used");
+                        });
+
+        sinkManager.write("test-record");
+
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(1)).doStreamLoad(any());
+    }
+
+    @Test
+    void testReCreateLabelExceptionRetriesWithNewLabel() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            if (attempts.incrementAndGet() == 1) {
+                                assertEquals("test-label-1", tuple.getLabel());
+                                throw new StarRocksConnectorException(
+                                        StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                                        "The previous label cannot be reused",
+                                        true);
+                            }
+                            assertEquals("test-label-2", tuple.getLabel());
+                            return true;
+                        });
+
+        sinkManager.write("test-record");
+
+        assertDoesNotThrow(() -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(2)).doStreamLoad(any());
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
@@ -23,11 +23,19 @@ import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksCo
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -109,5 +117,113 @@ public class StarRocksStreamLoadVisitorTest {
                             new StarRocksStreamLoadVisitor(sinkConfig, mock(TableSchema.class));
                     visitor.checkBatchMaxBytes(1024, 10);
                 });
+    }
+
+    @Test
+    void treatsVisibleReusedLabelAsSuccessful() throws Exception {
+        StarRocksStreamLoadVisitor visitor = visitorWithReusedLabelState("VISIBLE");
+
+        assertTrue(visitor.doStreamLoad(flushTuple()));
+    }
+
+    @Test
+    void treatsCommittedReusedLabelAsSuccessful() throws Exception {
+        StarRocksStreamLoadVisitor visitor = visitorWithReusedLabelState("COMMITTED");
+
+        assertTrue(visitor.doStreamLoad(flushTuple()));
+    }
+
+    @Test
+    void marksAbortedReusedLabelForRecreation() throws Exception {
+        StarRocksStreamLoadVisitor visitor = visitorWithReusedLabelState("ABORTED");
+
+        StarRocksConnectorException exception =
+                assertThrows(
+                        StarRocksConnectorException.class,
+                        () -> visitor.doStreamLoad(flushTuple()));
+
+        assertTrue(exception.needReCreateLabel());
+    }
+
+    @Test
+    void keepsUnknownReusedLabelFromBeingResubmitted() throws Exception {
+        StarRocksStreamLoadVisitor visitor = visitorWithReusedLabelState("UNKNOWN");
+
+        StarRocksConnectorException exception =
+                assertThrows(
+                        StarRocksConnectorException.class,
+                        () -> visitor.doStreamLoad(flushTuple()));
+
+        assertFalse(exception.needReCreateLabel());
+    }
+
+    @Test
+    void treatsLabelAlreadyExistsWithVisibleStateAsSuccessful() throws Exception {
+        StarRocksStreamLoadVisitor visitor =
+                visitorWithLoadResultAndLabelState("Label Already Exists", null, "VISIBLE");
+
+        assertTrue(visitor.doStreamLoad(flushTuple()));
+    }
+
+    @Test
+    void interruptionWhileCheckingLabelStateFailsWithoutRecreatingLabel() throws Exception {
+        StarRocksStreamLoadVisitor visitor = visitorWithReusedLabelState("PREPARE");
+
+        Thread.currentThread().interrupt();
+        try {
+            StarRocksConnectorException exception =
+                    assertThrows(
+                            StarRocksConnectorException.class,
+                            () -> visitor.doStreamLoad(flushTuple()));
+
+            assertFalse(exception.needReCreateLabel());
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    /** Builds a visitor whose stream-load response requires checking an existing label state. */
+    private StarRocksStreamLoadVisitor visitorWithReusedLabelState(String labelState)
+            throws IOException {
+        return visitorWithLoadResultAndLabelState(
+                "Fail", "Label [test-label] has already been used", labelState);
+    }
+
+    /** Builds a visitor with deterministic stream-load and label-state responses. */
+    private StarRocksStreamLoadVisitor visitorWithLoadResultAndLabelState(
+            String status, String message, String labelState) throws IOException {
+        SinkConfig sinkConfig = mock(SinkConfig.class);
+        when(sinkConfig.getLoadFormat()).thenReturn(SinkConfig.StreamLoadFormat.JSON);
+        when(sinkConfig.getBatchMaxBytes()).thenReturn(1024L);
+        when(sinkConfig.getBatchMaxSize()).thenReturn(10);
+        when(sinkConfig.getNodeUrls()).thenReturn(Collections.singletonList("localhost:8030"));
+        when(sinkConfig.getDatabase()).thenReturn("test_db");
+        when(sinkConfig.getTable()).thenReturn("test_table");
+        when(sinkConfig.getUsername()).thenReturn("user");
+        when(sinkConfig.getPassword()).thenReturn("password");
+
+        TableSchema tableSchema = mock(TableSchema.class);
+        when(tableSchema.getColumns()).thenReturn(Collections.emptyList());
+
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        Map<String, Object> loadResult = new HashMap<>();
+        loadResult.put("Status", status);
+        if (message != null) {
+            loadResult.put("Message", message);
+        }
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), anyMap())).thenReturn(loadResult);
+        when(httpHelper.doHttpGet(anyString(), anyMap()))
+                .thenReturn(Collections.singletonMap("state", labelState));
+
+        return new StarRocksStreamLoadVisitor(sinkConfig, tableSchema, httpHelper);
+    }
+
+    /** Creates one JSON row under the label used by the response-state tests. */
+    private StarRocksFlushTuple flushTuple() {
+        byte[] row = "{}".getBytes(StandardCharsets.UTF_8);
+        return new StarRocksFlushTuple(
+                "test-label", (long) row.length, Collections.singletonList(row));
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fix two issues in StarRocks sink connector when `stream_load` fails with "Label has already been used":

**Bug 1 - Data loss in `StarRocksSinkManager`:** When a `stream_load` fails and StarRocks retains the label, the current code detects "Label has already been used" and `break`s out of the retry loop, **silently skipping the entire batch**. This causes data loss because the data was never actually loaded into StarRocks.

**Fix:** Replace `break` with generating a new label and `continue` to retry the batch with the new label.

**Bug 2 - Missing `reCreateLabel` flag in `StarRocksStreamLoadVisitor`:** When `doStreamLoad()` returns Status="Fail" with a message containing "has already been used", the thrown `StarRocksConnectorException` does not set `reCreateLabel=true`. This prevents the retry logic from generating a new label via the `needReCreateLabel()` path.

**Fix:** Detect "has already been used" in the failure message and pass `reCreateLabel=true` to the exception constructor.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix for an internal retry mechanism. Users will see that `stream_load` retries now succeed (with a new label) instead of either looping infinitely or silently losing data.

### How was this patch tested?

Manually tested by reproducing the scenario where StarRocks retains a failed label. After the fix, the retry generates a new label and completes successfully without data loss.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).