### PR TITLE
[Fix][Zeta] prevent cancel stuck and downgrade tmp cleanup failure

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/commit/FileSinkAggregatedCommitter.java
@@ -59,8 +59,16 @@ public class FileSinkAggregatedCommitter
                                 hadoopFileSystemProxy.renameFile(
                                         mvFileEntry.getKey(), mvFileEntry.getValue(), true);
                             }
-                            // second delete transaction directory
-                            hadoopFileSystemProxy.deleteFile(entry.getKey());
+                            // Data files are already committed after rename; tmp cleanup is
+                            // best-effort and should not fail the whole checkpoint.
+                            try {
+                                hadoopFileSystemProxy.deleteFile(entry.getKey());
+                            } catch (Exception cleanupException) {
+                                log.warn(
+                                        "delete transaction directory [{}] failed after successful commit, ignore this cleanup error.",
+                                        entry.getKey(),
+                                        cleanupException);
+                            }
                         }
                     } catch (Throwable e) {
                         log.error(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
@@ -412,12 +412,10 @@ public class PhysicalVertex {
         int i = 0;
         // In order not to generate uncontrolled tasks, We will try again until the taskFuture is
         // completed
-        Address executionAddress;
+        Address executionAddress = getCurrentExecutionAddress();
         while (!taskFuture.isDone()
-                && nodeEngine
-                                .getClusterService()
-                                .getMember(executionAddress = getCurrentExecutionAddress())
-                        != null) {
+                && executionAddress != null
+                && nodeEngine.getClusterService().getMember(executionAddress) != null) {
             try {
                 i++;
                 log.info(
@@ -444,6 +442,15 @@ public class PhysicalVertex {
                     throw new RuntimeException(ex);
                 }
             }
+            executionAddress = getCurrentExecutionAddress();
+        }
+
+        if (!taskFuture.isDone() && ExecutionState.CANCELING.equals(getExecutionState())) {
+            log.warn(
+                    "{} cancel did not receive a terminal callback before member {} became unavailable, mark task as CANCELED locally.",
+                    taskFullName,
+                    executionAddress);
+            updateTaskState(ExecutionState.CANCELED);
         }
     }
 


### PR DESCRIPTION
## What changed
- make file sink transaction directory cleanup best-effort after data files have already been renamed into place
- mark tasks as `CANCELED` locally when a cancel request cannot receive a terminal callback because the execution member becomes unavailable

## Why
The current `dev` branch still has two edge cases:
1. `FileSinkAggregatedCommitter` treats tmp directory cleanup failure as commit failure even after data files are successfully committed.
2. `PhysicalVertex` can stay in `CANCELING` when the execution member disappears before sending back a terminal callback.

## Impact
- avoid failing a checkpoint on post-commit tmp cleanup errors
- prevent Zeta task cancellation from getting stuck when the target worker is gone

## Validation
- `./mvnw spotless:apply`
- started `./mvnw -q -DskipTests verify`, then stopped it due to long runtime and proceeded with a draft PR as requested so CI can validate online
