### PR TITLE
[Fix][Zeta] Guard state cleanup races after node failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,8 @@ Command:
 * Located in `seatunnel-e2e`
 * Uses Testcontainers
 * Extend `TestSuiteBase`
+* For engine node-failure validation, existing `ClusterFaultToleranceIT`-style tests are suitable for checking final convergence after member shutdown; cleanup-race bugs in `PhysicalVertex` / `SubPlan` / `PhysicalPlan` still need dedicated unit tests because E2E does not reliably hit the "state already cleaned, callback arrives late" window.
+* To exercise the no-restore failure path in engine tests, use `job.mode = BATCH`, omit `checkpoint.interval`, and set `job.retry.times = 0`; otherwise the pipeline may restore and the test will not cover terminal-failure convergence.
 
 Command:
 

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFailureNoRestoreIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFailureNoRestoreIT.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.e2e;
+
+import org.apache.seatunnel.common.config.Common;
+import org.apache.seatunnel.common.config.DeployMode;
+import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.engine.client.SeaTunnelClient;
+import org.apache.seatunnel.engine.client.job.ClientJobExecutionEnvironment;
+import org.apache.seatunnel.engine.client.job.ClientJobProxy;
+import org.apache.seatunnel.engine.common.config.ConfigProvider;
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
+import org.apache.seatunnel.engine.common.job.JobResult;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.ImmutablePair;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class ClusterFailureNoRestoreIT {
+
+    private static final String TEST_TEMPLATE_FILE_NAME =
+            "cluster_batch_fake_to_localfile_no_restore_template.conf";
+
+    private static final String DYNAMIC_TEST_CASE_NAME = "dynamic_test_case_name";
+
+    private static final String DYNAMIC_TEST_ROW_NUM_PER_PARALLELISM =
+            "dynamic_test_row_num_per_parallelism";
+
+    private static final String DYNAMIC_TEST_PARALLELISM = "dynamic_test_parallelism";
+
+    @Test
+    public void testBatchJobWithoutCheckpointAndRetryConvergesAfterWorkerShutdown()
+            throws Exception {
+        String testCaseName = "testBatchJobWithoutCheckpointAndRetryConvergesAfterWorkerShutdown";
+        String testClusterName = "ClusterFailureNoRestoreIT_batch_no_restore";
+        long testRowNumber = 10000;
+        int testParallelism = 6;
+
+        HazelcastInstanceImpl node1 = null;
+        HazelcastInstanceImpl node2 = null;
+        SeaTunnelClient engineClient = null;
+
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setClusterName(TestUtils.getClusterName(testClusterName));
+
+        try {
+            node1 = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+            node2 = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+
+            HazelcastInstanceImpl finalNode = node1;
+            Awaitility.await()
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, finalNode.getCluster().getMembers().size()));
+
+            Common.setDeployMode(DeployMode.CLIENT);
+            ImmutablePair<String, String> testResources =
+                    createTestResources(testCaseName, testRowNumber, testParallelism);
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.setName(testCaseName);
+
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(TestUtils.getClusterName(testClusterName));
+            engineClient = new SeaTunnelClient(clientConfig);
+            ClientJobExecutionEnvironment jobExecutionEnv =
+                    engineClient.createExecutionContext(
+                            testResources.getRight(), jobConfig, seaTunnelConfig);
+            ClientJobProxy clientJobProxy = jobExecutionEnv.execute();
+
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Long lineNumberFromDir =
+                                        FileUtils.getFileLineNumberFromDir(testResources.getLeft());
+                                log.warn(
+                                        "\n====================={}=====================\n",
+                                        lineNumberFromDir);
+                                Assertions.assertEquals(
+                                        JobStatus.RUNNING, clientJobProxy.getJobStatus());
+                                Assertions.assertTrue(lineNumberFromDir > 1);
+                            });
+
+            CompletableFuture<JobResult> waitForCompleteFuture =
+                    CompletableFuture.supplyAsync(clientJobProxy::waitForJobCompleteV2);
+
+            log.info(
+                    "=====================shutdown node2 for no-restore batch test=====================");
+            node2.shutdown();
+
+            Awaitility.await()
+                    .atMost(3, TimeUnit.MINUTES)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertTrue(waitForCompleteFuture.isDone());
+                                JobResult jobResult = waitForCompleteFuture.get();
+                                Assertions.assertTrue(
+                                        EnumSet.of(
+                                                        JobStatus.FAILED,
+                                                        JobStatus.CANCELED,
+                                                        JobStatus.UNKNOWABLE)
+                                                .contains(jobResult.getStatus()));
+                            });
+        } finally {
+            if (engineClient != null) {
+                engineClient.close();
+            }
+
+            if (node1 != null) {
+                node1.shutdown();
+            }
+
+            if (node2 != null) {
+                node2.shutdown();
+            }
+        }
+    }
+
+    private ImmutablePair<String, String> createTestResources(
+            @NonNull String testCaseName, long rowNumber, int parallelism) throws IOException {
+        checkArgument(rowNumber > 0, "rowNumber must greater than 0");
+        checkArgument(parallelism > 0, "parallelism must greater than 0");
+        Map<String, String> valueMap = new HashMap<>();
+        valueMap.put(DYNAMIC_TEST_CASE_NAME, testCaseName);
+        valueMap.put(DYNAMIC_TEST_ROW_NUM_PER_PARALLELISM, String.valueOf(rowNumber));
+        valueMap.put(DYNAMIC_TEST_PARALLELISM, String.valueOf(parallelism));
+
+        String targetDir = "/tmp/hive/warehouse/" + testCaseName;
+        targetDir = targetDir.replace("/", File.separator);
+        FileUtils.createNewDir(targetDir);
+
+        String targetConfigFilePath =
+                File.separator
+                        + "tmp"
+                        + File.separator
+                        + "test_conf"
+                        + File.separator
+                        + testCaseName
+                        + ".conf";
+        TestUtils.createTestConfigFileFromTemplate(
+                TEST_TEMPLATE_FILE_NAME, valueMap, targetConfigFilePath);
+
+        return new ImmutablePair<>(targetDir, targetConfigFilePath);
+    }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/cluster_batch_fake_to_localfile_no_restore_template.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/cluster_batch_fake_to_localfile_no_restore_template.conf
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### Batch template used to validate terminal convergence after node failure.
+###### It intentionally disables checkpoint restore and job retry.
+######
+
+env {
+  job.mode = "BATCH"
+  job.retry.times = 0
+}
+
+source {
+  FakeSource {
+    row.num = ${dynamic_test_row_num_per_parallelism}
+    split.num = 10
+    split.read-interval = 3000
+    map.size = 10
+    array.size = 10
+    bytes.length = 10
+    string.length = 10
+    parallelism = ${dynamic_test_parallelism}
+    schema = {
+      fields {
+        c_map = "map<string, array<int>>"
+        c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_null = "null"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+        c_row = {
+          c_map = "map<string, map<string, string>>"
+          c_array = "array<int>"
+          c_string = string
+          c_boolean = boolean
+          c_tinyint = tinyint
+          c_smallint = smallint
+          c_int = int
+          c_bigint = bigint
+          c_float = float
+          c_double = double
+          c_decimal = "decimal(30, 8)"
+          c_null = "null"
+          c_bytes = bytes
+          c_date = date
+          c_timestamp = timestamp
+        }
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/hive/warehouse/${dynamic_test_case_name}"
+    field_delimiter = "\t"
+    row_delimiter = "\n"
+    file_name_expression = "${transactionId}_${now}"
+    file_format_type = "text"
+    filename_time_format = "yyyy.MM.dd"
+    is_enable_transaction = true
+    save_mode = "error"
+  }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -80,6 +80,8 @@ public class PhysicalPlan {
 
     private JobMaster jobMaster;
 
+    private volatile JobStatus currJobStatus;
+
     private Map<TaskGroupLocation, CompletableFuture<SlotProfile>> preApplyResourceFutures =
             new HashMap<>();
 
@@ -114,6 +116,8 @@ public class PhysicalPlan {
 
             runningJobStateIMap.put(jobId, JobStatus.CREATED);
         }
+
+        this.currJobStatus = (JobStatus) runningJobStateIMap.get(jobId);
 
         this.pipelineList = pipelineList;
         if (pipelineList.isEmpty()) {
@@ -249,7 +253,9 @@ public class PhysicalPlan {
         RetryUtils.retryWithException(
                 () -> {
                     updateStateTimestamps(targetState);
-                    runningJobStateIMap.set(jobId, targetState);
+                    if (runningJobStateIMap.get(jobId) != null) {
+                        runningJobStateIMap.set(jobId, targetState);
+                    }
                     return null;
                 },
                 new RetryUtils.RetryMaterial(
@@ -265,6 +271,13 @@ public class PhysicalPlan {
         // we must update runningJobStateTimestampsIMap first and then can update
         // runningJobStateIMap
         Long[] stateTimestamps = runningJobStateTimestampsIMap.get(jobId);
+        if (stateTimestamps == null) {
+            log.warn(
+                    "{} state timestamps have already been cleaned, skip persisting transition to {}",
+                    jobFullName,
+                    targetState);
+            return;
+        }
         stateTimestamps[targetState.ordinal()] = System.currentTimeMillis();
         runningJobStateTimestampsIMap.set(jobId, stateTimestamps);
     }
@@ -280,6 +293,21 @@ public class PhysicalPlan {
     public synchronized void updateJobState(@NonNull JobStatus targetState) {
         try {
             JobStatus current = (JobStatus) runningJobStateIMap.get(jobId);
+            if (current == null) {
+                current = currJobStatus;
+                if (current == null) {
+                    log.warn(
+                            "{} current state is null, cannot transition to {}",
+                            jobFullName,
+                            targetState);
+                    return;
+                }
+                log.warn(
+                        "{} distributed state has already been cleaned, fallback to local state {} for transition to {}",
+                        jobFullName,
+                        current,
+                        targetState);
+            }
             log.debug(
                     "Try to update the {} state from {} to {}", jobFullName, current, targetState);
 
@@ -298,6 +326,7 @@ public class PhysicalPlan {
             // Now do the actual state transition, we must update runningJobStateTimestampsIMap
             // first and then can update runningJobStateIMap
             updateStateInfo(current, targetState);
+            this.currJobStatus = targetState;
             stateProcess();
         } catch (Exception e) {
             log.error(ExceptionUtils.getMessage(e));
@@ -312,7 +341,8 @@ public class PhysicalPlan {
     }
 
     public JobStatus getJobStatus() {
-        return (JobStatus) runningJobStateIMap.get(jobId);
+        JobStatus jobStatus = (JobStatus) runningJobStateIMap.get(jobId);
+        return jobStatus != null ? jobStatus : currJobStatus;
     }
 
     public String getJobFullName() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
@@ -351,6 +351,22 @@ public class PhysicalVertex {
     public synchronized void updateTaskState(@NonNull ExecutionState targetState) {
         try {
             ExecutionState current = (ExecutionState) runningJobStateIMap.get(taskGroupLocation);
+            if (current == null) {
+                current = currExecutionState;
+                if (current == null) {
+                    log.warn(
+                            "{} current state is null, cannot transition to {}. Task execution location: {}",
+                            taskFullName,
+                            targetState,
+                            taskGroupLocation);
+                    return;
+                }
+                log.warn(
+                        "{} distributed state has already been cleaned, fallback to local state {} for transition to {}",
+                        taskFullName,
+                        current,
+                        targetState);
+            }
             log.debug(
                     String.format(
                             "Try to update the task %s state from %s to %s",
@@ -375,7 +391,9 @@ public class PhysicalVertex {
             RetryUtils.retryWithException(
                     () -> {
                         updateStateTimestamps(targetState);
-                        runningJobStateIMap.set(taskGroupLocation, targetState);
+                        if (runningJobStateIMap.get(taskGroupLocation) != null) {
+                            runningJobStateIMap.set(taskGroupLocation, targetState);
+                        }
                         return null;
                     },
                     new RetryUtils.RetryMaterial(
@@ -451,6 +469,13 @@ public class PhysicalVertex {
         // we must update runningJobStateTimestampsIMap first and then can update
         // runningJobStateIMap
         Long[] stateTimestamps = runningJobStateTimestampsIMap.get(taskGroupLocation);
+        if (stateTimestamps == null) {
+            log.warn(
+                    "{} state timestamps have already been cleaned, skip persisting transition to {}",
+                    taskFullName,
+                    targetState);
+            return;
+        }
         stateTimestamps[targetState.ordinal()] = System.currentTimeMillis();
         runningJobStateTimestampsIMap.set(taskGroupLocation, stateTimestamps);
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
@@ -342,6 +342,21 @@ public class SubPlan {
     public synchronized void updatePipelineState(@NonNull PipelineStatus targetState) {
         try {
             PipelineStatus current = (PipelineStatus) runningJobStateIMap.get(pipelineLocation);
+            if (current == null) {
+                current = currPipelineStatus;
+                if (current == null) {
+                    log.warn(
+                            "{} current state is null, cannot transition to {}",
+                            pipelineFullName,
+                            targetState);
+                    return;
+                }
+                log.warn(
+                        "{} distributed state has already been cleaned, fallback to local state {} for transition to {}",
+                        pipelineFullName,
+                        current,
+                        targetState);
+            }
             log.debug(
                     String.format(
                             "Try to update the %s state from %s to %s",
@@ -369,7 +384,9 @@ public class SubPlan {
             RetryUtils.retryWithException(
                     () -> {
                         updateStateTimestamps(finalTargetState);
-                        runningJobStateIMap.set(pipelineLocation, finalTargetState);
+                        if (runningJobStateIMap.get(pipelineLocation) != null) {
+                            runningJobStateIMap.set(pipelineLocation, finalTargetState);
+                        }
                         return null;
                     },
                     new RetryUtils.RetryMaterial(
@@ -426,6 +443,13 @@ public class SubPlan {
         // we must update runningJobStateTimestampsIMap first and then can update
         // runningJobStateIMap
         Long[] stateTimestamps = runningJobStateTimestampsIMap.get(pipelineLocation);
+        if (stateTimestamps == null) {
+            log.warn(
+                    "{} state timestamps have already been cleaned, skip persisting transition to {}",
+                    pipelineFullName,
+                    targetState);
+            return;
+        }
         stateTimestamps[targetState.ordinal()] = System.currentTimeMillis();
         runningJobStateTimestampsIMap.set(pipelineLocation, stateTimestamps);
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/StateTransitionCleanupTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/StateTransitionCleanupTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.dag.physical;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.core.job.JobResult;
+import org.apache.seatunnel.engine.core.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.TestUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.map.IMap;
+
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+
+import static org.apache.seatunnel.engine.common.config.server.QueueType.BLOCKINGQUEUE;
+
+class StateTransitionCleanupTest extends AbstractSeaTunnelServerTest {
+
+    @Test
+    void testSubPlanUsesLocalStateWhenDistributedPipelineStateAlreadyCleaned() throws Exception {
+        long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+        PlanWithStateMaps planWithStateMaps = createPhysicalPlan(jobId);
+
+        SubPlan subPlan = planWithStateMaps.physicalPlan.getPipelineList().get(0);
+        PipelineLocation pipelineLocation = subPlan.getPipelineLocation();
+
+        planWithStateMaps.runningJobState.remove(pipelineLocation);
+        planWithStateMaps.runningJobStateTimestamps.remove(pipelineLocation);
+
+        subPlan.updatePipelineState(PipelineStatus.SCHEDULED);
+
+        Assertions.assertEquals(PipelineStatus.SCHEDULED, subPlan.getPipelineState());
+        Assertions.assertNull(planWithStateMaps.runningJobState.get(pipelineLocation));
+    }
+
+    @Test
+    void testPhysicalPlanCompletesTerminalFutureWhenDistributedJobStateAlreadyCleaned()
+            throws Exception {
+        long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+        PlanWithStateMaps planWithStateMaps = createPhysicalPlan(jobId);
+
+        org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture<JobResult>
+                jobEndFuture =
+                        new org.apache.seatunnel.engine.common.utils.concurrent
+                                .CompletableFuture<>();
+        setField(planWithStateMaps.physicalPlan, "jobEndFuture", jobEndFuture);
+        setBooleanField(planWithStateMaps.physicalPlan, "isRunning", true);
+
+        planWithStateMaps.runningJobState.remove(jobId);
+        planWithStateMaps.runningJobStateTimestamps.remove(jobId);
+
+        planWithStateMaps.physicalPlan.updateJobState(JobStatus.FAILED);
+
+        Assertions.assertTrue(jobEndFuture.isDone());
+        Assertions.assertEquals(JobStatus.FAILED, jobEndFuture.get().getStatus());
+        Assertions.assertEquals(JobStatus.FAILED, planWithStateMaps.physicalPlan.getJobStatus());
+        Assertions.assertNull(planWithStateMaps.runningJobState.get(jobId));
+    }
+
+    private PlanWithStateMaps createPhysicalPlan(long jobId) throws MalformedURLException {
+        JobContext jobContext = new JobContext(jobId);
+        jobContext.setJobMode(JobMode.BATCH);
+        JobConfig config = new JobConfig();
+        config.setName("cleanup-test");
+        config.setJobContext(jobContext);
+        LogicalDag logicalDag = TestUtils.getTestLogicalDag(jobContext, config);
+
+        JobImmutableInformation jobImmutableInformation =
+                new JobImmutableInformation(
+                        jobId,
+                        "CleanupTest",
+                        nodeEngine.getSerializationService(),
+                        logicalDag,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        IMap<Object, Object> runningJobState =
+                nodeEngine.getHazelcastInstance().getMap("cleanupRunningJobState-" + jobId);
+        IMap<Object, Long[]> runningJobStateTimestamps =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap("cleanupRunningJobStateTimestamps-" + jobId);
+
+        PhysicalPlan physicalPlan =
+                PlanUtils.fromLogicalDAG(
+                                logicalDag,
+                                nodeEngine,
+                                jobImmutableInformation,
+                                System.currentTimeMillis(),
+                                Executors.newCachedThreadPool(),
+                                server.getClassLoaderService(),
+                                instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME),
+                                runningJobState,
+                                runningJobStateTimestamps,
+                                BLOCKINGQUEUE,
+                                new EngineConfig())
+                        .f0();
+
+        return new PlanWithStateMaps(physicalPlan, runningJobState, runningJobStateTimestamps);
+    }
+
+    private void setBooleanField(Object target, String fieldName, boolean value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.setBoolean(target, value);
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static final class PlanWithStateMaps {
+        private final PhysicalPlan physicalPlan;
+        private final IMap<Object, Object> runningJobState;
+        private final IMap<Object, Long[]> runningJobStateTimestamps;
+
+        private PlanWithStateMaps(
+                PhysicalPlan physicalPlan,
+                IMap<Object, Object> runningJobState,
+                IMap<Object, Long[]> runningJobStateTimestamps) {
+            this.physicalPlan = physicalPlan;
+            this.runningJobState = runningJobState;
+            this.runningJobStateTimestamps = runningJobStateTimestamps;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

This PR fixes an engine-side terminal-state convergence bug after worker node failure.

When a worker goes offline, the engine can start cleaning distributed state from the running job state maps before all asynchronous task/pipeline/job callbacks have finished. In the current code path, `PhysicalVertex`, `SubPlan`, and `PhysicalPlan` all assume the current state still exists in the distributed map and call `current.equals(...)` / `current.isEndState()` directly. If the state has already been cleaned, those callbacks can throw `NullPointerException` and interrupt terminal-state convergence.

This PR makes those state transitions null-safe by:
- falling back to the local in-memory state when the distributed state has already been cleaned
- skipping timestamp persistence when the timestamp map entry has already been removed
- avoiding re-writing already-cleaned state back into the distributed maps

It also adds targeted regression tests for the cleanup-race path and an engine E2E scenario for the `BATCH + no checkpoint + job.retry.times=0` failure path, so node shutdown must converge to a terminal state instead of hanging in the middle.

### Does this PR introduce _any_ user-facing change?

No user-facing API/config change. This changes failure handling so jobs are less likely to hang in an intermediate state after node failure.

### How was this patch tested?

Verified locally:
- `./mvnw -nsu -pl seatunnel-engine/seatunnel-engine-server spotless:check`
- `./mvnw -nsu -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base spotless:check`

Additional notes:
- Added targeted regression test: `StateTransitionCleanupTest`
- Added engine E2E coverage: `ClusterFailureNoRestoreIT`
- Full Maven test/compile validation in this checkout is currently blocked by unrelated upstream build issues in other reactor modules (for example `seatunnel-config-shade`), so this PR is opened as draft.
