### PR TITLE
[Fix][Connector-V2][MySQL-CDC] Fix BinlogOffset.compareTo ignoring restartSkipRows when GTID sets are equal

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/offset/BinlogOffset.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/offset/BinlogOffset.java
@@ -141,9 +141,14 @@ public class BinlogOffset extends Offset {
                 GtidSet gtidSet = new GtidSet(gtidSetStr);
                 GtidSet targetGtidSet = new GtidSet(targetGtidSetStr);
                 if (gtidSet.equals(targetGtidSet)) {
-                    long restartSkipEvents = this.getRestartSkipEvents();
-                    long targetRestartSkipEvents = that.getRestartSkipEvents();
-                    return Long.compare(restartSkipEvents, targetRestartSkipEvents);
+                    // Same GTID set means both offsets are within the same transaction
+                    // boundary, so ordering must also consider per-event and per-row progress.
+                    int eventCompare =
+                            Long.compare(this.getRestartSkipEvents(), that.getRestartSkipEvents());
+                    if (eventCompare != 0) {
+                        return eventCompare;
+                    }
+                    return Long.compare(this.getRestartSkipRows(), that.getRestartSkipRows());
                 }
                 // The GTIDs are not an exact match, so figure out if this is a subset of the target
                 // offset

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/offset/BinlogOffsetTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/offset/BinlogOffsetTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.offset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BinlogOffsetTest {
+
+    private static final String GTID_SET_A = "036d85a9-64e5-11e6-9b48-42010af0000c:1-100";
+    private static final String GTID_SET_B = "036d85a9-64e5-11e6-9b48-42010af0000c:1-200";
+
+    @Test
+    public void testCompareToWithEqualGtidSetConsidersRestartSkipRows() {
+        BinlogOffset lower = new BinlogOffset("mysql-bin.000001", 4L, 1L, 5L, 0L, GTID_SET_A, 1);
+        BinlogOffset higher = new BinlogOffset("mysql-bin.000001", 4L, 1L, 9L, 0L, GTID_SET_A, 1);
+
+        Assertions.assertTrue(
+                lower.compareTo(higher) < 0,
+                "offset with smaller restartSkipRows must be ordered before a larger one "
+                        + "when the GTID set and restartSkipEvents are equal");
+        Assertions.assertTrue(higher.compareTo(lower) > 0);
+        Assertions.assertEquals(0, lower.compareTo(lower));
+    }
+
+    @Test
+    public void testCompareToWithEqualGtidSetPrefersRestartSkipEvents() {
+        BinlogOffset earlierEvent =
+                new BinlogOffset("mysql-bin.000001", 4L, 1L, 9L, 0L, GTID_SET_A, 1);
+        BinlogOffset laterEvent =
+                new BinlogOffset("mysql-bin.000001", 4L, 2L, 0L, 0L, GTID_SET_A, 1);
+
+        Assertions.assertTrue(
+                earlierEvent.compareTo(laterEvent) < 0,
+                "restartSkipEvents must take precedence over restartSkipRows");
+    }
+
+    @Test
+    public void testCompareToWithEqualGtidSetAndEqualProgress() {
+        BinlogOffset a = new BinlogOffset("mysql-bin.000001", 4L, 1L, 5L, 0L, GTID_SET_A, 1);
+        BinlogOffset b = new BinlogOffset("mysql-bin.000001", 4L, 1L, 5L, 0L, GTID_SET_A, 1);
+
+        Assertions.assertEquals(0, a.compareTo(b));
+    }
+
+    @Test
+    public void testCompareToWithGtidSubsetAndSuperset() {
+        BinlogOffset subset = new BinlogOffset("mysql-bin.000001", 4L, 0L, 0L, 0L, GTID_SET_A, 1);
+        BinlogOffset superset = new BinlogOffset("mysql-bin.000001", 4L, 0L, 0L, 0L, GTID_SET_B, 1);
+
+        Assertions.assertTrue(subset.compareTo(superset) < 0);
+        Assertions.assertTrue(superset.compareTo(subset) > 0);
+    }
+
+    @Test
+    public void testCompareToWithoutGtidFallsBackToEventsAndRows() {
+        BinlogOffset lowerRow = new BinlogOffset("mysql-bin.000001", 4L, 1L, 3L, 0L, null, 1);
+        BinlogOffset higherRow = new BinlogOffset("mysql-bin.000001", 4L, 1L, 7L, 0L, null, 1);
+
+        Assertions.assertTrue(lowerRow.compareTo(higherRow) < 0);
+        Assertions.assertTrue(higherRow.compareTo(lowerRow) > 0);
+    }
+
+    @Test
+    public void testNoStoppingOffsetIsAlwaysMaximum() {
+        BinlogOffset regular = new BinlogOffset("mysql-bin.000001", 4L, 1L, 5L, 0L, GTID_SET_A, 1);
+
+        Assertions.assertTrue(BinlogOffset.NO_STOPPING_OFFSET.compareTo(regular) > 0);
+        Assertions.assertTrue(regular.compareTo(BinlogOffset.NO_STOPPING_OFFSET) < 0);
+        Assertions.assertEquals(
+                0, BinlogOffset.NO_STOPPING_OFFSET.compareTo(BinlogOffset.NO_STOPPING_OFFSET));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10775.

When two BinlogOffsets share the same GTID set and restartSkipEvents, 
compareTo returned 0 and ignored restartSkipRows. 

Offsets at different row positions within the same binlog event were treated as equal, 
which could cause row-level progress to be lost during checkpoint restore, 
split boundary checks, and watermark comparison.

This PR aligns the GTID branch with the existing non-GTID branch: compare restartSkipEvents first, then fall back to restartSkipRows.

### Does this PR introduce _any_ user-facing change?

No. Internal comparison semantics only
no config or API change.


### How was this patch tested?

Added BinlogOffsetTest covering:
- Equal GTID + equal events + different rows (primary regression)
- Events take precedence over rows
- Fully equal offsets return 0
- GTID subset/superset ordering unchanged
- Non-GTID path unchanged
- NO_STOPPING_OFFSET remains maximum


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)