### PR TITLE
[Improve][CI] Optimize changes job engine module calculation

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -256,6 +256,16 @@ jobs:
           if [[ "zz"$pl_modules == "zz" ]];then
             exit 0
           fi
+
+          engine_modules='${{ steps.engine-modules.outputs.modules }}'
+          connector_modules='${{ steps.cv2-modules.outputs.modules }}'
+          if [[ "zz"$connector_modules == "zz" && "zz"$engine_modules != "zz" ]];then
+            # Engine changes already route the full downstream engine test set through engine=true.
+            # Keep the fixed smoke modules as the output without resolving the Maven dependency tree.
+            echo $pl_modules
+            echo "modules=$pl_modules" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           
           ./mvnw help:evaluate -Dexpression=project.modules -q -DforceStdout -pl $pl_modules > /tmp/sub_module.txt
           sub_modules=`python tools/update_modules_check/update_modules_check.py sub /tmp/sub_module.txt`
@@ -284,6 +294,20 @@ jobs:
           fi
           
           if [[ "zz"$pl_modules == "zz" ]];then
+            exit 0
+          fi
+
+          engine_modules='${{ steps.engine-modules.outputs.modules }}'
+          connector_modules='${{ steps.cv2-modules.outputs.modules }}'
+          connector_modules="$connector_modules"'${{ steps.cv2-e2e-modules.outputs.modules }}'
+          connector_modules="$connector_modules"'${{ steps.cv2-flink-e2e-modules.outputs.modules }}'
+          connector_modules="$connector_modules"'${{ steps.cv2-spark-e2e-modules.outputs.modules }}'
+          engine_e2e_modules='${{ steps.engine-e2e-modules.outputs.modules }}'
+          if [[ "zz${connector_modules}${engine_e2e_modules}" == "zz" && "zz"$engine_modules != "zz" ]];then
+            # Engine changes already trigger the broad downstream integration jobs through engine=true.
+            # Avoid a second Maven dependency tree pass when no connector or engine-e2e module changed.
+            echo $pl_modules
+            echo "modules=$pl_modules" >> $GITHUB_OUTPUT
             exit 0
           fi
           


### PR DESCRIPTION

This change optimizes the `changes` CI job by avoiding unnecessary Maven dependency tree resolution for engine-only updates. Previously, the job combined file change detection with affected-module calculation, which could add several minutes of overhead even when the downstream engine test scope was already fixed. With this update, engine-only changes take a fast path and return the predefined smoke modules directly, while mixed changes still use the original dependency-based module resolution to preserve coverage.


## Purpose

The `changes` workflow job currently spends most of its time in Maven dependency tree resolution when a change only touches engine files. Existing samples show this path can take 7-9 minutes even though engine changes already route broad downstream CI through `engine=true`.

## Changes

- Add a fast path for pure engine changes in `Make unit test modules`.
- Add the same fast path in `Make integration test modules` when no connector or engine-e2e module changed.
- Preserve the existing fixed engine smoke module outputs so downstream conditions remain compatible.

## Validation

- `git diff --check`
- Ruby YAML parse for `.github/workflows/backend.yml`
- Engine helper mapping check for `connector-seatunnel-e2e-base` and `connector-console-seatunnel-e2e`
- Bash simulation for engine-only and mixed engine+connector routing
- `./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true`
- `./mvnw -q -DskipTests verify -Dskip.ui=true -Dlicense.skipAddThirdParty=true -nsu -Dmaven.gitcommitid.skip=true -T 3C`
