### PR TITLE
[Fix][CI] Sync build status for recent PRs regardless of mergeable state

### DIFF
--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -38,7 +38,6 @@ jobs:
           script: |
             const SEARCH_WINDOW_DAYS = 7;
             const BATCH_SIZE = 10;
-            const maybeReady = ['behind', 'clean', 'draft', 'has_hooks', 'unknown', 'unstable'];
 
             function getSearchSince() {
               const windowStart = new Date(Date.now() - SEARCH_WINDOW_DAYS * 24 * 60 * 60 * 1000);
@@ -98,10 +97,6 @@ jobs:
 
                 console.log(`PR #${pr.number} SHA: ${pr.head.sha}`);
                 console.log(`  Mergeable status: ${pr.mergeable_state}`);
-                if (pr.mergeable_state != null && !maybeReady.includes(pr.mergeable_state)) {
-                  console.log(`  Skip PR #${pr.number}: mergeable state ${pr.mergeable_state}`);
-                  return;
-                }
 
                 const checkRuns = await github.request(
                   'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',


### PR DESCRIPTION
## Why

The scheduled build-status sync currently skips PRs whose `mergeable_state` is outside the allowlist added in `update_build_status.yml`.

That leaves mirrored `Build` checks stuck at `queued` even when the fork workflow already completed successfully. PR `#10752` is a concrete example: the fork `Build` run passed, but the scheduled sync kept logging `Skip PR #10752: mergeable state blocked` and never patched the upstream check.

## What

- keep the existing 7-day search window
- remove the `mergeable_state` gate from the scheduled sync workflow
- keep the existing no-op patch skip logic unchanged

## Verification

- `./mvnw spotless:apply -nsu -T 3C`
- `./mvnw -q -DskipTests verify -nsu -T 3C`  
  Fails in `seatunnel-ci-tools` test compilation on existing `log` symbol errors, unrelated to this workflow-only change.
