### PR TITLE
[Docs][Zeta] Clarify OSS checkpoint bucket URI format

### DIFF
--- a/docs/en/engines/zeta/checkpoint-storage.md
+++ b/docs/en/engines/zeta/checkpoint-storage.md
@@ -64,7 +64,7 @@ seatunnel:
         plugin-config:
           namespace: # checkpoint storage parent path, the default value is /seatunnel/checkpoint/
           storage.type: oss
-          oss.bucket: your-bucket
+          oss.bucket: oss://your-bucket
           fs.oss.accessKeyId: your-access-key
           fs.oss.accessKeySecret: your-secret-key
           fs.oss.endpoint: endpoint address

--- a/docs/zh/engines/zeta/checkpoint-storage.md
+++ b/docs/zh/engines/zeta/checkpoint-storage.md
@@ -62,7 +62,7 @@ seatunnel:
         plugin-config:
           namespace: # 检查点存储父路径，默认值为/seatunnel/checkpoint/
           storage.type: oss
-          oss.bucket: your-bucket
+          oss.bucket: oss://your-bucket
           fs.oss.accessKeyId: your-access-key
           fs.oss.accessKeySecret: your-secret-key
           fs.oss.endpoint: endpoint address


### PR DESCRIPTION
### Purpose of this pull request
This PR updates the OSS checkpoint storage examples in both English and Chinese docs to use a URI with protocol (`oss://your-bucket`) instead of a plain bucket name. This keeps the OSS example consistent with COS examples and with existing OSS configuration usage in the codebase.

### Does this PR introduce _any_ user-facing change?
Yes. Documentation examples for `oss.bucket` in checkpoint storage are corrected to use the `oss://` URI format.

### How was this patch tested?
- Manually verified the updated examples in:
  - `docs/en/engines/zeta/checkpoint-storage.md`
  - `docs/zh/engines/zeta/checkpoint-storage.md`
- Ran `./mvnw spotless:apply`
- Skipped `./mvnw -q -DskipTests verify` based on maintainer request for this change

### Check list
- [ ] New Apache 2.0 License and Notice files is added if any new 3rd party dependency is added
- [ ] If this is a feature, then this is documented
- [ ] If this is a breaking change, then this is documented
- [ ] If this is a new Connector, then `plugin-mapping.properties` is updated
