### PR TITLE
[Fix][CI] Increase test timeout

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -146,7 +146,7 @@ public class CoordinatorServiceTest {
         // 1) Terminate the real job first.
         coordinatorService.cancelJob(jobId).join();
 
-        await().atMost(30, TimeUnit.SECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertEquals(
@@ -189,7 +189,7 @@ public class CoordinatorServiceTest {
         // 3) Trigger master switch.
         instance1.shutdown();
 
-        await().atMost(20, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertTrue(server2.isMasterNode());
@@ -203,7 +203,7 @@ public class CoordinatorServiceTest {
         IMap<Object, Object> runningJobStateOnInstance2 =
                 instance2.getMap(Constant.IMAP_RUNNING_JOB_STATE);
 
-        await().atMost(20, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertFalse(
@@ -216,8 +216,8 @@ public class CoordinatorServiceTest {
 
         // 5) The important assertion:
         // terminal zombie metadata must NOT cause tasks to start running again.
-        await().during(10000, TimeUnit.MILLISECONDS)
-                .atMost(12000, TimeUnit.MILLISECONDS)
+        await().during(10, TimeUnit.SECONDS)
+                .atMost(20, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             for (TaskGroupLocation location : taskGroupLocations) {


### PR DESCRIPTION
### Purpose of this pull request

`testTerminalZombieJobShouldNotRestartAfterMasterSwitch()` has a relatively short timeout, which may lead to intermittent failures in the CI environment. This PR increases the timeout to make the test more stable.

```
[ERROR]   CoordinatorServiceTest.testTerminalZombieJobShouldNotRestartAfterMasterSwitch:150 ConditionTimeout
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)