### PR TITLE
[Docs] Fix RocketMQ connector documentation errors

### DIFF
--- a/docs/en/connectors/sink/RocketMQ.md
+++ b/docs/en/connectors/sink/RocketMQ.md
@@ -30,15 +30,18 @@ Write Rows to a Apache RocketMQ topic.
 |----------------------|---------|----------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | topic                | string  | yes      | -                        | `RocketMQ topic` name.                                                                                                                                              |
 | name.srv.addr        | string  | yes      | -                        | `RocketMQ` name server cluster address.                                                                                                                             |
-| acl.enabled          | Boolean | no       | false                    | false                                                                                                                                                               |
+| acl.enabled          | Boolean | no       | false                    | If true, access control is enabled, and access key and secret key need to be configured.                                                                                                                                                               |
 | access.key           | String  | no       |                          | When ACL_ENABLED is true, access key cannot be empty                                                                                                                |
 | secret.key           | String  | no       |                          | When ACL_ENABLED is true, secret key cannot be empty                                                                                                                |
-| producer.group       | String  | no       | SeaTunnel-producer-Group | SeaTunnel-producer-Group                                                                                                                                            |
+| producer.group       | String  | no       | SeaTunnel-Producer-Group | RocketMQ producer group id.                                                                                                                                            |
 | tag                  | String  | no       | -                        | `RocketMQ` message tag.                                                                                                                                             |
 | partition.key.fields | array   | no       | -                        | -                                                                                                                                                                   |
 | format               | String  | no       | json                     | Data format. The default format is json. Optional text format. The default field separator is ",".If you customize the delimiter, add the "field_delimiter" option. |
 | field.delimiter      | String  | no       | ,                        | Customize the field delimiter for data format.                                                                                                                      |
 | producer.send.sync   | Boolean | no       | false                    | If true, the message will be sync sent.                                                                                                                             |
+| exactly.once         | Boolean | no       | false                    | If true, the transaction message will be sent.                                                                                                                      |
+| max.message.size     | int     | no       | 4194304                  | Maximum allowed message body size in bytes.                                                                                                                         |
+| send.message.timeout | int     | no       | 3000                     | Timeout for sending messages in milliseconds.                                                                                                                       |
 | common-options       | config  | no       | -                        | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                        |
 
 ### partition.key.fields [array]
@@ -168,7 +171,6 @@ source {
     batch.size = "400"
     consumer.group = "test_topic_group"
     format = "json"
-    format = json
     schema = {
       fields {
         c_map = "map<string, string>"

--- a/docs/en/connectors/source/RocketMQ.md
+++ b/docs/en/connectors/source/RocketMQ.md
@@ -50,6 +50,7 @@ Source connector for Apache RocketMQ.
 | start.mode.timestamp                | Long    | no       |                            | The time required for consumption mode to be "CONSUME_FROM_TIMESTAMP".                                                                                                                                             |
 | partition.discovery.interval.millis | long    | no       | -1                         | The interval for dynamically discovering topics and partitions.                                                                                                                                                    |
 | ignore_parse_errors                 | Boolean | no       | false                      | Optional flag to skip parse errors instead of failing.                                                                                                                                                             |
+| consumer.poll.timeout.millis        | long    | no       | 5000                       | The poll timeout in milliseconds.                                                        |
 | common-options                      | config  | no       | -                          | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                  |
 
 ### start.mode.offsets

--- a/docs/zh/connectors/sink/RocketMQ.md
+++ b/docs/zh/connectors/sink/RocketMQ.md
@@ -30,15 +30,18 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 |----------------------|---------|----------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | topic                | string  | 是      | -                        | `RocketMQ topic` 名称.                                                                                                                                              |
 | name.srv.addr        | string  | 是      | -                        | `RocketMQ`名称服务器集群地址。                                                                                                                             |
-| acl.enabled          | Boolean | 否       | false                    | false                                                                                                                                                               |
-| access.key           | String  | 否       |                          | 当ACL_ENABLED为true时，access key不能为空。                                                                                                                |
-| secret.key           | String  | 否       |                          |  当ACL_ENABLED为true时, secret key 不能为空。                                                                                                                |
-| producer.group       | String  | 否       | SeaTunnel-producer-Group | SeaTunnel-producer-Group                                                                                                                                            |
+| acl.enabled          | Boolean | 否       | false                    | 如果为 true，启用访问控制，需要配置 access key 和 secret key。                                                                                                  |
+| access.key           | String  | 否       |                          | 当 ACL_ENABLED 为 true 时，access key 不能为空。                                                                                                                |
+| secret.key           | String  | 否       |                          | 当 ACL_ENABLED 为 true 时，secret key 不能为空。                                                                                                                |
+| producer.group       | String  | 否       | SeaTunnel-Producer-Group | RocketMQ 生产者组 ID。                                                                                                                                            |
 | tag                  | String  | 否       | -                        | `RocketMQ`消息标签。                                                                                                                                             |
 | partition.key.fields | array   | 否       | -                        | -                                                                                                                                                                   |
 | format               | String  | 否       | json                     | 数据格式。默认格式为json。可选text格式。默认字段分隔符为“，”。如果自定义分隔符，请添加“field_delimiter”选项。 |
 | field.delimiter      | String  | 否       | ,                        | 自定义数据格式的字段分隔符。                                                                                                                      |
 | producer.send.sync   | Boolean | 否       | false                    | 如果为 true, 则消息将同步发送。                                                                                                                             |
+| exactly.once         | Boolean | 否       | false                    | 如果为 true，将发送事务消息。                                                                                                                                     |
+| max.message.size     | int     | 否       | 4194304                  | 允许的最大消息体大小（字节）。                                                                                                                                    |
+| send.message.timeout | int     | 否       | 3000                     | 发送消息的超时时间（毫秒）。                                                                                                                                      |
 | common-options       | config  | 否       | -                        | Sink插件常用参数，请参考[sink common options]（../common-options/sink-common-options.md）了解详细信息。                                                        |
 
 ### partition.key.fields [array]
@@ -166,7 +169,6 @@ source {
     batch.size = "400"
     consumer.group = "test_topic_group"
     format = "json"
-    format = json
     schema = {
       fields {
         c_map = "map<string, string>"

--- a/docs/zh/connectors/source/RocketMQ.md
+++ b/docs/zh/connectors/source/RocketMQ.md
@@ -49,7 +49,8 @@ Apache RocketMQ 的源连接器。
 | start.mode.offsets                  |         | 否  |                            | 消费模式为 "CONSUME_FROM_SPECIFIC_OFFSETS" 所需的偏移量                                                                                                                  |
 | start.mode.timestamp                | Long    | 否  |                            | 消费模式为 "CONSUME_FROM_TIMESTAMP" 所需的时间。                                                                                                                         |
 | partition.discovery.interval.millis | long    | 否  | -1                         | 动态发现主题和分区的间隔。                                                                                                                                                 |
-| ignore_parse_errors                 | Boolean | 否  | false                      | 可选标志，跳过解析错误而不是失败。                                                                                                                                             |
+| ignore_parse_errors                 | Boolean | 否  | false                      | 可选标志，跳过解析错误而不是失败。                                                                                                                                 |
+| consumer.poll.timeout.millis        | long    | 否  | 5000                       | 拉取消息的超时时间（毫秒）。                                                                                                                                       |
 | common-options                      | config  | 否  | -                          | 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。                                                                                           |
 
 ### start.mode.offsets


### PR DESCRIPTION
## Purpose
Fix several documentation errors in RocketMQ source and sink connector docs.

## Changes
### RocketMQ Sink (`docs/en/connectors/sink/RocketMQ.md`)
- Fix `acl.enabled` description (was showing `false` instead of meaningful description)
- Fix `producer.group` default value case (`SeaTunnel-producer-Group` → `SeaTunnel-Producer-Group`)
- Add missing options: `exactly.once`, `max.message.size`, `send.message.timeout`
- Remove duplicate `format = json` line in task example

### RocketMQ Source (`docs/en/connectors/source/RocketMQ.md`)
- Add missing option: `consumer.poll.timeout.millis` (default: 5000ms)