### PR TITLE
[Improve][Zeta] Improve engine-server local IDE startup experience

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/pom.xml
+++ b/seatunnel-engine/seatunnel-engine-server/pom.xml
@@ -89,6 +89,12 @@
             <version>${jakarta.servlet-api}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
@@ -179,7 +179,7 @@ public class SeaTunnelServer
             jettyService.createJettyServer();
         }
 
-        // A trick to fix StatisticsDataReferenceCleaner thread class loader leak.
+        // a trick way to fix StatisticsDataReferenceCleaner thread class loader leak.
         // see https://issues.apache.org/jira/browse/HADOOP-19049
         FileSystem.Statistics statistics = new FileSystem.Statistics("SeaTunnel");
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
@@ -181,12 +181,7 @@ public class SeaTunnelServer
 
         // A trick to fix StatisticsDataReferenceCleaner thread class loader leak.
         // see https://issues.apache.org/jira/browse/HADOOP-19049
-        // Only load Hadoop classes when checkpoint storage actually requires them.
-        String storageType =
-                seaTunnelConfig.getEngineConfig().getCheckpointConfig().getStorage().getStorage();
-        if (!"localfile".equalsIgnoreCase(storageType)) {
-            FileSystem.Statistics statistics = new FileSystem.Statistics("SeaTunnel");
-        }
+        FileSystem.Statistics statistics = new FileSystem.Statistics("SeaTunnel");
     }
 
     private void startMaster() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
@@ -179,9 +179,14 @@ public class SeaTunnelServer
             jettyService.createJettyServer();
         }
 
-        // a trick way to fix StatisticsDataReferenceCleaner thread class loader leak.
+        // A trick to fix StatisticsDataReferenceCleaner thread class loader leak.
         // see https://issues.apache.org/jira/browse/HADOOP-19049
-        FileSystem.Statistics statistics = new FileSystem.Statistics("SeaTunnel");
+        // Only load Hadoop classes when checkpoint storage actually requires them.
+        String storageType =
+                seaTunnelConfig.getEngineConfig().getCheckpointConfig().getStorage().getStorage();
+        if (!"localfile".equalsIgnoreCase(storageType)) {
+            FileSystem.Statistics statistics = new FileSystem.Statistics("SeaTunnel");
+        }
     }
 
     private void startMaster() {


### PR DESCRIPTION
### Purpose of this pull request

Closes #10730

When running `SeaTunnelServerStarter` directly from IntelliJ (using the module classpath of `seatunnel-engine-server`), the engine fails to start with `NoClassDefFoundError: com/google/gson/Gson`. This doesn't happen when launching via `seatunnel-cluster.sh` because the full `lib/*` classpath covers everything.

### What was changed

**Declare Gson as an explicit dependency**

Several classes in `seatunnel-engine-server` (`PendingJobsServlet`, `BaseServlet`, `RestHttpGetCommandProcessor`) import `com.google.gson.*`, but `gson` was never declared in the module's `pom.xml` — it only showed up transitively in distribution builds. Added it with `provided` scope so the IDE picks it up at compile time without affecting the packaged distribution.

### Does this PR introduce _any_ user-facing change?

No. Production behavior is unchanged.

### How was this patch tested?

Started `SeaTunnelServerStarter` from IntelliJ — engine boots cleanly without `NoClassDefFoundError`.