### PR TITLE
[Improve][Connectors-v2] [ORC]parse config on file level rather than field level

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/OrcReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/OrcReadStrategy.java
@@ -91,6 +91,16 @@ public class OrcReadStrategy extends AbstractReadStrategy {
                             path);
             throw new FileConnectorException(FileConnectorErrorCode.FILE_TYPE_INVALID, errorMsg);
         }
+
+        Charset charset = StandardCharsets.UTF_8;
+        if (pluginConfig != null) {
+            charset =
+                    ReadonlyConfig.fromConfig(pluginConfig)
+                            .getOptional(FileBaseSourceOptions.ENCODING)
+                            .map(Charset::forName)
+                            .orElse(StandardCharsets.UTF_8);
+        }
+
         Map<String, String> partitionsMap = parsePartitionsByPath(path);
         try (Reader reader =
                 hadoopFileSystemProxy.doWithHadoopAuth(
@@ -132,7 +142,8 @@ public class OrcReadStrategy extends AbstractReadStrategy {
                                             cols[j],
                                             children.get(j),
                                             seaTunnelRowType.getFieldType(j),
-                                            num);
+                                            num,
+                                            charset);
                         }
                     }
                     SeaTunnelRow seaTunnelRow = new SeaTunnelRow(fields);
@@ -357,7 +368,8 @@ public class OrcReadStrategy extends AbstractReadStrategy {
             ColumnVector colVec,
             TypeDescription colType,
             @Nullable SeaTunnelDataType<?> dataType,
-            int rowNum) {
+            int rowNum,
+            Charset charset) {
         Object columnObj = null;
         if (!colVec.isNull[rowNum]) {
             switch (colVec.type) {
@@ -374,7 +386,7 @@ public class OrcReadStrategy extends AbstractReadStrategy {
                     }
                     break;
                 case BYTES:
-                    columnObj = readBytesVal(colVec, colType, dataType, rowNum);
+                    columnObj = readBytesVal(colVec, colType, dataType, rowNum, charset);
                     break;
                 case DECIMAL:
                     columnObj = readDecimalVal(colVec, dataType, rowNum);
@@ -383,7 +395,7 @@ public class OrcReadStrategy extends AbstractReadStrategy {
                     columnObj = readTimestampVal(colVec, colType, dataType, rowNum);
                     break;
                 case STRUCT:
-                    columnObj = readStructVal(colVec, colType, dataType, rowNum);
+                    columnObj = readStructVal(colVec, colType, dataType, rowNum, charset);
                     break;
                 case LIST:
                     columnObj = readListVal(colVec, colType, rowNum);
@@ -392,7 +404,7 @@ public class OrcReadStrategy extends AbstractReadStrategy {
                     columnObj = readMapVal(colVec, colType, rowNum);
                     break;
                 case UNION:
-                    columnObj = readUnionVal(colVec, colType, rowNum);
+                    columnObj = readUnionVal(colVec, colType, rowNum, charset);
                     break;
                 default:
                     throw new FileConnectorException(
@@ -435,16 +447,8 @@ public class OrcReadStrategy extends AbstractReadStrategy {
             ColumnVector colVec,
             TypeDescription typeDescription,
             SeaTunnelDataType<?> dataType,
-            int rowNum) {
-        Charset charset = StandardCharsets.UTF_8;
-        if (pluginConfig != null) {
-            charset =
-                    ReadonlyConfig.fromConfig(pluginConfig)
-                            .getOptional(FileBaseSourceOptions.ENCODING)
-                            .map(Charset::forName)
-                            .orElse(StandardCharsets.UTF_8);
-        }
-
+            int rowNum,
+            Charset charset) {
         Object bytesObj = null;
         if (!colVec.isNull[rowNum]) {
             BytesColumnVector bytesVector = (BytesColumnVector) colVec;
@@ -533,7 +537,8 @@ public class OrcReadStrategy extends AbstractReadStrategy {
             ColumnVector colVec,
             TypeDescription colType,
             SeaTunnelDataType<?> dataType,
-            int rowNum) {
+            int rowNum,
+            Charset charset) {
         Object structObj = null;
         if (!colVec.isNull[rowNum]) {
             StructColumnVector structVector = (StructColumnVector) colVec;
@@ -543,9 +548,11 @@ public class OrcReadStrategy extends AbstractReadStrategy {
             for (int i = 0; i < fieldVec.length; i++) {
                 if (dataType instanceof SeaTunnelRowType) {
                     SeaTunnelDataType<?> fieldType = ((SeaTunnelRowType) dataType).getFieldType(i);
-                    fieldValues[i] = readColumn(fieldVec[i], fieldTypes.get(i), fieldType, rowNum);
+                    fieldValues[i] =
+                            readColumn(fieldVec[i], fieldTypes.get(i), fieldType, rowNum, charset);
                 } else {
-                    fieldValues[i] = readColumn(fieldVec[i], fieldTypes.get(i), null, rowNum);
+                    fieldValues[i] =
+                            readColumn(fieldVec[i], fieldTypes.get(i), null, rowNum, charset);
                 }
             }
             structObj = new SeaTunnelRow(fieldValues);
@@ -624,7 +631,8 @@ public class OrcReadStrategy extends AbstractReadStrategy {
         return mapList;
     }
 
-    private Object readUnionVal(ColumnVector colVec, TypeDescription colType, int rowNum) {
+    private Object readUnionVal(
+            ColumnVector colVec, TypeDescription colType, int rowNum, Charset charset) {
         Pair<TypeDescription, Object> columnValuePair;
         UnionColumnVector unionVector = (UnionColumnVector) colVec;
         int tagVal = unionVector.tags[rowNum];
@@ -633,7 +641,7 @@ public class OrcReadStrategy extends AbstractReadStrategy {
             TypeDescription fieldType = unionFieldTypes.get(tagVal);
             if (tagVal < unionVector.fields.length) {
                 ColumnVector fieldVector = unionVector.fields[tagVal];
-                Object unionValue = readColumn(fieldVector, fieldType, null, rowNum);
+                Object unionValue = readColumn(fieldVector, fieldType, null, rowNum, charset);
                 columnValuePair = Pair.of(fieldType, unionValue);
             } else {
                 throw new FileConnectorException(


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Now the charset is extract from Config on field level.
If I have a 20 rows data, each row has 30 string type fields, the extract need run 20*30 times.
Update to extract on file level, only extract once. 
This update can significantly improve performance.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)