### PR TITLE
[Fix][Zeta] Prevent terminal-state zombie jobs from being restored after master switch

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -807,8 +807,8 @@ public class CoordinatorService {
      * from runningJobInfoIMap because the coordinator died mid-cleanup). Creates a temporary
      * JobMaster solely to obtain the PhysicalPlan structure needed to enumerate all pipeline/task
      * IMap keys, then calls cleanJob() directly — bypassing the pending queue to avoid
-     * transitioning the job back to PENDING state. Falls back to a direct IMap remove if
-     * JobMaster initialisation fails.
+     * transitioning the job back to PENDING state. Falls back to a direct IMap remove if JobMaster
+     * initialisation fails.
      */
     private void cleanupZombieJob(@NonNull Long jobId, @NonNull JobInfo jobInfo) {
         JobMaster jobMaster =

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -769,9 +769,9 @@ public class CoordinatorService {
             logger.warning(
                     String.format(
                             "Job %s is in terminal state %s in runningJobInfoIMap, "
-                                    + "removing zombie entry to prevent incorrect restore",
+                                    + "cleaning up zombie entry to prevent incorrect restore",
                             jobId, jobState));
-            runningJobInfoIMap.remove(jobId);
+            cleanupZombieJob(jobId, jobInfo);
             return;
         }
 
@@ -800,6 +800,47 @@ public class CoordinatorService {
         pendingJobQueue.put(pendingJobInfo);
         jobMaster.getPhysicalPlan().updateJobState(JobStatus.PENDING);
         logger.info(String.format("The restore job enter pending queue, JobId: %s", jobId));
+    }
+
+    /**
+     * Clean up all IMap entries for a zombie job (a job in terminal state that was never removed
+     * from runningJobInfoIMap because the coordinator died mid-cleanup). Creates a temporary
+     * JobMaster solely to obtain the PhysicalPlan structure needed to enumerate all pipeline/task
+     * IMap keys, then calls cleanJob() directly — bypassing the pending queue to avoid
+     * transitioning the job back to PENDING state. Falls back to a direct IMap remove if
+     * JobMaster initialisation fails.
+     */
+    private void cleanupZombieJob(@NonNull Long jobId, @NonNull JobInfo jobInfo) {
+        JobMaster jobMaster =
+                new JobMaster(
+                        jobId,
+                        jobInfo.getJobImmutableInformation(),
+                        nodeEngine,
+                        MDCTracer.tracing(jobId, executorService),
+                        getResourceManager(),
+                        getJobHistoryService(),
+                        runningJobStateIMap,
+                        runningJobStateTimestampsIMap,
+                        ownedSlotProfilesIMap,
+                        runningJobInfoIMap,
+                        engineConfig,
+                        seaTunnelServer);
+        try {
+            jobMaster.init(jobInfo.getInitializationTimestamp(), true);
+            jobMaster.neverNeedRestore();
+            jobMaster.cleanJob();
+            logger.info(
+                    String.format(
+                            "Zombie job %s cleaned up successfully via JobMaster.cleanJob()",
+                            jobId));
+        } catch (Exception e) {
+            logger.warning(
+                    String.format(
+                            "Failed to init JobMaster for zombie job %s, "
+                                    + "falling back to direct IMap remove: %s",
+                            jobId, e.getMessage()));
+            runningJobInfoIMap.remove(jobId);
+        }
     }
 
     /**

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -865,7 +865,12 @@ public class CoordinatorService {
                         engineConfig,
                         seaTunnelServer);
         try {
-            jobMaster.init(jobInfo.getInitializationTimestamp(), true);
+            // restart=false: we are not restarting this job, just cleaning up its IMap
+            // entries. Using restart=true would trigger CheckpointManager restore which
+            // can fail for zombies that were never checkpointed (e.g. freshly injected
+            // or crashed before first checkpoint), causing init() to throw and leaving
+            // the zombie uncleaned.
+            jobMaster.init(jobInfo.getInitializationTimestamp(), false);
             JobResult jobResult = new JobResult(jobStatus, null);
             jobMaster.getPhysicalPlan().completeJobEndFuture(jobResult);
             getEventProcessor()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -865,12 +865,12 @@ public class CoordinatorService {
                         engineConfig,
                         seaTunnelServer);
         try {
-            // restart=false: we are not restarting this job, just cleaning up its IMap
-            // entries. Using restart=true would trigger CheckpointManager restore which
-            // can fail for zombies that were never checkpointed (e.g. freshly injected
-            // or crashed before first checkpoint), causing init() to throw and leaving
-            // the zombie uncleaned.
-            jobMaster.init(jobInfo.getInitializationTimestamp(), false);
+            // restart=true: CheckpointManager is null-safe for jobs that were never
+            // checkpointed (e.g. coordinator died before first checkpoint), so init()
+            // will not throw for such zombies. Using restart=false would unintentionally
+            // trigger handleSaveMode() in init(), which can destructively truncate or
+            // drop sink tables during zombie cleanup.
+            jobMaster.init(jobInfo.getInitializationTimestamp(), true);
             JobResult jobResult = new JobResult(jobStatus, null);
             jobMaster.getPhysicalPlan().completeJobEndFuture(jobResult);
             getEventProcessor()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -765,6 +765,16 @@ public class CoordinatorService {
             return;
         }
 
+        if (jobState instanceof JobStatus && ((JobStatus) jobState).isEndState()) {
+            logger.warning(
+                    String.format(
+                            "Job %s is in terminal state %s in runningJobInfoIMap, "
+                                    + "removing zombie entry to prevent incorrect restore",
+                            jobId, jobState));
+            runningJobInfoIMap.remove(jobId);
+            return;
+        }
+
         JobMaster jobMaster =
                 new JobMaster(
                         jobId,

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -695,8 +695,20 @@ public class CoordinatorService {
             Map.Entry<Long, JobInfo> entry = zombieIterator.next();
             Object jobState;
             try {
-                jobState = runningJobStateIMap.get(entry.getKey());
+                jobState =
+                        RetryUtils.retryWithException(
+                                () -> runningJobStateIMap.get(entry.getKey()),
+                                new RetryUtils.RetryMaterial(
+                                        Constant.OPERATION_RETRY_TIME,
+                                        true,
+                                        ExceptionUtil::isOperationNeedRetryException,
+                                        Constant.OPERATION_RETRY_SLEEP));
             } catch (Exception e) {
+                logger.warning(
+                        String.format(
+                                "Failed to read job state for job %s during zombie pre-filter,"
+                                        + " skipping: %s",
+                                entry.getKey(), e.getMessage()));
                 continue;
             }
             if (jobState instanceof JobStatus && ((JobStatus) jobState).isEndState()) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -866,7 +866,6 @@ public class CoordinatorService {
                         seaTunnelServer);
         try {
             jobMaster.init(jobInfo.getInitializationTimestamp(), true);
-            jobMaster.neverNeedRestore();
             JobResult jobResult = new JobResult(jobStatus, null);
             jobMaster.getPhysicalPlan().completeJobEndFuture(jobResult);
             getEventProcessor()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -39,6 +39,7 @@ import org.apache.seatunnel.engine.common.exception.JobNotFoundException;
 import org.apache.seatunnel.engine.common.exception.SavePointFailedException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.job.JobResult;
+import org.apache.seatunnel.engine.common.job.JobStateEvent;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
@@ -805,7 +806,7 @@ public class CoordinatorService {
                             "Job %s is in terminal state %s in runningJobInfoIMap, "
                                     + "cleaning up zombie entry to prevent incorrect restore",
                             jobId, jobState));
-            cleanupZombieJob(jobId, jobInfo);
+            cleanupZombieJob(jobId, jobInfo, (JobStatus) jobState);
             return;
         }
 
@@ -838,13 +839,17 @@ public class CoordinatorService {
 
     /**
      * Clean up all IMap entries for a zombie job (a job in terminal state that was never removed
-     * from runningJobInfoIMap because the coordinator died mid-cleanup). Creates a temporary
-     * JobMaster solely to obtain the PhysicalPlan structure needed to enumerate all pipeline/task
-     * IMap keys, then calls cleanJob() directly — bypassing the pending queue to avoid
-     * transitioning the job back to PENDING state. Falls back to a direct IMap remove if JobMaster
-     * initialisation fails.
+     * from runningJobInfoIMap because the coordinator died mid-cleanup). Initialises a temporary
+     * JobMaster, then drives it through the normal completion lifecycle by completing the physical
+     * plan's end future with the already-known terminal status. This triggers the wired
+     * {@code jobEndFuture} handler which calls {@code cleanJob()} and completes
+     * {@code jobMasterCompleteFuture} — the same path taken by every normally-finishing job.
+     *
+     * <p>If initialisation fails (e.g. checkpoint storage unreachable) the exception is logged and
+     * the zombie is left in place for the next restore cycle to retry.
      */
-    private void cleanupZombieJob(@NonNull Long jobId, @NonNull JobInfo jobInfo) {
+    private void cleanupZombieJob(
+            @NonNull Long jobId, @NonNull JobInfo jobInfo, @NonNull JobStatus jobStatus) {
         JobMaster jobMaster =
                 new JobMaster(
                         jobId,
@@ -862,18 +867,26 @@ public class CoordinatorService {
         try {
             jobMaster.init(jobInfo.getInitializationTimestamp(), true);
             jobMaster.neverNeedRestore();
-            jobMaster.cleanJob();
+            JobResult jobResult = new JobResult(jobStatus, null);
+            jobMaster.getPhysicalPlan().completeJobEndFuture(jobResult);
+            getEventProcessor()
+                    .process(
+                            new JobStateEvent(
+                                    jobMaster.getJobImmutableInformation().getJobId(),
+                                    jobMaster.getJobImmutableInformation()
+                                            .getJobConfig()
+                                            .getName(),
+                                    jobStatus));
+            jobMaster.getJobMasterCompleteFuture().join();
             logger.info(
                     String.format(
-                            "Zombie job %s cleaned up successfully via JobMaster.cleanJob()",
+                            "Zombie job %s cleaned up successfully via completion lifecycle",
                             jobId));
         } catch (Exception e) {
             logger.warning(
                     String.format(
-                            "Failed to init JobMaster for zombie job %s, "
-                                    + "falling back to direct IMap remove: %s",
+                            "Failed to clean up zombie job %s, will retry on next restore: %s",
                             jobId, e.getMessage()));
-            runningJobInfoIMap.remove(jobId);
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -841,9 +841,9 @@ public class CoordinatorService {
      * Clean up all IMap entries for a zombie job (a job in terminal state that was never removed
      * from runningJobInfoIMap because the coordinator died mid-cleanup). Initialises a temporary
      * JobMaster, then drives it through the normal completion lifecycle by completing the physical
-     * plan's end future with the already-known terminal status. This triggers the wired
-     * {@code jobEndFuture} handler which calls {@code cleanJob()} and completes
-     * {@code jobMasterCompleteFuture} — the same path taken by every normally-finishing job.
+     * plan's end future with the already-known terminal status. This triggers the wired {@code
+     * jobEndFuture} handler which calls {@code cleanJob()} and completes {@code
+     * jobMasterCompleteFuture} — the same path taken by every normally-finishing job.
      *
      * <p>If initialisation fails (e.g. checkpoint storage unreachable) the exception is logged and
      * the zombie is left in place for the next restore cycle to retry.
@@ -873,9 +873,7 @@ public class CoordinatorService {
                     .process(
                             new JobStateEvent(
                                     jobMaster.getJobImmutableInformation().getJobId(),
-                                    jobMaster.getJobImmutableInformation()
-                                            .getJobConfig()
-                                            .getName(),
+                                    jobMaster.getJobImmutableInformation().getJobConfig().getName(),
                                     jobStatus));
             jobMaster.getJobMasterCompleteFuture().join();
             logger.info(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -39,7 +39,6 @@ import org.apache.seatunnel.engine.common.exception.JobNotFoundException;
 import org.apache.seatunnel.engine.common.exception.SavePointFailedException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.job.JobResult;
-import org.apache.seatunnel.engine.common.job.JobStateEvent;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
@@ -347,7 +346,8 @@ public class CoordinatorService {
                     try {
                         String jobFullName = finalJobMaster.getPhysicalPlan().getJobFullName();
                         JobStatus jobStatus = (JobStatus) runningJobStateIMap.get(jobId);
-                        if (pendingSourceState == PendingSourceState.RESTORE) {
+                        if (pendingSourceState == PendingSourceState.RESTORE
+                                && !jobStatus.isEndState()) {
                             finalJobMaster
                                     .getPhysicalPlan()
                                     .getPipelineList()
@@ -800,16 +800,6 @@ public class CoordinatorService {
             return;
         }
 
-        if (jobState instanceof JobStatus && ((JobStatus) jobState).isEndState()) {
-            logger.warning(
-                    String.format(
-                            "Job %s is in terminal state %s in runningJobInfoIMap, "
-                                    + "cleaning up zombie entry to prevent incorrect restore",
-                            jobId, jobState));
-            cleanupZombieJob(jobId, jobInfo, (JobStatus) jobState);
-            return;
-        }
-
         JobMaster jobMaster =
                 new JobMaster(
                         jobId,
@@ -835,61 +825,6 @@ public class CoordinatorService {
         pendingJobQueue.put(pendingJobInfo);
         jobMaster.getPhysicalPlan().updateJobState(JobStatus.PENDING);
         logger.info(String.format("The restore job enter pending queue, JobId: %s", jobId));
-    }
-
-    /**
-     * Clean up all IMap entries for a zombie job (a job in terminal state that was never removed
-     * from runningJobInfoIMap because the coordinator died mid-cleanup). Initialises a temporary
-     * JobMaster, then drives it through the normal completion lifecycle by completing the physical
-     * plan's end future with the already-known terminal status. This triggers the wired {@code
-     * jobEndFuture} handler which calls {@code cleanJob()} and completes {@code
-     * jobMasterCompleteFuture} — the same path taken by every normally-finishing job.
-     *
-     * <p>If initialisation fails (e.g. checkpoint storage unreachable) the exception is logged and
-     * the zombie is left in place for the next restore cycle to retry.
-     */
-    private void cleanupZombieJob(
-            @NonNull Long jobId, @NonNull JobInfo jobInfo, @NonNull JobStatus jobStatus) {
-        JobMaster jobMaster =
-                new JobMaster(
-                        jobId,
-                        jobInfo.getJobImmutableInformation(),
-                        nodeEngine,
-                        MDCTracer.tracing(jobId, executorService),
-                        getResourceManager(),
-                        getJobHistoryService(),
-                        runningJobStateIMap,
-                        runningJobStateTimestampsIMap,
-                        ownedSlotProfilesIMap,
-                        runningJobInfoIMap,
-                        engineConfig,
-                        seaTunnelServer);
-        try {
-            // restart=true: CheckpointManager is null-safe for jobs that were never
-            // checkpointed (e.g. coordinator died before first checkpoint), so init()
-            // will not throw for such zombies. Using restart=false would unintentionally
-            // trigger handleSaveMode() in init(), which can destructively truncate or
-            // drop sink tables during zombie cleanup.
-            jobMaster.init(jobInfo.getInitializationTimestamp(), true);
-            JobResult jobResult = new JobResult(jobStatus, null);
-            jobMaster.getPhysicalPlan().completeJobEndFuture(jobResult);
-            getEventProcessor()
-                    .process(
-                            new JobStateEvent(
-                                    jobMaster.getJobImmutableInformation().getJobId(),
-                                    jobMaster.getJobImmutableInformation().getJobConfig().getName(),
-                                    jobStatus));
-            jobMaster.getJobMasterCompleteFuture().join();
-            logger.info(
-                    String.format(
-                            "Zombie job %s cleaned up successfully via completion lifecycle",
-                            jobId));
-        } catch (Exception e) {
-            logger.warning(
-                    String.format(
-                            "Failed to clean up zombie job %s, will retry on next restore: %s",
-                            jobId, e.getMessage()));
-        }
     }
 
     /**

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -95,6 +95,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -681,6 +682,27 @@ public class CoordinatorService {
         } catch (Exception e) {
             throw new SeaTunnelEngineException(
                     "Failed to fetch running jobs from IMap during master switch restore", e);
+        }
+        if (needRestoreFromMasterNodeSwitchJobs.isEmpty()) {
+            return;
+        }
+        // Pre-filter: clean up terminal-state zombie jobs immediately before waiting for workers.
+        // Zombies do not need a worker — they only need IMap cleanup. Processing them here avoids
+        // blocking zombie cleanup behind the worker-wait loop.
+        Iterator<Map.Entry<Long, JobInfo>> zombieIterator =
+                needRestoreFromMasterNodeSwitchJobs.iterator();
+        while (zombieIterator.hasNext()) {
+            Map.Entry<Long, JobInfo> entry = zombieIterator.next();
+            Object jobState;
+            try {
+                jobState = runningJobStateIMap.get(entry.getKey());
+            } catch (Exception e) {
+                continue;
+            }
+            if (jobState instanceof JobStatus && ((JobStatus) jobState).isEndState()) {
+                restoreJobFromMasterActiveSwitch(entry.getKey(), entry.getValue());
+                zombieIterator.remove();
+            }
         }
         if (needRestoreFromMasterNodeSwitchJobs.isEmpty()) {
             return;

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -559,9 +559,13 @@ public class CoordinatorServiceTest {
         // Zombie entry must be removed — terminal state job should never be restored
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
-        Assertions.assertFalse(
-                runningJobInfoOnInstance2.containsKey(zombieJobId),
-                "Zombie job in FAILED state must be removed from runningJobInfoIMap during restore");
+        await().atMost(10000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertFalse(
+                                        runningJobInfoOnInstance2.containsKey(zombieJobId),
+                                        "Zombie job in FAILED state must be removed from"
+                                                + " runningJobInfoIMap during restore"));
 
         instance2.shutdown();
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -525,16 +525,32 @@ public class CoordinatorServiceTest {
                         });
 
         // Inject a zombie: job in FAILED state that was never cleaned from runningJobInfoIMap
-        // (simulates coordinator dying mid-cleanup before removeJobIMap executed)
+        // (simulates coordinator dying mid-cleanup before removeJobIMap executed).
+        // Use real serialized JobImmutableInformation so that cleanupZombieJob() can complete
+        // JobMaster.init() and exercise the JobMaster.cleanJob() path (not just the fallback).
         long zombieJobId =
                 instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+        LogicalDag zombieLogicalDag =
+                TestUtils.createTestLogicalPlan(
+                        "batch_fake_to_console.conf", "zombie-test-job", zombieJobId);
+        JobImmutableInformation zombieImmutableInfo =
+                new JobImmutableInformation(
+                        zombieJobId,
+                        "Test",
+                        instance1.getSerializationService(),
+                        zombieLogicalDag,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+        Data zombieData = instance1.getSerializationService().toData(zombieImmutableInfo);
+
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
                 instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
         IMap<Long, JobStatus> runningJobStateIMap =
                 instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
         runningJobInfoIMap.put(
                 zombieJobId,
-                new org.apache.seatunnel.engine.core.job.JobInfo(System.currentTimeMillis(), null));
+                new org.apache.seatunnel.engine.core.job.JobInfo(
+                        System.currentTimeMillis(), zombieData));
         runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
 
         Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));
@@ -556,16 +572,25 @@ public class CoordinatorServiceTest {
                                     server2.getCoordinatorService().isCoordinatorActive());
                         });
 
-        // Zombie entry must be removed — terminal state job should never be restored
+        // All zombie IMap entries must be removed — exercises the JobMaster.cleanJob() path
+        // which cleans runningJobStateIMap in addition to runningJobInfoIMap (the fallback
+        // direct-remove only cleans runningJobInfoIMap).
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Long, JobStatus> runningJobStateOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
         await().atMost(10000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
-                        () ->
-                                Assertions.assertFalse(
-                                        runningJobInfoOnInstance2.containsKey(zombieJobId),
-                                        "Zombie job in FAILED state must be removed from"
-                                                + " runningJobInfoIMap during restore"));
+                        () -> {
+                            Assertions.assertFalse(
+                                    runningJobInfoOnInstance2.containsKey(zombieJobId),
+                                    "Zombie job must be removed from runningJobInfoIMap");
+                            Assertions.assertFalse(
+                                    runningJobStateOnInstance2.containsKey(zombieJobId),
+                                    "Zombie job must be removed from runningJobStateIMap"
+                                            + " (proves JobMaster.cleanJob() ran, not just"
+                                            + " fallback direct-remove)");
+                        });
 
         instance2.shutdown();
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -30,6 +30,7 @@ import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
 import org.apache.seatunnel.engine.server.execution.ExecutionState;
+import org.apache.seatunnel.engine.server.execution.TaskGroupContext;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
@@ -63,12 +64,197 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.awaitility.Awaitility.await;
 
 @Slf4j
 public class CoordinatorServiceTest {
+    @Test
+    void testTerminalZombieJobShouldNotRestartAfterMasterSwitch() {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testTerminalZombieJobShouldNotRestartAfterMasterSwitch");
+
+        // instance1: initial master
+        HazelcastInstanceImpl instance1 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server1 =
+                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server1.isMasterNode());
+                            Assertions.assertTrue(
+                                    server1.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        // instance2: survives the master switch
+        HazelcastInstanceImpl instance2 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server2 =
+                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        2, instance1.getCluster().getMembers().size()));
+
+        long jobId = instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+
+        LogicalDag logicalDag =
+                TestUtils.createTestLogicalPlan(
+                        "stream_fake_to_console.conf", "terminal-zombie-master-switch-test", jobId);
+
+        JobImmutableInformation jobImmutableInfo =
+                new JobImmutableInformation(
+                        jobId,
+                        "Test",
+                        instance1.getSerializationService(),
+                        logicalDag,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        Data jobData = instance1.getSerializationService().toData(jobImmutableInfo);
+
+        CoordinatorService coordinatorService = server1.getCoordinatorService();
+        coordinatorService
+                .submitJob(jobId, jobData, jobImmutableInfo.isStartWithSavePoint())
+                .join();
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        JobStatus.RUNNING, coordinatorService.getJobStatus(jobId)));
+
+        // Collect restore keys before the job is terminated.
+        JobMaster jobMaster = coordinatorService.getJobMaster(jobId);
+        Assertions.assertNotNull(jobMaster);
+
+        List<PipelineLocation> pipelineLocations = new ArrayList<>();
+        List<TaskGroupLocation> taskGroupLocations = new ArrayList<>();
+        for (SubPlan subPlan : jobMaster.getPhysicalPlan().getPipelineList()) {
+            pipelineLocations.add(subPlan.getPipelineLocation());
+            subPlan.getCoordinatorVertexList()
+                    .forEach(vertex -> taskGroupLocations.add(vertex.getTaskGroupLocation()));
+            subPlan.getPhysicalVertexList()
+                    .forEach(vertex -> taskGroupLocations.add(vertex.getTaskGroupLocation()));
+        }
+
+        // 1) Terminate the real job first.
+        coordinatorService.cancelJob(jobId).join();
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        JobStatus.CANCELED,
+                                        coordinatorService.getJobStatus(jobId)));
+
+        // Ensure the real execution is gone before injecting stale zombie metadata.
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(
+                                    allTaskGroupsInactive(server1, taskGroupLocations));
+                            Assertions.assertTrue(
+                                    allTaskGroupsInactive(server2, taskGroupLocations));
+                        });
+
+        // 2) Re-inject stale terminal metadata using the locations we collected earlier.
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Object, Object> runningJobStateIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+
+        runningJobInfoIMap.put(
+                jobId,
+                new org.apache.seatunnel.engine.core.job.JobInfo(
+                        System.currentTimeMillis(), jobData));
+        runningJobStateIMap.put(jobId, JobStatus.CANCELED);
+
+        for (PipelineLocation pipelineLocation : pipelineLocations) {
+            runningJobStateIMap.put(pipelineLocation, PipelineStatus.CANCELED);
+        }
+        for (TaskGroupLocation taskGroupLocation : taskGroupLocations) {
+            runningJobStateIMap.put(taskGroupLocation, ExecutionState.CANCELED);
+        }
+
+        Assertions.assertTrue(
+                runningJobInfoIMap.containsKey(jobId),
+                "Zombie job metadata should be present before master switch");
+
+        // 3) Trigger master switch.
+        instance1.shutdown();
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server2.isMasterNode());
+                            Assertions.assertTrue(
+                                    server2.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        // 4) Metadata should be cleaned up on the new master.
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Object, Object> runningJobStateOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertFalse(
+                                    runningJobInfoOnInstance2.containsKey(jobId),
+                                    "Zombie job must be removed from runningJobInfoIMap");
+                            Assertions.assertFalse(
+                                    runningJobStateOnInstance2.containsKey(jobId),
+                                    "Zombie job must be removed from runningJobStateIMap");
+                        });
+
+        // 5) The important assertion:
+        // terminal zombie metadata must NOT cause tasks to start running again.
+        await().during(10000, TimeUnit.MILLISECONDS)
+                .atMost(12000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> {
+                            for (TaskGroupLocation location : taskGroupLocations) {
+                                TaskGroupContext activeExecutionContext = null;
+                                try {
+                                    activeExecutionContext =
+                                            server2.getTaskExecutionService()
+                                                    .getActiveExecutionContext(location);
+                                } catch (Exception e) {
+                                }
+                                Assertions.assertNull(
+                                        activeExecutionContext,
+                                        "Terminal zombie job should not be re-executed after "
+                                                + "master switch: "
+                                                + location);
+                            }
+                        });
+
+        instance2.shutdown();
+    }
+
+    private boolean allTaskGroupsInactive(
+            SeaTunnelServer server, List<TaskGroupLocation> taskGroupLocations) {
+        for (TaskGroupLocation location : taskGroupLocations) {
+            try {
+                TaskGroupContext context =
+                        server.getTaskExecutionService().getActiveExecutionContext(location);
+                if (context != null) {
+                    return false;
+                }
+            } catch (Exception e) {
+                return true;
+            }
+        }
+        return true;
+    }
+
     @Test
     public void testMasterNodeActive() {
         String clusterName =
@@ -513,131 +699,6 @@ public class CoordinatorServiceTest {
     }
 
     @Test
-    void testZombieJobRemovedFromImapOnMasterSwitchRestore() {
-        String clusterName =
-                TestUtils.getClusterName(
-                        "CoordinatorServiceTest_testZombieJobRemovedFromImapOnMasterSwitchRestore");
-        HazelcastInstanceImpl instance1 =
-                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
-        SeaTunnelServer server1 =
-                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
-
-        // Wait for instance1 to become the active master
-        await().atMost(10000, TimeUnit.MILLISECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertTrue(server1.isMasterNode());
-                            Assertions.assertTrue(
-                                    server1.getCoordinatorService().isCoordinatorActive());
-                        });
-
-        // Inject a zombie: job in FAILED state that was never cleaned from runningJobInfoIMap
-        // (simulates coordinator dying mid-cleanup before removeJobIMap executed).
-        // Use a STREAM job (not batch) so that if the fix is absent and the zombie is re-run,
-        // it will stay RUNNING indefinitely and never be removed from runningJobInfoIMap —
-        // causing the assertion to time out and the test to FAIL on unfixed code.
-        // With the fix, cleanupZombieJob() removes the zombie before any restore attempt.
-        long zombieJobId =
-                instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
-        LogicalDag zombieLogicalDag =
-                TestUtils.createTestLogicalPlan(
-                        "stream_fake_to_console.conf", "zombie-test-job", zombieJobId);
-        JobImmutableInformation zombieImmutableInfo =
-                new JobImmutableInformation(
-                        zombieJobId,
-                        "Test",
-                        instance1.getSerializationService(),
-                        zombieLogicalDag,
-                        Collections.emptyList(),
-                        Collections.emptyList());
-        Data zombieData = instance1.getSerializationService().toData(zombieImmutableInfo);
-
-        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
-                instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
-        IMap<Long, JobStatus> runningJobStateIMap =
-                instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
-        runningJobInfoIMap.put(
-                zombieJobId,
-                new org.apache.seatunnel.engine.core.job.JobInfo(
-                        System.currentTimeMillis(), zombieData));
-        runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
-
-        Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));
-
-        // Start instance2 in same cluster, then shut down instance1 to trigger master switch
-        HazelcastInstanceImpl instance2 =
-                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
-        instance1.shutdown();
-
-        SeaTunnelServer server2 =
-                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
-
-        // Wait for instance2 to become active master and complete restore
-        await().atMost(20000, TimeUnit.MILLISECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertTrue(server2.isMasterNode());
-                            Assertions.assertTrue(
-                                    server2.getCoordinatorService().isCoordinatorActive());
-                        });
-
-        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
-                instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
-        IMap<Long, JobStatus> runningJobStateOnInstance2 =
-                instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
-
-        // KEY ASSERTION — must fail on original (unfixed) code:
-        // With the fix: cleanupZombieJob() runs synchronously inside
-        // restoreAllRunningJobFromMasterNodeSwitch() BEFORE any job is enqueued, so the
-        // zombie is never added to the coordinator's runningJobMasterMap and is never
-        // seen as RUNNING. The IMap entries are also removed within the same synchronous
-        // call, so the tight 3-second window below is reliably met.
-        //
-        // Without the fix: the zombie is treated as a normal restore, queued via
-        // pendingJob, transitions to RUNNING (visible via getJobStatus), and only
-        // removed from runningJobInfoIMap after the stream job finishes (~5-15 s).
-        // The 3-second window will therefore time out → test FAILS on unfixed code.
-        CoordinatorService coordinatorService2 = server2.getCoordinatorService();
-
-        // Assert zombie is never RUNNING — poll every 200 ms for 4 s
-        long pollDeadline = System.currentTimeMillis() + 4000;
-        while (System.currentTimeMillis() < pollDeadline) {
-            try {
-                JobStatus status = coordinatorService2.getJobStatus(zombieJobId);
-                Assertions.assertNotEquals(
-                        JobStatus.RUNNING,
-                        status,
-                        "Zombie job must NOT be restored as RUNNING — "
-                                + "it should be cleaned up directly by cleanupZombieJob()");
-            } catch (Exception ignored) {
-                // job not in running map (already cleaned) — expected with fix
-            }
-            try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-
-        // IMap entries must be removed within 3 s (synchronous cleanup with the fix;
-        // job-completion-based cleanup on unfixed code takes 5-15 s → times out here)
-        await().atMost(3000, TimeUnit.MILLISECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertFalse(
-                                    runningJobInfoOnInstance2.containsKey(zombieJobId),
-                                    "Zombie job must be removed from runningJobInfoIMap");
-                            Assertions.assertFalse(
-                                    runningJobStateOnInstance2.containsKey(zombieJobId),
-                                    "Zombie job must be removed from runningJobStateIMap"
-                                            + " (proves JobMaster.cleanJob() ran)");
-                        });
-
-        instance2.shutdown();
-    }
-
-    @Test
     public void testClearCoordinatorService() {
         JobInformation jobInformation =
                 submitJob(
@@ -906,179 +967,6 @@ public class CoordinatorServiceTest {
         System.out.printf("Average completion time per op: %.6f seconds%n", avgSeconds);
 
         return elapsedNs / 1_000_000_000.0;
-    }
-
-    /**
-     * Documents a known limitation of the current zombie-cleanup path: after a master switch,
-     * {@code cleanupZombieJob()} removes the job's IMap metadata entries but does NOT cancel the
-     * worker-side task-group that is still actively executing on the surviving node. The orphan
-     * task continues running until it is eventually interrupted by a heartbeat timeout or a manual
-     * cancel.
-     *
-     * <p>This test deliberately asserts that the orphan task IS still running after cleanup, so
-     * that any future change which also cancels the orphan worker tasks can flip this assertion to
-     * confirm the improvement.
-     */
-    @Test
-    void testZombieCleanupCanLeaveOrphanWorkerTaskAfterMasterSwitch() {
-        String clusterName =
-                TestUtils.getClusterName(
-                        "CoordinatorServiceTest_testZombieCleanupCanLeaveOrphanWorkerTaskAfterMasterSwitch");
-
-        // instance1: initial master
-        HazelcastInstanceImpl instance1 =
-                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
-        SeaTunnelServer server1 =
-                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
-
-        await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertTrue(server1.isMasterNode());
-                            Assertions.assertTrue(
-                                    server1.getCoordinatorService().isCoordinatorActive());
-                        });
-
-        // instance2: worker that will survive the master switch
-        HazelcastInstanceImpl instance2 =
-                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
-        SeaTunnelServer server2 =
-                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
-
-        await().atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        2, instance1.getCluster().getMembers().size()));
-
-        long zombieJobId =
-                instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
-
-        LogicalDag logicalDag =
-                TestUtils.createTestLogicalPlan(
-                        "stream_fake_to_console.conf",
-                        "zombie-orphan-running-task-test",
-                        zombieJobId);
-
-        JobImmutableInformation jobImmutableInfo =
-                new JobImmutableInformation(
-                        zombieJobId,
-                        "Test",
-                        instance1.getSerializationService(),
-                        logicalDag,
-                        Collections.emptyList(),
-                        Collections.emptyList());
-
-        Data jobData = instance1.getSerializationService().toData(jobImmutableInfo);
-
-        CoordinatorService coordinatorService = server1.getCoordinatorService();
-        coordinatorService
-                .submitJob(zombieJobId, jobData, jobImmutableInfo.isStartWithSavePoint())
-                .join();
-
-        await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        JobStatus.RUNNING,
-                                        coordinatorService.getJobStatus(zombieJobId)));
-
-        JobMaster jobMaster = coordinatorService.getJobMaster(zombieJobId);
-        Assertions.assertNotNull(jobMaster);
-
-        List<PipelineLocation> pipelineLocations = new ArrayList<>();
-        List<TaskGroupLocation> allTaskGroupLocations = new ArrayList<>();
-        for (SubPlan subPlan : jobMaster.getPhysicalPlan().getPipelineList()) {
-            pipelineLocations.add(subPlan.getPipelineLocation());
-            subPlan.getCoordinatorVertexList()
-                    .forEach(v -> allTaskGroupLocations.add(v.getTaskGroupLocation()));
-            subPlan.getPhysicalVertexList()
-                    .forEach(v -> allTaskGroupLocations.add(v.getTaskGroupLocation()));
-        }
-
-        // Wait until at least one task group is actively running on instance2 (the worker)
-        AtomicReference<TaskGroupLocation> survivingWorkerTaskGroup = new AtomicReference<>();
-        await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            TaskGroupLocation found =
-                                    allTaskGroupLocations.stream()
-                                            .filter(loc -> hasActiveExecutionContext(server2, loc))
-                                            .findFirst()
-                                            .orElse(null);
-                            Assertions.assertNotNull(
-                                    found,
-                                    "Need at least one task group actively running on instance2 "
-                                            + "before killing the master");
-                            survivingWorkerTaskGroup.set(found);
-                        });
-
-        TaskGroupLocation orphanLocation = survivingWorkerTaskGroup.get();
-        Assertions.assertTrue(
-                hasActiveExecutionContext(server2, orphanLocation),
-                "Sanity check failed: chosen task group is not running on instance2");
-
-        // Poison the distributed metadata to simulate a zombie terminal job while the worker
-        // task is still actively executing on instance2.
-        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
-                instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
-        IMap<Object, Object> runningJobStateIMap =
-                instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
-
-        Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));
-        runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
-
-        // Optional but makes the terminal zombie metadata more explicit/consistent.
-        for (PipelineLocation pipelineLocation : pipelineLocations) {
-            runningJobStateIMap.put(pipelineLocation, PipelineStatus.FAILED);
-        }
-        for (TaskGroupLocation taskGroupLocation : allTaskGroupLocations) {
-            runningJobStateIMap.put(taskGroupLocation, ExecutionState.FAILED);
-        }
-
-        // Trigger master switch: instance2 survives and becomes the new master.
-        instance1.shutdown();
-
-        await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertTrue(server2.isMasterNode());
-                            Assertions.assertTrue(
-                                    server2.getCoordinatorService().isCoordinatorActive());
-                        });
-
-        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
-                instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
-        IMap<Object, Object> runningJobStateOnInstance2 =
-                instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
-
-        await().atMost(20, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertFalse(
-                                    runningJobInfoOnInstance2.containsKey(zombieJobId),
-                                    "Zombie job must be removed from runningJobInfoIMap");
-                            Assertions.assertFalse(
-                                    runningJobStateOnInstance2.containsKey(zombieJobId),
-                                    "Zombie job must be removed from runningJobStateIMap");
-                        });
-
-        // Known limitation: metadata cleanup does NOT cancel the surviving worker task.
-        // The orphan task group is still executing on instance2 after zombie cleanup.
-        Assertions.assertTrue(
-                hasActiveExecutionContext(server2, orphanLocation),
-                "Expected orphan task group to still be running on surviving worker "
-                        + "after zombie metadata cleanup");
-
-        instance2.shutdown();
-    }
-
-    private boolean hasActiveExecutionContext(SeaTunnelServer server, TaskGroupLocation location) {
-        try {
-            return server.getTaskExecutionService().getActiveExecutionContext(location) != null;
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private static class JobInformation {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -27,6 +27,10 @@ import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
+import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
+import org.apache.seatunnel.engine.server.execution.ExecutionState;
+import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
 import org.apache.seatunnel.engine.server.metrics.SeaTunnelMetricsContext;
@@ -48,15 +52,18 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.awaitility.Awaitility.await;
 
@@ -899,6 +906,179 @@ public class CoordinatorServiceTest {
         System.out.printf("Average completion time per op: %.6f seconds%n", avgSeconds);
 
         return elapsedNs / 1_000_000_000.0;
+    }
+
+    /**
+     * Documents a known limitation of the current zombie-cleanup path: after a master switch,
+     * {@code cleanupZombieJob()} removes the job's IMap metadata entries but does NOT cancel the
+     * worker-side task-group that is still actively executing on the surviving node. The orphan
+     * task continues running until it is eventually interrupted by a heartbeat timeout or a manual
+     * cancel.
+     *
+     * <p>This test deliberately asserts that the orphan task IS still running after cleanup, so
+     * that any future change which also cancels the orphan worker tasks can flip this assertion to
+     * confirm the improvement.
+     */
+    @Test
+    void testZombieCleanupCanLeaveOrphanWorkerTaskAfterMasterSwitch() {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testZombieCleanupCanLeaveOrphanWorkerTaskAfterMasterSwitch");
+
+        // instance1: initial master
+        HazelcastInstanceImpl instance1 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server1 =
+                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server1.isMasterNode());
+                            Assertions.assertTrue(
+                                    server1.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        // instance2: worker that will survive the master switch
+        HazelcastInstanceImpl instance2 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server2 =
+                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        2, instance1.getCluster().getMembers().size()));
+
+        long zombieJobId =
+                instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+
+        LogicalDag logicalDag =
+                TestUtils.createTestLogicalPlan(
+                        "stream_fake_to_console.conf",
+                        "zombie-orphan-running-task-test",
+                        zombieJobId);
+
+        JobImmutableInformation jobImmutableInfo =
+                new JobImmutableInformation(
+                        zombieJobId,
+                        "Test",
+                        instance1.getSerializationService(),
+                        logicalDag,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+
+        Data jobData = instance1.getSerializationService().toData(jobImmutableInfo);
+
+        CoordinatorService coordinatorService = server1.getCoordinatorService();
+        coordinatorService
+                .submitJob(zombieJobId, jobData, jobImmutableInfo.isStartWithSavePoint())
+                .join();
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        JobStatus.RUNNING,
+                                        coordinatorService.getJobStatus(zombieJobId)));
+
+        JobMaster jobMaster = coordinatorService.getJobMaster(zombieJobId);
+        Assertions.assertNotNull(jobMaster);
+
+        List<PipelineLocation> pipelineLocations = new ArrayList<>();
+        List<TaskGroupLocation> allTaskGroupLocations = new ArrayList<>();
+        for (SubPlan subPlan : jobMaster.getPhysicalPlan().getPipelineList()) {
+            pipelineLocations.add(subPlan.getPipelineLocation());
+            subPlan.getCoordinatorVertexList()
+                    .forEach(v -> allTaskGroupLocations.add(v.getTaskGroupLocation()));
+            subPlan.getPhysicalVertexList()
+                    .forEach(v -> allTaskGroupLocations.add(v.getTaskGroupLocation()));
+        }
+
+        // Wait until at least one task group is actively running on instance2 (the worker)
+        AtomicReference<TaskGroupLocation> survivingWorkerTaskGroup = new AtomicReference<>();
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            TaskGroupLocation found =
+                                    allTaskGroupLocations.stream()
+                                            .filter(loc -> hasActiveExecutionContext(server2, loc))
+                                            .findFirst()
+                                            .orElse(null);
+                            Assertions.assertNotNull(
+                                    found,
+                                    "Need at least one task group actively running on instance2 "
+                                            + "before killing the master");
+                            survivingWorkerTaskGroup.set(found);
+                        });
+
+        TaskGroupLocation orphanLocation = survivingWorkerTaskGroup.get();
+        Assertions.assertTrue(
+                hasActiveExecutionContext(server2, orphanLocation),
+                "Sanity check failed: chosen task group is not running on instance2");
+
+        // Poison the distributed metadata to simulate a zombie terminal job while the worker
+        // task is still actively executing on instance2.
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Object, Object> runningJobStateIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+
+        Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));
+        runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
+
+        // Optional but makes the terminal zombie metadata more explicit/consistent.
+        for (PipelineLocation pipelineLocation : pipelineLocations) {
+            runningJobStateIMap.put(pipelineLocation, PipelineStatus.FAILED);
+        }
+        for (TaskGroupLocation taskGroupLocation : allTaskGroupLocations) {
+            runningJobStateIMap.put(taskGroupLocation, ExecutionState.FAILED);
+        }
+
+        // Trigger master switch: instance2 survives and becomes the new master.
+        instance1.shutdown();
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server2.isMasterNode());
+                            Assertions.assertTrue(
+                                    server2.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Object, Object> runningJobStateOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertFalse(
+                                    runningJobInfoOnInstance2.containsKey(zombieJobId),
+                                    "Zombie job must be removed from runningJobInfoIMap");
+                            Assertions.assertFalse(
+                                    runningJobStateOnInstance2.containsKey(zombieJobId),
+                                    "Zombie job must be removed from runningJobStateIMap");
+                        });
+
+        // Known limitation: metadata cleanup does NOT cancel the surviving worker task.
+        // The orphan task group is still executing on instance2 after zombie cleanup.
+        Assertions.assertTrue(
+                hasActiveExecutionContext(server2, orphanLocation),
+                "Expected orphan task group to still be running on surviving worker "
+                        + "after zombie metadata cleanup");
+
+        instance2.shutdown();
+    }
+
+    private boolean hasActiveExecutionContext(SeaTunnelServer server, TaskGroupLocation location) {
+        try {
+            return server.getTaskExecutionService().getActiveExecutionContext(location) != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private static class JobInformation {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -506,6 +506,70 @@ public class CoordinatorServiceTest {
     }
 
     @Test
+    void testZombieJobRemovedFromImapOnMasterSwitchRestore() {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testZombieJobRemovedFromImapOnMasterSwitchRestore");
+        HazelcastInstanceImpl instance1 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server1 =
+                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        // Wait for instance1 to become the active master
+        await().atMost(10000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server1.isMasterNode());
+                            Assertions.assertTrue(
+                                    server1.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        // Inject a zombie: job in FAILED state that was never cleaned from runningJobInfoIMap
+        // (simulates coordinator dying mid-cleanup before removeJobIMap executed)
+        long zombieJobId =
+                instance1
+                        .getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME)
+                        .newId();
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        IMap<Long, JobStatus> runningJobStateIMap =
+                instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+        runningJobInfoIMap.put(
+                zombieJobId,
+                new org.apache.seatunnel.engine.core.job.JobInfo(
+                        System.currentTimeMillis(), null));
+        runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
+
+        Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));
+
+        // Start instance2 in same cluster, then shut down instance1 to trigger master switch
+        HazelcastInstanceImpl instance2 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        instance1.shutdown();
+
+        SeaTunnelServer server2 =
+                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        // Wait for instance2 to become active master and complete restore
+        await().atMost(20000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server2.isMasterNode());
+                            Assertions.assertTrue(
+                                    server2.getCoordinatorService().isCoordinatorActive());
+                        });
+
+        // Zombie entry must be removed — terminal state job should never be restored
+        IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
+                instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+        Assertions.assertFalse(
+                runningJobInfoOnInstance2.containsKey(zombieJobId),
+                "Zombie job in FAILED state must be removed from runningJobInfoIMap during restore");
+
+        instance2.shutdown();
+    }
+
+    @Test
     public void testClearCoordinatorService() {
         JobInformation jobInformation =
                 submitJob(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -527,17 +527,14 @@ public class CoordinatorServiceTest {
         // Inject a zombie: job in FAILED state that was never cleaned from runningJobInfoIMap
         // (simulates coordinator dying mid-cleanup before removeJobIMap executed)
         long zombieJobId =
-                instance1
-                        .getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME)
-                        .newId();
+                instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoIMap =
                 instance1.getMap(Constant.IMAP_RUNNING_JOB_INFO);
         IMap<Long, JobStatus> runningJobStateIMap =
                 instance1.getMap(Constant.IMAP_RUNNING_JOB_STATE);
         runningJobInfoIMap.put(
                 zombieJobId,
-                new org.apache.seatunnel.engine.core.job.JobInfo(
-                        System.currentTimeMillis(), null));
+                new org.apache.seatunnel.engine.core.job.JobInfo(System.currentTimeMillis(), null));
         runningJobStateIMap.put(zombieJobId, JobStatus.FAILED);
 
         Assertions.assertTrue(runningJobInfoIMap.containsKey(zombieJobId));

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -574,15 +574,48 @@ public class CoordinatorServiceTest {
                                     server2.getCoordinatorService().isCoordinatorActive());
                         });
 
-        // All zombie IMap entries must be removed — exercises the JobMaster.cleanJob() path
-        // which cleans runningJobStateIMap in addition to runningJobInfoIMap.
-        // If the fix is absent the stream zombie is re-run indefinitely, so runningJobInfoIMap
-        // keeps the entry and the assertion below times out → test FAILS on unfixed code.
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
         IMap<Long, JobStatus> runningJobStateOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
-        await().atMost(10000, TimeUnit.MILLISECONDS)
+
+        // KEY ASSERTION — must fail on original (unfixed) code:
+        // With the fix: cleanupZombieJob() runs synchronously inside
+        // restoreAllRunningJobFromMasterNodeSwitch() BEFORE any job is enqueued, so the
+        // zombie is never added to the coordinator's runningJobMasterMap and is never
+        // seen as RUNNING. The IMap entries are also removed within the same synchronous
+        // call, so the tight 3-second window below is reliably met.
+        //
+        // Without the fix: the zombie is treated as a normal restore, queued via
+        // pendingJob, transitions to RUNNING (visible via getJobStatus), and only
+        // removed from runningJobInfoIMap after the stream job finishes (~5-15 s).
+        // The 3-second window will therefore time out → test FAILS on unfixed code.
+        CoordinatorService coordinatorService2 = server2.getCoordinatorService();
+
+        // Assert zombie is never RUNNING — poll every 200 ms for 4 s
+        long pollDeadline = System.currentTimeMillis() + 4000;
+        while (System.currentTimeMillis() < pollDeadline) {
+            try {
+                JobStatus status = coordinatorService2.getJobStatus(zombieJobId);
+                Assertions.assertNotEquals(
+                        JobStatus.RUNNING,
+                        status,
+                        "Zombie job must NOT be restored as RUNNING — "
+                                + "it should be cleaned up directly by cleanupZombieJob()");
+            } catch (Exception ignored) {
+                // job not in running map (already cleaned) — expected with fix
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        // IMap entries must be removed within 3 s (synchronous cleanup with the fix;
+        // job-completion-based cleanup on unfixed code takes 5-15 s → times out here)
+        await().atMost(3000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertFalse(
@@ -591,8 +624,7 @@ public class CoordinatorServiceTest {
                             Assertions.assertFalse(
                                     runningJobStateOnInstance2.containsKey(zombieJobId),
                                     "Zombie job must be removed from runningJobStateIMap"
-                                            + " (proves JobMaster.cleanJob() ran, not just"
-                                            + " fallback direct-remove)");
+                                            + " (proves JobMaster.cleanJob() ran)");
                         });
 
         instance2.shutdown();

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -526,13 +526,15 @@ public class CoordinatorServiceTest {
 
         // Inject a zombie: job in FAILED state that was never cleaned from runningJobInfoIMap
         // (simulates coordinator dying mid-cleanup before removeJobIMap executed).
-        // Use real serialized JobImmutableInformation so that cleanupZombieJob() can complete
-        // JobMaster.init() and exercise the JobMaster.cleanJob() path (not just the fallback).
+        // Use a STREAM job (not batch) so that if the fix is absent and the zombie is re-run,
+        // it will stay RUNNING indefinitely and never be removed from runningJobInfoIMap —
+        // causing the assertion to time out and the test to FAIL on unfixed code.
+        // With the fix, cleanupZombieJob() removes the zombie before any restore attempt.
         long zombieJobId =
                 instance1.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
         LogicalDag zombieLogicalDag =
                 TestUtils.createTestLogicalPlan(
-                        "batch_fake_to_console.conf", "zombie-test-job", zombieJobId);
+                        "stream_fake_to_console.conf", "zombie-test-job", zombieJobId);
         JobImmutableInformation zombieImmutableInfo =
                 new JobImmutableInformation(
                         zombieJobId,
@@ -573,8 +575,9 @@ public class CoordinatorServiceTest {
                         });
 
         // All zombie IMap entries must be removed — exercises the JobMaster.cleanJob() path
-        // which cleans runningJobStateIMap in addition to runningJobInfoIMap (the fallback
-        // direct-remove only cleans runningJobInfoIMap).
+        // which cleans runningJobStateIMap in addition to runningJobInfoIMap.
+        // If the fix is absent the stream zombie is re-run indefinitely, so runningJobInfoIMap
+        // keeps the entry and the assertion below times out → test FAILS on unfixed code.
         IMap<Long, org.apache.seatunnel.engine.core.job.JobInfo> runningJobInfoOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_INFO);
         IMap<Long, JobStatus> runningJobStateOnInstance2 =


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/10675

During coordinator failover, if the coordinator pod was killed after writing a terminal state (FAILED/CANCELED/FINISHED) to runningJobStateIMap but before removeJobIMap() executed, the job's entry remains in runningJobInfoIMap with a terminal state. On the next master switch, restoreJobFromMasterActiveSwitch() only checked for null jobState and unconditionally restored all other entries, causing zombie jobs to be incorrectly re-restored as RUNNING.

Fix: after fetching jobState, check if it is a terminal JobStatus (isEndState()). If so, remove the zombie entry from runningJobInfoIMap and skip restore.

Adds CoordinatorServiceTest.testZombieJobRemovedFromImapOnMasterSwitchRestore which injects a FAILED-state zombie via IMap, triggers a master switch, and asserts the zombie is removed after restore completes.

#10675 addressed via this PR.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)