### PR TITLE
[Improve][Docs] Update docker-compose cluster setup to use service name discovery

### DIFF
--- a/docs/en/getting-started/docker/docker.md
+++ b/docs/en/getting-started/docker/docker.md
@@ -225,60 +225,57 @@ docker run -d --name seatunnel_worker_1 \
 
 The `docker-compose.yaml` file is :
 ```yaml
-version: '3.8'
 
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
-      "    
+      "
     ports:
-      - "5801:5801"  
+      - "5801:5801"
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -295,77 +292,75 @@ After that, you can use client or restapi to submit job to this cluster.
 If you want to increase cluster node, like add a new work node.
 
 ```yaml
-version: '3.8'
 
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
-      "    
+      "
     ports:
-      - "5801:5801"  
+      - "5801:5801"
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
+
   ####
   ## add new worker node
-  ####      
+  ####
   worker3:
     image: apache/seatunnel
     container_name: seatunnel_worker_3
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4,172.16.0.5 # add ip to here
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801,seatunnel_worker_3:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.5        # use a not used ip
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -375,23 +370,30 @@ and run `docker-compose up -d` command, the new worker node will start, and the 
 ### Job Operation on cluster
 
 #### use docker as a client
-- submit job :
+- submit job (local):
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m local
+```
+- submit job (cluster):
+```shell
+docker run --name seatunnel_client \
+    --network seatunnel-network \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
+    --rm \
+    apache/seatunnel \
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m cluster
 ```
 
 - list job
 ```shell
-# you need update yourself master container ip to `ST_DOCKER_MEMBER_LIST`
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l

--- a/docs/zh/getting-started/docker/docker.md
+++ b/docs/zh/getting-started/docker/docker.md
@@ -223,60 +223,57 @@ docker run -d --name seatunnel_worker_1 \
 ### 使用docker-compose
 `docker-compose.yaml` 配置文件为：
 ```yaml
-version: '3.8'
 
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
-      "    
+      "
     ports:
       - "5801:5801"
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 运行 `docker-compose up`命令来启动集群，该配置会启动一个master节点，2个worker节点
@@ -288,77 +285,75 @@ networks:
 #### 集群扩容
 当你需要对集群扩容, 例如需要添加一个worker节点时
 ```yaml
-version: '3.8'
 
 services:
   master:
     image: apache/seatunnel
     container_name: seatunnel_master
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4    
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r master
-      "    
+      "
     ports:
-      - "5801:5801"  
+      - "5801:5801"
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.2
+      - seatunnel_network
 
   worker1:
     image: apache/seatunnel
     container_name: seatunnel_worker_1
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.3
+      - seatunnel_network
 
   worker2:
     image: apache/seatunnel
     container_name: seatunnel_worker_2
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.4
+      - seatunnel_network
+
   ####
   ## 添加新节点配置
-  ####      
+  ####
   worker3:
     image: apache/seatunnel
     container_name: seatunnel_worker_3
+    restart: unless-stopped
     environment:
-      - ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4,172.16.0.5 # 添加ip到这里
+      - ST_DOCKER_MEMBER_LIST=seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801,seatunnel_worker_3:5801
     entrypoint: >
       /bin/sh -c "
       /opt/seatunnel/bin/seatunnel-cluster.sh -r worker
-      " 
+      "
     depends_on:
       - master
     networks:
-      seatunnel_network:
-        ipv4_address: 172.16.0.5        # 设置新节点ip
+      - seatunnel_network
 
 networks:
   seatunnel_network:
+    name: seatunnel-network
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.16.0.0/24
 
 ```
 
@@ -367,23 +362,30 @@ networks:
 ### 提交作业到集群
 
 #### 使用docker container作为客户端
-- 提交任务
+- 提交任务 (local模式):
 ```shell
-# 将ST_DOCKER_MEMBER_LIST设置为master容器的ip
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
-    ./bin/seatunnel.sh  -c config/v2.batch.config.template
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m local
+```
+- 提交任务 (cluster模式):
+```shell
+docker run --name seatunnel_client \
+    --network seatunnel-network \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
+    --rm \
+    apache/seatunnel \
+    ./bin/seatunnel.sh  -c config/v2.batch.config.template -m cluster
 ```
 
 - 查看作业列表
 ```shell
-# 将ST_DOCKER_MEMBER_LIST设置为master容器的ip
 docker run --name seatunnel_client \
     --network seatunnel-network \
-    -e ST_DOCKER_MEMBER_LIST=172.18.0.2:5801 \
+    -e ST_DOCKER_MEMBER_LIST=seatunnel_master:5801 \
     --rm \
     apache/seatunnel \
     ./bin/seatunnel.sh  -l


### PR DESCRIPTION
## Summary

This PR updates the Docker cluster getting-started documentation (both EN and ZH) to replace the fragile static IP-based configuration with Docker DNS service name discovery.

### Problems with the old approach

- `ST_DOCKER_MEMBER_LIST=172.16.0.2,172.16.0.3,172.16.0.4` requires IPAM static IP assignment, which is brittle and environment-specific
- `version: '3.8'` is deprecated in Docker Compose v2 and produces warnings
- No `restart` policy means containers do not recover from crashes
- Client submit commands required users to manually look up the master container IP

### Changes

- **Remove `version: '3.8'`** — deprecated in Docker Compose v2 (compose-spec)
- **Replace static IP member list** with container service name format: `seatunnel_master:5801,seatunnel_worker_1:5801,seatunnel_worker_2:5801`
- **Remove IPAM subnet configuration** from all service network sections
- **Add `name: seatunnel-network`** to top-level networks to avoid Docker Compose project-name prefix
- **Use list format for service networks**: `- seatunnel_network` (valid YAML per compose-spec)
- **Add `restart: unless-stopped`** to all services
- **Update client submit commands** to use hostname and add separate `-m local` / `-m cluster` examples
- Applied to both `docs/en` and `docs/zh`

### Validation

- `docker compose config` passes with correct YAML structure
- 3-node cluster (1 master + 2 workers) starts cleanly with `docker compose up -d`
- Master logs confirm `Members {size:3}` with both workers registered
- `seatunnel_master`, `seatunnel_worker_1`, `seatunnel_worker_2` resolve correctly via Docker DNS

Related to apache/seatunnel-website#443 and apache/seatunnel-website#444