### PR TITLE
[ Improve ][Docs] Improve Redshift sink connector documentation

### DIFF
--- a/docs/en/connectors/sink/Redshift.md
+++ b/docs/en/connectors/sink/Redshift.md
@@ -2,35 +2,24 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 # Redshift
 
-> JDBC Redshift sink Connector
+> JDBC Redshift Sink Connector
 
-## Support those engines
+## Support Redshift Version
+
+- Amazon Redshift (all available versions)
+
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
-> Seatunnel Zeta<br/>
-
-## Key features
-
-- [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
-
-> Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
-> support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
+> SeaTunnel Zeta<br/>
 
 ## Description
 
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
+Write data through JDBC. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
 semantics (using XA transaction guarantee).
 
-## Supported DataSource list
-
-| datasource |                    supported versions                    |             driver              |                   url                   |                                       maven                                        |
-|------------|----------------------------------------------------------|---------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
-| redshift   | Different dependency version has different driver class. | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [Download](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
-
-## Database dependency
+## Using Dependency
 
 ### For Spark/Flink Engine
 
@@ -40,27 +29,114 @@ semantics (using XA transaction guarantee).
 
 > 1. You need to ensure that the [jdbc driver jar package](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) has been placed in directory `${SEATUNNEL_HOME}/lib/`.
 
+## Key Features
+
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+
+> Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
+> support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
+
+## Supported DataSource Info
+
+| Datasource |                    Supported Versions                    |             Driver              |                   Url                   |                                       Maven                                        |
+|------------|----------------------------------------------------------|---------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
+| Redshift   | Different dependency version has different driver class. | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [Download](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
+
 ## Data Type Mapping
 
-|   SeaTunnel Data type   | Redshift Data type |
-|-------------------------|--------------------|
-| BOOLEAN                 | BOOLEAN            |
-| TINYINT<br/> SMALLINT   | SMALLINT           |
-| INT                     | INTEGER            |
-| BIGINT                  | BIGINT             |
-| FLOAT                   | REAL               |
-| DOUBLE                  | DOUBLE PRECISION   |
-| DECIMAL                 | NUMERIC            |
-| STRING(<=65535)         | CHARACTER VARYING  |
-| STRING(>65535)          | SUPER              |
-| BYTES                   | BINARY VARYING     |
-| TIME                    | TIME               |
-| TIMESTAMP               | TIMESTAMP          |
-| MAP<br/> ARRAY<br/> ROW | SUPER              |
+|      SeaTunnel Data Type       |  Redshift Data Type  |
+|--------------------------------|----------------------|
+| BOOLEAN                        | BOOLEAN              |
+| TINYINT<br/>SMALLINT           | SMALLINT             |
+| INT                            | INTEGER              |
+| BIGINT                         | BIGINT               |
+| FLOAT                          | REAL                 |
+| DOUBLE                         | DOUBLE PRECISION     |
+| DECIMAL                        | NUMERIC              |
+| STRING(<=65535)                | CHARACTER VARYING    |
+| STRING(>65535)                 | SUPER                |
+| BYTES                          | BINARY VARYING       |
+| TIME                           | TIME                 |
+| TIMESTAMP                      | TIMESTAMP            |
+| MAP<br/>ARRAY<br/>ROW          | SUPER                |
+
+## Sink Options
+
+|                   Name                    |  Type   | Required |           Default            |                                                                                                                  Description                                                                                                                   |
+|-------------------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                                       | String  | Yes      | -                            | The URL of the JDBC connection. Refer to a case: `jdbc:redshift://localhost:5439/mydatabase`                                                                                                                                                   |
+| driver                                    | String  | Yes      | -                            | The jdbc class name used to connect to the remote data source, the value is `com.amazon.redshift.jdbc.Driver`.                                                                                                                                 |
+| username                                  | String  | No       | -                            | Connection instance user name                                                                                                                                                                                                                  |
+| password                                  | String  | No       | -                            | Connection instance password                                                                                                                                                                                                                   |
+| query                                     | String  | No       | -                            | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
+| database                                  | String  | No       | -                            | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                        |
+| table                                     | String  | No       | -                            | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                            |
+| schema                                    | String  | No       | public                       | The schema name of the target table in Redshift.                                                                                                                                                                                               |
+| primary_keys                              | Array   | No       | -                            | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql.                                                                                                                            |
+| connection_check_timeout_sec              | Int     | No       | 30                           | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                             |
+| max_retries                               | Int     | No       | 0                            | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
+| batch_size                                | Int     | No       | 1000                         | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
+| is_exactly_once                           | Boolean | No       | false                        | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`.                                                                                                              |
+| generate_sink_sql                         | Boolean | No       | false                        | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
+| xa_data_source_class_name                 | String  | No       | -                            | The xa data source class name of the database Driver, for Redshift it is `com.amazon.redshift.xa.RedshiftXADataSource`                                                                                                                        |
+| max_commit_attempts                       | Int     | No       | 3                            | The number of retries for transaction commit failures                                                                                                                                                                                          |
+| transaction_timeout_sec                   | Int     | No       | -1                           | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
+| auto_commit                               | Boolean | No       | true                         | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
+| field_ide                                 | String  | No       | -                            | Identify whether the field needs to be converted when synchronizing from the source to the sink. `ORIGINAL` indicates no conversion is needed;`UPPERCASE` indicates conversion to uppercase;`LOWERCASE` indicates conversion to lowercase.      |
+| properties                                | Map     | No       | -                            | Additional connection configuration parameters, when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in Redshift, properties take precedence over the URL. |
+| common-options                            |         | No       | -                            | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                     |
+| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Before the synchronous task is turned on, different treatment schemes are selected for the existing surface structure of the target side.                                                                                                       |
+| data_save_mode                            | Enum    | No       | APPEND_DATA                  | Before the synchronous task is turned on, different processing schemes are selected for data existing data on the target side.                                                                                                                  |
+| custom_sql                                | String  | No       | -                            | When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL parameter. This parameter usually fills in a SQL that can be executed. SQL will be executed before synchronization tasks.                                      |
+| enable_upsert                             | Boolean | No       | true                         | Enable upsert by primary_keys exist, If the task only has `insert`, setting this parameter to `false` can speed up data import                                                                                                                 |
+| multi_table_sink_replica                  | Int     | No       | 1                            | The number of replicas for multi-table write, when `multi_table_sink_replica > 1`, the data will be written to multiple tables in parallel                                                                                                     |
 
 ## Task Example
 
 ### Simple
+
+> This example defines a SeaTunnel synchronization task that automatically generates data through FakeSource and sends it to JDBC Sink. FakeSource generates a total of 16 rows of data (row.num=16), with each row having two fields, name (string type) and age (int type). The final target table is test_table will also be 16 rows of data in the table. Before run this job, you need create database and table test_table in your Redshift. And if you have not yet installed and deployed SeaTunnel, you need to follow the instructions in [Install SeaTunnel](../../getting-started/locally/deployment.md) to install and deploy SeaTunnel. And then follow the instructions in [Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md) to run this job.
+
+```
+# Defining the runtime environment
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 16
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+    jdbc {
+        url = "jdbc:redshift://localhost:5439/mydatabase"
+        driver = "com.amazon.redshift.jdbc.Driver"
+        username = "myUser"
+        password = "myPassword"
+        query = "insert into test_table(name,age) values(?,?)"
+    }
+}
+```
+
+### Generate Sink SQL
+
+> This example does not need to write complex sql statements, you can configure the database name and table name to automatically generate add statements for you
 
 ```
 sink {
@@ -69,17 +145,36 @@ sink {
         driver = "com.amazon.redshift.jdbc.Driver"
         username = "myUser"
         password = "myPassword"
-        
         generate_sink_sql = true
+        database = mydatabase
         schema = "public"
-        table = "sink_table"
+        table = test_table
     }
 }
 ```
 
-### CDC(Change data capture) event
+### Exactly-Once
 
-> CDC change data is also supported by us In this case, you need config database, table and primary_keys.
+> For accurate write scene we guarantee accurate once
+
+```
+sink {
+    jdbc {
+        url = "jdbc:redshift://localhost:5439/mydatabase"
+        driver = "com.amazon.redshift.jdbc.Driver"
+        max_retries = 0
+        username = "myUser"
+        password = "myPassword"
+        query = "insert into test_table(name,age) values(?,?)"
+        is_exactly_once = "true"
+        xa_data_source_class_name = "com.amazon.redshift.xa.RedshiftXADataSource"
+    }
+}
+```
+
+### CDC(Change Data Capture) Event
+
+> CDC change data is also supported by us. In this case, you need config database, table and primary_keys.
 
 ```
 sink {
@@ -87,15 +182,101 @@ sink {
         url = "jdbc:redshift://localhost:5439/mydatabase"
         driver = "com.amazon.redshift.jdbc.Driver"
         username = "myUser"
-        password = "mypassword"
-        
+        password = "myPassword"
         generate_sink_sql = true
+        database = mydatabase
         schema = "public"
-        table = "sink_table"
-        
-        # config update/delete primary keys
+        table = sink_table
         primary_keys = ["id","name"]
+        field_ide = UPPERCASE
+        schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+        data_save_mode = "APPEND_DATA"
     }
+}
+```
+
+### Multiple Table Sync
+
+#### Example 1: CDC Multiple Table Sync to Redshift
+
+> Sync multiple tables from a CDC source to target Redshift database, using placeholders for dynamic table name mapping
+
+```
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  Mysql-CDC {
+    url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
+    username = "root"
+    password = "******"
+    table-names = ["seatunnel.role","seatunnel.user","seatunnel.order"]
+  }
+}
+
+transform {
+}
+
+sink {
+  jdbc {
+    url = "jdbc:redshift://redshift-cluster.xxxx.region.redshift.amazonaws.com:5439/mydatabase"
+    driver = "com.amazon.redshift.jdbc.Driver"
+    username = "myUser"
+    password = "myPassword"
+    generate_sink_sql = true
+    database = mydatabase
+    schema = "public"
+    table = "${table_name}_sink"
+    primary_keys = ["${primary_key}"]
+  }
+}
+```
+
+#### Example 2: JDBC Source Multiple Table Sync to Redshift
+
+> Batch sync multiple tables from a database using JDBC Source to Redshift
+
+```
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = com.mysql.cj.jdbc.Driver
+    url = "jdbc:mysql://localhost:3306/source_db"
+    username = "root"
+    password = "123456"
+    table_list = [
+      {
+        table_path = "source_db.table_1"
+      },
+      {
+        table_path = "source_db.table_2"
+      }
+    ]
+  }
+}
+
+transform {
+}
+
+sink {
+  jdbc {
+    url = "jdbc:redshift://redshift-cluster.xxxx.region.redshift.amazonaws.com:5439/mydatabase"
+    driver = "com.amazon.redshift.jdbc.Driver"
+    username = "myUser"
+    password = "myPassword"
+    generate_sink_sql = true
+    database = mydatabase
+    schema = "public"
+    table = "${table_name}_copy"
+    primary_keys = ["${primary_key}"]
+  }
 }
 ```
 

--- a/docs/en/connectors/sink/Redshift.md
+++ b/docs/en/connectors/sink/Redshift.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Support Redshift Version
 
-- Amazon Redshift (all available versions)
+- Amazon Redshift
 
 ## Support Those Engines
 
@@ -64,6 +64,8 @@ semantics (using XA transaction guarantee).
 
 ## Sink Options
 
+> Redshift sink is implemented on top of the JDBC sink. The table below focuses on the most commonly used Redshift options. For inherited advanced JDBC sink options such as `compatible_mode`, `dialect`, `is_primary_key_updated`, `support_upsert_by_insert_only`, `use_copy_statement`, `tablePrefix`, `tableSuffix`, and `create_index`, see [JDBC Sink](Jdbc.md).
+
 |                   Name                    |  Type   | Required |           Default            |                                                                                                                  Description                                                                                                                   |
 |-------------------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                                       | String  | Yes      | -                            | The URL of the JDBC connection. Refer to a case: `jdbc:redshift://localhost:5439/mydatabase`                                                                                                                                                   |
@@ -73,7 +75,7 @@ semantics (using XA transaction guarantee).
 | query                                     | String  | No       | -                            | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
 | database                                  | String  | No       | -                            | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                        |
 | table                                     | String  | No       | -                            | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                            |
-| schema                                    | String  | No       | public                       | The schema name of the target table in Redshift.                                                                                                                                                                                               |
+| schema                                    | String  | No       | -                            | The schema name of the target table in Redshift. SeaTunnel does not apply a default value for this option. Configure it explicitly when the target table is not already schema-qualified or when using catalog-based operations such as `generate_sink_sql`, `schema_save_mode`, and `data_save_mode`. |
 | primary_keys                              | Array   | No       | -                            | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql.                                                                                                                            |
 | connection_check_timeout_sec              | Int     | No       | 30                           | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                             |
 | max_retries                               | Int     | No       | 0                            | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |

--- a/docs/zh/connectors/sink/Redshift.md
+++ b/docs/zh/connectors/sink/Redshift.md
@@ -4,62 +4,137 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > JDBC Redshift 接收器连接器
 
+## 支持的 Redshift 版本
+
+- Amazon Redshift（所有可用版本）
+
 ## 支持以下引擎
 
 > Spark<br/>
 > Flink<br/>
-> Seatunnel Zeta<br/>
-
-## 关键特性
-
-- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
-- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [更改数据捕获](../../introduction/concepts/connector-v2-features.md)
-
-> 使用 `Xa transactions` 确保 `exactly-once`. 因此，数据库只支持 `exactly-once` 
-> 即支持 `Xa transactions`. 您可以设置 `is_exactly_once=true` 来启用它.
+> SeaTunnel Zeta<br/>
 
 ## 描述
 
-通过jdbc写入数据. 支持批处理模式和流模式，支持并发写入，只支持一次语义 (使用 XA transaction guarantee).
+通过 JDBC 写入数据。支持批处理模式和流模式，支持并发写入，支持精确一次语义（使用 XA 事务保证）。
 
-## 支持的数据源列表
+## 需要的依赖项
 
-| 数据源 |                    支持版本                    | 驱动                              |                   url                   | maven                                                                        |
-|------------|----------------------------------------------------------|---------------------------------|-----------------------------------------|------------------------------------------------------------------------------|
-| redshift   | 不同的依赖版本有不同的驱动程序类. | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [下载](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
+### 对于 Spark/Flink 引擎
 
-## 数据库相关性
+> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
 
-### 适用于 Spark/Flink 引擎
+### 对于 SeaTunnel Zeta 引擎
 
-> 1. 您需要确保 [jdbc driver jar package](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/plugins/`.
+> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
 
-### 适用于 SeaTunnel Zeta 引擎
+## 主要功能
 
-> 1. 您需要确保 [jdbc driver jar package](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/lib/`.
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+
+> 使用 `Xa 事务` 确保 `精确一次`。因此仅支持 `精确一次` 的数据库才支持 `Xa 事务`。您可以设置 `is_exactly_once=true` 来启用它。
+
+## 支持的数据源信息
+
+| 数据源     |         支持的版本          |             驱动              |                   URL                   |                                       Maven                                        |
+|------------|----------------------------------------------------------|---------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
+| Redshift   | 不同的依赖版本有不同的驱动程序类 | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [下载](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
 
 ## 数据类型映射
 
-| SeaTunnel 数据类型          | Redshift 数据类型 |
-|-------------------------|--------------------|
-| BOOLEAN                 | BOOLEAN            |
-| TINYINT<br/> SMALLINT   | SMALLINT           |
-| INT                     | INTEGER            |
-| BIGINT                  | BIGINT             |
-| FLOAT                   | REAL               |
-| DOUBLE                  | DOUBLE PRECISION   |
-| DECIMAL                 | NUMERIC            |
-| STRING(<=65535)         | CHARACTER VARYING  |
-| STRING(>65535)          | SUPER              |
-| BYTES                   | BINARY VARYING     |
-| TIME                    | TIME               |
-| TIMESTAMP               | TIMESTAMP          |
-| MAP<br/> ARRAY<br/> ROW | SUPER              |
+|      SeaTunnel 数据类型       |  Redshift 数据类型  |
+|--------------------------------|----------------------|
+| BOOLEAN                        | BOOLEAN              |
+| TINYINT<br/>SMALLINT           | SMALLINT             |
+| INT                            | INTEGER              |
+| BIGINT                         | BIGINT               |
+| FLOAT                          | REAL                 |
+| DOUBLE                         | DOUBLE PRECISION     |
+| DECIMAL                        | NUMERIC              |
+| STRING(<=65535)                | CHARACTER VARYING    |
+| STRING(>65535)                 | SUPER                |
+| BYTES                          | BINARY VARYING       |
+| TIME                           | TIME                 |
+| TIMESTAMP                      | TIMESTAMP            |
+| MAP<br/>ARRAY<br/>ROW          | SUPER                |
+
+## Sink 参数
+
+| 名称                           | 类型    | 是否必填 |           默认值            |                                                                                                                  描述                                                                                                                   |
+|------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                          | String  | 是      | -                            | JDBC 连接的 URL。参见示例：`jdbc:redshift://localhost:5439/mydatabase`                                                                                                                                                                        |
+| driver                       | String  | 是      | -                            | 用于连接远程数据源的 JDBC 类名，值为 `com.amazon.redshift.jdbc.Driver`。                                                                                                                                                                     |
+| username                     | String  | 否       | -                            | 连接实例用户名                                                                                                                                                                                                                                 |
+| password                     | String  | 否       | -                            | 连接实例密码                                                                                                                                                                                                                                   |
+| query                        | String  | 否       | -                            | 使用此 SQL 将上游输入数据写入数据库。例如 `INSERT ...`，`query` 具有更高的优先级                                                                                                                                                               |
+| database                     | String  | 否       | -                            | 使用此 `database` 和 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。<br/>此选项与 `query` 互斥，具有更高的优先级。                                                                                                                    |
+| table                        | String  | 否       | -                            | 使用数据库和此表名自动生成 SQL 并接收上游输入数据写入数据库。<br/>此选项与 `query` 互斥，具有更高的优先级。                                                                                                                                    |
+| schema                       | String  | 否       | public                       | Redshift 中目标表的 schema 名称。                                                                                                                                                                                                              |
+| primary_keys                 | Array   | 否       | -                            | 此选项用于支持自动生成 SQL 时的 `insert`、`delete` 和 `update` 操作。                                                                                                                                                                          |
+| connection_check_timeout_sec | Int     | 否       | 30                           | 等待用于验证连接的数据库操作完成的时间（秒）。                                                                                                                                                                                                 |
+| max_retries                  | Int     | 否       | 0                            | 提交失败的重试次数（executeBatch）                                                                                                                                                                                                             |
+| batch_size                   | Int     | 否       | 1000                         | 对于批量写入，当缓冲记录数量达到 `batch_size` 的数量或时间达到 `checkpoint.interval` 时，<br/>数据将被刷新到数据库中                                                                                                                          |
+| is_exactly_once              | Boolean | 否       | false                        | 是否启用精确一次语义，将使用 Xa 事务。如果启用，则需要设置 `xa_data_source_class_name`。                                                                                                                                                       |
+| generate_sink_sql            | Boolean | 否       | false                        | 根据要写入的数据库表生成 SQL 语句                                                                                                                                                                                                              |
+| xa_data_source_class_name    | String  | 否       | -                            | 数据库驱动的 XA 数据源类名，Redshift 为 `com.amazon.redshift.xa.RedshiftXADataSource`                                                                                                                                                         |
+| max_commit_attempts          | Int     | 否       | 3                            | 事务提交失败的重试次数                                                                                                                                                                                                                         |
+| transaction_timeout_sec      | Int     | 否       | -1                           | 事务打开后的超时时间，默认值为 -1（永不超时）。注意设置超时可能会影响精确一次语义                                                                                                                                                                 |
+| auto_commit                  | Boolean | 否       | true                         | 默认启用自动事务提交                                                                                                                                                                                                                           |
+| field_ide                    | String  | 否       | -                            | 确定从源同步到 Sink 时是否需要转换字段。`ORIGINAL` 表示不需要转换；`UPPERCASE` 表示转换为大写；`LOWERCASE` 表示转换为小写。                                                                                                                     |
+| properties                   | Map     | 否       | -                            | 其他连接配置参数，当属性和 URL 具有相同的参数时，优先级由驱动程序的特定实现决定。                                                                                                                                                                |
+| common-options               |         | 否       | -                            | Sink 插件常用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详情                                                                                                                                              |
+| schema_save_mode             | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 在启动同步任务之前，对目标端已有的表结构选择不同的处理方案。                                                                                                                                                                                     |
+| data_save_mode               | Enum    | 否       | APPEND_DATA                  | 在启动同步任务之前，对目标端已有的数据选择不同的处理方案。                                                                                                                                                                                       |
+| custom_sql                   | String  | 否       | -                            | 当 data_save_mode 选择 CUSTOM_PROCESSING 时，您需要填写 CUSTOM_SQL 参数。此参数通常填写一个可执行的 SQL，该 SQL 将在同步任务之前执行。                                                                                                          |
+| enable_upsert                | Boolean | 否       | true                         | 通过 primary_keys 启用 upsert，如果任务只有 `insert`，将此参数设置为 `false` 可以加快数据导入                                                                                                                                                   |
+| multi_table_sink_replica     | Int     | 否       | 1                            | 多表写入的副本数，当 `multi_table_sink_replica > 1` 时，数据将并行写入多个表                                                                                                                                                                    |
 
 ## 任务示例
 
 ### 简单示例
+
+> 此示例定义了一个 SeaTunnel 同步任务，该任务通过 FakeSource 自动生成数据并将其发送到 JDBC Sink。FakeSource 总共生成 16 行数据（row.num=16），每行有两个字段：name（字符串类型）和 age（int 类型）。最终目标表 test_table 中也将有 16 行数据。在运行此作业之前，您需要在 Redshift 中创建数据库和表 test_table。如果您尚未安装和部署 SeaTunnel，请按照[安装 SeaTunnel](../../getting-started/locally/deployment.md) 中的说明进行安装和部署，然后按照[快速启动 SeaTunnel 引擎](../../getting-started/locally/quick-start-seatunnel-engine.md) 中的说明运行此作业。
+
+```
+# Defining the runtime environment
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    parallelism = 1
+    plugin_output = "fake"
+    row.num = 16
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+    jdbc {
+        url = "jdbc:redshift://localhost:5439/mydatabase"
+        driver = "com.amazon.redshift.jdbc.Driver"
+        username = "myUser"
+        password = "myPassword"
+        query = "insert into test_table(name,age) values(?,?)"
+    }
+}
+```
+
+### 生成 Sink SQL
+
+> 此示例不需要编写复杂的 SQL 语句，您可以配置数据库名和表名来自动为您生成插入语句
 
 ```
 sink {
@@ -68,17 +143,36 @@ sink {
         driver = "com.amazon.redshift.jdbc.Driver"
         username = "myUser"
         password = "myPassword"
-        
         generate_sink_sql = true
+        database = mydatabase
         schema = "public"
-        table = "sink_table"
+        table = test_table
     }
 }
 ```
 
-### CDC(更改数据捕获) 事件
+### 精确一次
 
-> 我们也支持CDC更改数据。在这种情况下，您需要配置数据库、表和主键.
+> 对于需要精确写入的场景，我们保证精确一次
+
+```
+sink {
+    jdbc {
+        url = "jdbc:redshift://localhost:5439/mydatabase"
+        driver = "com.amazon.redshift.jdbc.Driver"
+        max_retries = 0
+        username = "myUser"
+        password = "myPassword"
+        query = "insert into test_table(name,age) values(?,?)"
+        is_exactly_once = "true"
+        xa_data_source_class_name = "com.amazon.redshift.xa.RedshiftXADataSource"
+    }
+}
+```
+
+### CDC（变更数据捕获）事件
+
+> 我们也支持 CDC 变更数据。在这种情况下，您需要配置数据库、表和主键。
 
 ```
 sink {
@@ -86,15 +180,101 @@ sink {
         url = "jdbc:redshift://localhost:5439/mydatabase"
         driver = "com.amazon.redshift.jdbc.Driver"
         username = "myUser"
-        password = "mypassword"
-        
+        password = "myPassword"
         generate_sink_sql = true
+        database = mydatabase
         schema = "public"
-        table = "sink_table"
-        
-        # config update/delete primary keys
+        table = sink_table
         primary_keys = ["id","name"]
+        field_ide = UPPERCASE
+        schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+        data_save_mode = "APPEND_DATA"
     }
+}
+```
+
+### 多表同步
+
+#### 示例1：CDC 多表同步到 Redshift
+
+> 通过 CDC 源同步多张表到目标 Redshift 数据库，使用占位符实现动态表名映射
+
+```
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  Mysql-CDC {
+    url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
+    username = "root"
+    password = "******"
+    table-names = ["seatunnel.role","seatunnel.user","seatunnel.order"]
+  }
+}
+
+transform {
+}
+
+sink {
+  jdbc {
+    url = "jdbc:redshift://redshift-cluster.xxxx.region.redshift.amazonaws.com:5439/mydatabase"
+    driver = "com.amazon.redshift.jdbc.Driver"
+    username = "myUser"
+    password = "myPassword"
+    generate_sink_sql = true
+    database = mydatabase
+    schema = "public"
+    table = "${table_name}_sink"
+    primary_keys = ["${primary_key}"]
+  }
+}
+```
+
+#### 示例2：JDBC Source 多表同步到 Redshift
+
+> 从数据库使用 JDBC Source 批量同步多张表到 Redshift
+
+```
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = com.mysql.cj.jdbc.Driver
+    url = "jdbc:mysql://localhost:3306/source_db"
+    username = "root"
+    password = "123456"
+    table_list = [
+      {
+        table_path = "source_db.table_1"
+      },
+      {
+        table_path = "source_db.table_2"
+      }
+    ]
+  }
+}
+
+transform {
+}
+
+sink {
+  jdbc {
+    url = "jdbc:redshift://redshift-cluster.xxxx.region.redshift.amazonaws.com:5439/mydatabase"
+    driver = "com.amazon.redshift.jdbc.Driver"
+    username = "myUser"
+    password = "myPassword"
+    generate_sink_sql = true
+    database = mydatabase
+    schema = "public"
+    table = "${table_name}_copy"
+    primary_keys = ["${primary_key}"]
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/Redshift.md
+++ b/docs/zh/connectors/sink/Redshift.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 支持的 Redshift 版本
 
-- Amazon Redshift（所有可用版本）
+- Amazon Redshift
 
 ## 支持以下引擎
 
@@ -62,6 +62,8 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Sink 参数
 
+> Redshift Sink 基于 JDBC Sink 实现。下表聚焦于 Redshift 常用参数。对于继承自 JDBC Sink 的高级参数，例如 `compatible_mode`、`dialect`、`is_primary_key_updated`、`support_upsert_by_insert_only`、`use_copy_statement`、`tablePrefix`、`tableSuffix` 和 `create_index`，请参考 [JDBC Sink](Jdbc.md)。
+
 | 名称                           | 类型    | 是否必填 |           默认值            |                                                                                                                  描述                                                                                                                   |
 |------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                          | String  | 是      | -                            | JDBC 连接的 URL。参见示例：`jdbc:redshift://localhost:5439/mydatabase`                                                                                                                                                                        |
@@ -71,7 +73,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | query                        | String  | 否       | -                            | 使用此 SQL 将上游输入数据写入数据库。例如 `INSERT ...`，`query` 具有更高的优先级                                                                                                                                                               |
 | database                     | String  | 否       | -                            | 使用此 `database` 和 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。<br/>此选项与 `query` 互斥，具有更高的优先级。                                                                                                                    |
 | table                        | String  | 否       | -                            | 使用数据库和此表名自动生成 SQL 并接收上游输入数据写入数据库。<br/>此选项与 `query` 互斥，具有更高的优先级。                                                                                                                                    |
-| schema                       | String  | 否       | public                       | Redshift 中目标表的 schema 名称。                                                                                                                                                                                                              |
+| schema                       | String  | 否       | -                            | Redshift 中目标表的 schema 名称。SeaTunnel 不会为该参数自动填充默认值。当目标表没有在 `table` 中显式携带 schema，或使用 `generate_sink_sql`、`schema_save_mode`、`data_save_mode` 等基于 catalog 的操作时，建议显式配置该参数。 |
 | primary_keys                 | Array   | 否       | -                            | 此选项用于支持自动生成 SQL 时的 `insert`、`delete` 和 `update` 操作。                                                                                                                                                                          |
 | connection_check_timeout_sec | Int     | 否       | 30                           | 等待用于验证连接的数据库操作完成的时间（秒）。                                                                                                                                                                                                 |
 | max_retries                  | Int     | 否       | 0                            | 提交失败的重试次数（executeBatch）                                                                                                                                                                                                             |


### PR DESCRIPTION
## Purpose of this pull request

Improve the Redshift sink connector documentation to make it more complete and usable, referencing the MySQL sink documentation structure.

## Changes

### Documentation improvements for both English and Chinese:

- Added **Sink Options** table with all supported configuration parameters (url, driver, username, password, query, database, table, schema, primary_keys, batch_size, is_exactly_once, xa_data_source_class_name, schema_save_mode, data_save_mode, enable_upsert, multi_table_sink_replica, etc.)
- Added **Support Redshift Version** section
- Added **Using Dependency** section with separate instructions for Spark/Flink and Zeta engines
- Added **Key Features** section that correctly includes support for multiple table write
- Added **Simple example** with a complete job configuration (env + source + transform + sink)
- Added **Generate Sink SQL** example
- Added **Exactly-Once** example with XA transaction configuration
- Improved **CDC** example with schema_save_mode and data_save_mode
- Added **Multiple Table Sync** examples:
  - CDC multiple table sync to Redshift
  - JDBC Source multiple table sync to Redshift
- Standardized section naming and formatting to be consistent with other connector docs (e.g., MySQL sink)
