### PR TITLE
Disable ASF Dependabot update PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,6 +43,7 @@ github:
     - SEZ9
     - boy-xiaozhang
     - nzw921rx
+  dependabot_updates: false
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
Since the bot does not handle the CI errors in the PRs it submits, all PRs raised by the bot were previously closed manually, and it has been found that they can be closed. For reference:
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#depend_alerts


## What changed
- add `github.dependabot_updates: false` to `.asf.yaml`

## Why
- disable ASF-managed Dependabot update PRs for this repository
- keep the change minimal and scoped to repository infrastructure config

## Impact
- Dependabot update PRs will stop being opened from the ASF repository configuration
- no code, docs, or workflow files are changed

## Validation
- `./mvnw spotless:apply -nsu -T 3C`
- `./mvnw -q -DskipTests verify -nsu -T 3C`
