### PR TITLE
[Fix][Zeta] CleanLogOperation receives jobId=0 in separated cluster mode

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerService.java
@@ -44,16 +44,17 @@ public class TaskLogManagerService {
     }
 
     public void clean(long jobId) {
-        log.info("Cleaning logs for jobId: {} , path : {}", jobId, path);
-        if (path == null) {
+        if (path == null || jobId <= 0) {
             return;
         }
         String[] logFiles = getLogFiles(jobId, path);
         for (String logFile : logFiles) {
+            String logPath = path + "/" + logFile;
+            log.info("Cleaning logs for jobId: {} , path : {}", jobId, logPath);
             try {
-                Files.delete(Paths.get(path + "/" + logFile));
+                Files.delete(Paths.get(logPath));
             } catch (IOException e) {
-                log.warn("Failed to delete log file: {}", logFile, e);
+                log.warn("Failed to delete log file: {}", logPath, e);
             }
         }
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/operation/CleanLogOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/operation/CleanLogOperation.java
@@ -22,7 +22,11 @@ import org.apache.seatunnel.engine.server.serializable.TaskDataSerializerHook;
 import org.apache.seatunnel.engine.server.task.operation.TracingOperation;
 import org.apache.seatunnel.engine.server.telemetry.log.TaskLogManagerService;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
 
 public class CleanLogOperation extends TracingOperation implements IdentifiedDataSerializable {
 
@@ -42,6 +46,18 @@ public class CleanLogOperation extends TracingOperation implements IdentifiedDat
         if (taskLogManagerService != null) {
             taskLogManagerService.clean(jobId);
         }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeLong(jobId);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        this.jobId = in.readLong();
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerServiceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.telemetry.log;
+
+import org.apache.seatunnel.common.utils.ReflectionUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TaskLogManagerServiceTest {
+
+    @TempDir Path tempDir;
+
+    private TaskLogManagerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TaskLogManagerService(null);
+        ReflectionUtils.setField(service, "path", tempDir.toString());
+    }
+
+    @Test
+    void testCleanDoesNothingWhenJobIdIsZero() throws IOException {
+        Path logFile = tempDir.resolve("job-1111022.log");
+        Files.write(logFile, "test log content".getBytes(StandardCharsets.UTF_8));
+
+        service.clean(0);
+
+        assertTrue(Files.exists(logFile), "Log file should NOT be deleted when jobId is 0");
+    }
+
+    @Test
+    void testCleanDeletesMatchingLogFiles() throws IOException {
+        long jobId = 12345L;
+        Path matchFile1 = tempDir.resolve("seatunnel-" + jobId + "-task-1.log");
+        Path matchFile2 = tempDir.resolve("worker-" + jobId + "-task-2.log");
+        Path otherFile = tempDir.resolve("seatunnel-99999-task.log");
+
+        Files.write(matchFile1, "log1".getBytes(StandardCharsets.UTF_8));
+        Files.write(matchFile2, "log2".getBytes(StandardCharsets.UTF_8));
+        Files.write(otherFile, "other".getBytes(StandardCharsets.UTF_8));
+
+        service.clean(jobId);
+
+        assertFalse(Files.exists(matchFile1), "Log file containing jobId should be deleted");
+        assertFalse(Files.exists(matchFile2), "Log file containing jobId should be deleted");
+        assertTrue(Files.exists(otherFile), "Log file not matching jobId should be preserved");
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/log/operation/CleanLogOperationSerializationTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/log/operation/CleanLogOperationSerializationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.telemetry.log.operation;
+
+import org.apache.seatunnel.common.utils.ReflectionUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.internal.serialization.Data;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that CleanLogOperation correctly preserves jobId through Hazelcast serialization
+ * round-trip (writeInternal / readInternal).
+ *
+ * <p>This is critical in split-deployment mode where the operation is serialized on the master node
+ * and deserialized on the worker node. Without proper writeInternal/readInternal, the worker
+ * receives jobId=0.
+ */
+public class CleanLogOperationSerializationTest {
+
+    private InternalSerializationService serializationService;
+
+    @BeforeEach
+    void setUp() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @Test
+    void testJobIdIsPreservedAfterSerialization() {
+        long expectedJobId = 123456789L;
+
+        CleanLogOperation original = new CleanLogOperation(expectedJobId);
+        Data data = serializationService.toData(original);
+
+        CleanLogOperation deserialized = serializationService.toObject(data);
+        Long jobId =
+                ReflectionUtils.getField(deserialized, "jobId")
+                        .map(field -> (long) field)
+                        .orElseThrow(
+                                () -> new RuntimeException("Failed to read jobId via reflection"));
+
+        assertEquals(expectedJobId, jobId);
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
In separated cluster mode, `CleanLogOperation` is serialized on the master node and deserialized on the worker node. Since `jobId` was not included in `writeInternal`/`readInternal`, the worker always received `jobId=0`, causing all log files whose name contains "0" to be deleted by mistake.

#### Root Cause
`CleanLogOperation` extends `TracingOperation` which extends Hazelcast `Operation`. When Hazelcast deserializes an `IdentifiedDataSerializable` on a remote node, it uses the no-arg constructor and then calls `readInternal` to restore fields. Since `CleanLogOperation` did not override these methods, the `jobId` field defaulted to `0` after deserialization. The `getLogFiles` method uses `name.contains(String.valueOf(jobId))` as the filter, so `jobId=0` matches nearly every log file in the directory.

#### Changes:
- Add `writeInternal/readInternal` to `CleanLogOperation` to properly
  serialize jobId across Hazelcast nodes
- Add boundary guard `(path == null || jobId <= 0)` in
  `TaskLogManagerService.clean()` to prevent invalid cleanup attempts

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
No

### How was this patch tested?

Added unit tests:

- `CleanLogOperationSerializationTest`: Verifies `jobId` is preserved through Hazelcast `SerializationService` round-trip (serialize via `writeInternal`, deserialize via `readInternal`). Tests normal `jobId` value.
- `TaskLogManagerServiceTest`: Verifies the boundary guard in `clean(long jobId)`:
  - `jobId=0`: guard takes effect, no files deleted
  - Normal `jobId`: matching log files are deleted, unrelated files are preserved

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)