### PR TITLE
[Fix][Connector-V2] Fix RocketMQ source checkpoint recovery losing committed offsets

### DIFF
--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSource.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSource.java
@@ -90,6 +90,7 @@ public class RocketMqSource
                 sourceConfig.getMetadata(),
                 sourceConfig.getTopicConfigs(),
                 context,
-                sourceConfig.getDiscoveryIntervalMillis());
+                sourceConfig.getDiscoveryIntervalMillis(),
+                sourceState);
     }
 }

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
@@ -65,6 +65,26 @@ public class RocketMqSourceSplitEnumerator
     // ms
     private long discoveryIntervalMillis;
 
+    /**
+     * Tracks message queues whose splits were restored from a checkpoint. These splits already have
+     * the correct startOffset and should not have their offset overwritten by
+     * setPartitionStartOffset().
+     */
+    private final Set<MessageQueue> restoredSplits = new HashSet<>();
+
+    /**
+     * Indicates whether this enumerator was created to restore from a checkpoint state. When true,
+     * addSplitsBack() will preserve the checkpoint offsets instead of resetting them.
+     */
+    private boolean isRestored = false;
+
+    /**
+     * Set to true after the first run() completes. Used to distinguish the initial startup phase
+     * (where addSplitsBack may be called with checkpoint splits) from later reader
+     * re-registrations.
+     */
+    private volatile boolean initialized = false;
+
     public RocketMqSourceSplitEnumerator(
             ConsumerMetadata metadata,
             Map<String, TopicTableConfig> topicConfigs,
@@ -86,6 +106,32 @@ public class RocketMqSourceSplitEnumerator
             long discoveryIntervalMillis) {
         this(metadata, topicConfigs, context);
         this.discoveryIntervalMillis = discoveryIntervalMillis;
+    }
+
+    /**
+     * Creates an enumerator that restores state from a checkpoint.
+     *
+     * <p>The {@code sourceState} parameter is intentionally unused. The actual split restoration
+     * happens via {@link #addSplitsBack(List, int)}, which the engine calls before {@link #run()}
+     * with the splits carrying the correct startOffset from the reader-side checkpoint. Using
+     * {@code sourceState} to pre-populate {@code assignedSplit} would cause {@link #assignSplit()}
+     * to skip those splits (since they would already appear in {@code assignedSplit}), preventing
+     * them from being dispatched to any reader.
+     *
+     * @param metadata consumer metadata
+     * @param topicConfigs per-topic configuration map
+     * @param context enumerator context
+     * @param discoveryIntervalMillis interval for dynamic queue discovery, in milliseconds
+     * @param sourceState the checkpoint state (unused; retained for API contract compatibility)
+     */
+    public RocketMqSourceSplitEnumerator(
+            ConsumerMetadata metadata,
+            Map<String, TopicTableConfig> topicConfigs,
+            SourceSplitEnumerator.Context<RocketMqSourceSplit> context,
+            long discoveryIntervalMillis,
+            RocketMqSourceState sourceState) {
+        this(metadata, topicConfigs, context, discoveryIntervalMillis);
+        this.isRestored = true;
     }
 
     private static int getSplitOwner(MessageQueue messageQueue, int numReaders) {
@@ -113,7 +159,9 @@ public class RocketMqSourceSplitEnumerator
                     executor.scheduleWithFixedDelay(
                             () -> {
                                 try {
-                                    discoverySplits();
+                                    if (initialized) {
+                                        discoverySplits();
+                                    }
                                 } catch (Exception e) {
                                     log.error("Dynamic discovery failure:", e);
                                 }
@@ -129,10 +177,15 @@ public class RocketMqSourceSplitEnumerator
         synchronized (lock) {
             fetchPendingPartitionSplit();
             setPartitionStartOffset();
+            restoredSplits.clear();
         }
 
         synchronized (lock) {
             assignSplit();
+        }
+
+        if (!initialized) {
+            initialized = true;
         }
     }
 
@@ -149,6 +202,20 @@ public class RocketMqSourceSplitEnumerator
     @Override
     public void addSplitsBack(List<RocketMqSourceSplit> splits, int subtaskId) {
         if (!splits.isEmpty()) {
+            synchronized (lock) {
+                if (isRestored && !initialized) {
+                    // During checkpoint recovery the engine returns previously assigned splits
+                    // to the enumerator before run() is called. These splits already have the
+                    // correct startOffset from the checkpoint snapshot, so we must NOT call
+                    // convertToNextSplit() (which resets offset to the broker's latest value).
+                    splits.forEach(
+                            split -> {
+                                restoredSplits.add(split.getMessageQueue());
+                                pendingSplit.put(split.getMessageQueue(), split.copy());
+                            });
+                    return;
+                }
+            }
             pendingSplit.putAll(convertToNextSplit(splits));
             assignSplit();
         }
@@ -192,7 +259,7 @@ public class RocketMqSourceSplitEnumerator
 
     @Override
     public void registerReader(int subtaskId) {
-        if (!pendingSplit.isEmpty()) {
+        if (!pendingSplit.isEmpty() && initialized) {
             assignSplit();
         }
     }
@@ -259,8 +326,18 @@ public class RocketMqSourceSplitEnumerator
 
     private void setPartitionStartOffset() throws MQClientException {
         // Group pending partitions by their effective start mode (per-topic override or global).
+        // Restored splits already carry the correct checkpoint offset; skip them entirely so we
+        // do not overwrite the persisted position with a broker-derived offset.
         Map<StartMode, List<MessageQueue>> partitionsByMode = new LinkedHashMap<>();
         for (MessageQueue mq : pendingSplit.keySet()) {
+            if (restoredSplits.contains(mq)) {
+                log.debug(
+                        "Skipping offset reset for restored split: topic={}, broker={}, queueId={}",
+                        mq.getTopic(),
+                        mq.getBrokerName(),
+                        mq.getQueueId());
+                continue;
+            }
             StartMode effectiveMode = getEffectiveStartMode(mq.getTopic());
             partitionsByMode.computeIfAbsent(effectiveMode, k -> new ArrayList<>()).add(mq);
         }

--- a/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumeratorTest.java
@@ -31,12 +31,15 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -169,6 +172,145 @@ class RocketMqSourceSplitEnumeratorTest {
 
         Map<String, RocketMqSourceSplit> splitsByTopic = captureAssignedSplits(context);
         Assertions.assertEquals(33L, splitsByTopic.get("topic_specific").getStartOffset());
+    }
+
+    /**
+     * Verifies that when an enumerator is restored from a checkpoint, the splits returned via
+     * addSplitsBack() retain their checkpoint offsets and are NOT reset to the broker's offset.
+     *
+     * <p>Scenario: the checkpoint recorded startOffset=50 for a queue whose broker minOffset=0.
+     * After restore, consumption must resume from 50, not restart from 0.
+     */
+    @Test
+    void testRestore_preservesCheckpointOffsets() throws Exception {
+        ConsumerMetadata metadata = new ConsumerMetadata();
+        metadata.setTopics(Collections.singletonList("topic_restore"));
+        metadata.setStartMode(StartMode.CONSUME_FROM_LAST_OFFSET);
+
+        MessageQueue messageQueue = new MessageQueue("topic_restore", "broker-restore", 0);
+
+        // The split saved in the checkpoint carries startOffset=50
+        final long checkpointOffset = 50L;
+        RocketMqSourceSplit checkpointSplit =
+                new RocketMqSourceSplit(messageQueue, checkpointOffset, 99L);
+
+        Set<RocketMqSourceSplit> checkpointSplits = new HashSet<>();
+        checkpointSplits.add(checkpointSplit);
+        RocketMqSourceState checkpointState = new RocketMqSourceState(checkpointSplits);
+
+        SourceSplitEnumerator.Context<RocketMqSourceSplit> context = mockContext();
+
+        try (MockedStatic<RocketMqAdminUtil> mockedAdmin =
+                Mockito.mockStatic(RocketMqAdminUtil.class)) {
+            // Broker reports the queue exists with minOffset=0, maxOffset=100
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.offsetTopics(any(), any()))
+                    .thenReturn(
+                            Collections.singletonList(
+                                    topicOffsets(queueOffset(messageQueue, 0L, 100L))));
+
+            RocketMqSourceSplitEnumerator enumerator =
+                    new RocketMqSourceSplitEnumerator(
+                            metadata, Collections.emptyMap(), context, -1L, checkpointState);
+
+            // Simulate the engine returning the checkpoint split before run()
+            enumerator.addSplitsBack(Collections.singletonList(checkpointSplit.copy()), 0);
+
+            enumerator.run();
+        }
+
+        Map<String, RocketMqSourceSplit> splitsByTopic = captureAssignedSplits(context);
+        Assertions.assertEquals(
+                checkpointOffset,
+                splitsByTopic.get("topic_restore").getStartOffset(),
+                "Checkpoint offset must be preserved after restore; offset must not be reset");
+    }
+
+    /**
+     * Verifies that when restoring from a checkpoint, newly discovered queues (not present at
+     * snapshot time) are assigned with offsets derived from the configured start mode, while the
+     * restored splits keep their checkpoint offsets.
+     */
+    @Test
+    void testRestore_newQueueUsesConfiguredStartMode() throws Exception {
+        ConsumerMetadata metadata = new ConsumerMetadata();
+        metadata.setTopics(Collections.singletonList("topic_mixed"));
+        metadata.setStartMode(StartMode.CONSUME_FROM_LAST_OFFSET);
+
+        MessageQueue restoredQueue = new MessageQueue("topic_mixed", "broker", 0);
+        MessageQueue newQueue = new MessageQueue("topic_mixed", "broker", 1);
+
+        final long checkpointOffset = 75L;
+        final long newQueueLastOffset = 200L;
+        RocketMqSourceSplit restoredSplit =
+                new RocketMqSourceSplit(restoredQueue, checkpointOffset, 99L);
+
+        Set<RocketMqSourceSplit> checkpointSplits = new HashSet<>();
+        checkpointSplits.add(restoredSplit);
+        RocketMqSourceState checkpointState = new RocketMqSourceState(checkpointSplits);
+
+        SourceSplitEnumerator.Context<RocketMqSourceSplit> context =
+                Mockito.mock(SourceSplitEnumerator.Context.class);
+        Mockito.when(context.currentParallelism()).thenReturn(2);
+
+        try (MockedStatic<RocketMqAdminUtil> mockedAdmin =
+                Mockito.mockStatic(RocketMqAdminUtil.class)) {
+            // Both queues now exist on the broker
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.offsetTopics(any(), any()))
+                    .thenReturn(
+                            Collections.singletonList(
+                                    topicOffsets(
+                                            queueOffset(restoredQueue, 0L, 99L),
+                                            queueOffset(newQueue, 0L, newQueueLastOffset))));
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.flatOffsetTopics(any(), any()))
+                    .thenReturn(
+                            topicOffsets(
+                                    queueOffset(restoredQueue, 0L, 99L),
+                                    queueOffset(newQueue, 0L, newQueueLastOffset)));
+
+            RocketMqSourceSplitEnumerator enumerator =
+                    new RocketMqSourceSplitEnumerator(
+                            metadata, Collections.emptyMap(), context, -1L, checkpointState);
+
+            enumerator.addSplitsBack(Collections.singletonList(restoredSplit.copy()), 0);
+
+            enumerator.run();
+        }
+
+        // Capture all assigned splits across all subtasks
+        ArgumentCaptor<List> splitsCaptor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(context, Mockito.atLeastOnce())
+                .assignSplit(any(Integer.class), splitsCaptor.capture());
+
+        List<RocketMqSourceSplit> allSplits = new ArrayList<>();
+        for (List captured : splitsCaptor.getAllValues()) {
+            for (Object obj : captured) {
+                allSplits.add((RocketMqSourceSplit) obj);
+            }
+        }
+        Map<String, RocketMqSourceSplit> splitsByQueue =
+                allSplits.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        s ->
+                                                s.getMessageQueue().getTopic()
+                                                        + "-"
+                                                        + s.getMessageQueue().getQueueId(),
+                                        s -> s));
+
+        // Restored split must keep checkpoint offset
+        Assertions.assertEquals(
+                checkpointOffset,
+                splitsByQueue.get("topic_mixed-0").getStartOffset(),
+                "Restored split must keep its checkpoint offset");
+
+        // New split must get the broker's last offset (CONSUME_FROM_LAST_OFFSET)
+        Assertions.assertEquals(
+                newQueueLastOffset,
+                splitsByQueue.get("topic_mixed-1").getStartOffset(),
+                "New split must use the configured start mode offset");
     }
 
     private SourceSplitEnumerator.Context<RocketMqSourceSplit> mockContext() {


### PR DESCRIPTION
### Purpose of this pull request

Fix RocketMQ source connector losing checkpoint offsets during recovery, causing data loss or duplicate consumption.

Closes #9940

**Root Cause:**

When `RocketMqSourceSplitEnumerator` is restored from a checkpoint, the engine calls `addSplitsBack()` with splits that already carry the correct checkpoint offsets. However, the existing code has two paths that overwrite these offsets:

1. `addSplitsBack()` calls `convertToNextSplit()`, which queries the broker for the latest offset and **hard-codes `CONSUME_FROM_LAST_OFFSET`** — this causes data loss by skipping ahead.
2. `run()` calls `setPartitionStartOffset()`, which resets the offset based on the user-configured `StartMode` — this may cause duplicate consumption (e.g., restarting from offset 0 with `CONSUME_FROM_FIRST_OFFSET`).

As a result, checkpoint recovery never actually resumes from the checkpointed position.

**Fix:**

- Add `isRestored` and `initialized` flags to identify the checkpoint recovery window (between construction and the first `run()` completion).
- During recovery (`isRestored && !initialized`), `addSplitsBack()` preserves checkpoint offsets by storing splits directly into `pendingSplit` without calling `convertToNextSplit()`.
- Track restored message queues in a `restoredSplits` set so `setPartitionStartOffset()` skips them, preventing offset overwrite.
- Add `initialized` guard in `registerReader()` and the discovery thread to prevent premature split assignment before `run()` completes.
- Newly discovered queues (not in the checkpoint) still get offsets from the configured `StartMode`, preserving existing behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, when a streaming job restored from a checkpoint, the RocketMQ source would reset offsets to either the broker's latest offset or the configured start mode offset, causing **data loss** (skipping messages) or **duplicate consumption** (re-reading from the beginning). After this fix, checkpoint recovery correctly resumes from the last committed offset.

This is a bug fix — the previous behavior was unintentional and no user should depend on it.

### How was this patch tested?

Two unit test cases were added in `RocketMqSourceSplitEnumeratorTest`:

1. **`testRestore_preservesCheckpointOffsets()`** — Verifies that after restoring from a checkpoint, the split's startOffset (50) is preserved and not reset to the broker's minOffset (0).

2. **`testRestore_newQueueUsesConfiguredStartMode()`** — Verifies that restored queues keep their checkpoint offset (75) while newly discovered queues get the broker's last offset (200) per the configured `CONSUME_FROM_LAST_OFFSET` start mode.

All existing tests continue to pass:

```bash
./mvnw -pl seatunnel-connectors-v2/connector-rocketmq test
```
**Why no E2E test:**

An E2E test for checkpoint recovery would require simulating a job failure 
and restart mid-consumption, which is significantly more complex than the 
existing RocketMQ E2E tests (which only verify basic read/write). The two 
unit tests directly validate the core logic — that `addSplitsBack()` and 
`setPartitionStartOffset()` correctly preserve checkpoint offsets — with 
full mock coverage of all relevant code paths. If reviewers prefer, I'm 
happy to add an E2E test in a follow-up PR.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)

> Note: This is a bug fix PR that does not add new connectors, new dependencies, new config options, or change any existing defaults. No documentation, license, or plugin-mapping updates are required. The checklist items above are not applicable to this change.