### PR TITLE
[Improve][Connector-V2] Complete OptionRule declarations for RocketMQ source and sink

### DIFF
--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/sink/RocketMqSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/sink/RocketMqSinkFactory.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.rocketmq.config.RocketMqBaseOptions;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.config.RocketMqSinkOptions;
 
 import com.google.auto.service.AutoService;
@@ -43,7 +44,16 @@ public class RocketMqSinkFactory implements TableSinkFactory {
                         RocketMqSinkOptions.EXACTLY_ONCE,
                         RocketMqSinkOptions.SEND_SYNC,
                         RocketMqSinkOptions.MAX_MESSAGE_SIZE,
-                        RocketMqSinkOptions.SEND_MESSAGE_TIMEOUT_MILLIS)
+                        RocketMqSinkOptions.SEND_MESSAGE_TIMEOUT_MILLIS,
+                        RocketMqSinkOptions.TAG,
+                        RocketMqBaseOptions.FORMAT,
+                        RocketMqBaseOptions.FIELD_DELIMITER,
+                        RocketMqBaseOptions.ACL_ENABLED)
+                .conditional(
+                        RocketMqBaseOptions.ACL_ENABLED,
+                        true,
+                        RocketMqBaseOptions.ACCESS_KEY,
+                        RocketMqBaseOptions.SECRET_KEY)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceFactory.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.common.StartMode;
+import org.apache.seatunnel.connectors.seatunnel.rocketmq.config.RocketMqBaseOptions;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.config.RocketMqSourceOptions;
 
 import com.google.auto.service.AutoService;
@@ -49,6 +50,7 @@ public class RocketMqSourceFactory implements TableSourceFactory {
                         RocketMqSourceOptions.TABLE_LIST)
                 .optional(
                         RocketMqSourceOptions.FORMAT,
+                        RocketMqBaseOptions.FIELD_DELIMITER,
                         RocketMqSourceOptions.TAGS,
                         RocketMqSourceOptions.START_MODE,
                         RocketMqSourceOptions.CONSUMER_GROUP,
@@ -57,7 +59,8 @@ public class RocketMqSourceFactory implements TableSourceFactory {
                         RocketMqSourceOptions.KEY_PARTITION_DISCOVERY_INTERVAL_MILLIS,
                         RocketMqSourceOptions.POLL_TIMEOUT_MILLIS,
                         RocketMqSourceOptions.BATCH_SIZE,
-                        RocketMqSourceOptions.IGNORE_PARSE_ERRORS)
+                        RocketMqSourceOptions.IGNORE_PARSE_ERRORS,
+                        RocketMqBaseOptions.ACL_ENABLED)
                 .conditional(
                         RocketMqSourceOptions.START_MODE,
                         StartMode.CONSUME_FROM_TIMESTAMP,
@@ -66,6 +69,11 @@ public class RocketMqSourceFactory implements TableSourceFactory {
                         RocketMqSourceOptions.START_MODE,
                         StartMode.CONSUME_FROM_SPECIFIC_OFFSETS,
                         RocketMqSourceOptions.START_MODE_OFFSETS)
+                .conditional(
+                        RocketMqBaseOptions.ACL_ENABLED,
+                        true,
+                        RocketMqBaseOptions.ACCESS_KEY,
+                        RocketMqBaseOptions.SECRET_KEY)
                 .build();
     }
 


### PR DESCRIPTION
## Purpose

Complete the `optionRule()` declarations in `RocketMqSinkFactory` and `RocketMqSourceFactory`
by adding missing configuration options that were defined in code but not declared in the
option rules, so they are properly exposed in SeaTunnel Web UI.

## Changes

### `RocketMqSinkFactory`
- Add `tag` to optional options
- Add `format` to optional options
- Add `field.delimiter` to optional options
- Add `acl.enabled` to optional options
- Add conditional rule: when `acl.enabled = true`, `access.key` and `secret.key` are required

### `RocketMqSourceFactory`
- Add `field.delimiter` to optional options
- Add `acl.enabled` to optional options
- Add conditional rule: when `acl.enabled = true`, `access.key` and `secret.key` are required

## Discussion: `field.delimiter` and `format`

Currently the RocketMQ connector supports two formats: `json` (default) and `text`.
`field.delimiter` is only meaningful when `format = text`.

A stricter approach would be to declare it as a conditional:
```java
.conditional(RocketMqBaseOptions.FORMAT, SchemaFormat.TEXT, RocketMqBaseOptions.FIELD_DELIMITER)
