### PR TITLE
[Feature][E2E] Add MySQL CDC multi-database multi-table E2E test

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/testutils/UniqueDatabase.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/testutils/UniqueDatabase.java
@@ -162,10 +162,11 @@ public class UniqueDatabase {
                                                 .collect(Collectors.joining("\n"))
                                                 .split(";"))
                                 .map(x -> x.replace("$$", ";"))
+                                .map(String::trim)
+                                .filter(x -> !x.isEmpty())
                                 .collect(Collectors.toList());
                 for (String stmt : statements) {
                     statement.execute(stmt);
-                    log.info(stmt);
                 }
             }
         } catch (final Exception e) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/testutils/UniqueDatabase.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/testutils/UniqueDatabase.java
@@ -167,6 +167,7 @@ public class UniqueDatabase {
                                 .collect(Collectors.toList());
                 for (String stmt : statements) {
                     statement.execute(stmt);
+                    log.info(stmt);
                 }
             }
         } catch (final Exception e) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -439,8 +439,8 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                 });
 
         // snapshot phase
-        await().atMost(60000, TimeUnit.MILLISECONDS)
-                .pollInterval(1000, TimeUnit.MILLISECONDS)
+        await().atMost(120000, TimeUnit.MILLISECONDS)
+                .pollInterval(2000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(
@@ -469,8 +469,8 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_SOURCE_TABLE_A);
         upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_SOURCE_TABLE_B);
 
-        await().atMost(60000, TimeUnit.MILLISECONDS)
-                .pollInterval(1000, TimeUnit.MILLISECONDS)
+        await().atMost(120000, TimeUnit.MILLISECONDS)
+                .pollInterval(2000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -100,8 +100,8 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
     private static final String MULTI_DATABASE_A = "mysql_multi_cdc_db_a";
     private static final String MULTI_DATABASE_B = "mysql_multi_cdc_db_b";
     private static final String MULTI_DATABASE_SINK = "mysql_multi_cdc_db_sink";
-    private static final String MULTI_SOURCE_TABLE_A = "multi_src_a";
-    private static final String MULTI_SOURCE_TABLE_B = "multi_src_b";
+    private static final String MULTI_DATABASE_TABLE_A = "multi_src_a";
+    private static final String MULTI_DATABASE_TABLE_B = "multi_src_b";
 
     protected MySqlContainer MYSQL_CONTAINER;
     protected UniqueDatabase inventoryDatabase;
@@ -424,8 +424,9 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             disabledReason = "Currently SPARK do not support cdc")
     public void testMysqlCdcMultiDatabaseMultiTableE2e(TestContainer container) {
         inventoryDatabase.setTemplateName("mysql_cdc_multi_db").createAndInitialize();
-        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
-        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
+
+        clearTable(MULTI_DATABASE_SINK, MULTI_DATABASE_TABLE_A);
+        clearTable(MULTI_DATABASE_SINK, MULTI_DATABASE_TABLE_B);
 
         CompletableFuture.supplyAsync(
                 () -> {
@@ -449,28 +450,28 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_A,
-                                                                        MULTI_SOURCE_TABLE_A)),
+                                                                        MULTI_DATABASE_TABLE_A)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_A))),
+                                                                        MULTI_DATABASE_TABLE_A))),
                                         () ->
                                                 Assertions.assertIterableEquals(
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_B,
-                                                                        MULTI_SOURCE_TABLE_B)),
+                                                                        MULTI_DATABASE_TABLE_B)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_B)))));
+                                                                        MULTI_DATABASE_TABLE_B)))));
 
         // incremental phase
-        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_SOURCE_TABLE_A);
-        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_SOURCE_TABLE_B);
+        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_DATABASE_TABLE_A);
+        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_DATABASE_TABLE_B);
 
-        await().atMost(120000, TimeUnit.MILLISECONDS)
-                .pollInterval(2000, TimeUnit.MILLISECONDS)
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(
@@ -479,21 +480,21 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_A,
-                                                                        MULTI_SOURCE_TABLE_A)),
+                                                                        MULTI_DATABASE_TABLE_A)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_A))),
+                                                                        MULTI_DATABASE_TABLE_A))),
                                         () ->
                                                 Assertions.assertIterableEquals(
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_B,
-                                                                        MULTI_SOURCE_TABLE_B)),
+                                                                        MULTI_DATABASE_TABLE_B)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_B)))));
+                                                                        MULTI_DATABASE_TABLE_B)))));
     }
 
     @TestTemplate
@@ -503,9 +504,11 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             disabledReason = "Currently SPARK and FLINK do not support restore")
     public void testMultiDatabaseWithRestore(TestContainer container)
             throws IOException, InterruptedException {
+
         inventoryDatabase.setTemplateName("mysql_cdc_multi_db").createAndInitialize();
-        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
-        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
+
+        clearTable(MULTI_DATABASE_SINK, MULTI_DATABASE_TABLE_B);
+        clearTable(MULTI_DATABASE_SINK, MULTI_DATABASE_TABLE_A);
 
         Long jobId = JobIdGenerator.newJobId();
         CompletableFuture.supplyAsync(
@@ -521,17 +524,27 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                 });
 
         // wait for snapshot data
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(100000, TimeUnit.MILLISECONDS)
                 .pollInterval(1000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
-                                Assertions.assertTrue(
-                                        query(
-                                                                getSourceQuerySQL(
-                                                                        MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_A))
-                                                        .size()
-                                                > 1));
+                                Assertions.assertAll(
+                                        () ->
+                                                Assertions.assertTrue(
+                                                        query(
+                                                                                getSourceQuerySQL(
+                                                                                        MULTI_DATABASE_SINK,
+                                                                                        MULTI_DATABASE_TABLE_A))
+                                                                        .size()
+                                                                > 1),
+                                        () ->
+                                                Assertions.assertTrue(
+                                                        query(
+                                                                                getSourceQuerySQL(
+                                                                                        MULTI_DATABASE_SINK,
+                                                                                        MULTI_DATABASE_TABLE_B))
+                                                                        .size()
+                                                                > 1)));
 
         // savepoint + restore
         Assertions.assertEquals(0, container.savepointJob(String.valueOf(jobId)).getExitCode());
@@ -549,11 +562,18 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                 });
 
         // incremental changes after restore
-        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_SOURCE_TABLE_A);
-        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_SOURCE_TABLE_B);
+        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_DATABASE_TABLE_A);
+        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_DATABASE_TABLE_B);
+
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .until(() -> getConnectionStatus("st_user_source").size() == 1);
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .until(() -> getConnectionStatus("st_user_sink").size() == 1);
 
         await().atMost(300000, TimeUnit.MILLISECONDS)
-                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .pollInterval(10000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(
@@ -562,21 +582,21 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_A,
-                                                                        MULTI_SOURCE_TABLE_A)),
+                                                                        MULTI_DATABASE_TABLE_A)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_A))),
+                                                                        MULTI_DATABASE_TABLE_A))),
                                         () ->
                                                 Assertions.assertIterableEquals(
                                                         query(
                                                                 getSourceQuerySQL(
                                                                         MULTI_DATABASE_B,
-                                                                        MULTI_SOURCE_TABLE_B)),
+                                                                        MULTI_DATABASE_TABLE_B)),
                                                         query(
                                                                 getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
-                                                                        MULTI_SOURCE_TABLE_B)))));
+                                                                        MULTI_DATABASE_TABLE_B)))));
     }
 
     @TestTemplate
@@ -738,7 +758,8 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         upsertDeleteSourceTable(MYSQL_DATABASE, SOURCE_TABLE_2_CUSTOM_PRIMARY_KEY);
 
         // stream stage
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120000, TimeUnit.MILLISECONDS)
+                .pollInterval(2000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -470,8 +470,8 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_DATABASE_TABLE_A);
         upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_DATABASE_TABLE_B);
 
-        await().atMost(60000, TimeUnit.MILLISECONDS)
-                .pollInterval(1000, TimeUnit.MILLISECONDS)
+        await().atMost(300000, TimeUnit.MILLISECONDS)
+                .pollInterval(3000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -97,6 +97,12 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             "mysql_cdc_e2e_source_table_2_custom_primary_key";
     private static final String SINK_TABLE = "mysql_cdc_e2e_sink_table";
 
+    private static final String MULTI_DATABASE_A = "mysql_multi_cdc_db_a";
+    private static final String MULTI_DATABASE_B = "mysql_multi_cdc_db_b";
+    private static final String MULTI_DATABASE_SINK = "mysql_multi_cdc_db_sink";
+    private static final String MULTI_SOURCE_TABLE_A = "multi_src_a";
+    private static final String MULTI_SOURCE_TABLE_B = "multi_src_b";
+
     protected MySqlContainer MYSQL_CONTAINER;
     protected UniqueDatabase inventoryDatabase;
 
@@ -409,6 +415,168 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                 getSourceQuerySQL(
                                                                         MYSQL_DATABASE2,
                                                                         SOURCE_TABLE_2)))));
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK},
+            disabledReason = "Currently SPARK do not support cdc")
+    public void testMysqlCdcMultiDatabaseMultiTableE2e(TestContainer container) {
+        initializeMultiDbTables();
+        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
+        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
+
+        CompletableFuture.supplyAsync(
+                () -> {
+                    try {
+                        container.executeJob("/mysqlcdc_to_mysql_with_multi_db_multi_table.conf");
+                    } catch (Exception e) {
+                        log.error("Commit task exception :" + e.getMessage());
+                        throw new RuntimeException(e);
+                    }
+                    return null;
+                });
+
+        // snapshot phase
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertAll(
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_A,
+                                                                        MULTI_SOURCE_TABLE_A)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_A))),
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_B,
+                                                                        MULTI_SOURCE_TABLE_B)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_B)))));
+
+        // incremental phase
+        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_SOURCE_TABLE_A);
+        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_SOURCE_TABLE_B);
+
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertAll(
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_A,
+                                                                        MULTI_SOURCE_TABLE_A)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_A))),
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_B,
+                                                                        MULTI_SOURCE_TABLE_B)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_B)))));
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK, EngineType.FLINK},
+            disabledReason = "Currently SPARK and FLINK do not support restore")
+    public void testMultiDatabaseWithRestore(TestContainer container)
+            throws IOException, InterruptedException {
+        initializeMultiDbTables();
+        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
+        clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
+
+        Long jobId = JobIdGenerator.newJobId();
+        CompletableFuture.supplyAsync(
+                () -> {
+                    try {
+                        return container.executeJob(
+                                "/mysqlcdc_to_mysql_with_multi_db_multi_table.conf",
+                                String.valueOf(jobId));
+                    } catch (Exception e) {
+                        log.error("Commit task exception :" + e.getMessage());
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        // wait for snapshot data
+        await().atMost(60000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertTrue(
+                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_A))
+                                                        .size()
+                                                > 1));
+
+        // savepoint + restore
+        Assertions.assertEquals(0, container.savepointJob(String.valueOf(jobId)).getExitCode());
+        CompletableFuture.supplyAsync(
+                () -> {
+                    try {
+                        container.restoreJob(
+                                "/mysqlcdc_to_mysql_with_multi_db_multi_table.conf",
+                                String.valueOf(jobId));
+                    } catch (Exception e) {
+                        log.error("Commit task exception :" + e.getMessage());
+                        throw new RuntimeException(e);
+                    }
+                    return null;
+                });
+
+        // incremental changes after restore
+        upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_SOURCE_TABLE_A);
+        upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_SOURCE_TABLE_B);
+
+        await().atMost(300000, TimeUnit.MILLISECONDS)
+                .pollInterval(1000, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertAll(
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_A,
+                                                                        MULTI_SOURCE_TABLE_A)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_A))),
+                                        () ->
+                                                Assertions.assertIterableEquals(
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_B,
+                                                                        MULTI_SOURCE_TABLE_B)),
+                                                        query(
+                                                                getSourceQuerySQL(
+                                                                        MULTI_DATABASE_SINK,
+                                                                        MULTI_SOURCE_TABLE_B)))));
     }
 
     @TestTemplate
@@ -800,6 +968,10 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         if (MYSQL_CONTAINER != null) {
             MYSQL_CONTAINER.close();
         }
+    }
+
+    private void initializeMultiDbTables() {
+        new UniqueDatabase(MYSQL_CONTAINER, "mysql_cdc_multi_db").createAndInitialize();
     }
 
     private void clearTable(String database, String tableName) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -451,7 +451,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_A,
                                                                         MULTI_SOURCE_TABLE_A)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_A))),
                                         () ->
@@ -461,7 +461,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_B,
                                                                         MULTI_SOURCE_TABLE_B)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_B)))));
 
@@ -481,7 +481,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_A,
                                                                         MULTI_SOURCE_TABLE_A)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_A))),
                                         () ->
@@ -491,7 +491,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_B,
                                                                         MULTI_SOURCE_TABLE_B)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_B)))));
     }
@@ -564,7 +564,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_A,
                                                                         MULTI_SOURCE_TABLE_A)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_A))),
                                         () ->
@@ -574,7 +574,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                                                                         MULTI_DATABASE_B,
                                                                         MULTI_SOURCE_TABLE_B)),
                                                         query(
-                                                                getSourceQuerySQL(
+                                                                getSinkQuerySQL(
                                                                         MULTI_DATABASE_SINK,
                                                                         MULTI_SOURCE_TABLE_B)))));
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -423,7 +423,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             type = {EngineType.SPARK},
             disabledReason = "Currently SPARK do not support cdc")
     public void testMysqlCdcMultiDatabaseMultiTableE2e(TestContainer container) {
-        initializeMultiDbTables();
+        inventoryDatabase.setTemplateName("mysql_cdc_multi_db").createAndInitialize();
         clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
         clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
 
@@ -503,7 +503,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             disabledReason = "Currently SPARK and FLINK do not support restore")
     public void testMultiDatabaseWithRestore(TestContainer container)
             throws IOException, InterruptedException {
-        initializeMultiDbTables();
+        inventoryDatabase.setTemplateName("mysql_cdc_multi_db").createAndInitialize();
         clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_A);
         clearTable(MULTI_DATABASE_SINK, MULTI_SOURCE_TABLE_B);
 
@@ -968,10 +968,6 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         if (MYSQL_CONTAINER != null) {
             MYSQL_CONTAINER.close();
         }
-    }
-
-    private void initializeMultiDbTables() {
-        new UniqueDatabase(MYSQL_CONTAINER, "mysql_cdc_multi_db").createAndInitialize();
     }
 
     private void clearTable(String database, String tableName) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -440,8 +440,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
                 });
 
         // snapshot phase
-        await().atMost(120000, TimeUnit.MILLISECONDS)
-                .pollInterval(2000, TimeUnit.MILLISECONDS)
+        await().atMost(60000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(
@@ -470,8 +469,7 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
         upsertDeleteSourceTable(MULTI_DATABASE_A, MULTI_DATABASE_TABLE_A);
         upsertDeleteSourceTable(MULTI_DATABASE_B, MULTI_DATABASE_TABLE_B);
 
-        await().atMost(300000, TimeUnit.MILLISECONDS)
-                .pollInterval(3000, TimeUnit.MILLISECONDS)
+        await().atMost(60000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertAll(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/ddl/mysql_cdc_multi_db.sql
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/ddl/mysql_cdc_multi_db.sql
@@ -1,0 +1,306 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  mysql_multi_cdc_db_a  (source A)
+-- ----------------------------------------------------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS `mysql_multi_cdc_db_a`;
+
+use mysql_multi_cdc_db_a;
+
+CREATE TABLE IF NOT EXISTS multi_src_a
+(
+    `id`                   int       NOT NULL AUTO_INCREMENT,
+    `f_binary`             binary(64)                     DEFAULT NULL,
+    `f_blob`               blob,
+    `f_long_varbinary`     mediumblob,
+    `f_longblob`           longblob,
+    `f_tinyblob`           tinyblob,
+    `f_varbinary`          varbinary(100)                 DEFAULT NULL,
+    `f_smallint`           smallint                       DEFAULT NULL,
+    `f_smallint_unsigned`  smallint unsigned              DEFAULT NULL,
+    `f_mediumint`          mediumint                      DEFAULT NULL,
+    `f_mediumint_unsigned` mediumint unsigned             DEFAULT NULL,
+    `f_int`                int                            DEFAULT NULL,
+    `f_int_unsigned`       int unsigned                   DEFAULT NULL,
+    `f_integer`            int                            DEFAULT NULL,
+    `f_integer_unsigned`   int unsigned                   DEFAULT NULL,
+    `f_bigint`             bigint                         DEFAULT NULL,
+    `f_bigint_unsigned`    bigint unsigned                DEFAULT NULL,
+    `f_numeric`            decimal(10, 0)                 DEFAULT NULL,
+    `f_decimal`            decimal(10, 0)                 DEFAULT NULL,
+    `f_float`              float                          DEFAULT NULL,
+    `f_double`             double                         DEFAULT NULL,
+    `f_double_precision`   double                         DEFAULT NULL,
+    `f_longtext`           longtext,
+    `f_mediumtext`         mediumtext,
+    `f_text`               text,
+    `f_tinytext`           tinytext,
+    `f_varchar`            varchar(100)                   DEFAULT NULL,
+    `f_date`               date                           DEFAULT NULL,
+    `f_datetime`           datetime                       DEFAULT NULL,
+    `f_timestamp`          timestamp NULL                 DEFAULT NULL,
+    `f_bit1`               bit(1)                         DEFAULT NULL,
+    `f_bit64`              bit(64)                        DEFAULT NULL,
+    `f_char`               char(1)                        DEFAULT NULL,
+    `f_enum`               enum ('enum1','enum2','enum3') DEFAULT NULL,
+    `f_mediumblob`         mediumblob,
+    `f_long_varchar`       mediumtext,
+    `f_real`               double                         DEFAULT NULL,
+    `f_time`               time                           DEFAULT NULL,
+    `f_tinyint`            tinyint                        DEFAULT NULL,
+    `f_tinyint_unsigned`   tinyint unsigned               DEFAULT NULL,
+    `f_json`               json                           DEFAULT NULL,
+    `f_year`               year                           DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 2
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+truncate table multi_src_a;
+
+INSERT INTO multi_src_a ( id, f_binary, f_blob, f_long_varbinary, f_longblob, f_tinyblob, f_varbinary, f_smallint,
+                    f_smallint_unsigned, f_mediumint, f_mediumint_unsigned, f_int, f_int_unsigned, f_integer,
+                    f_integer_unsigned, f_bigint, f_bigint_unsigned, f_numeric, f_decimal, f_float, f_double,
+                    f_double_precision, f_longtext, f_mediumtext, f_text, f_tinytext, f_varchar, f_date, f_datetime,
+                    f_timestamp, f_bit1, f_bit64, f_char, f_enum, f_mediumblob, f_long_varchar, f_real, f_time,
+                    f_tinyint, f_tinyint_unsigned, f_json, f_year )
+VALUES ( 1, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL,
+         0x74696E79626C6F62, 0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321,
+         123456789, 987654321, 123, 789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field',
+         'This is a text field', 'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00',
+         '2023-04-27 11:08:40', 1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field',
+         12.345, '14:30:00', -128, 255, '{ "key": "value" }', 2022 ),
+       ( 2, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL, 0x74696E79626C6F62,
+         0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321, 123456789, 987654321,
+         123, 789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field', 'This is a text field',
+         'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00', '2023-04-27 11:08:40',
+         1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field',
+         112.345, '14:30:00', -128, 22, '{ "key": "value" }', 2013 ),
+       ( 3, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL, 0x74696E79626C6F62,
+         0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321, 123456789, 987654321, 123,
+         789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field', 'This is a text field',
+         'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00', '2023-04-27 11:08:40',
+         1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field', 112.345,
+         '14:30:00', -128, 22, '{ "key": "value" }', 2021 );
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  mysql_multi_cdc_db_b  (source B)
+-- ----------------------------------------------------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS `mysql_multi_cdc_db_b`;
+
+use mysql_multi_cdc_db_b;
+
+CREATE TABLE IF NOT EXISTS multi_src_b
+(
+    `id`                   int       NOT NULL AUTO_INCREMENT,
+    `f_binary`             binary(64)                     DEFAULT NULL,
+    `f_blob`               blob,
+    `f_long_varbinary`     mediumblob,
+    `f_longblob`           longblob,
+    `f_tinyblob`           tinyblob,
+    `f_varbinary`          varbinary(100)                 DEFAULT NULL,
+    `f_smallint`           smallint                       DEFAULT NULL,
+    `f_smallint_unsigned`  smallint unsigned              DEFAULT NULL,
+    `f_mediumint`          mediumint                      DEFAULT NULL,
+    `f_mediumint_unsigned` mediumint unsigned             DEFAULT NULL,
+    `f_int`                int                            DEFAULT NULL,
+    `f_int_unsigned`       int unsigned                   DEFAULT NULL,
+    `f_integer`            int                            DEFAULT NULL,
+    `f_integer_unsigned`   int unsigned                   DEFAULT NULL,
+    `f_bigint`             bigint                         DEFAULT NULL,
+    `f_bigint_unsigned`    bigint unsigned                DEFAULT NULL,
+    `f_numeric`            decimal(10, 0)                 DEFAULT NULL,
+    `f_decimal`            decimal(10, 0)                 DEFAULT NULL,
+    `f_float`              float                          DEFAULT NULL,
+    `f_double`             double                         DEFAULT NULL,
+    `f_double_precision`   double                         DEFAULT NULL,
+    `f_longtext`           longtext,
+    `f_mediumtext`         mediumtext,
+    `f_text`               text,
+    `f_tinytext`           tinytext,
+    `f_varchar`            varchar(100)                   DEFAULT NULL,
+    `f_date`               date                           DEFAULT NULL,
+    `f_datetime`           datetime                       DEFAULT NULL,
+    `f_timestamp`          timestamp NULL                 DEFAULT NULL,
+    `f_bit1`               bit(1)                         DEFAULT NULL,
+    `f_bit64`              bit(64)                        DEFAULT NULL,
+    `f_char`               char(1)                        DEFAULT NULL,
+    `f_enum`               enum ('enum1','enum2','enum3') DEFAULT NULL,
+    `f_mediumblob`         mediumblob,
+    `f_long_varchar`       mediumtext,
+    `f_real`               double                         DEFAULT NULL,
+    `f_time`               time                           DEFAULT NULL,
+    `f_tinyint`            tinyint                        DEFAULT NULL,
+    `f_tinyint_unsigned`   tinyint unsigned               DEFAULT NULL,
+    `f_json`               json                           DEFAULT NULL,
+    `f_year`               year                           DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 2
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+truncate table multi_src_b;
+
+INSERT INTO multi_src_b ( id, f_binary, f_blob, f_long_varbinary, f_longblob, f_tinyblob, f_varbinary, f_smallint,
+                    f_smallint_unsigned, f_mediumint, f_mediumint_unsigned, f_int, f_int_unsigned, f_integer,
+                    f_integer_unsigned, f_bigint, f_bigint_unsigned, f_numeric, f_decimal, f_float, f_double,
+                    f_double_precision, f_longtext, f_mediumtext, f_text, f_tinytext, f_varchar, f_date, f_datetime,
+                    f_timestamp, f_bit1, f_bit64, f_char, f_enum, f_mediumblob, f_long_varchar, f_real, f_time,
+                    f_tinyint, f_tinyint_unsigned, f_json, f_year )
+VALUES ( 1, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL,
+         0x74696E79626C6F62, 0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321,
+         123456789, 987654321, 123, 789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field',
+         'This is a text field', 'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00',
+         '2023-04-27 11:08:40', 1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field',
+         12.345, '14:30:00', -128, 255, '{ "key": "value" }', 2022 ),
+       ( 2, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL, 0x74696E79626C6F62,
+         0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321, 123456789, 987654321,
+         123, 789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field', 'This is a text field',
+         'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00', '2023-04-27 11:08:40',
+         1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field',
+         112.345, '14:30:00', -128, 22, '{ "key": "value" }', 2013 ),
+       ( 3, 0x61626374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+         0x68656C6C6F, 0x18000000789C0BC9C82C5600A244859CFCBC7485B2C4A2A4CCBCC4A24A00697308D4, NULL, 0x74696E79626C6F62,
+         0x48656C6C6F20776F726C64, 12345, 54321, 123456, 654321, 1234567, 7654321, 1234567, 7654321, 123456789, 987654321, 123,
+         789, 12.34, 56.78, 90.12, 'This is a long text field', 'This is a medium text field', 'This is a text field',
+         'This is a tiny text field', 'This is a varchar field', '2022-04-27', '2022-04-27 14:30:00', '2023-04-27 11:08:40',
+         1, b'0101010101010101010101010101010101010101010101010101010101010101', 'C', 'enum2',
+         0x1B000000789C0BC9C82C5600A24485DCD494CCD25C85A49CFC2485B4CCD49C140083FF099A, 'This is a long varchar field', 112.345,
+         '14:30:00', -128, 22, '{ "key": "value" }', 2021 );
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  mysql_multi_cdc_db_sink  (sink for multi-db CDC)
+-- ----------------------------------------------------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS `mysql_multi_cdc_db_sink`;
+
+use mysql_multi_cdc_db_sink;
+
+CREATE TABLE IF NOT EXISTS multi_src_a
+(
+    `id`                   int       NOT NULL AUTO_INCREMENT,
+    `f_binary`             binary(64)                     DEFAULT NULL,
+    `f_blob`               blob,
+    `f_long_varbinary`     mediumblob,
+    `f_longblob`           longblob,
+    `f_tinyblob`           tinyblob,
+    `f_varbinary`          varbinary(100)                 DEFAULT NULL,
+    `f_smallint`           smallint                       DEFAULT NULL,
+    `f_smallint_unsigned`  smallint unsigned              DEFAULT NULL,
+    `f_mediumint`          mediumint                      DEFAULT NULL,
+    `f_mediumint_unsigned` mediumint unsigned             DEFAULT NULL,
+    `f_int`                int                            DEFAULT NULL,
+    `f_int_unsigned`       int unsigned                   DEFAULT NULL,
+    `f_integer`            int                            DEFAULT NULL,
+    `f_integer_unsigned`   int unsigned                   DEFAULT NULL,
+    `f_bigint`             bigint                         DEFAULT NULL,
+    `f_bigint_unsigned`    bigint unsigned                DEFAULT NULL,
+    `f_numeric`            decimal(10, 0)                 DEFAULT NULL,
+    `f_decimal`            decimal(10, 0)                 DEFAULT NULL,
+    `f_float`              float                          DEFAULT NULL,
+    `f_double`             double                         DEFAULT NULL,
+    `f_double_precision`   double                         DEFAULT NULL,
+    `f_longtext`           longtext,
+    `f_mediumtext`         mediumtext,
+    `f_text`               text,
+    `f_tinytext`           tinytext,
+    `f_varchar`            varchar(100)                   DEFAULT NULL,
+    `f_date`               date                           DEFAULT NULL,
+    `f_datetime`           datetime                       DEFAULT NULL,
+    `f_timestamp`          timestamp NULL                 DEFAULT NULL,
+    `f_bit1`               bit(1)                         DEFAULT NULL,
+    `f_bit64`              bit(64)                        DEFAULT NULL,
+    `f_char`               char(1)                        DEFAULT NULL,
+    `f_enum`               enum ('enum1','enum2','enum3') DEFAULT NULL,
+    `f_mediumblob`         mediumblob,
+    `f_long_varchar`       mediumtext,
+    `f_real`               double                         DEFAULT NULL,
+    `f_time`               time                           DEFAULT NULL,
+    `f_tinyint`            tinyint                        DEFAULT NULL,
+    `f_tinyint_unsigned`   tinyint unsigned               DEFAULT NULL,
+    `f_json`               json                           DEFAULT NULL,
+    `f_year`               year                           DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 2
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS multi_src_b
+(
+    `id`                   int       NOT NULL AUTO_INCREMENT,
+    `f_binary`             binary(64)                     DEFAULT NULL,
+    `f_blob`               blob,
+    `f_long_varbinary`     mediumblob,
+    `f_longblob`           longblob,
+    `f_tinyblob`           tinyblob,
+    `f_varbinary`          varbinary(100)                 DEFAULT NULL,
+    `f_smallint`           smallint                       DEFAULT NULL,
+    `f_smallint_unsigned`  smallint unsigned              DEFAULT NULL,
+    `f_mediumint`          mediumint                      DEFAULT NULL,
+    `f_mediumint_unsigned` mediumint unsigned             DEFAULT NULL,
+    `f_int`                int                            DEFAULT NULL,
+    `f_int_unsigned`       int unsigned                   DEFAULT NULL,
+    `f_integer`            int                            DEFAULT NULL,
+    `f_integer_unsigned`   int unsigned                   DEFAULT NULL,
+    `f_bigint`             bigint                         DEFAULT NULL,
+    `f_bigint_unsigned`    bigint unsigned                DEFAULT NULL,
+    `f_numeric`            decimal(10, 0)                 DEFAULT NULL,
+    `f_decimal`            decimal(10, 0)                 DEFAULT NULL,
+    `f_float`              float                          DEFAULT NULL,
+    `f_double`             double                         DEFAULT NULL,
+    `f_double_precision`   double                         DEFAULT NULL,
+    `f_longtext`           longtext,
+    `f_mediumtext`         mediumtext,
+    `f_text`               text,
+    `f_tinytext`           tinytext,
+    `f_varchar`            varchar(100)                   DEFAULT NULL,
+    `f_date`               date                           DEFAULT NULL,
+    `f_datetime`           datetime                       DEFAULT NULL,
+    `f_timestamp`          timestamp NULL                 DEFAULT NULL,
+    `f_bit1`               bit(1)                         DEFAULT NULL,
+    `f_bit64`              bit(64)                        DEFAULT NULL,
+    `f_char`               char(1)                        DEFAULT NULL,
+    `f_enum`               enum ('enum1','enum2','enum3') DEFAULT NULL,
+    `f_mediumblob`         mediumblob,
+    `f_long_varchar`       mediumtext,
+    `f_real`               double                         DEFAULT NULL,
+    `f_time`               time                           DEFAULT NULL,
+    `f_tinyint`            tinyint                        DEFAULT NULL,
+    `f_tinyint_unsigned`   tinyint unsigned               DEFAULT NULL,
+    `f_json`               json                           DEFAULT NULL,
+    `f_year`               year                           DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 2
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+truncate table multi_src_a;
+truncate table multi_src_b;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  MySQL-CDC {
+    plugin_output = "multi_db_cdc"
+    server-id = 5670-5680
+    username = "st_user_source"
+    password = "mysqlpw"
+    database-names = ["mysql_multi_cdc_db_a", "mysql_multi_cdc_db_b"]
+    table-names = ["mysql_multi_cdc_db_a.multi_src_a", "mysql_multi_cdc_db_b.multi_src_b"]
+    url = "jdbc:mysql://mysql_cdc_e2e:3306"
+    snapshot.split.size = 1
+    snapshot.fetch.size = 1
+    table-names-config = [
+        {
+            table = "mysql_multi_cdc_db_a.multi_src_a"
+            primaryKeys = []
+            snapshotSplitColumn = "f_bigint"
+        },
+        {
+            table = "mysql_multi_cdc_db_b.multi_src_b"
+            primaryKeys = []
+            snapshotSplitColumn = "f_bigint"
+        }
+    ]
+  }
+}
+
+transform {
+}
+
+sink {
+  jdbc {
+    plugin_input = "multi_db_cdc"
+    url = "jdbc:mysql://mysql_cdc_e2e:3306/mysql_multi_cdc_db_sink"
+    driver = "com.mysql.cj.jdbc.Driver"
+    user = "st_user_sink"
+    password = "mysqlpw"
+
+    database = "mysql_multi_cdc_db_sink"
+    table = "${table_name}"
+    primary_keys = ["${primary_key}"]
+    generate_sink_sql = true
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
@@ -19,7 +19,7 @@
 ######
 
 env {
-  parallelism = 2
+  parallelism = 1
   job.mode = "STREAMING"
   checkpoint.interval = 5000
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_multi_db_multi_table.conf
@@ -38,12 +38,12 @@ source {
     table-names-config = [
         {
             table = "mysql_multi_cdc_db_a.multi_src_a"
-            primaryKeys = []
+            primaryKeys = ["id"]
             snapshotSplitColumn = "f_bigint"
         },
         {
             table = "mysql_multi_cdc_db_b.multi_src_b"
-            primaryKeys = []
+            primaryKeys = ["id"]
             snapshotSplitColumn = "f_bigint"
         }
     ]


### PR DESCRIPTION
## [Test][E2E] Add MySQL CDC multi-database multi-table E2E test

### Summary

Add E2E tests for MySQL-CDC `database-names` configuration, which was previously untested. The new tests verify that a single CDC job can capture changes from **two different source databases** and correctly route them to a sink database.

- `testMysqlCdcMultiDatabaseMultiTableE2e`: validates snapshot + incremental sync across databases
- `testMultiDatabaseWithRestore`: validates checkpoint savepoint/restore works correctly with multi-database CDC

Closes #10722

### Changes

- **New**: `ddl/mysql_cdc_multi_db.sql` — DDL for 3 databases (`mysql_multi_cdc_db_a`, `mysql_multi_cdc_db_b`, `mysql_multi_cdc_db_sink`)
- **New**: `mysqlcdc_to_mysql_with_multi_db_multi_table.conf` — job config using `database-names`
- **Modified**: `AbstractMysqlCDCITBase.java` — 2 new test methods + `initializeMultiDbTables()` helper
