### PR TITLE
[fix][CI] Stabilize pipeline cleanup Hazelcast serialization test

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/cleanup/PipelineCleanupRecordHazelcastSerializationTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/cleanup/PipelineCleanupRecordHazelcastSerializationTest.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.engine.server.master.cleanup;
 
 import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.config.ConfigProvider;
+import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
 import org.apache.seatunnel.engine.server.TestUtils;
@@ -28,9 +30,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.map.IMap;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,10 +51,9 @@ class PipelineCleanupRecordHazelcastSerializationTest {
         String clusterName =
                 TestUtils.getClusterName(
                         "PipelineCleanupRecordHazelcastSerializationTest_testPutAndGetAcrossMembers");
-        HazelcastInstanceImpl instance1 =
-                SeaTunnelServerStarter.createHazelcastInstance(clusterName);
-        HazelcastInstanceImpl instance2 =
-                SeaTunnelServerStarter.createHazelcastInstance(clusterName);
+        int[] ports = findTwoFreePorts();
+        HazelcastInstanceImpl instance1 = createHazelcastInstance(clusterName, ports[0], ports[1]);
+        HazelcastInstanceImpl instance2 = createHazelcastInstance(clusterName, ports[1], ports[0]);
         try {
             await().atMost(30, TimeUnit.SECONDS)
                     .until(() -> instance1.getCluster().getMembers().size() == 2);
@@ -96,6 +100,50 @@ class PipelineCleanupRecordHazelcastSerializationTest {
         } finally {
             instance1.shutdown();
             instance2.shutdown();
+        }
+    }
+
+    private HazelcastInstanceImpl createHazelcastInstance(
+            String clusterName, int localPort, int peerPort) {
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        Config hazelcastConfig =
+                Config.loadFromString(buildHazelcastConfig(clusterName, localPort, peerPort));
+        seaTunnelConfig.setHazelcastConfig(hazelcastConfig);
+        return SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+    }
+
+    private String buildHazelcastConfig(String clusterName, int localPort, int peerPort) {
+        return "hazelcast:\n"
+                + "  cluster-name: "
+                + clusterName
+                + "\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      tcp-ip:\n"
+                + "        enabled: true\n"
+                + "        member-list:\n"
+                + "          - 127.0.0.1:"
+                + localPort
+                + "\n"
+                + "          - 127.0.0.1:"
+                + peerPort
+                + "\n"
+                + "    port:\n"
+                + "      auto-increment: false\n"
+                + "      port-count: 1\n"
+                + "      port: "
+                + localPort
+                + "\n";
+    }
+
+    private int[] findTwoFreePorts() {
+        try (ServerSocket first = new ServerSocket(0);
+                ServerSocket second = new ServerSocket(0)) {
+            first.setReuseAddress(true);
+            second.setReuseAddress(true);
+            return new int[] {first.getLocalPort(), second.getLocalPort()};
+        } catch (IOException e) {
+            throw new RuntimeException("No free Hazelcast ports available", e);
         }
     }
 }


### PR DESCRIPTION


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request
<img width="1875" height="654" alt="image" src="https://github.com/user-attachments/assets/75799ea5-613d-4df3-9239-10d78b75b45c" />

This pull request stabilizes `PipelineCleanupRecordHazelcastSerializationTest`.

The original test relied on the default Hazelcast TCP/IP seed ports and port auto-increment. In CI, those default ports could already be occupied by other parallel test clusters, so the two test members started on different ports but still probed the default seed range, failed to discover each other, and eventually timed out while waiting for a 2-member cluster.

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)