### PR TITLE
Test/rocketmq restore e2e

### DIFF
--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSource.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSource.java
@@ -90,6 +90,7 @@ public class RocketMqSource
                 sourceConfig.getMetadata(),
                 sourceConfig.getTopicConfigs(),
                 context,
-                sourceConfig.getDiscoveryIntervalMillis());
+                sourceConfig.getDiscoveryIntervalMillis(),
+                sourceState);
     }
 }

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
@@ -65,6 +65,26 @@ public class RocketMqSourceSplitEnumerator
     // ms
     private long discoveryIntervalMillis;
 
+    /**
+     * Tracks message queues whose splits were restored from a checkpoint. These splits already have
+     * the correct startOffset and should not have their offset overwritten by
+     * setPartitionStartOffset().
+     */
+    private final Set<MessageQueue> restoredSplits = new HashSet<>();
+
+    /**
+     * Indicates whether this enumerator was created to restore from a checkpoint state. When true,
+     * addSplitsBack() will preserve the checkpoint offsets instead of resetting them.
+     */
+    private boolean isRestored = false;
+
+    /**
+     * Set to true after the first run() completes. Used to distinguish the initial startup phase
+     * (where addSplitsBack may be called with checkpoint splits) from later reader
+     * re-registrations.
+     */
+    private volatile boolean initialized = false;
+
     public RocketMqSourceSplitEnumerator(
             ConsumerMetadata metadata,
             Map<String, TopicTableConfig> topicConfigs,
@@ -86,6 +106,32 @@ public class RocketMqSourceSplitEnumerator
             long discoveryIntervalMillis) {
         this(metadata, topicConfigs, context);
         this.discoveryIntervalMillis = discoveryIntervalMillis;
+    }
+
+    /**
+     * Creates an enumerator that restores state from a checkpoint.
+     *
+     * <p>The {@code sourceState} parameter is intentionally unused. The actual split restoration
+     * happens via {@link #addSplitsBack(List, int)}, which the engine calls before {@link #run()}
+     * with the splits carrying the correct startOffset from the reader-side checkpoint. Using
+     * {@code sourceState} to pre-populate {@code assignedSplit} would cause {@link #assignSplit()}
+     * to skip those splits (since they would already appear in {@code assignedSplit}), preventing
+     * them from being dispatched to any reader.
+     *
+     * @param metadata consumer metadata
+     * @param topicConfigs per-topic configuration map
+     * @param context enumerator context
+     * @param discoveryIntervalMillis interval for dynamic queue discovery, in milliseconds
+     * @param sourceState the checkpoint state (unused; retained for API contract compatibility)
+     */
+    public RocketMqSourceSplitEnumerator(
+            ConsumerMetadata metadata,
+            Map<String, TopicTableConfig> topicConfigs,
+            SourceSplitEnumerator.Context<RocketMqSourceSplit> context,
+            long discoveryIntervalMillis,
+            RocketMqSourceState sourceState) {
+        this(metadata, topicConfigs, context, discoveryIntervalMillis);
+        this.isRestored = true;
     }
 
     private static int getSplitOwner(MessageQueue messageQueue, int numReaders) {
@@ -113,7 +159,9 @@ public class RocketMqSourceSplitEnumerator
                     executor.scheduleWithFixedDelay(
                             () -> {
                                 try {
-                                    discoverySplits();
+                                    if (initialized) {
+                                        discoverySplits();
+                                    }
                                 } catch (Exception e) {
                                     log.error("Dynamic discovery failure:", e);
                                 }
@@ -129,10 +177,15 @@ public class RocketMqSourceSplitEnumerator
         synchronized (lock) {
             fetchPendingPartitionSplit();
             setPartitionStartOffset();
+            restoredSplits.clear();
         }
 
         synchronized (lock) {
             assignSplit();
+        }
+
+        if (!initialized) {
+            initialized = true;
         }
     }
 
@@ -149,6 +202,20 @@ public class RocketMqSourceSplitEnumerator
     @Override
     public void addSplitsBack(List<RocketMqSourceSplit> splits, int subtaskId) {
         if (!splits.isEmpty()) {
+            synchronized (lock) {
+                if (isRestored && !initialized) {
+                    // During checkpoint recovery the engine returns previously assigned splits
+                    // to the enumerator before run() is called. These splits already have the
+                    // correct startOffset from the checkpoint snapshot, so we must NOT call
+                    // convertToNextSplit() (which resets offset to the broker's latest value).
+                    splits.forEach(
+                            split -> {
+                                restoredSplits.add(split.getMessageQueue());
+                                pendingSplit.put(split.getMessageQueue(), split.copy());
+                            });
+                    return;
+                }
+            }
             pendingSplit.putAll(convertToNextSplit(splits));
             assignSplit();
         }
@@ -192,7 +259,7 @@ public class RocketMqSourceSplitEnumerator
 
     @Override
     public void registerReader(int subtaskId) {
-        if (!pendingSplit.isEmpty()) {
+        if (!pendingSplit.isEmpty() && initialized) {
             assignSplit();
         }
     }
@@ -259,8 +326,18 @@ public class RocketMqSourceSplitEnumerator
 
     private void setPartitionStartOffset() throws MQClientException {
         // Group pending partitions by their effective start mode (per-topic override or global).
+        // Restored splits already carry the correct checkpoint offset; skip them entirely so we
+        // do not overwrite the persisted position with a broker-derived offset.
         Map<StartMode, List<MessageQueue>> partitionsByMode = new LinkedHashMap<>();
         for (MessageQueue mq : pendingSplit.keySet()) {
+            if (restoredSplits.contains(mq)) {
+                log.debug(
+                        "Skipping offset reset for restored split: topic={}, broker={}, queueId={}",
+                        mq.getTopic(),
+                        mq.getBrokerName(),
+                        mq.getQueueId());
+                continue;
+            }
             StartMode effectiveMode = getEffectiveStartMode(mq.getTopic());
             partitionsByMode.computeIfAbsent(effectiveMode, k -> new ArrayList<>()).add(mq);
         }

--- a/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumeratorTest.java
@@ -31,12 +31,15 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -169,6 +172,145 @@ class RocketMqSourceSplitEnumeratorTest {
 
         Map<String, RocketMqSourceSplit> splitsByTopic = captureAssignedSplits(context);
         Assertions.assertEquals(33L, splitsByTopic.get("topic_specific").getStartOffset());
+    }
+
+    /**
+     * Verifies that when an enumerator is restored from a checkpoint, the splits returned via
+     * addSplitsBack() retain their checkpoint offsets and are NOT reset to the broker's offset.
+     *
+     * <p>Scenario: the checkpoint recorded startOffset=50 for a queue whose broker minOffset=0.
+     * After restore, consumption must resume from 50, not restart from 0.
+     */
+    @Test
+    void testRestore_preservesCheckpointOffsets() throws Exception {
+        ConsumerMetadata metadata = new ConsumerMetadata();
+        metadata.setTopics(Collections.singletonList("topic_restore"));
+        metadata.setStartMode(StartMode.CONSUME_FROM_LAST_OFFSET);
+
+        MessageQueue messageQueue = new MessageQueue("topic_restore", "broker-restore", 0);
+
+        // The split saved in the checkpoint carries startOffset=50
+        final long checkpointOffset = 50L;
+        RocketMqSourceSplit checkpointSplit =
+                new RocketMqSourceSplit(messageQueue, checkpointOffset, 99L);
+
+        Set<RocketMqSourceSplit> checkpointSplits = new HashSet<>();
+        checkpointSplits.add(checkpointSplit);
+        RocketMqSourceState checkpointState = new RocketMqSourceState(checkpointSplits);
+
+        SourceSplitEnumerator.Context<RocketMqSourceSplit> context = mockContext();
+
+        try (MockedStatic<RocketMqAdminUtil> mockedAdmin =
+                Mockito.mockStatic(RocketMqAdminUtil.class)) {
+            // Broker reports the queue exists with minOffset=0, maxOffset=100
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.offsetTopics(any(), any()))
+                    .thenReturn(
+                            Collections.singletonList(
+                                    topicOffsets(queueOffset(messageQueue, 0L, 100L))));
+
+            RocketMqSourceSplitEnumerator enumerator =
+                    new RocketMqSourceSplitEnumerator(
+                            metadata, Collections.emptyMap(), context, -1L, checkpointState);
+
+            // Simulate the engine returning the checkpoint split before run()
+            enumerator.addSplitsBack(Collections.singletonList(checkpointSplit.copy()), 0);
+
+            enumerator.run();
+        }
+
+        Map<String, RocketMqSourceSplit> splitsByTopic = captureAssignedSplits(context);
+        Assertions.assertEquals(
+                checkpointOffset,
+                splitsByTopic.get("topic_restore").getStartOffset(),
+                "Checkpoint offset must be preserved after restore; offset must not be reset");
+    }
+
+    /**
+     * Verifies that when restoring from a checkpoint, newly discovered queues (not present at
+     * snapshot time) are assigned with offsets derived from the configured start mode, while the
+     * restored splits keep their checkpoint offsets.
+     */
+    @Test
+    void testRestore_newQueueUsesConfiguredStartMode() throws Exception {
+        ConsumerMetadata metadata = new ConsumerMetadata();
+        metadata.setTopics(Collections.singletonList("topic_mixed"));
+        metadata.setStartMode(StartMode.CONSUME_FROM_LAST_OFFSET);
+
+        MessageQueue restoredQueue = new MessageQueue("topic_mixed", "broker", 0);
+        MessageQueue newQueue = new MessageQueue("topic_mixed", "broker", 1);
+
+        final long checkpointOffset = 75L;
+        final long newQueueLastOffset = 200L;
+        RocketMqSourceSplit restoredSplit =
+                new RocketMqSourceSplit(restoredQueue, checkpointOffset, 99L);
+
+        Set<RocketMqSourceSplit> checkpointSplits = new HashSet<>();
+        checkpointSplits.add(restoredSplit);
+        RocketMqSourceState checkpointState = new RocketMqSourceState(checkpointSplits);
+
+        SourceSplitEnumerator.Context<RocketMqSourceSplit> context =
+                Mockito.mock(SourceSplitEnumerator.Context.class);
+        Mockito.when(context.currentParallelism()).thenReturn(2);
+
+        try (MockedStatic<RocketMqAdminUtil> mockedAdmin =
+                Mockito.mockStatic(RocketMqAdminUtil.class)) {
+            // Both queues now exist on the broker
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.offsetTopics(any(), any()))
+                    .thenReturn(
+                            Collections.singletonList(
+                                    topicOffsets(
+                                            queueOffset(restoredQueue, 0L, 99L),
+                                            queueOffset(newQueue, 0L, newQueueLastOffset))));
+            mockedAdmin
+                    .when(() -> RocketMqAdminUtil.flatOffsetTopics(any(), any()))
+                    .thenReturn(
+                            topicOffsets(
+                                    queueOffset(restoredQueue, 0L, 99L),
+                                    queueOffset(newQueue, 0L, newQueueLastOffset)));
+
+            RocketMqSourceSplitEnumerator enumerator =
+                    new RocketMqSourceSplitEnumerator(
+                            metadata, Collections.emptyMap(), context, -1L, checkpointState);
+
+            enumerator.addSplitsBack(Collections.singletonList(restoredSplit.copy()), 0);
+
+            enumerator.run();
+        }
+
+        // Capture all assigned splits across all subtasks
+        ArgumentCaptor<List> splitsCaptor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(context, Mockito.atLeastOnce())
+                .assignSplit(any(Integer.class), splitsCaptor.capture());
+
+        List<RocketMqSourceSplit> allSplits = new ArrayList<>();
+        for (List captured : splitsCaptor.getAllValues()) {
+            for (Object obj : captured) {
+                allSplits.add((RocketMqSourceSplit) obj);
+            }
+        }
+        Map<String, RocketMqSourceSplit> splitsByQueue =
+                allSplits.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        s ->
+                                                s.getMessageQueue().getTopic()
+                                                        + "-"
+                                                        + s.getMessageQueue().getQueueId(),
+                                        s -> s));
+
+        // Restored split must keep checkpoint offset
+        Assertions.assertEquals(
+                checkpointOffset,
+                splitsByQueue.get("topic_mixed-0").getStartOffset(),
+                "Restored split must keep its checkpoint offset");
+
+        // New split must get the broker's last offset (CONSUME_FROM_LAST_OFFSET)
+        Assertions.assertEquals(
+                newQueueLastOffset,
+                splitsByQueue.get("topic_mixed-1").getStartOffset(),
+                "New split must use the configured start mode offset");
     }
 
     private SourceSplitEnumerator.Context<RocketMqSourceSplit> mockContext() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
@@ -44,6 +44,8 @@ import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.engine.common.Constant;
 
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.common.admin.TopicOffset;
 import org.apache.rocketmq.common.message.Message;
@@ -51,9 +53,11 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.protocol.route.QueueData;
 import org.apache.rocketmq.common.protocol.route.TopicRouteData;
+import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,6 +77,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -80,6 +85,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.e2e.connector.rocketmq.RocketMqContainer.NAMESRV_PORT;
@@ -541,6 +549,197 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
 
     interface ProducerRecordConverter {
         Message convert(SeaTunnelRow row);
+    }
+
+    // ------------------------------ restore --------------------------------
+
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK, EngineType.FLINK},
+            disabledReason = "Currently SPARK and FLINK do not support restore")
+    public void testSourceRocketMqRestore(TestContainer container)
+            throws IOException, InterruptedException, MQBrokerException, RemotingException,
+                    MQClientException, ExecutionException {
+
+        final String sourceTopic = "test_topic_restore";
+        final String sinkTopic = "test_topic_restore_output";
+        final String payload = "Seatunnel RocketMQ Restore Test Data";
+        final String jobId = "20260416";
+
+        for (int i = 0; i < 20; i++) {
+            Message msg = new Message(sourceTopic, (payload + "_initial_" + i).getBytes());
+            producer.send(msg, new MessageQueue(sourceTopic, RocketMqContainer.BROKER_NAME, 0));
+        }
+
+        long srcEndBeforeStart = getTopicMaxOffset(sourceTopic);
+        log.info("[Restore] srcEndBeforeStart={}, sourceTopic={}", srcEndBeforeStart, sourceTopic);
+
+        CompletableFuture<Container.ExecResult> firstJobFuture =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return container.executeJob(
+                                        "/rocketmq/rocketmq_source_restore.conf", jobId);
+                            } catch (Exception e) {
+                                log.error("First job execution exception", e);
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        Awaitility.await()
+                .pollDelay(5, TimeUnit.SECONDS)
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> true);
+
+        for (int i = 0; i < 10; i++) {
+            Message msg = new Message(sourceTopic, (payload + "_additional_" + i).getBytes());
+            producer.send(msg, new MessageQueue(sourceTopic, RocketMqContainer.BROKER_NAME, 0));
+        }
+
+        final long expectedSinkAfterFirstRun = srcEndBeforeStart + 10;
+        log.info(
+                "[Restore] expectedSinkAfterFirstRun={}, waiting for sinkTopic={}",
+                expectedSinkAfterFirstRun,
+                sinkTopic);
+        Awaitility.await()
+                .pollInterval(5, TimeUnit.SECONDS)
+                .atMost(3, TimeUnit.MINUTES)
+                .until(
+                        () -> {
+                            long current = getTopicMaxOffset(sinkTopic);
+                            log.info(
+                                    "[Restore] polling sinkTopic offset: current={}, expected={}",
+                                    current,
+                                    expectedSinkAfterFirstRun);
+                            return current >= expectedSinkAfterFirstRun;
+                        });
+
+        Container.ExecResult savepointResult = container.savepointJob(jobId);
+        Assertions.assertEquals(
+                0,
+                savepointResult.getExitCode(),
+                "Savepoint failed: " + savepointResult.getStderr());
+
+        Assertions.assertEquals(
+                0,
+                firstJobFuture.get().getExitCode(),
+                "First job should exit successfully after savepoint");
+
+        for (int i = 0; i < 15; i++) {
+            Message msg = new Message(sourceTopic, (payload + "_restore_" + i).getBytes());
+            producer.send(msg, new MessageQueue(sourceTopic, RocketMqContainer.BROKER_NAME, 0));
+        }
+
+        long srcEndAfterAll = getTopicMaxOffset(sourceTopic);
+        Assertions.assertTrue(
+                srcEndAfterAll >= srcEndBeforeStart + 25,
+                "Source end offset should advance by at least 25, actual: "
+                        + (srcEndAfterAll - srcEndBeforeStart));
+
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        container.restoreJob("/rocketmq/rocketmq_source_restore.conf", jobId);
+                    } catch (Exception e) {
+                        log.error("Restore job execution exception", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        Awaitility.await()
+                .pollDelay(3, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.MINUTES)
+                .until(() -> getTopicMaxOffset(sinkTopic) >= expectedSinkAfterFirstRun + 15);
+
+        Thread.sleep(5000);
+        long finalSinkOffset = getTopicMaxOffset(sinkTopic);
+        long expectedTotal = expectedSinkAfterFirstRun + 15;
+        Assertions.assertEquals(
+                expectedTotal,
+                finalSinkOffset,
+                "Sink offset mismatch after restore — possible duplicate consumption. "
+                        + "Expected: "
+                        + expectedTotal
+                        + ", actual: "
+                        + finalSinkOffset);
+
+        List<String> allSinkMessages = pollMessagesFromOffset(sinkTopic, 0);
+        long initialCount =
+                allSinkMessages.stream().filter(body -> body.contains("_initial_")).count();
+        long additionalCount =
+                allSinkMessages.stream().filter(body -> body.contains("_additional_")).count();
+        long restoreCount =
+                allSinkMessages.stream().filter(body -> body.contains("_restore_")).count();
+        Assertions.assertEquals(
+                20, initialCount, "Expected 20 '_initial_' messages, got: " + initialCount);
+        Assertions.assertEquals(
+                10,
+                additionalCount,
+                "Expected 10 '_additional_' messages, got: " + additionalCount);
+        Assertions.assertEquals(
+                15, restoreCount, "Expected 15 '_restore_' messages, got: " + restoreCount);
+    }
+
+    private List<String> pollMessagesFromOffset(String topicName, long fromOffset) {
+        List<String> result = new ArrayList<>();
+        try {
+            DefaultLitePullConsumer consumer =
+                    RocketMqAdminUtil.initDefaultLitePullConsumer(newConfiguration(), false);
+            consumer.start();
+            Map<MessageQueue, TopicOffset> queueOffsets =
+                    RetryUtils.retryWithException(
+                            () ->
+                                    RocketMqAdminUtil.offsetTopics(
+                                                    newConfiguration(),
+                                                    Lists.newArrayList(topicName))
+                                            .get(0),
+                            new RetryUtils.RetryMaterial(
+                                    Constant.OPERATION_RETRY_TIME,
+                                    false,
+                                    exception -> exception instanceof RocketMqConnectorException,
+                                    Constant.OPERATION_RETRY_SLEEP));
+            consumer.assign(queueOffsets.keySet());
+            for (MessageQueue mq : queueOffsets.keySet()) {
+                long seekTo = Math.max(fromOffset, queueOffsets.get(mq).getMinOffset());
+                consumer.seek(mq, seekTo);
+            }
+            long deadline = System.currentTimeMillis() + 15_000;
+            while (System.currentTimeMillis() < deadline) {
+                List<MessageExt> messages = consumer.poll(5000);
+                if (messages.isEmpty()) {
+                    break;
+                }
+                for (MessageExt msg : messages) {
+                    result.add(new String(msg.getBody(), StandardCharsets.UTF_8));
+                }
+            }
+            consumer.shutdown();
+        } catch (Exception e) {
+            log.warn("Failed to poll messages from {}: {}", topicName, e.getMessage(), e);
+        }
+        return result;
+    }
+
+    private long getTopicMaxOffset(String topicName) {
+        try {
+            List<Map<MessageQueue, TopicOffset>> offsetTopics =
+                    RocketMqAdminUtil.offsetTopics(
+                            newConfiguration(), Lists.newArrayList(topicName));
+            if (offsetTopics.isEmpty()) {
+                return 0;
+            }
+            Map<MessageQueue, TopicOffset> offsetMap = offsetTopics.get(0);
+            long total = 0;
+            for (TopicOffset offset : offsetMap.values()) {
+                total += offset.getMaxOffset();
+            }
+            return total;
+        } catch (Exception e) {
+            log.warn("Failed to get max offset for topic {}: {}", topicName, e.getMessage());
+            return 0;
+        }
     }
 
     private void deleteTopicIfExist(String topicName) {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/resources/rocketmq/rocketmq_source_restore.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/resources/rocketmq/rocketmq_source_restore.conf
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+  checkpoint.timeout = 60000
+}
+
+source {
+  Rocketmq {
+    name.srv.addr = "rocketmq-e2e:9876"
+    topics = "test_topic_restore"
+    plugin_output = "rocketmq_restore_table"
+    format = text
+    start.mode = "CONSUME_FROM_FIRST_OFFSET"
+    consumer.group = "restore_consumer_group"
+    schema = {
+      fields {
+        content = string
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  Rocketmq {
+    name.srv.addr = "rocketmq-e2e:9876"
+    topic = "test_topic_restore_output"
+    format = text
+    producer.send.sync = true
+  }
+}


### PR DESCRIPTION
## Purpose

This PR adds an E2E test for RocketMQ source checkpoint save/restore, covering the fix in #10752.

## What the test does

- Sends messages to a source topic, starts a streaming job, then sends more messages while the job is running
- Triggers a savepoint, sends additional messages, then restores the job from the savepoint
- Verifies that the restored job picks up only the new messages after savepoint (no duplicates, no data loss)
- Uses `assertEquals` on sink offset to catch any duplicate consumption caused by broken checkpoint restore

## Changes

- `RocketMqIT.java` — added `testSourceRocketMqRestore()` and helper `getTopicMaxOffset()`
- `rocketmq_source_restore.conf` — new config for the restore test (streaming mode with checkpoint)

## Note

Depends on #10752. Should be merged after that PR.
