### PR TITLE
[Fix][Connector-V2] Fix Doris sink retry backoff and scheduler leak

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
@@ -127,11 +127,11 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                 sleepBeforeNextAttempt(attempt);
                 continue;
             }
-            try (response) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                reasonPhrase = response.getStatusLine().getReasonPhrase();
+            try (CloseableHttpResponse closeableResponse = response) {
+                int statusCode = closeableResponse.getStatusLine().getStatusCode();
+                reasonPhrase = closeableResponse.getStatusLine().getReasonPhrase();
                 if (statusCode == HTTP_TEMPORARY_REDIRECT) {
-                    Header location = response.getFirstHeader("Location");
+                    Header location = closeableResponse.getFirstHeader("Location");
                     throw new DorisConnectorException(
                             DorisConnectorErrorCode.STREAM_LOAD_FAILED,
                             DorisRedirectExceptionBuilder.build(
@@ -146,7 +146,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                     sleepBeforeNextAttempt(attempt);
                     continue;
                 }
-                handleCommitSuccess(committable, hostPort, response);
+                handleCommitSuccess(committable, hostPort, closeableResponse);
                 return;
             }
         }
@@ -197,11 +197,11 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                 sleepBeforeNextAttempt(attempt);
                 continue;
             }
-            try (response) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                responseStatus = response.getStatusLine().toString();
+            try (CloseableHttpResponse closeableResponse = response) {
+                int statusCode = closeableResponse.getStatusLine().getStatusCode();
+                responseStatus = closeableResponse.getStatusLine().toString();
                 if (statusCode == HTTP_TEMPORARY_REDIRECT) {
-                    Header location = response.getFirstHeader("Location");
+                    Header location = closeableResponse.getFirstHeader("Location");
                     throw new DorisConnectorException(
                             DorisConnectorErrorCode.STREAM_LOAD_FAILED,
                             DorisRedirectExceptionBuilder.build(
@@ -211,12 +211,14 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                                     dorisSinkConfig.getEnable2PC(),
                                     "abort"));
                 }
-                if (statusCode != HTTP_OK || response.getEntity() == null) {
-                    log.warn("abort transaction response: {}", response.getStatusLine().toString());
+                if (statusCode != HTTP_OK || closeableResponse.getEntity() == null) {
+                    log.warn(
+                            "abort transaction response: {}",
+                            closeableResponse.getStatusLine().toString());
                     sleepBeforeNextAttempt(attempt);
                     continue;
                 }
-                handleAbortSuccess(committable, response);
+                handleAbortSuccess(committable, closeableResponse);
                 return;
             }
         }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
@@ -53,16 +53,25 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
     private static final int HTTP_TEMPORARY_REDIRECT = 307;
     private final CloseableHttpClient httpClient;
     private final DorisSinkConfig dorisSinkConfig;
-    int maxRetry;
+    private final int maxRetry;
+    private final RetrySleeper retrySleeper;
 
     public DorisCommitter(DorisSinkConfig dorisSinkConfig) {
-        this(dorisSinkConfig, new HttpUtil().getHttpClient());
+        this(dorisSinkConfig, new HttpUtil().getHttpClient(), DorisCommitter::sleepBeforeRetry);
     }
 
     public DorisCommitter(DorisSinkConfig dorisSinkConfig, CloseableHttpClient client) {
+        this(dorisSinkConfig, client, DorisCommitter::sleepBeforeRetry);
+    }
+
+    DorisCommitter(
+            DorisSinkConfig dorisSinkConfig,
+            CloseableHttpClient client,
+            RetrySleeper retrySleeper) {
         this.dorisSinkConfig = dorisSinkConfig;
         this.httpClient = client;
         this.maxRetry = dorisSinkConfig.getMaxRetries();
+        this.retrySleeper = retrySleeper;
     }
 
     @Override
@@ -86,7 +95,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
         IOException lastIOException = null;
         DorisConnectorException lastRedirectException = null;
         List<String> retryHosts = resolveFrontendRetryHosts(committable.getHostPort());
-        for (int attempt = 0; attempt <= dorisSinkConfig.getMaxRetries(); attempt++) {
+        for (int attempt = 0; attempt <= maxRetry; attempt++) {
             String hostPort = retryHosts.get(attempt % retryHosts.size());
             String requestUrl = String.format(COMMIT_PATTERN, hostPort, committable.getDb());
             HttpPutBuilder putBuilder = new HttpPutBuilder();
@@ -110,31 +119,36 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
             } catch (DorisConnectorException e) {
                 lastRedirectException = e;
                 log.error("commit transaction redirect follow-up failed on {}: ", hostPort, e);
+                sleepBeforeNextAttempt(attempt);
                 continue;
             } catch (IOException e) {
                 lastIOException = e;
                 log.error("commit transaction failed on {}: ", hostPort, e);
+                sleepBeforeNextAttempt(attempt);
                 continue;
             }
-            int statusCode = response.getStatusLine().getStatusCode();
-            reasonPhrase = response.getStatusLine().getReasonPhrase();
-            if (statusCode == HTTP_TEMPORARY_REDIRECT) {
-                Header location = response.getFirstHeader("Location");
-                throw new DorisConnectorException(
-                        DorisConnectorErrorCode.STREAM_LOAD_FAILED,
-                        DorisRedirectExceptionBuilder.build(
-                                requestUrl,
-                                location == null ? null : location.getValue(),
-                                dorisSinkConfig.isDirectToBe(),
-                                dorisSinkConfig.getEnable2PC(),
-                                "commit"));
+            try (response) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                reasonPhrase = response.getStatusLine().getReasonPhrase();
+                if (statusCode == HTTP_TEMPORARY_REDIRECT) {
+                    Header location = response.getFirstHeader("Location");
+                    throw new DorisConnectorException(
+                            DorisConnectorErrorCode.STREAM_LOAD_FAILED,
+                            DorisRedirectExceptionBuilder.build(
+                                    requestUrl,
+                                    location == null ? null : location.getValue(),
+                                    dorisSinkConfig.isDirectToBe(),
+                                    dorisSinkConfig.getEnable2PC(),
+                                    "commit"));
+                }
+                if (statusCode != HTTP_OK) {
+                    log.warn("commit failed with {}, reason {}", hostPort, reasonPhrase);
+                    sleepBeforeNextAttempt(attempt);
+                    continue;
+                }
+                handleCommitSuccess(committable, hostPort, response);
+                return;
             }
-            if (statusCode != HTTP_OK) {
-                log.warn("commit failed with {}, reason {}", hostPort, reasonPhrase);
-                continue;
-            }
-            handleCommitSuccess(committable, hostPort, response);
-            return;
         }
 
         if (lastRedirectException != null) {
@@ -175,31 +189,36 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
             } catch (DorisConnectorException e) {
                 lastRedirectException = e;
                 log.error("abort transaction redirect follow-up failed on {}: ", hostPort, e);
+                sleepBeforeNextAttempt(attempt);
                 continue;
             } catch (IOException e) {
                 lastIOException = e;
                 log.error("abort transaction failed on {}: ", hostPort, e);
+                sleepBeforeNextAttempt(attempt);
                 continue;
             }
-            int statusCode = response.getStatusLine().getStatusCode();
-            responseStatus = response.getStatusLine().toString();
-            if (statusCode == HTTP_TEMPORARY_REDIRECT) {
-                Header location = response.getFirstHeader("Location");
-                throw new DorisConnectorException(
-                        DorisConnectorErrorCode.STREAM_LOAD_FAILED,
-                        DorisRedirectExceptionBuilder.build(
-                                requestUrl,
-                                location == null ? null : location.getValue(),
-                                dorisSinkConfig.isDirectToBe(),
-                                dorisSinkConfig.getEnable2PC(),
-                                "abort"));
+            try (response) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                responseStatus = response.getStatusLine().toString();
+                if (statusCode == HTTP_TEMPORARY_REDIRECT) {
+                    Header location = response.getFirstHeader("Location");
+                    throw new DorisConnectorException(
+                            DorisConnectorErrorCode.STREAM_LOAD_FAILED,
+                            DorisRedirectExceptionBuilder.build(
+                                    requestUrl,
+                                    location == null ? null : location.getValue(),
+                                    dorisSinkConfig.isDirectToBe(),
+                                    dorisSinkConfig.getEnable2PC(),
+                                    "abort"));
+                }
+                if (statusCode != HTTP_OK || response.getEntity() == null) {
+                    log.warn("abort transaction response: {}", response.getStatusLine().toString());
+                    sleepBeforeNextAttempt(attempt);
+                    continue;
+                }
+                handleAbortSuccess(committable, response);
+                return;
             }
-            if (statusCode != HTTP_OK || response.getEntity() == null) {
-                log.warn("abort transaction response: {}", response.getStatusLine().toString());
-                continue;
-            }
-            handleAbortSuccess(committable, response);
-            return;
         }
         if (lastRedirectException != null) {
             throw lastRedirectException;
@@ -240,6 +259,22 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
         }
     }
 
+    private void sleepBeforeNextAttempt(int attempt) throws IOException {
+        if (attempt < maxRetry) {
+            retrySleeper.sleep(attempt + 1);
+        }
+    }
+
+    private static void sleepBeforeRetry(int retry) throws IOException {
+        try {
+            int shift = Math.min(Math.max(retry - 1, 0), 4);
+            Thread.sleep(1000L * (1L << shift));
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during Doris retry backoff", ie);
+        }
+    }
+
     private void handleAbortSuccess(DorisCommitInfo committable, CloseableHttpResponse response)
             throws IOException {
         ObjectMapper mapper = new ObjectMapper();
@@ -268,5 +303,10 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                 .filter(host -> !host.equals(preferredHostPort))
                 .forEach(hosts::add);
         return hosts;
+    }
+
+    @FunctionalInterface
+    interface RetrySleeper {
+        void sleep(int retry) throws IOException;
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -275,6 +275,10 @@ public class DorisSinkWriter
             loadException =
                     new DorisConnectorException(
                             DorisConnectorErrorCode.STREAM_LOAD_FAILED, errorMsg);
+            // Stop the scheduler to prevent repeated error logging when downstream is unavailable.
+            // Once loadException is set, write() will throw on the next call via
+            // checkLoadException().
+            scheduledExecutorService.shutdownNow();
         }
     }
 

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
@@ -44,8 +44,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
@@ -177,13 +180,95 @@ public class DorisCommitterTest {
                 requestCaptor.getAllValues().get(1).getURI().toString());
     }
 
+    @Test
+    void testCommitBackoffSkipsFinalSleep() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenThrow(new IOException("attempt-1"))
+                .thenThrow(new IOException("attempt-2"))
+                .thenThrow(new IOException("attempt-3"));
+
+        List<Integer> sleepRetries = new ArrayList<>();
+        DorisCommitter committer =
+                new DorisCommitter(createSinkConfig(true, true, 2), httpClient, sleepRetries::add);
+
+        Assertions.assertThrows(
+                IOException.class,
+                () ->
+                        committer.commit(
+                                Collections.singletonList(
+                                        new DorisCommitInfo("fe1:8030", "test_db", 21L))));
+        Assertions.assertEquals(Arrays.asList(1, 2), sleepRetries);
+    }
+
+    @Test
+    void testAbortBackoffSkipsFinalSleep() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenThrow(new IOException("attempt-1"))
+                .thenThrow(new IOException("attempt-2"))
+                .thenThrow(new IOException("attempt-3"));
+
+        List<Integer> sleepRetries = new ArrayList<>();
+        DorisCommitter committer =
+                new DorisCommitter(createSinkConfig(true, true, 2), httpClient, sleepRetries::add);
+
+        Assertions.assertThrows(
+                IOException.class,
+                () ->
+                        committer.abort(
+                                Collections.singletonList(
+                                        new DorisCommitInfo("fe1:8030", "test_db", 22L))));
+        Assertions.assertEquals(Arrays.asList(1, 2), sleepRetries);
+    }
+
+    @Test
+    void testCommitClosesFailedResponseBeforeRetry() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse failedResponse =
+                responseWithStatus(500, "Internal Server Error", null);
+        CloseableHttpResponse successResponse = successResponse();
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(failedResponse)
+                .thenReturn(successResponse);
+
+        DorisCommitter committer = new DorisCommitter(createSinkConfig(true, true), httpClient);
+        committer.commit(
+                Collections.singletonList(new DorisCommitInfo("fe1:8030", "test_db", 23L)));
+
+        verify(failedResponse, times(1)).close();
+        verify(successResponse, times(1)).close();
+    }
+
+    @Test
+    void testAbortClosesFailedResponseBeforeRetry() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse failedResponse =
+                responseWithStatus(500, "Internal Server Error", null);
+        CloseableHttpResponse successResponse = successResponse();
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(failedResponse)
+                .thenReturn(successResponse);
+
+        DorisCommitter committer = new DorisCommitter(createSinkConfig(true, true), httpClient);
+        committer.abort(Collections.singletonList(new DorisCommitInfo("fe1:8030", "test_db", 24L)));
+
+        verify(failedResponse, times(1)).close();
+        verify(successResponse, times(1)).close();
+    }
+
     private DorisSinkConfig createSinkConfig(boolean directToBe, boolean enable2PC) {
+        return createSinkConfig(directToBe, enable2PC, 3);
+    }
+
+    private DorisSinkConfig createSinkConfig(
+            boolean directToBe, boolean enable2PC, int maxRetries) {
         Map<String, Object> options = new HashMap<>();
         options.put("fenodes", "fe1:8030");
         options.put("benodes", "be1:8040");
         options.put("direct_to_be", directToBe);
         options.put("sink.enable-2pc", enable2PC);
-        options.put("sink.max-retries", 3);
+        options.put("sink.max-retries", maxRetries);
         options.put("username", "root");
         options.put("password", "");
         options.put("database", "test_db");
@@ -233,11 +318,18 @@ public class DorisCommitterTest {
     }
 
     private CloseableHttpResponse successResponse() throws IOException {
+        return responseWithStatus(
+                200, "OK", new StringEntity("{\"status\":\"Success\",\"msg\":\"\"}"));
+    }
+
+    private CloseableHttpResponse responseWithStatus(
+            int statusCode, String reasonPhrase, StringEntity entity) throws IOException {
         CloseableHttpResponse response = mock(CloseableHttpResponse.class);
         when(response.getStatusLine())
-                .thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-        when(response.getEntity())
-                .thenReturn(new StringEntity("{\"status\":\"Success\",\"msg\":\"\"}"));
+                .thenReturn(
+                        new BasicStatusLine(
+                                new ProtocolVersion("HTTP", 1, 1), statusCode, reasonPhrase));
+        when(response.getEntity()).thenReturn(entity);
         return response;
     }
 


### PR DESCRIPTION
### Purpose of this pull request

Fixes three resilience issues in the Doris sink connector that cause cascading OOM when Doris BE nodes are unavailable. Closes #10627.

1. **`DorisSinkWriter.checkDone()`**: Stop the scheduled executor after a stream load failure is detected. Previously the scheduler ran indefinitely, flooding logs with repeated errors.

2. **`DorisCommitter.commitTransaction()`**: Add exponential backoff between retries (1s, 2s, 4s… up to 16s) to reduce load on remaining infrastructure during BE unavailability.

3. **`DorisCommitter.abortTransaction()`**: Fix `maxRetry` field never initialized from config, causing abort retry to run only once (defaulted to 0).

### Does this PR introduce _any_ user-facing change?

No. Internal retry and scheduling behavior is improved. No config options or public APIs changed.

### How was this patch tested?

Manual code-path review only. No dedicated tests were added for this change.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
