### PR TITLE
[Feature][Connector-V2] Refactoring to have per-connector version management of Debezium

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import java.util.Collection;
+
+/**
+ * SPI for connector-specific Debezium implementations. Loaded via {@link java.util.ServiceLoader}.
+ */
+public interface DebeziumAdapter {
+
+    DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config);
+
+    DebeziumSchemaHistory createSchemaHistory(
+            String instanceName, Collection<TableChangeInfo> tableChanges);
+
+    DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix);
+
+    String getDebeziumVersion();
+
+    boolean supports(String connectorType);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapterFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapterFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Factory for loading connector-specific Debezium adapters via ServiceLoader. */
+public class DebeziumAdapterFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DebeziumAdapterFactory.class);
+
+    private static final Map<String, DebeziumAdapter> ADAPTERS = new ConcurrentHashMap<>();
+
+    public static DebeziumAdapter getAdapter(String connectorType) {
+        return ADAPTERS.computeIfAbsent(
+                connectorType,
+                type -> {
+                    LOG.info("Loading DebeziumAdapter for connector type: {}", type);
+                    ServiceLoader<DebeziumAdapter> loader =
+                            ServiceLoader.load(DebeziumAdapter.class);
+
+                    for (DebeziumAdapter adapter : loader) {
+                        if (adapter.supports(type)) {
+                            LOG.info(
+                                    "Found DebeziumAdapter for {}: {} (Debezium version: {})",
+                                    type,
+                                    adapter.getClass().getName(),
+                                    adapter.getDebeziumVersion());
+                            return adapter;
+                        }
+                    }
+
+                    throw new IllegalStateException(
+                            "No DebeziumAdapter found for connector type: "
+                                    + type
+                                    + ". Ensure META-INF/services configuration is present.");
+                });
+    }
+
+    public static void clearCache() {
+        ADAPTERS.clear();
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcher.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import java.util.Map;
+
+/** @param <P> Partition type */
+public interface DebeziumEventDispatcher<P> {
+
+    void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset offset)
+            throws InterruptedException;
+
+    Object getQueue();
+
+    String getPrimaryTopic();
+
+    void close();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcherConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcherConfig.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+/** Configuration for creating event dispatchers. */
+public class DebeziumEventDispatcherConfig {
+
+    private final Object connectorConfig;
+    private final DebeziumTopicNaming<?> topicNaming;
+    private final Object databaseSchema;
+    private final Object queue;
+    private final Object dataCollectionFilter;
+    private final Object changeEventCreator;
+    private final Object metadataProvider;
+    private final Object heartbeatFactory;
+    private final Object schemaNameAdjuster;
+
+    private DebeziumEventDispatcherConfig(Builder builder) {
+        this.connectorConfig = builder.connectorConfig;
+        this.topicNaming = builder.topicNaming;
+        this.databaseSchema = builder.databaseSchema;
+        this.queue = builder.queue;
+        this.dataCollectionFilter = builder.dataCollectionFilter;
+        this.changeEventCreator = builder.changeEventCreator;
+        this.metadataProvider = builder.metadataProvider;
+        this.heartbeatFactory = builder.heartbeatFactory;
+        this.schemaNameAdjuster = builder.schemaNameAdjuster;
+    }
+
+    public Object getConnectorConfig() {
+        return connectorConfig;
+    }
+
+    public DebeziumTopicNaming<?> getTopicNaming() {
+        return topicNaming;
+    }
+
+    public Object getDatabaseSchema() {
+        return databaseSchema;
+    }
+
+    public Object getQueue() {
+        return queue;
+    }
+
+    public Object getDataCollectionFilter() {
+        return dataCollectionFilter;
+    }
+
+    public Object getChangeEventCreator() {
+        return changeEventCreator;
+    }
+
+    public Object getMetadataProvider() {
+        return metadataProvider;
+    }
+
+    public Object getHeartbeatFactory() {
+        return heartbeatFactory;
+    }
+
+    public Object getSchemaNameAdjuster() {
+        return schemaNameAdjuster;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for DebeziumEventDispatcherConfig */
+    public static class Builder {
+        private Object connectorConfig;
+        private DebeziumTopicNaming<?> topicNaming;
+        private Object databaseSchema;
+        private Object queue;
+        private Object dataCollectionFilter;
+        private Object changeEventCreator;
+        private Object metadataProvider;
+        private Object heartbeatFactory;
+        private Object schemaNameAdjuster;
+
+        public Builder connectorConfig(Object connectorConfig) {
+            this.connectorConfig = connectorConfig;
+            return this;
+        }
+
+        public Builder topicNaming(DebeziumTopicNaming<?> topicNaming) {
+            this.topicNaming = topicNaming;
+            return this;
+        }
+
+        public Builder databaseSchema(Object databaseSchema) {
+            this.databaseSchema = databaseSchema;
+            return this;
+        }
+
+        public Builder queue(Object queue) {
+            this.queue = queue;
+            return this;
+        }
+
+        public Builder dataCollectionFilter(Object dataCollectionFilter) {
+            this.dataCollectionFilter = dataCollectionFilter;
+            return this;
+        }
+
+        public Builder changeEventCreator(Object changeEventCreator) {
+            this.changeEventCreator = changeEventCreator;
+            return this;
+        }
+
+        public Builder metadataProvider(Object metadataProvider) {
+            this.metadataProvider = metadataProvider;
+            return this;
+        }
+
+        public Builder heartbeatFactory(Object heartbeatFactory) {
+            this.heartbeatFactory = heartbeatFactory;
+            return this;
+        }
+
+        public Builder schemaNameAdjuster(Object schemaNameAdjuster) {
+            this.schemaNameAdjuster = schemaNameAdjuster;
+            return this;
+        }
+
+        public DebeziumEventDispatcherConfig build() {
+            return new DebeziumEventDispatcherConfig(this);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumSchemaHistory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumSchemaHistory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface DebeziumSchemaHistory {
+
+    void registerHistory(String instanceName, Collection<TableChangeInfo> changes);
+
+    Collection<TableChangeInfo> removeHistory(String instanceName);
+
+    void configure(Map<String, ?> config);
+
+    void start();
+
+    void stop();
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumTopicNaming.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumTopicNaming.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+/** @param <T> Table identifier type */
+public interface DebeziumTopicNaming<T> {
+
+    String getPrimaryTopic();
+
+    String getHeartbeatTopic();
+
+    String dataChangeTopicName(T tableId);
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/TableChangeInfo.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/debezium/TableChangeInfo.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class TableChangeInfo implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public enum TableChangeType {
+        CREATE,
+        ALTER,
+        DROP
+    }
+
+    private final Object tableId;
+    private final TableChangeType changeType;
+    private final byte[] serializedTableSchema;
+
+    public TableChangeInfo(
+            Object tableId, TableChangeType changeType, byte[] serializedTableSchema) {
+        this.tableId = tableId;
+        this.changeType = changeType;
+        this.serializedTableSchema = serializedTableSchema;
+    }
+
+    public Object getTableId() {
+        return tableId;
+    }
+
+    public TableChangeType getChangeType() {
+        return changeType;
+    }
+
+    public byte[] getSerializedTableSchema() {
+        return serializedTableSchema;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableChangeInfo that = (TableChangeInfo) o;
+        return Objects.equals(tableId, that.tableId) && changeType == that.changeType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, changeType);
+    }
+
+    @Override
+    public String toString() {
+        return "TableChangeInfo{"
+                + "tableId="
+                + tableId
+                + ", changeType="
+                + changeType
+                + ", schemaSize="
+                + (serializedTableSchema != null ? serializedTableSchema.length : 0)
+                + '}';
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/JdbcSourceEventDispatcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/relational/JdbcSourceEventDispatcher.java
@@ -84,6 +84,10 @@ public class JdbcSourceEventDispatcher<P extends Partition> extends EventDispatc
         return queue;
     }
 
+    public String getPrimaryTopic() {
+        return topic;
+    }
+
     public void dispatchWatermarkEvent(
             Map<String, ?> sourcePartition,
             SourceSplitBase sourceSplit,

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapterFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumAdapterFactoryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** Unit tests for DebeziumAdapterFactory */
+public class DebeziumAdapterFactoryTest {
+
+    @BeforeEach
+    public void setUp() {
+        // Clear cache before each test
+        DebeziumAdapterFactory.clearCache();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Clear cache after each test
+        DebeziumAdapterFactory.clearCache();
+    }
+
+    @Test
+    public void testGetAdapterWithMockImplementation() {
+        // This test will only work if a mock adapter is registered via ServiceLoader
+        // Since we're in the base module without concrete implementations,
+        // we test the exception case
+        try {
+            DebeziumAdapterFactory.getAdapter("nonexistent-connector");
+            fail("Expected IllegalStateException for unknown connector type");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("No DebeziumAdapter found"));
+            assertTrue(e.getMessage().contains("nonexistent-connector"));
+        }
+    }
+
+    @Test
+    public void testClearCache() {
+        // First call should trigger ServiceLoader
+        try {
+            DebeziumAdapterFactory.getAdapter("test-connector");
+        } catch (IllegalStateException e) {
+            // Expected - no adapter registered
+        }
+
+        // Clear the cache
+        DebeziumAdapterFactory.clearCache();
+
+        // Second call should trigger ServiceLoader again
+        try {
+            DebeziumAdapterFactory.getAdapter("test-connector");
+        } catch (IllegalStateException e) {
+            // Expected - no adapter registered
+            assertTrue(e.getMessage().contains("No DebeziumAdapter found"));
+        }
+    }
+
+    @Test
+    public void testAdapterCaching() {
+        // Create a mock adapter that can be registered
+        MockDebeziumAdapter mockAdapter = new MockDebeziumAdapter("test");
+
+        // Manually register it (simulating what ServiceLoader would do)
+        // Since we can't actually use ServiceLoader in unit tests without
+        // META-INF/services files, this test validates the caching logic
+
+        // For now, this test just validates the exception behavior
+        try {
+            DebeziumAdapter adapter = DebeziumAdapterFactory.getAdapter("test");
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            // Expected when no adapter is registered
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    /** Mock implementation for testing */
+    private static class MockDebeziumAdapter implements DebeziumAdapter {
+        private final String connectorType;
+
+        public MockDebeziumAdapter(String connectorType) {
+            this.connectorType = connectorType;
+        }
+
+        @Override
+        public DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config) {
+            return null;
+        }
+
+        @Override
+        public DebeziumSchemaHistory createSchemaHistory(
+                String instanceName, java.util.Collection<TableChangeInfo> tableChanges) {
+            return null;
+        }
+
+        @Override
+        public DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix) {
+            return null;
+        }
+
+        @Override
+        public String getDebeziumVersion() {
+            return "1.9.8-test";
+        }
+
+        @Override
+        public boolean supports(String connectorType) {
+            return this.connectorType.equals(connectorType);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcherConfigTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/DebeziumEventDispatcherConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** Unit tests for DebeziumEventDispatcherConfig */
+public class DebeziumEventDispatcherConfigTest {
+
+    @Test
+    public void testBuilderWithAllFields() {
+        Object connectorConfig = new Object();
+        MockTopicNaming topicNaming = new MockTopicNaming();
+        Object databaseSchema = new Object();
+        Object queue = new Object();
+        Object dataCollectionFilter = new Object();
+        Object changeEventCreator = new Object();
+        Object metadataProvider = new Object();
+        Object heartbeatFactory = new Object();
+        Object schemaNameAdjuster = new Object();
+
+        DebeziumEventDispatcherConfig config =
+                DebeziumEventDispatcherConfig.builder()
+                        .connectorConfig(connectorConfig)
+                        .topicNaming(topicNaming)
+                        .databaseSchema(databaseSchema)
+                        .queue(queue)
+                        .dataCollectionFilter(dataCollectionFilter)
+                        .changeEventCreator(changeEventCreator)
+                        .metadataProvider(metadataProvider)
+                        .heartbeatFactory(heartbeatFactory)
+                        .schemaNameAdjuster(schemaNameAdjuster)
+                        .build();
+
+        assertNotNull(config);
+        assertEquals(connectorConfig, config.getConnectorConfig());
+        assertEquals(topicNaming, config.getTopicNaming());
+        assertEquals(databaseSchema, config.getDatabaseSchema());
+        assertEquals(queue, config.getQueue());
+        assertEquals(dataCollectionFilter, config.getDataCollectionFilter());
+        assertEquals(changeEventCreator, config.getChangeEventCreator());
+        assertEquals(metadataProvider, config.getMetadataProvider());
+        assertEquals(heartbeatFactory, config.getHeartbeatFactory());
+        assertEquals(schemaNameAdjuster, config.getSchemaNameAdjuster());
+    }
+
+    @Test
+    public void testBuilderWithPartialFields() {
+        MockTopicNaming topicNaming = new MockTopicNaming();
+        Object queue = new Object();
+
+        DebeziumEventDispatcherConfig config =
+                DebeziumEventDispatcherConfig.builder()
+                        .topicNaming(topicNaming)
+                        .queue(queue)
+                        .build();
+
+        assertNotNull(config);
+        assertNull(config.getConnectorConfig());
+        assertEquals(topicNaming, config.getTopicNaming());
+        assertNull(config.getDatabaseSchema());
+        assertEquals(queue, config.getQueue());
+        assertNull(config.getDataCollectionFilter());
+        assertNull(config.getChangeEventCreator());
+        assertNull(config.getMetadataProvider());
+        assertNull(config.getHeartbeatFactory());
+        assertNull(config.getSchemaNameAdjuster());
+    }
+
+    @Test
+    public void testBuilderReuse() {
+        MockTopicNaming topicNaming1 = new MockTopicNaming();
+        MockTopicNaming topicNaming2 = new MockTopicNaming();
+
+        DebeziumEventDispatcherConfig.Builder builder =
+                DebeziumEventDispatcherConfig.builder().topicNaming(topicNaming1);
+
+        DebeziumEventDispatcherConfig config1 = builder.build();
+        assertEquals(topicNaming1, config1.getTopicNaming());
+
+        // Reuse builder with different value
+        DebeziumEventDispatcherConfig config2 = builder.topicNaming(topicNaming2).build();
+        assertEquals(topicNaming2, config2.getTopicNaming());
+    }
+
+    @Test
+    public void testEmptyBuilder() {
+        DebeziumEventDispatcherConfig config = DebeziumEventDispatcherConfig.builder().build();
+
+        assertNotNull(config);
+        assertNull(config.getConnectorConfig());
+        assertNull(config.getTopicNaming());
+        assertNull(config.getDatabaseSchema());
+        assertNull(config.getQueue());
+        assertNull(config.getDataCollectionFilter());
+        assertNull(config.getChangeEventCreator());
+        assertNull(config.getMetadataProvider());
+        assertNull(config.getHeartbeatFactory());
+        assertNull(config.getSchemaNameAdjuster());
+    }
+
+    /** Mock implementation of DebeziumTopicNaming for testing */
+    private static class MockTopicNaming implements DebeziumTopicNaming<Object> {
+        @Override
+        public String getPrimaryTopic() {
+            return "primary-topic";
+        }
+
+        @Override
+        public String getHeartbeatTopic() {
+            return "heartbeat-topic";
+        }
+
+        @Override
+        public String dataChangeTopicName(Object tableId) {
+            return "data-change-topic";
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/TableChangeInfoTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/debezium/TableChangeInfoTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.debezium;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for TableChangeInfo */
+public class TableChangeInfoTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        String tableId = "db.schema.table";
+        TableChangeInfo.TableChangeType changeType = TableChangeInfo.TableChangeType.CREATE;
+        byte[] schema = "{\"type\":\"table\"}".getBytes();
+
+        TableChangeInfo info = new TableChangeInfo(tableId, changeType, schema);
+
+        assertEquals(tableId, info.getTableId());
+        assertEquals(changeType, info.getChangeType());
+        assertArrayEquals(schema, info.getSerializedTableSchema());
+    }
+
+    @Test
+    public void testTableChangeTypes() {
+        // Verify all enum values exist
+        assertEquals(3, TableChangeInfo.TableChangeType.values().length);
+        assertNotNull(TableChangeInfo.TableChangeType.CREATE);
+        assertNotNull(TableChangeInfo.TableChangeType.ALTER);
+        assertNotNull(TableChangeInfo.TableChangeType.DROP);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        String tableId = "db.schema.table";
+        TableChangeInfo.TableChangeType changeType = TableChangeInfo.TableChangeType.CREATE;
+        byte[] schema1 = "{\"type\":\"table\"}".getBytes();
+        byte[] schema2 = "{\"type\":\"different\"}".getBytes();
+
+        TableChangeInfo info1 = new TableChangeInfo(tableId, changeType, schema1);
+        TableChangeInfo info2 = new TableChangeInfo(tableId, changeType, schema2);
+        TableChangeInfo info3 = new TableChangeInfo("different.table", changeType, schema1);
+
+        // Same tableId and changeType should be equal
+        assertEquals(info1, info2);
+        assertEquals(info1.hashCode(), info2.hashCode());
+
+        // Different tableId should not be equal
+        assertNotEquals(info1, info3);
+    }
+
+    @Test
+    public void testEqualsSameObject() {
+        TableChangeInfo info =
+                new TableChangeInfo("table", TableChangeInfo.TableChangeType.CREATE, new byte[0]);
+        assertEquals(info, info);
+    }
+
+    @Test
+    public void testEqualsNull() {
+        TableChangeInfo info =
+                new TableChangeInfo("table", TableChangeInfo.TableChangeType.CREATE, new byte[0]);
+        assertNotEquals(info, null);
+    }
+
+    @Test
+    public void testEqualsDifferentClass() {
+        TableChangeInfo info =
+                new TableChangeInfo("table", TableChangeInfo.TableChangeType.CREATE, new byte[0]);
+        assertNotEquals(info, "not a TableChangeInfo");
+    }
+
+    @Test
+    public void testToString() {
+        String tableId = "db.schema.table";
+        TableChangeInfo.TableChangeType changeType = TableChangeInfo.TableChangeType.ALTER;
+        byte[] schema = new byte[100];
+
+        TableChangeInfo info = new TableChangeInfo(tableId, changeType, schema);
+        String str = info.toString();
+
+        assertTrue(str.contains("TableChangeInfo"));
+        assertTrue(str.contains(tableId));
+        assertTrue(str.contains("ALTER"));
+        assertTrue(str.contains("100"));
+    }
+
+    @Test
+    public void testToStringWithNullSchema() {
+        TableChangeInfo info =
+                new TableChangeInfo("table", TableChangeInfo.TableChangeType.DROP, null);
+        String str = info.toString();
+
+        assertTrue(str.contains("TableChangeInfo"));
+        assertTrue(str.contains("DROP"));
+        assertTrue(str.contains("0"));
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        String tableId = "db.schema.table";
+        TableChangeInfo.TableChangeType changeType = TableChangeInfo.TableChangeType.CREATE;
+        byte[] schema = "{\"columns\":[]}".getBytes();
+
+        TableChangeInfo original = new TableChangeInfo(tableId, changeType, schema);
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        TableChangeInfo deserialized = (TableChangeInfo) ois.readObject();
+        ois.close();
+
+        // Verify
+        assertEquals(original, deserialized);
+        assertEquals(original.getTableId(), deserialized.getTableId());
+        assertEquals(original.getChangeType(), deserialized.getChangeType());
+        assertArrayEquals(
+                original.getSerializedTableSchema(), deserialized.getSerializedTableSchema());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/pom.xml
@@ -29,6 +29,7 @@
     <name>SeaTunnel : Connectors V2 : CDC : Mongodb</name>
 
     <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
         <mongo.driver.version>4.7.1</mongo.driver.version>
         <avro.version>1.11.3</avro.version>
         <mongo-kafka-connect.version>1.10.1</mongo-kafka-connect.version>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>connector-cdc-mysql</artifactId>
     <name>SeaTunnel : Connectors V2 : CDC : MySql</name>
 
+    <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlDebeziumAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlDebeziumAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+
+import java.util.Collection;
+
+public class MySqlDebeziumAdapter implements DebeziumAdapter {
+
+    private static final String DEBEZIUM_VERSION = "1.9.8.Final";
+    private static final String CONNECTOR_TYPE = "mysql";
+
+    @Override
+    public DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config) {
+        return new MySqlEventDispatcherAdapter(config);
+    }
+
+    @Override
+    public DebeziumSchemaHistory createSchemaHistory(
+            String instanceName, Collection<TableChangeInfo> tableChanges) {
+        return new MySqlSchemaHistoryAdapter(instanceName, tableChanges);
+    }
+
+    @Override
+    public DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix) {
+        throw new UnsupportedOperationException(
+                "MySQL connector does not use adapter for topic naming");
+    }
+
+    @Override
+    public String getDebeziumVersion() {
+        return DEBEZIUM_VERSION;
+    }
+
+    @Override
+    public boolean supports(String connectorType) {
+        return CONNECTOR_TYPE.equalsIgnoreCase(connectorType);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlEventDispatcherAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlEventDispatcherAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionFilters.DataCollectionFilter;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+
+public class MySqlEventDispatcherAdapter implements DebeziumEventDispatcher<MySqlPartition> {
+
+    private final JdbcSourceEventDispatcher<MySqlPartition> delegate;
+
+    @SuppressWarnings("unchecked")
+    public MySqlEventDispatcherAdapter(DebeziumEventDispatcherConfig config) {
+        CommonConnectorConfig connectorConfig = (CommonConnectorConfig) config.getConnectorConfig();
+        TopicSelector<TableId> topicSelector = (TopicSelector<TableId>) config.getTopicNaming();
+        DatabaseSchema<TableId> schema = (DatabaseSchema<TableId>) config.getDatabaseSchema();
+        ChangeEventQueue<DataChangeEvent> queue =
+                (ChangeEventQueue<DataChangeEvent>) config.getQueue();
+        DataCollectionFilter<TableId> filter =
+                (DataCollectionFilter<TableId>) config.getDataCollectionFilter();
+        ChangeEventCreator changeEventCreator = (ChangeEventCreator) config.getChangeEventCreator();
+        EventMetadataProvider metadataProvider =
+                (EventMetadataProvider) config.getMetadataProvider();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                (HeartbeatFactory<TableId>) config.getHeartbeatFactory();
+        SchemaNameAdjuster schemaNameAdjuster = (SchemaNameAdjuster) config.getSchemaNameAdjuster();
+
+        this.delegate =
+                new JdbcSourceEventDispatcher<>(
+                        connectorConfig,
+                        topicSelector,
+                        schema,
+                        queue,
+                        filter,
+                        changeEventCreator,
+                        metadataProvider,
+                        heartbeatFactory,
+                        schemaNameAdjuster);
+    }
+
+    @Override
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset offset)
+            throws InterruptedException {
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, getPrimaryTopic(), splitId, watermarkKind, offset);
+        ChangeEventQueue<DataChangeEvent> queue = (ChangeEventQueue<DataChangeEvent>) getQueue();
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+
+    @Override
+    public Object getQueue() {
+        return delegate.getQueue();
+    }
+
+    @Override
+    public String getPrimaryTopic() {
+        return delegate.getPrimaryTopic();
+    }
+
+    @Override
+    public void close() {}
+
+    public JdbcSourceEventDispatcher<MySqlPartition> getDelegate() {
+        return delegate;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlSchemaHistoryAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/adapter/MySqlSchemaHistoryAdapter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+import org.apache.seatunnel.connectors.cdc.debezium.ConnectTableChangeSerializer;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import io.debezium.relational.history.TableChanges;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MySqlSchemaHistoryAdapter implements DebeziumSchemaHistory {
+
+    private final String instanceName;
+    private final Collection<TableChangeInfo> initialChanges;
+    private final ConnectTableChangeSerializer tableChangeSerializer;
+    private final JsonConverter jsonConverter;
+
+    public MySqlSchemaHistoryAdapter(String instanceName, Collection<TableChangeInfo> changes) {
+        this.instanceName = instanceName;
+        this.initialChanges = changes;
+        this.tableChangeSerializer = new ConnectTableChangeSerializer();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", true), false);
+    }
+
+    @Override
+    public void registerHistory(String instanceName, Collection<TableChangeInfo> changes) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                changes.stream()
+                        .map(this::convertToDebeziumTableChange)
+                        .collect(Collectors.toList());
+
+        EmbeddedDatabaseHistory.registerHistory(instanceName, debeziumChanges);
+    }
+
+    @Override
+    public Collection<TableChangeInfo> removeHistory(String instanceName) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                EmbeddedDatabaseHistory.removeHistory(instanceName);
+
+        return debeziumChanges.stream()
+                .map(this::convertFromDebeziumTableChange)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {}
+
+    @Override
+    public void start() {
+        if (initialChanges != null && !initialChanges.isEmpty()) {
+            registerHistory(instanceName, initialChanges);
+        }
+    }
+
+    @Override
+    public void stop() {
+        removeHistory(instanceName);
+    }
+
+    private TableChanges.TableChange convertToDebeziumTableChange(TableChangeInfo info) {
+        SchemaAndValue schemaAndValue =
+                jsonConverter.toConnectData("topic", info.getSerializedTableSchema());
+        Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+        TableChanges tableChanges =
+                tableChangeSerializer.deserialize(
+                        Collections.singletonList(deserializedStruct), false);
+
+        Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+        TableChanges.TableChange tableChange = null;
+        while (iterator.hasNext()) {
+            if (tableChange != null) {
+                throw new IllegalStateException("The table changes should only have one element");
+            }
+            tableChange = iterator.next();
+        }
+
+        if (tableChange == null) {
+            throw new IllegalStateException("No table change found in deserialized data");
+        }
+
+        return tableChange;
+    }
+
+    private TableChangeInfo convertFromDebeziumTableChange(TableChanges.TableChange change) {
+        TableChangeInfo.TableChangeType type = convertChangeType(change.getType());
+
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serializedStructs = tableChangeSerializer.serialize(tableChanges);
+
+        byte[] serialized;
+        if (serializedStructs.isEmpty()) {
+            serialized = new byte[0];
+        } else {
+            Struct struct = serializedStructs.get(0);
+            serialized = jsonConverter.fromConnectData("topic", struct.schema(), struct);
+        }
+
+        return new TableChangeInfo(change.getId(), type, serialized);
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/reader/fetch/MySqlSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/reader/fetch/MySqlSourceFetchTaskContext.java
@@ -21,12 +21,19 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapterFactory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
 import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
 import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.adapter.MySqlEventDispatcherAdapter;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config.MySqlSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.offset.BinlogOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.utils.MySqlConnectionUtils;
@@ -67,6 +74,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
@@ -75,6 +83,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -93,6 +102,7 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     private final MySqlConnection connection;
     private final BinaryLogClient binaryLogClient;
     private final MySqlEventMetadataProvider metadataProvider;
+    private DebeziumAdapter adapter;
     private MySqlDatabaseSchema databaseSchema;
     private MySqlTaskContextImpl taskContext;
     private MySqlOffsetContext offsetContext;
@@ -118,9 +128,11 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     public void configure(SourceSplitBase sourceSplitBase) {
         super.registerDatabaseHistory(sourceSplitBase, connection);
 
-        // initial stateful objects
         final MySqlConnectorConfig connectorConfig = getDbzConnectorConfig();
         final boolean tableIdCaseInsensitive = connection.isTableIdCaseSensitive();
+
+        this.adapter = DebeziumAdapterFactory.getAdapter("mysql");
+
         this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
 
         this.databaseSchema =
@@ -153,25 +165,35 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                 () ->
                                         taskContext.configureLoggingContext(
                                                 "mysql-cdc-connector-task"))
-                        // do not buffer any element, we use signal event
-                        // .buffering()
                         .build();
-        this.dispatcher =
-                new JdbcSourceEventDispatcher<>(
+
+        io.debezium.pipeline.spi.ChangeEventCreator changeEventCreator = DataChangeEvent::new;
+        io.debezium.schema.DataCollectionFilters.DataCollectionFilter<TableId>
+                dataCollectionFilter = connectorConfig.getTableFilters().dataCollectionFilter();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                new HeartbeatFactory<>(
                         connectorConfig,
                         topicSelector,
-                        databaseSchema,
-                        queue,
-                        connectorConfig.getTableFilters().dataCollectionFilter(),
-                        DataChangeEvent::new,
-                        metadataProvider,
-                        new HeartbeatFactory<>(
-                                connectorConfig,
-                                topicSelector,
-                                schemaNameAdjuster,
-                                new DefaultHeartbeatConnectionProvider(connection),
-                                null),
-                        schemaNameAdjuster);
+                        schemaNameAdjuster,
+                        new DefaultHeartbeatConnectionProvider(connection),
+                        null);
+
+        DebeziumEventDispatcherConfig dispatcherConfig =
+                DebeziumEventDispatcherConfig.builder()
+                        .connectorConfig(connectorConfig)
+                        .topicNaming((DebeziumTopicNaming<?>) (Object) topicSelector)
+                        .databaseSchema(databaseSchema)
+                        .queue(queue)
+                        .dataCollectionFilter(dataCollectionFilter)
+                        .changeEventCreator(changeEventCreator)
+                        .metadataProvider(metadataProvider)
+                        .heartbeatFactory(heartbeatFactory)
+                        .schemaNameAdjuster(schemaNameAdjuster)
+                        .build();
+
+        MySqlEventDispatcherAdapter eventDispatcher =
+                (MySqlEventDispatcherAdapter) adapter.createEventDispatcher(dispatcherConfig);
+        this.dispatcher = eventDispatcher.getDelegate();
 
         final MySqlChangeEventSourceMetricsFactory changeEventSourceMetricsFactory =
                 new MySqlChangeEventSourceMetricsFactory(
@@ -272,6 +294,88 @@ public class MySqlSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     @Override
     public Offset getStreamOffset(SourceRecord sourceRecord) {
         return MySqlUtils.getBinlogPosition(sourceRecord);
+    }
+
+    @Override
+    protected void registerDatabaseHistory(
+            SourceSplitBase sourceSplitBase, JdbcConnection connection) {
+        List<TableChanges.TableChange> engineHistory = new java.util.ArrayList<>();
+        if (sourceSplitBase.isSnapshotSplit()) {
+            engineHistory.add(
+                    dataSourceDialect.queryTableSchema(
+                            connection, sourceSplitBase.asSnapshotSplit().getTableId()));
+        } else {
+            java.util.Map<TableId, byte[]> historyTableChanges =
+                    sourceSplitBase.asIncrementalSplit().getHistoryTableChanges();
+            for (TableId tableId : sourceSplitBase.asIncrementalSplit().getTableIds()) {
+                if (historyTableChanges != null && historyTableChanges.containsKey(tableId)) {
+                    org.apache.kafka.connect.data.SchemaAndValue schemaAndValue =
+                            jsonConverter.toConnectData("topic", historyTableChanges.get(tableId));
+                    Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+                    TableChanges tableChanges =
+                            tableChangeSerializer.deserialize(
+                                    java.util.Collections.singletonList(deserializedStruct), false);
+
+                    java.util.Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+                    TableChanges.TableChange tableChange = null;
+                    while (iterator.hasNext()) {
+                        if (tableChange != null) {
+                            throw new IllegalStateException(
+                                    "The table changes should only have one element");
+                        }
+                        tableChange = iterator.next();
+                    }
+                    engineHistory.add(tableChange);
+                    continue;
+                }
+                engineHistory.add(dataSourceDialect.queryTableSchema(connection, tableId));
+            }
+        }
+
+        Collection<TableChangeInfo> tableChangeInfos = convertToTableChangeInfo(engineHistory);
+
+        String instanceName =
+                sourceConfig.getDbzConfiguration().getString("database.history.instance.name");
+        DebeziumSchemaHistory schemaHistory =
+                adapter.createSchemaHistory(instanceName, tableChangeInfos);
+        schemaHistory.start();
+    }
+
+    private Collection<TableChangeInfo> convertToTableChangeInfo(
+            Collection<TableChanges.TableChange> changes) {
+        return changes.stream()
+                .map(
+                        change ->
+                                new TableChangeInfo(
+                                        change.getId(),
+                                        convertChangeType(change.getType()),
+                                        serializeTableChange(change)))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+
+    private byte[] serializeTableChange(TableChanges.TableChange change) {
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serialized = tableChangeSerializer.serialize(tableChanges);
+        if (serialized.isEmpty()) {
+            return new byte[0];
+        }
+        return jsonConverter.fromConnectData(
+                "topic", serialized.get(0).schema(), serialized.get(0));
     }
 
     /** Loads the connector's persistent offset (if present) via the given loader. */

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
@@ -1,0 +1,1 @@
+org.apache.seatunnel.connectors.seatunnel.cdc.mysql.adapter.MySqlDebeziumAdapter

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/pom.xml
@@ -29,6 +29,7 @@
     <name>SeaTunnel : Connectors V2 : CDC : Oracle</name>
 
     <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
         <oracle.version>19.18.0.0</oracle.version>
     </properties>
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleDebeziumAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleDebeziumAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oracle.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+
+import java.util.Collection;
+
+public class OracleDebeziumAdapter implements DebeziumAdapter {
+
+    private static final String DEBEZIUM_VERSION = "1.9.8.Final";
+    private static final String CONNECTOR_TYPE = "oracle";
+
+    @Override
+    public DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config) {
+        return new OracleEventDispatcherAdapter(config);
+    }
+
+    @Override
+    public DebeziumSchemaHistory createSchemaHistory(
+            String instanceName, Collection<TableChangeInfo> tableChanges) {
+        return new OracleSchemaHistoryAdapter(instanceName, tableChanges);
+    }
+
+    @Override
+    public DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix) {
+        throw new UnsupportedOperationException(
+                "Oracle connector does not use adapter for topic naming");
+    }
+
+    @Override
+    public String getDebeziumVersion() {
+        return DEBEZIUM_VERSION;
+    }
+
+    @Override
+    public boolean supports(String connectorType) {
+        return CONNECTOR_TYPE.equalsIgnoreCase(connectorType);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleEventDispatcherAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleEventDispatcherAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oracle.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.oracle.OraclePartition;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionFilters.DataCollectionFilter;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+
+public class OracleEventDispatcherAdapter implements DebeziumEventDispatcher<OraclePartition> {
+
+    private final JdbcSourceEventDispatcher<OraclePartition> delegate;
+
+    @SuppressWarnings("unchecked")
+    public OracleEventDispatcherAdapter(DebeziumEventDispatcherConfig config) {
+        CommonConnectorConfig connectorConfig = (CommonConnectorConfig) config.getConnectorConfig();
+        TopicSelector<TableId> topicSelector = (TopicSelector<TableId>) config.getTopicNaming();
+        DatabaseSchema<TableId> schema = (DatabaseSchema<TableId>) config.getDatabaseSchema();
+        ChangeEventQueue<DataChangeEvent> queue =
+                (ChangeEventQueue<DataChangeEvent>) config.getQueue();
+        DataCollectionFilter<TableId> filter =
+                (DataCollectionFilter<TableId>) config.getDataCollectionFilter();
+        ChangeEventCreator changeEventCreator = (ChangeEventCreator) config.getChangeEventCreator();
+        EventMetadataProvider metadataProvider =
+                (EventMetadataProvider) config.getMetadataProvider();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                (HeartbeatFactory<TableId>) config.getHeartbeatFactory();
+        SchemaNameAdjuster schemaNameAdjuster = (SchemaNameAdjuster) config.getSchemaNameAdjuster();
+
+        this.delegate =
+                new JdbcSourceEventDispatcher<>(
+                        connectorConfig,
+                        topicSelector,
+                        schema,
+                        queue,
+                        filter,
+                        changeEventCreator,
+                        metadataProvider,
+                        heartbeatFactory,
+                        schemaNameAdjuster);
+    }
+
+    @Override
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset offset)
+            throws InterruptedException {
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, getPrimaryTopic(), splitId, watermarkKind, offset);
+        ChangeEventQueue<DataChangeEvent> queue = (ChangeEventQueue<DataChangeEvent>) getQueue();
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+
+    @Override
+    public Object getQueue() {
+        return delegate.getQueue();
+    }
+
+    @Override
+    public String getPrimaryTopic() {
+        return delegate.getPrimaryTopic();
+    }
+
+    @Override
+    public void close() {}
+
+    public JdbcSourceEventDispatcher<OraclePartition> getDelegate() {
+        return delegate;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleSchemaHistoryAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/adapter/OracleSchemaHistoryAdapter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oracle.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+import org.apache.seatunnel.connectors.cdc.debezium.ConnectTableChangeSerializer;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import io.debezium.relational.history.TableChanges;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OracleSchemaHistoryAdapter implements DebeziumSchemaHistory {
+
+    private final String instanceName;
+    private final Collection<TableChangeInfo> initialChanges;
+    private final ConnectTableChangeSerializer tableChangeSerializer;
+    private final JsonConverter jsonConverter;
+
+    public OracleSchemaHistoryAdapter(String instanceName, Collection<TableChangeInfo> changes) {
+        this.instanceName = instanceName;
+        this.initialChanges = changes;
+        this.tableChangeSerializer = new ConnectTableChangeSerializer();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", true), false);
+    }
+
+    @Override
+    public void registerHistory(String instanceName, Collection<TableChangeInfo> changes) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                changes.stream()
+                        .map(this::convertToDebeziumTableChange)
+                        .collect(Collectors.toList());
+
+        EmbeddedDatabaseHistory.registerHistory(instanceName, debeziumChanges);
+    }
+
+    @Override
+    public Collection<TableChangeInfo> removeHistory(String instanceName) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                EmbeddedDatabaseHistory.removeHistory(instanceName);
+
+        return debeziumChanges.stream()
+                .map(this::convertFromDebeziumTableChange)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {}
+
+    @Override
+    public void start() {
+        if (initialChanges != null && !initialChanges.isEmpty()) {
+            registerHistory(instanceName, initialChanges);
+        }
+    }
+
+    @Override
+    public void stop() {
+        removeHistory(instanceName);
+    }
+
+    private TableChanges.TableChange convertToDebeziumTableChange(TableChangeInfo info) {
+        SchemaAndValue schemaAndValue =
+                jsonConverter.toConnectData("topic", info.getSerializedTableSchema());
+        Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+        TableChanges tableChanges =
+                tableChangeSerializer.deserialize(
+                        Collections.singletonList(deserializedStruct), false);
+
+        Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+        TableChanges.TableChange tableChange = null;
+        while (iterator.hasNext()) {
+            if (tableChange != null) {
+                throw new IllegalStateException("The table changes should only have one element");
+            }
+            tableChange = iterator.next();
+        }
+
+        if (tableChange == null) {
+            throw new IllegalStateException("No table change found in deserialized data");
+        }
+
+        return tableChange;
+    }
+
+    private TableChangeInfo convertFromDebeziumTableChange(TableChanges.TableChange change) {
+        TableChangeInfo.TableChangeType type = convertChangeType(change.getType());
+
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serializedStructs = tableChangeSerializer.serialize(tableChanges);
+
+        byte[] serialized;
+        if (serializedStructs.isEmpty()) {
+            serialized = new byte[0];
+        } else {
+            Struct struct = serializedStructs.get(0);
+            serialized = jsonConverter.fromConnectData("topic", struct.schema(), struct);
+        }
+
+        return new TableChangeInfo(change.getId(), type, serialized);
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -19,11 +19,18 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.oracle.source.reader.fetch
 
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapterFactory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
 import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.oracle.adapter.OracleEventDispatcherAdapter;
 import org.apache.seatunnel.connectors.seatunnel.cdc.oracle.config.OracleSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.oracle.source.offset.RedoLogOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.oracle.utils.OracleUtils;
@@ -72,6 +79,7 @@ import static org.apache.seatunnel.connectors.seatunnel.cdc.oracle.utils.OracleC
 public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     private final OracleConnection connection;
     private final OracleEventMetadataProvider metadataProvider;
+    private DebeziumAdapter adapter;
 
     private OracleDatabaseSchema databaseSchema;
     private OracleTaskContext taskContext;
@@ -95,11 +103,12 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
 
     @Override
     public void configure(SourceSplitBase sourceSplitBase) {
-        // Initializes the table schema
         super.registerDatabaseHistory(sourceSplitBase, connection);
 
-        // initial stateful objects
         final OracleConnectorConfig connectorConfig = getDbzConnectorConfig();
+
+        this.adapter = DebeziumAdapterFactory.getAdapter("oracle");
+
         this.topicSelector = OracleTopicSelector.defaultSelector(connectorConfig);
 
         this.databaseSchema = OracleUtils.createOracleDatabaseSchema(connectorConfig, connection);
@@ -130,25 +139,35 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                 () ->
                                         taskContext.configureLoggingContext(
                                                 "oracle-cdc-connector-task"))
-                        // do not buffer any element, we use signal event
-                        // .buffering()
                         .build();
-        this.dispatcher =
-                new JdbcSourceEventDispatcher<>(
+
+        io.debezium.pipeline.spi.ChangeEventCreator changeEventCreator = DataChangeEvent::new;
+        io.debezium.schema.DataCollectionFilters.DataCollectionFilter<TableId>
+                dataCollectionFilter = connectorConfig.getTableFilters().dataCollectionFilter();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                new HeartbeatFactory<>(
                         connectorConfig,
                         topicSelector,
-                        databaseSchema,
-                        queue,
-                        connectorConfig.getTableFilters().dataCollectionFilter(),
-                        DataChangeEvent::new,
-                        metadataProvider,
-                        new HeartbeatFactory<>(
-                                connectorConfig,
-                                topicSelector,
-                                schemaNameAdjuster,
-                                new DefaultHeartbeatConnectionProvider(connection),
-                                null),
-                        schemaNameAdjuster);
+                        schemaNameAdjuster,
+                        new DefaultHeartbeatConnectionProvider(connection),
+                        null);
+
+        DebeziumEventDispatcherConfig dispatcherConfig =
+                DebeziumEventDispatcherConfig.builder()
+                        .connectorConfig(connectorConfig)
+                        .topicNaming((DebeziumTopicNaming<?>) (Object) topicSelector)
+                        .databaseSchema(databaseSchema)
+                        .queue(queue)
+                        .dataCollectionFilter(dataCollectionFilter)
+                        .changeEventCreator(changeEventCreator)
+                        .metadataProvider(metadataProvider)
+                        .heartbeatFactory(heartbeatFactory)
+                        .schemaNameAdjuster(schemaNameAdjuster)
+                        .build();
+
+        OracleEventDispatcherAdapter eventDispatcher =
+                (OracleEventDispatcherAdapter) adapter.createEventDispatcher(dispatcherConfig);
+        this.dispatcher = eventDispatcher.getDelegate();
 
         final OracleChangeEventSourceMetricsFactory changeEventSourceMetricsFactory =
                 new OracleChangeEventSourceMetricsFactory(
@@ -253,6 +272,94 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                 (OracleOffsetContext) loader.load(offset.getOffset());
 
         return oracleOffsetContext;
+    }
+
+    @Override
+    protected void registerDatabaseHistory(
+            SourceSplitBase sourceSplitBase, io.debezium.jdbc.JdbcConnection connection) {
+        java.util.List<io.debezium.relational.history.TableChanges.TableChange> engineHistory =
+                new java.util.ArrayList<>();
+        if (sourceSplitBase.isSnapshotSplit()) {
+            engineHistory.add(
+                    dataSourceDialect.queryTableSchema(
+                            connection, sourceSplitBase.asSnapshotSplit().getTableId()));
+        } else {
+            java.util.Map<TableId, byte[]> historyTableChanges =
+                    sourceSplitBase.asIncrementalSplit().getHistoryTableChanges();
+            for (TableId tableId : sourceSplitBase.asIncrementalSplit().getTableIds()) {
+                if (historyTableChanges != null && historyTableChanges.containsKey(tableId)) {
+                    org.apache.kafka.connect.data.SchemaAndValue schemaAndValue =
+                            jsonConverter.toConnectData("topic", historyTableChanges.get(tableId));
+                    Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+                    io.debezium.relational.history.TableChanges tableChanges =
+                            tableChangeSerializer.deserialize(
+                                    java.util.Collections.singletonList(deserializedStruct), false);
+
+                    java.util.Iterator<io.debezium.relational.history.TableChanges.TableChange>
+                            iterator = tableChanges.iterator();
+                    io.debezium.relational.history.TableChanges.TableChange tableChange = null;
+                    while (iterator.hasNext()) {
+                        if (tableChange != null) {
+                            throw new IllegalStateException(
+                                    "The table changes should only have one element");
+                        }
+                        tableChange = iterator.next();
+                    }
+                    engineHistory.add(tableChange);
+                    continue;
+                }
+                engineHistory.add(dataSourceDialect.queryTableSchema(connection, tableId));
+            }
+        }
+
+        java.util.Collection<TableChangeInfo> tableChangeInfos =
+                convertToTableChangeInfo(engineHistory);
+
+        String instanceName =
+                sourceConfig.getDbzConfiguration().getString("database.history.instance.name");
+        DebeziumSchemaHistory schemaHistory =
+                adapter.createSchemaHistory(instanceName, tableChangeInfos);
+        schemaHistory.start();
+    }
+
+    private java.util.Collection<TableChangeInfo> convertToTableChangeInfo(
+            java.util.Collection<io.debezium.relational.history.TableChanges.TableChange> changes) {
+        return changes.stream()
+                .map(
+                        change ->
+                                new TableChangeInfo(
+                                        change.getId(),
+                                        convertChangeType(change.getType()),
+                                        serializeTableChange(change)))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(
+            io.debezium.relational.history.TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+
+    private byte[] serializeTableChange(
+            io.debezium.relational.history.TableChanges.TableChange change) {
+        io.debezium.relational.history.TableChanges tableChanges =
+                new io.debezium.relational.history.TableChanges();
+        tableChanges.create(change.getTable());
+        java.util.List<Struct> serialized = tableChangeSerializer.serialize(tableChanges);
+        if (serialized.isEmpty()) {
+            return new byte[0];
+        }
+        return jsonConverter.fromConnectData(
+                "topic", serialized.get(0).schema(), serialized.get(0));
     }
 
     private void validateAndLoadDatabaseHistory(

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
@@ -1,0 +1,1 @@
+org.apache.seatunnel.connectors.seatunnel.cdc.oracle.adapter.OracleDebeziumAdapter

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>connector-cdc-postgres</artifactId>
     <name>SeaTunnel : Connectors V2 : CDC : Postgres</name>
 
+    <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresDebeziumAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresDebeziumAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+
+import java.util.Collection;
+
+public class PostgresDebeziumAdapter implements DebeziumAdapter {
+
+    private static final String DEBEZIUM_VERSION = "1.9.8.Final";
+    private static final String CONNECTOR_TYPE = "postgres";
+
+    @Override
+    public DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config) {
+        return new PostgresEventDispatcherAdapter(config);
+    }
+
+    @Override
+    public DebeziumSchemaHistory createSchemaHistory(
+            String instanceName, Collection<TableChangeInfo> tableChanges) {
+        return new PostgresSchemaHistoryAdapter(instanceName, tableChanges);
+    }
+
+    @Override
+    public DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix) {
+        throw new UnsupportedOperationException(
+                "PostgreSQL connector does not use adapter for topic naming");
+    }
+
+    @Override
+    public String getDebeziumVersion() {
+        return DEBEZIUM_VERSION;
+    }
+
+    @Override
+    public boolean supports(String connectorType) {
+        return CONNECTOR_TYPE.equalsIgnoreCase(connectorType);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresEventDispatcherAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresEventDispatcherAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.postgresql.PostgresPartition;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionFilters.DataCollectionFilter;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+
+public class PostgresEventDispatcherAdapter implements DebeziumEventDispatcher<PostgresPartition> {
+
+    private final JdbcSourceEventDispatcher<PostgresPartition> delegate;
+
+    @SuppressWarnings("unchecked")
+    public PostgresEventDispatcherAdapter(DebeziumEventDispatcherConfig config) {
+        CommonConnectorConfig connectorConfig = (CommonConnectorConfig) config.getConnectorConfig();
+        TopicSelector<TableId> topicSelector = (TopicSelector<TableId>) config.getTopicNaming();
+        DatabaseSchema<TableId> schema = (DatabaseSchema<TableId>) config.getDatabaseSchema();
+        ChangeEventQueue<DataChangeEvent> queue =
+                (ChangeEventQueue<DataChangeEvent>) config.getQueue();
+        DataCollectionFilter<TableId> filter =
+                (DataCollectionFilter<TableId>) config.getDataCollectionFilter();
+        ChangeEventCreator changeEventCreator = (ChangeEventCreator) config.getChangeEventCreator();
+        EventMetadataProvider metadataProvider =
+                (EventMetadataProvider) config.getMetadataProvider();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                (HeartbeatFactory<TableId>) config.getHeartbeatFactory();
+        SchemaNameAdjuster schemaNameAdjuster = (SchemaNameAdjuster) config.getSchemaNameAdjuster();
+
+        this.delegate =
+                new JdbcSourceEventDispatcher<>(
+                        connectorConfig,
+                        topicSelector,
+                        schema,
+                        queue,
+                        filter,
+                        changeEventCreator,
+                        metadataProvider,
+                        heartbeatFactory,
+                        schemaNameAdjuster);
+    }
+
+    @Override
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset offset)
+            throws InterruptedException {
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, getPrimaryTopic(), splitId, watermarkKind, offset);
+        ChangeEventQueue<DataChangeEvent> queue = (ChangeEventQueue<DataChangeEvent>) getQueue();
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+
+    @Override
+    public Object getQueue() {
+        return delegate.getQueue();
+    }
+
+    @Override
+    public String getPrimaryTopic() {
+        return delegate.getPrimaryTopic();
+    }
+
+    @Override
+    public void close() {}
+
+    public JdbcSourceEventDispatcher<PostgresPartition> getDelegate() {
+        return delegate;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresSchemaHistoryAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresSchemaHistoryAdapter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+import org.apache.seatunnel.connectors.cdc.debezium.ConnectTableChangeSerializer;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import io.debezium.relational.history.TableChanges;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PostgresSchemaHistoryAdapter implements DebeziumSchemaHistory {
+
+    private final String instanceName;
+    private final Collection<TableChangeInfo> initialChanges;
+    private final ConnectTableChangeSerializer tableChangeSerializer;
+    private final JsonConverter jsonConverter;
+
+    public PostgresSchemaHistoryAdapter(String instanceName, Collection<TableChangeInfo> changes) {
+        this.instanceName = instanceName;
+        this.initialChanges = changes;
+        this.tableChangeSerializer = new ConnectTableChangeSerializer();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", true), false);
+    }
+
+    @Override
+    public void registerHistory(String instanceName, Collection<TableChangeInfo> changes) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                changes.stream()
+                        .map(this::convertToDebeziumTableChange)
+                        .collect(Collectors.toList());
+
+        EmbeddedDatabaseHistory.registerHistory(instanceName, debeziumChanges);
+    }
+
+    @Override
+    public Collection<TableChangeInfo> removeHistory(String instanceName) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                EmbeddedDatabaseHistory.removeHistory(instanceName);
+
+        return debeziumChanges.stream()
+                .map(this::convertFromDebeziumTableChange)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {}
+
+    @Override
+    public void start() {
+        if (initialChanges != null && !initialChanges.isEmpty()) {
+            registerHistory(instanceName, initialChanges);
+        }
+    }
+
+    @Override
+    public void stop() {
+        removeHistory(instanceName);
+    }
+
+    private TableChanges.TableChange convertToDebeziumTableChange(TableChangeInfo info) {
+        SchemaAndValue schemaAndValue =
+                jsonConverter.toConnectData("topic", info.getSerializedTableSchema());
+        Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+        TableChanges tableChanges =
+                tableChangeSerializer.deserialize(
+                        Collections.singletonList(deserializedStruct), false);
+
+        Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+        TableChanges.TableChange tableChange = null;
+        while (iterator.hasNext()) {
+            if (tableChange != null) {
+                throw new IllegalStateException("The table changes should only have one element");
+            }
+            tableChange = iterator.next();
+        }
+
+        if (tableChange == null) {
+            throw new IllegalStateException("No table change found in deserialized data");
+        }
+
+        return tableChange;
+    }
+
+    private TableChangeInfo convertFromDebeziumTableChange(TableChanges.TableChange change) {
+        TableChangeInfo.TableChangeType type = convertChangeType(change.getType());
+
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serializedStructs = tableChangeSerializer.serialize(tableChanges);
+
+        byte[] serialized;
+        if (serializedStructs.isEmpty()) {
+            serialized = new byte[0];
+        } else {
+            Struct struct = serializedStructs.get(0);
+            serialized = jsonConverter.fromConnectData("topic", struct.schema(), struct);
+        }
+
+        return new TableChangeInfo(change.getId(), type, serialized);
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresTopicNamingAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/adapter/PostgresTopicNamingAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+
+import io.debezium.relational.TableId;
+import io.debezium.schema.TopicSelector;
+
+public class PostgresTopicNamingAdapter implements DebeziumTopicNaming<TableId> {
+
+    private final TopicSelector<TableId> delegate;
+    private final String heartbeatPrefix;
+
+    public PostgresTopicNamingAdapter(TopicSelector<TableId> delegate, String heartbeatPrefix) {
+        this.delegate = delegate;
+        this.heartbeatPrefix = heartbeatPrefix;
+    }
+
+    @Override
+    public String getPrimaryTopic() {
+        return delegate.getPrimaryTopic();
+    }
+
+    @Override
+    public String getHeartbeatTopic() {
+        return heartbeatPrefix;
+    }
+
+    @Override
+    public String dataChangeTopicName(TableId tableId) {
+        return delegate.topicNameFor(tableId);
+    }
+
+    public TopicSelector<TableId> getDelegate() {
+        return delegate;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
@@ -20,11 +20,18 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapterFactory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
 import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter.PostgresEventDispatcherAdapter;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.config.PostgresSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.exception.PostgresConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset.LsnOffset;
@@ -52,15 +59,18 @@ import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.data.Envelope;
 import io.debezium.heartbeat.DefaultHeartbeatConnectionProvider;
 import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.relational.history.TableChanges;
+import io.debezium.schema.DataCollectionFilters;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.LoggingContext;
 import lombok.Getter;
@@ -69,6 +79,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -89,6 +100,8 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     @Getter private ReplicationConnection replicationConnection;
 
     private final EventMetadataProvider metadataProvider;
+
+    private DebeziumAdapter adapter;
 
     @Getter private Snapshotter snapshotter;
     private PostgresSchema databaseSchema;
@@ -128,13 +141,13 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     public void configure(SourceSplitBase sourceSplitBase) {
         super.registerDatabaseHistory(sourceSplitBase, dataConnection);
 
-        // initial stateful objects
         final PostgresConnectorConfig connectorConfig = getDbzConnectorConfig();
         PostgresConnectorConfig.SnapshotMode snapshotMode =
                 PostgresConnectorConfig.SnapshotMode.parse(
                         connectorConfig.getConfig().getString(SNAPSHOT_MODE));
         this.snapshotter = snapshotMode.getSnapshotter(connectorConfig.getConfig());
 
+        this.adapter = DebeziumAdapterFactory.getAdapter("postgres");
         this.topicSelector = PostgresTopicSelector.create(connectorConfig);
         final TypeRegistry typeRegistry = dataConnection.getTypeRegistry();
 
@@ -239,26 +252,36 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                             .maxQueueSizeInBytes(connectorConfig.getMaxQueueSizeInBytes())
                             .loggingContextSupplier(
                                     () -> taskContext.configureLoggingContext(CONTEXT_NAME))
-                            // do not buffer any element, we use signal event
-                            // .buffering()
                             .build();
 
-            this.dispatcher =
-                    new JdbcSourceEventDispatcher<>(
+            ChangeEventCreator changeEventCreator = DataChangeEvent::new;
+            DataCollectionFilters.DataCollectionFilter<TableId> dataCollectionFilter =
+                    connectorConfig.getTableFilters().dataCollectionFilter();
+            HeartbeatFactory<TableId> heartbeatFactory =
+                    new HeartbeatFactory<>(
                             connectorConfig,
                             topicSelector,
-                            databaseSchema,
-                            queue,
-                            connectorConfig.getTableFilters().dataCollectionFilter(),
-                            DataChangeEvent::new,
-                            metadataProvider,
-                            new HeartbeatFactory<>(
-                                    connectorConfig,
-                                    topicSelector,
-                                    schemaNameAdjuster,
-                                    new DefaultHeartbeatConnectionProvider(dataConnection),
-                                    null),
-                            schemaNameAdjuster);
+                            schemaNameAdjuster,
+                            new DefaultHeartbeatConnectionProvider(dataConnection),
+                            null);
+
+            DebeziumEventDispatcherConfig dispatcherConfig =
+                    DebeziumEventDispatcherConfig.builder()
+                            .connectorConfig(connectorConfig)
+                            .topicNaming((DebeziumTopicNaming<?>) (Object) topicSelector)
+                            .databaseSchema(databaseSchema)
+                            .queue(queue)
+                            .dataCollectionFilter(dataCollectionFilter)
+                            .changeEventCreator(changeEventCreator)
+                            .metadataProvider(metadataProvider)
+                            .heartbeatFactory(heartbeatFactory)
+                            .schemaNameAdjuster(schemaNameAdjuster)
+                            .build();
+
+            PostgresEventDispatcherAdapter eventDispatcher =
+                    (PostgresEventDispatcherAdapter)
+                            adapter.createEventDispatcher(dispatcherConfig);
+            this.dispatcher = eventDispatcher.getDelegate();
 
             this.pgEventDispatcher =
                     new PostgresEventDispatcher<>(
@@ -376,6 +399,56 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
         } catch (Exception e) {
             log.warn("Failed to close connection", e);
         }
+    }
+
+    @Override
+    protected void registerDatabaseHistory(
+            SourceSplitBase sourceSplitBase, JdbcConnection connection) {
+        super.registerDatabaseHistory(sourceSplitBase, connection);
+
+        Collection<TableChangeInfo> tableChangeInfos = convertToTableChangeInfo(engineHistory);
+
+        String instanceName =
+                sourceConfig.getDbzConfiguration().getString("database.history.instance.name");
+        DebeziumSchemaHistory schemaHistory =
+                adapter.createSchemaHistory(instanceName, tableChangeInfos);
+        schemaHistory.start();
+    }
+
+    private Collection<TableChangeInfo> convertToTableChangeInfo(
+            Collection<TableChanges.TableChange> changes) {
+        return changes.stream()
+                .map(
+                        change ->
+                                new TableChangeInfo(
+                                        change.getId(),
+                                        convertChangeType(change.getType()),
+                                        serializeTableChange(change)))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+
+    private byte[] serializeTableChange(TableChanges.TableChange change) {
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serialized = tableChangeSerializer.serialize(tableChanges);
+        if (serialized.isEmpty()) {
+            return new byte[0];
+        }
+        return jsonConverter.fromConnectData(
+                "topic", serialized.get(0).schema(), serialized.get(0));
     }
 
     /** Loads the connector's persistent offset (if present) via the given loader. */

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
@@ -1,0 +1,1 @@
+org.apache.seatunnel.connectors.seatunnel.cdc.postgres.adapter.PostgresDebeziumAdapter

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>connector-cdc-sqlserver</artifactId>
     <name>SeaTunnel : Connectors V2 : CDC : SqlServer</name>
 
+    <properties>
+        <debezium.version>1.9.8.Final</debezium.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerDebeziumAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerDebeziumAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+
+import java.util.Collection;
+
+public class SqlServerDebeziumAdapter implements DebeziumAdapter {
+
+    private static final String DEBEZIUM_VERSION = "1.9.8.Final";
+    private static final String CONNECTOR_TYPE = "sqlserver";
+
+    @Override
+    public DebeziumEventDispatcher createEventDispatcher(DebeziumEventDispatcherConfig config) {
+        return new SqlServerEventDispatcherAdapter(config);
+    }
+
+    @Override
+    public DebeziumSchemaHistory createSchemaHistory(
+            String instanceName, Collection<TableChangeInfo> tableChanges) {
+        return new SqlServerSchemaHistoryAdapter(instanceName, tableChanges);
+    }
+
+    @Override
+    public DebeziumTopicNaming createTopicNaming(String logicalName, String heartbeatPrefix) {
+        throw new UnsupportedOperationException(
+                "SqlServer connector does not use adapter for topic naming");
+    }
+
+    @Override
+    public String getDebeziumVersion() {
+        return DEBEZIUM_VERSION;
+    }
+
+    @Override
+    public boolean supports(String connectorType) {
+        return CONNECTOR_TYPE.equalsIgnoreCase(connectorType);
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerEventDispatcherAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerEventDispatcherAdapter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkEvent;
+import org.apache.seatunnel.connectors.cdc.base.source.split.wartermark.WatermarkKind;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionFilters.DataCollectionFilter;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+import java.util.Map;
+
+public class SqlServerEventDispatcherAdapter
+        implements DebeziumEventDispatcher<SqlServerPartition> {
+
+    private final JdbcSourceEventDispatcher<SqlServerPartition> delegate;
+
+    @SuppressWarnings("unchecked")
+    public SqlServerEventDispatcherAdapter(DebeziumEventDispatcherConfig config) {
+        CommonConnectorConfig connectorConfig = (CommonConnectorConfig) config.getConnectorConfig();
+        TopicSelector<TableId> topicSelector = (TopicSelector<TableId>) config.getTopicNaming();
+        DatabaseSchema<TableId> schema = (DatabaseSchema<TableId>) config.getDatabaseSchema();
+        ChangeEventQueue<DataChangeEvent> queue =
+                (ChangeEventQueue<DataChangeEvent>) config.getQueue();
+        DataCollectionFilter<TableId> filter =
+                (DataCollectionFilter<TableId>) config.getDataCollectionFilter();
+        ChangeEventCreator changeEventCreator = (ChangeEventCreator) config.getChangeEventCreator();
+        EventMetadataProvider metadataProvider =
+                (EventMetadataProvider) config.getMetadataProvider();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                (HeartbeatFactory<TableId>) config.getHeartbeatFactory();
+        SchemaNameAdjuster schemaNameAdjuster = (SchemaNameAdjuster) config.getSchemaNameAdjuster();
+
+        this.delegate =
+                new JdbcSourceEventDispatcher<>(
+                        connectorConfig,
+                        topicSelector,
+                        schema,
+                        queue,
+                        filter,
+                        changeEventCreator,
+                        metadataProvider,
+                        heartbeatFactory,
+                        schemaNameAdjuster);
+    }
+
+    @Override
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            String splitId,
+            WatermarkKind watermarkKind,
+            Offset offset)
+            throws InterruptedException {
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, getPrimaryTopic(), splitId, watermarkKind, offset);
+        ChangeEventQueue<DataChangeEvent> queue = (ChangeEventQueue<DataChangeEvent>) getQueue();
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+
+    @Override
+    public Object getQueue() {
+        return delegate.getQueue();
+    }
+
+    @Override
+    public String getPrimaryTopic() {
+        return delegate.getPrimaryTopic();
+    }
+
+    @Override
+    public void close() {}
+
+    public JdbcSourceEventDispatcher<SqlServerPartition> getDelegate() {
+        return delegate;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerSchemaHistoryAdapter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/adapter/SqlServerSchemaHistoryAdapter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.adapter;
+
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
+import org.apache.seatunnel.connectors.cdc.debezium.ConnectTableChangeSerializer;
+import org.apache.seatunnel.connectors.cdc.debezium.EmbeddedDatabaseHistory;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import io.debezium.relational.history.TableChanges;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SqlServerSchemaHistoryAdapter implements DebeziumSchemaHistory {
+
+    private final String instanceName;
+    private final Collection<TableChangeInfo> initialChanges;
+    private final ConnectTableChangeSerializer tableChangeSerializer;
+    private final JsonConverter jsonConverter;
+
+    public SqlServerSchemaHistoryAdapter(String instanceName, Collection<TableChangeInfo> changes) {
+        this.instanceName = instanceName;
+        this.initialChanges = changes;
+        this.tableChangeSerializer = new ConnectTableChangeSerializer();
+        this.jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", true), false);
+    }
+
+    @Override
+    public void registerHistory(String instanceName, Collection<TableChangeInfo> changes) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                changes.stream()
+                        .map(this::convertToDebeziumTableChange)
+                        .collect(Collectors.toList());
+
+        EmbeddedDatabaseHistory.registerHistory(instanceName, debeziumChanges);
+    }
+
+    @Override
+    public Collection<TableChangeInfo> removeHistory(String instanceName) {
+        Collection<TableChanges.TableChange> debeziumChanges =
+                EmbeddedDatabaseHistory.removeHistory(instanceName);
+
+        return debeziumChanges.stream()
+                .map(this::convertFromDebeziumTableChange)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void configure(Map<String, ?> config) {}
+
+    @Override
+    public void start() {
+        if (initialChanges != null && !initialChanges.isEmpty()) {
+            registerHistory(instanceName, initialChanges);
+        }
+    }
+
+    @Override
+    public void stop() {
+        removeHistory(instanceName);
+    }
+
+    private TableChanges.TableChange convertToDebeziumTableChange(TableChangeInfo info) {
+        SchemaAndValue schemaAndValue =
+                jsonConverter.toConnectData("topic", info.getSerializedTableSchema());
+        Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+        TableChanges tableChanges =
+                tableChangeSerializer.deserialize(
+                        Collections.singletonList(deserializedStruct), false);
+
+        Iterator<TableChanges.TableChange> iterator = tableChanges.iterator();
+        TableChanges.TableChange tableChange = null;
+        while (iterator.hasNext()) {
+            if (tableChange != null) {
+                throw new IllegalStateException("The table changes should only have one element");
+            }
+            tableChange = iterator.next();
+        }
+
+        if (tableChange == null) {
+            throw new IllegalStateException("No table change found in deserialized data");
+        }
+
+        return tableChange;
+    }
+
+    private TableChangeInfo convertFromDebeziumTableChange(TableChanges.TableChange change) {
+        TableChangeInfo.TableChangeType type = convertChangeType(change.getType());
+
+        TableChanges tableChanges = new TableChanges();
+        tableChanges.create(change.getTable());
+        List<Struct> serializedStructs = tableChangeSerializer.serialize(tableChanges);
+
+        byte[] serialized;
+        if (serializedStructs.isEmpty()) {
+            serialized = new byte[0];
+        } else {
+            Struct struct = serializedStructs.get(0);
+            serialized = jsonConverter.fromConnectData("topic", struct.schema(), struct);
+        }
+
+        return new TableChangeInfo(change.getId(), type, serialized);
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/reader/fetch/SqlServerSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/reader/fetch/SqlServerSourceFetchTaskContext.java
@@ -18,11 +18,18 @@
 package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.source.reader.fetch;
 
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapterFactory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumEventDispatcherConfig;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumSchemaHistory;
+import org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumTopicNaming;
+import org.apache.seatunnel.connectors.cdc.base.debezium.TableChangeInfo;
 import org.apache.seatunnel.connectors.cdc.base.dialect.JdbcDataSourceDialect;
 import org.apache.seatunnel.connectors.cdc.base.relational.JdbcSourceEventDispatcher;
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+import org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.adapter.SqlServerEventDispatcherAdapter;
 import org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.config.SqlServerSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.source.offset.LsnOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.utils.SqlServerConnectionUtils;
@@ -71,6 +78,7 @@ public class SqlServerSourceFetchTaskContext extends JdbcSourceFetchTaskContext 
     private SqlServerConnection metadataConnection;
 
     private final SqlServerEventMetadataProvider metadataProvider;
+    private DebeziumAdapter adapter;
     private SqlServerDatabaseSchema databaseSchema;
     private SqlServerOffsetContext offsetContext;
     private SqlServerPartition partition;
@@ -96,8 +104,9 @@ public class SqlServerSourceFetchTaskContext extends JdbcSourceFetchTaskContext 
     public void configure(SourceSplitBase sourceSplitBase) {
         super.registerDatabaseHistory(sourceSplitBase, dataConnection);
 
-        // initial stateful objects
         final SqlServerConnectorConfig connectorConfig = getDbzConnectorConfig();
+
+        this.adapter = DebeziumAdapterFactory.getAdapter("sqlserver");
 
         this.topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
 
@@ -133,25 +142,35 @@ public class SqlServerSourceFetchTaskContext extends JdbcSourceFetchTaskContext 
                                 () ->
                                         taskContext.configureLoggingContext(
                                                 "sqlServer-cdc-connector-task"))
-                        // do not buffer any element, we use signal event
-                        // .buffering()
                         .build();
-        this.dispatcher =
-                new JdbcSourceEventDispatcher<>(
+
+        io.debezium.pipeline.spi.ChangeEventCreator changeEventCreator = DataChangeEvent::new;
+        io.debezium.schema.DataCollectionFilters.DataCollectionFilter<TableId>
+                dataCollectionFilter = connectorConfig.getTableFilters().dataCollectionFilter();
+        HeartbeatFactory<TableId> heartbeatFactory =
+                new HeartbeatFactory<>(
                         connectorConfig,
                         topicSelector,
-                        databaseSchema,
-                        queue,
-                        connectorConfig.getTableFilters().dataCollectionFilter(),
-                        DataChangeEvent::new,
-                        metadataProvider,
-                        new HeartbeatFactory<>(
-                                connectorConfig,
-                                topicSelector,
-                                schemaNameAdjuster,
-                                new DefaultHeartbeatConnectionProvider(dataConnection),
-                                null),
-                        schemaNameAdjuster);
+                        schemaNameAdjuster,
+                        new DefaultHeartbeatConnectionProvider(dataConnection),
+                        null);
+
+        DebeziumEventDispatcherConfig dispatcherConfig =
+                DebeziumEventDispatcherConfig.builder()
+                        .connectorConfig(connectorConfig)
+                        .topicNaming((DebeziumTopicNaming<?>) (Object) topicSelector)
+                        .databaseSchema(databaseSchema)
+                        .queue(queue)
+                        .dataCollectionFilter(dataCollectionFilter)
+                        .changeEventCreator(changeEventCreator)
+                        .metadataProvider(metadataProvider)
+                        .heartbeatFactory(heartbeatFactory)
+                        .schemaNameAdjuster(schemaNameAdjuster)
+                        .build();
+
+        SqlServerEventDispatcherAdapter eventDispatcher =
+                (SqlServerEventDispatcherAdapter) adapter.createEventDispatcher(dispatcherConfig);
+        this.dispatcher = eventDispatcher.getDelegate();
 
         final DefaultChangeEventSourceMetricsFactory<SqlServerPartition>
                 changeEventSourceMetricsFactory = new DefaultChangeEventSourceMetricsFactory();
@@ -262,6 +281,94 @@ public class SqlServerSourceFetchTaskContext extends JdbcSourceFetchTaskContext 
             SqlServerOffsetContext offset, SqlServerDatabaseSchema schema) {
         schema.initializeStorage();
         schema.recover(partition, offset);
+    }
+
+    @Override
+    protected void registerDatabaseHistory(
+            SourceSplitBase sourceSplitBase, io.debezium.jdbc.JdbcConnection connection) {
+        java.util.List<io.debezium.relational.history.TableChanges.TableChange> engineHistory =
+                new java.util.ArrayList<>();
+        if (sourceSplitBase.isSnapshotSplit()) {
+            engineHistory.add(
+                    dataSourceDialect.queryTableSchema(
+                            connection, sourceSplitBase.asSnapshotSplit().getTableId()));
+        } else {
+            java.util.Map<TableId, byte[]> historyTableChanges =
+                    sourceSplitBase.asIncrementalSplit().getHistoryTableChanges();
+            for (TableId tableId : sourceSplitBase.asIncrementalSplit().getTableIds()) {
+                if (historyTableChanges != null && historyTableChanges.containsKey(tableId)) {
+                    org.apache.kafka.connect.data.SchemaAndValue schemaAndValue =
+                            jsonConverter.toConnectData("topic", historyTableChanges.get(tableId));
+                    Struct deserializedStruct = (Struct) schemaAndValue.value();
+
+                    io.debezium.relational.history.TableChanges tableChanges =
+                            tableChangeSerializer.deserialize(
+                                    java.util.Collections.singletonList(deserializedStruct), false);
+
+                    java.util.Iterator<io.debezium.relational.history.TableChanges.TableChange>
+                            iterator = tableChanges.iterator();
+                    io.debezium.relational.history.TableChanges.TableChange tableChange = null;
+                    while (iterator.hasNext()) {
+                        if (tableChange != null) {
+                            throw new IllegalStateException(
+                                    "The table changes should only have one element");
+                        }
+                        tableChange = iterator.next();
+                    }
+                    engineHistory.add(tableChange);
+                    continue;
+                }
+                engineHistory.add(dataSourceDialect.queryTableSchema(connection, tableId));
+            }
+        }
+
+        java.util.Collection<TableChangeInfo> tableChangeInfos =
+                convertToTableChangeInfo(engineHistory);
+
+        String instanceName =
+                sourceConfig.getDbzConfiguration().getString("database.history.instance.name");
+        DebeziumSchemaHistory schemaHistory =
+                adapter.createSchemaHistory(instanceName, tableChangeInfos);
+        schemaHistory.start();
+    }
+
+    private java.util.Collection<TableChangeInfo> convertToTableChangeInfo(
+            java.util.Collection<io.debezium.relational.history.TableChanges.TableChange> changes) {
+        return changes.stream()
+                .map(
+                        change ->
+                                new TableChangeInfo(
+                                        change.getId(),
+                                        convertChangeType(change.getType()),
+                                        serializeTableChange(change)))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private TableChangeInfo.TableChangeType convertChangeType(
+            io.debezium.relational.history.TableChanges.TableChangeType type) {
+        switch (type) {
+            case CREATE:
+                return TableChangeInfo.TableChangeType.CREATE;
+            case ALTER:
+                return TableChangeInfo.TableChangeType.ALTER;
+            case DROP:
+                return TableChangeInfo.TableChangeType.DROP;
+            default:
+                throw new IllegalArgumentException("Unknown table change type: " + type);
+        }
+    }
+
+    private byte[] serializeTableChange(
+            io.debezium.relational.history.TableChanges.TableChange change) {
+        io.debezium.relational.history.TableChanges tableChanges =
+                new io.debezium.relational.history.TableChanges();
+        tableChanges.create(change.getTable());
+        java.util.List<Struct> serialized = tableChangeSerializer.serialize(tableChanges);
+        if (serialized.isEmpty()) {
+            return new byte[0];
+        }
+        return jsonConverter.fromConnectData(
+                "topic", serialized.get(0).schema(), serialized.get(0));
     }
 
     /** Loads the connector's persistent offset (if present) via the given loader. */

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/resources/META-INF/services/org.apache.seatunnel.connectors.cdc.base.debezium.DebeziumAdapter
@@ -1,0 +1,1 @@
+org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.adapter.SqlServerDebeziumAdapter


### PR DESCRIPTION
## Purpose of this pull request

  This PR introduces an abstraction layer for Debezium version management
  across all CDC connectors, enabling independent Debezium version upgrades
  per connector without forcing a monolithic upgrade across the entire CDC
  module.
  This PR implements an adapter pattern with Service Provider Interface (SPI)
   that:

  - Decouples SeaTunnel CDC framework from specific Debezium versions
  - Allows each connector to declare its own `debezium.version` property
  - Provides version-agnostic interfaces (`DebeziumAdapter`,
  `DebeziumEventDispatcher`, `DebeziumSchemaHistory`)
  - Enables future independent connector upgrades (e.g., PostgreSQL → 2.7.4
  while MySQL stays on 1.9.8)

  **Implementation Details:**

  1. **New Abstraction Interfaces** (in `connector-cdc-base`):
     - `DebeziumAdapter` - SPI for version-specific implementations
     - `DebeziumEventDispatcher<P>` - Version-agnostic event dispatcher
     - `DebeziumSchemaHistory` - Version-agnostic schema history
     - `DebeziumTopicNaming<T>` - Version-agnostic topic naming
     - `TableChangeInfo` - Version-independent table schema representation
     - `DebeziumEventDispatcherConfig` - Builder for dispatcher configuration

  2. **Per-Connector Adapters** (created for each database):
     - PostgreSQL: `PostgresDebeziumAdapter`,
  `PostgresEventDispatcherAdapter`, `PostgresSchemaHistoryAdapter`
     - MySQL: `MySqlDebeziumAdapter`, `MySqlEventDispatcherAdapter`,
  `MySqlSchemaHistoryAdapter`
     - Oracle: `OracleDebeziumAdapter`, `OracleEventDispatcherAdapter`,
  `OracleSchemaHistoryAdapter`
     - SQL Server: `SqlServerDebeziumAdapter`,
  `SqlServerEventDispatcherAdapter`, `SqlServerSchemaHistoryAdapter`
     - MongoDB: Version property added (uses different architecture, no
  adapter needed)

  3. **ServiceLoader SPI Registration**:
     - Each connector registers its adapter via `META-INF/services/org.apache
  .seatunnel.connectors.cdc.base.debezium.DebeziumAdapter`
     - Runtime discovery using
  `DebeziumAdapterFactory.getAdapter("postgres")`

  4. **Refactored Components**:
     - `JdbcSourceEventDispatcher` - Now uses generic partition types
     - All `*SourceFetchTaskContext` classes - Load adapters and create
  components via SPI
     - Removed direct `EmbeddedDatabaseHistory` calls - Now use
  `DebeziumSchemaHistory` abstraction


**Does this PR introduce any user-facing change?** 

**How was this patch tested?** 

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
  