### PR TITLE
[Fix][CI] Increase all-connectors-it-5 timeout

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -895,7 +895,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 180
+    timeout-minutes: 270
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
### Purpose

The `all-connectors-it-5` GitHub Actions job repeatedly hit the configured 180-minute job timeout while checking PR #10780.

Observed evidence from run `24603834085` attempt 3:
- `Run / all-connectors-it-5 (11, ubuntu-latest)` started at `2026-04-19T05:03:51Z` and was cancelled at `2026-04-19T08:04:06Z`.
- `Run / all-connectors-it-5 (8, ubuntu-latest)` started at `2026-04-19T05:03:51Z` and was cancelled at `2026-04-19T08:04:06Z`.
- The cancelled step in both jobs was `run connector-v2 integration test (part-5)`.

This connector group contains heavy modules such as ClickHouse, Elasticsearch, Iceberg S3, MaxCompute, Postgres CDC, SLS, and HugeGraph. The timeout is unrelated to the DB2 CDC/JDBC changes in #10780.

### Changes

- Increase `all-connectors-it-5` timeout from 180 minutes to 270 minutes.
- Keep it consistent with the existing heavy `all-connectors-it-4` job timeout.

### Tests

- `./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true -T 3C`
- `git diff --check`
- `./mvnw -q -DskipTests verify -nsu -Dmaven.gitcommitid.skip=true -T 3C`