### PR TITLE
[Fix][Zeta] Fix log API returning master port for all nodes in cluster

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -130,32 +130,40 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                                     r2.getStdout().trim().isEmpty(), "worker has no log files yet");
                         });
 
-        Container.ExecResult logsResult =
-                masterServer.execInContainer(
-                        "sh",
-                        "-c",
-                        "curl -sf 'http://localhost:" + MASTER_HTTP_PORT + "/logs?format=JSON'");
+        final String[] jsonBodyHolder = {null};
+        Awaitility.await()
+                .atMost(1, TimeUnit.MINUTES)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Container.ExecResult logsResult =
+                                    masterServer.execInContainer(
+                                            "sh",
+                                            "-c",
+                                            "curl -sf 'http://localhost:"
+                                                    + MASTER_HTTP_PORT
+                                                    + "/logs?format=JSON'");
+                            Assertions.assertEquals(
+                                    0,
+                                    logsResult.getExitCode(),
+                                    "curl /logs?format=JSON failed: " + logsResult.getStderr());
+                            String body = logsResult.getStdout();
+                            Assertions.assertFalse(body.trim().isEmpty(), "Log list JSON is empty");
+                            ArrayNode nodes = JsonUtils.parseArray(body);
+                            Assertions.assertFalse(nodes.isEmpty(), "No logs returned from master");
+                            Set<String> respondedHosts = new HashSet<>();
+                            for (JsonNode entry : nodes) {
+                                respondedHosts.add(extractHost(entry.get("node").asText()));
+                            }
+                            Assertions.assertEquals(
+                                    2,
+                                    respondedHosts.size(),
+                                    "Expected both cluster nodes in /logs response, got: "
+                                            + respondedHosts);
+                            jsonBodyHolder[0] = body;
+                        });
 
-        Assertions.assertEquals(
-                0,
-                logsResult.getExitCode(),
-                "curl /logs?format=JSON failed: " + logsResult.getStderr());
-
-        String jsonBody = logsResult.getStdout();
-        Assertions.assertFalse(jsonBody.trim().isEmpty(), "Log list JSON is empty");
-
-        ArrayNode logArray = JsonUtils.parseArray(jsonBody);
-        Assertions.assertFalse(logArray.isEmpty(), "No logs returned from master");
-
-        Set<String> respondedHosts = new HashSet<>();
-        for (JsonNode entry : logArray) {
-            respondedHosts.add(extractHost(entry.get("node").asText()));
-        }
-        Assertions.assertEquals(
-                2,
-                respondedHosts.size(),
-                "Expected both cluster nodes in /logs response, got: " + respondedHosts);
-
+        ArrayNode logArray = JsonUtils.parseArray(jsonBodyHolder[0]);
         for (JsonNode entry : logArray) {
             String link = entry.get("logLink").asText();
             Container.ExecResult curlResult =

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -51,10 +51,8 @@ import static io.restassured.RestAssured.given;
 import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
 
 /**
- * Verifies that each node's logLink URL uses that node's own REST port, not the master's port.
- *
- * <p>Bug: when nodes have different REST ports, allLogNameList() always used the master's port for
- * every URL. Fix: GetNodeHttpPortOperation fetches the REST port from the target node itself.
+ * Verifies that each node's logLink URL uses that node's own REST port when nodes in the cluster
+ * are configured with different REST ports.
  */
 public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
 
@@ -81,7 +79,6 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
         masterServer = createServer("server", "job-log-multiport/seatunnel-master.yaml");
         workerServer = createServer("secondServer", "job-log-multiport/seatunnel-worker.yaml");
 
-        // wait until both members joined
         Awaitility.await()
                 .atMost(2, TimeUnit.MINUTES)
                 .untilAsserted(
@@ -111,14 +108,8 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
         CLUSTER_NETWORK.close();
     }
 
-    /**
-     * Verifies that the /logs?format=JSON response covers all cluster nodes and that every logLink
-     * URL is reachable (HTTP 200). If a logLink used the master's port instead of the worker's
-     * port, the curl would fail — proving the fix is effective.
-     */
     @Test
     public void testLogUrlUsesPerNodePort() throws IOException, InterruptedException {
-        // wait for seatunnel.log to appear on both nodes
         Awaitility.await()
                 .atMost(1, TimeUnit.MINUTES)
                 .untilAsserted(
@@ -139,7 +130,6 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                                     r2.getStdout().isBlank(), "worker has no log files yet");
                         });
 
-        // call /logs?format=JSON from inside the master container
         Container.ExecResult logsResult =
                 masterServer.execInContainer(
                         "sh",
@@ -157,7 +147,6 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
         ArrayNode logArray = JsonUtils.parseArray(jsonBody);
         Assertions.assertFalse(logArray.isEmpty(), "No logs returned from master");
 
-        // Step 1: all cluster nodes must be represented in the response
         Set<String> respondedHosts = new HashSet<>();
         for (JsonNode entry : logArray) {
             respondedHosts.add(extractHost(entry.get("node").asText()));
@@ -167,7 +156,6 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                 respondedHosts.size(),
                 "Expected both cluster nodes in /logs response, got: " + respondedHosts);
 
-        // Step 2: every logLink URL must return HTTP 200 — wrong port means connection refused
         for (JsonNode entry : logArray) {
             String link = entry.get("logLink").asText();
             Container.ExecResult curlResult =
@@ -196,21 +184,18 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
         copySeaTunnelStarterToContainer(container);
         container.setExposedPorts(Collections.singletonList(5801));
 
-        // base config (hazelcast + default seatunnel)
         container.withCopyFileToContainer(
                 MountableFile.forHostPath(MULTIPORT_RESOURCES), CONFIG_PATH.toString());
 
-        // cluster hazelcast config (both nodes use the same topology config)
         container.withCopyFileToContainer(
                 MountableFile.forHostPath(MULTIPORT_RESOURCES + "job-log-multiport/hazelcast.yaml"),
                 CONFIG_PATH.resolve("hazelcast.yaml").toString());
 
-        // node-specific seatunnel config (different REST port per node)
+        // each node uses a different REST port, so seatunnel.yaml is node-specific
         container.withCopyFileToContainer(
                 MountableFile.forHostPath(MULTIPORT_RESOURCES + seatunnelYamlRelPath),
                 CONFIG_PATH.resolve("seatunnel.yaml").toString());
 
-        // log4j2 config that writes per-job log files to /tmp/seatunnel/logs/
         container.withCopyFileToContainer(
                 MountableFile.forHostPath(
                         MULTIPORT_RESOURCES + "job-log-multiport/log4j2.properties"),

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.e2e.joblog;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.apache.seatunnel.common.utils.JsonUtils;
+import org.apache.seatunnel.e2e.common.util.ContainerUtil;
+import org.apache.seatunnel.engine.e2e.SeaTunnelEngineContainer;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerLoggerFactory;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.response.Response;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+
+/**
+ * Verifies that each node's logLink URL uses that node's own REST port, not the master's port.
+ *
+ * <p>Bug: when nodes have different REST ports, allLogNameList() always used the master's port for
+ * every URL. Fix: GetNodeHttpPortOperation fetches the REST port from the target node itself.
+ */
+public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
+
+    private static final int MASTER_HTTP_PORT = 8080;
+    private static final int WORKER_HTTP_PORT = 8081;
+
+    private static final Path BIN_PATH = Paths.get(SEATUNNEL_HOME, "bin", SERVER_SHELL);
+    private static final Path CONFIG_PATH = Paths.get(SEATUNNEL_HOME, "config");
+    private static final Path HADOOP_JAR_PATH =
+            Paths.get(SEATUNNEL_HOME, "lib/seatunnel-hadoop3-3.1.4-uber.jar");
+
+    private static final String MULTIPORT_RESOURCES =
+            PROJECT_ROOT_PATH
+                    + "/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base"
+                    + "/src/test/resources/";
+
+    private GenericContainer<?> masterServer;
+    private GenericContainer<?> workerServer;
+    private final Network CLUSTER_NETWORK = Network.newNetwork();
+
+    @Override
+    @BeforeEach
+    public void startUp() throws Exception {
+        masterServer = createServer("server", "job-log-multiport/seatunnel-master.yaml");
+        workerServer = createServer("secondServer", "job-log-multiport/seatunnel-worker.yaml");
+
+        // wait until both members joined
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            Response response =
+                                    given().get(
+                                                    "http://"
+                                                            + masterServer.getHost()
+                                                            + ":"
+                                                            + masterServer.getMappedPort(5801)
+                                                            + "/hazelcast/rest/cluster");
+                            response.then().statusCode(200);
+                            Assertions.assertEquals(
+                                    2, response.jsonPath().getList("members").size());
+                        });
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (masterServer != null) {
+            masterServer.close();
+        }
+        if (workerServer != null) {
+            workerServer.close();
+        }
+        CLUSTER_NETWORK.close();
+    }
+
+    /**
+     * Verifies that the /logs?format=JSON response covers all cluster nodes and that every logLink
+     * URL is reachable (HTTP 200). If a logLink used the master's port instead of the worker's
+     * port, the curl would fail — proving the fix is effective.
+     */
+    @Test
+    public void testLogUrlUsesPerNodePort() throws IOException, InterruptedException {
+        // wait for seatunnel.log to appear on both nodes
+        Awaitility.await()
+                .atMost(1, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            Container.ExecResult r1 =
+                                    masterServer.execInContainer(
+                                            "sh",
+                                            "-c",
+                                            "ls /tmp/seatunnel/logs/ 2>/dev/null | head -1");
+                            Container.ExecResult r2 =
+                                    workerServer.execInContainer(
+                                            "sh",
+                                            "-c",
+                                            "ls /tmp/seatunnel/logs/ 2>/dev/null | head -1");
+                            Assertions.assertFalse(
+                                    r1.getStdout().isBlank(), "master has no log files yet");
+                            Assertions.assertFalse(
+                                    r2.getStdout().isBlank(), "worker has no log files yet");
+                        });
+
+        // call /logs?format=JSON from inside the master container
+        Container.ExecResult logsResult =
+                masterServer.execInContainer(
+                        "sh",
+                        "-c",
+                        "curl -sf 'http://localhost:" + MASTER_HTTP_PORT + "/logs?format=JSON'");
+
+        Assertions.assertEquals(
+                0,
+                logsResult.getExitCode(),
+                "curl /logs?format=JSON failed: " + logsResult.getStderr());
+
+        String jsonBody = logsResult.getStdout();
+        Assertions.assertFalse(jsonBody.isBlank(), "Log list JSON is empty");
+
+        ArrayNode logArray = JsonUtils.parseArray(jsonBody);
+        Assertions.assertFalse(logArray.isEmpty(), "No logs returned from master");
+
+        // Step 1: all cluster nodes must be represented in the response
+        Set<String> respondedHosts = new HashSet<>();
+        for (JsonNode entry : logArray) {
+            respondedHosts.add(extractHost(entry.get("node").asText()));
+        }
+        Assertions.assertEquals(
+                2,
+                respondedHosts.size(),
+                "Expected both cluster nodes in /logs response, got: " + respondedHosts);
+
+        // Step 2: every logLink URL must return HTTP 200 — wrong port means connection refused
+        for (JsonNode entry : logArray) {
+            String link = entry.get("logLink").asText();
+            Container.ExecResult curlResult =
+                    masterServer.execInContainer(
+                            "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", link);
+            Assertions.assertEquals(
+                    "200", curlResult.getStdout(), "logLink not reachable (wrong port?): " + link);
+        }
+    }
+
+    private GenericContainer<?> createServer(String networkAlias, String seatunnelYamlRelPath)
+            throws IOException, InterruptedException {
+        GenericContainer<?> container =
+                new GenericContainer<>(getDockerImage())
+                        .withNetwork(CLUSTER_NETWORK)
+                        .withEnv("TZ", "UTC")
+                        .withCommand(ContainerUtil.adaptPathForWin(BIN_PATH.toString()))
+                        .withNetworkAliases(networkAlias)
+                        .withExposedPorts()
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(
+                                                "seatunnel-engine:" + JDK_DOCKER_IMAGE)))
+                        .waitingFor(Wait.forListeningPort());
+
+        copySeaTunnelStarterToContainer(container);
+        container.setExposedPorts(Collections.singletonList(5801));
+
+        // base config (hazelcast + default seatunnel)
+        container.withCopyFileToContainer(
+                MountableFile.forHostPath(MULTIPORT_RESOURCES), CONFIG_PATH.toString());
+
+        // cluster hazelcast config (both nodes use the same topology config)
+        container.withCopyFileToContainer(
+                MountableFile.forHostPath(MULTIPORT_RESOURCES + "job-log-multiport/hazelcast.yaml"),
+                CONFIG_PATH.resolve("hazelcast.yaml").toString());
+
+        // node-specific seatunnel config (different REST port per node)
+        container.withCopyFileToContainer(
+                MountableFile.forHostPath(MULTIPORT_RESOURCES + seatunnelYamlRelPath),
+                CONFIG_PATH.resolve("seatunnel.yaml").toString());
+
+        // log4j2 config that writes per-job log files to /tmp/seatunnel/logs/
+        container.withCopyFileToContainer(
+                MountableFile.forHostPath(
+                        MULTIPORT_RESOURCES + "job-log-multiport/log4j2.properties"),
+                CONFIG_PATH.resolve("log4j2.properties").toString());
+
+        container.withCopyFileToContainer(
+                MountableFile.forHostPath(
+                        PROJECT_ROOT_PATH
+                                + "/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/target/seatunnel-hadoop3-3.1.4-uber.jar"),
+                HADOOP_JAR_PATH.toString());
+
+        container.start();
+        executeExtraCommands(container);
+        ContainerUtil.copyConnectorJarToContainer(
+                container,
+                "/fakesource_to_console.conf",
+                getConnectorModulePath(),
+                getConnectorNamePrefix(),
+                getConnectorType(),
+                SEATUNNEL_HOME);
+
+        return container;
+    }
+
+    /** Extracts the host part from a "host:port" string. */
+    private String extractHost(String nodeField) {
+        if (nodeField == null) {
+            return "";
+        }
+        int colon = nodeField.lastIndexOf(':');
+        return colon >= 0 ? nodeField.substring(0, colon) : nodeField;
+    }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -125,9 +125,11 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                                             "-c",
                                             "ls /tmp/seatunnel/logs/ 2>/dev/null | head -1");
                             Assertions.assertFalse(
-                                    r1.getStdout().isBlank(), "master has no log files yet");
+                                    r1.getStdout().trim().isEmpty(),
+                                    "master has no log files yet");
                             Assertions.assertFalse(
-                                    r2.getStdout().isBlank(), "worker has no log files yet");
+                                    r2.getStdout().trim().isEmpty(),
+                                    "worker has no log files yet");
                         });
 
         Container.ExecResult logsResult =
@@ -142,7 +144,7 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                 "curl /logs?format=JSON failed: " + logsResult.getStderr());
 
         String jsonBody = logsResult.getStdout();
-        Assertions.assertFalse(jsonBody.isBlank(), "Log list JSON is empty");
+        Assertions.assertFalse(jsonBody.trim().isEmpty(), "Log list JSON is empty");
 
         ArrayNode logArray = JsonUtils.parseArray(jsonBody);
         Assertions.assertFalse(logArray.isEmpty(), "No logs returned from master");

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -125,11 +125,9 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
                                             "-c",
                                             "ls /tmp/seatunnel/logs/ 2>/dev/null | head -1");
                             Assertions.assertFalse(
-                                    r1.getStdout().trim().isEmpty(),
-                                    "master has no log files yet");
+                                    r1.getStdout().trim().isEmpty(), "master has no log files yet");
                             Assertions.assertFalse(
-                                    r2.getStdout().trim().isEmpty(),
-                                    "worker has no log files yet");
+                                    r2.getStdout().trim().isEmpty(), "worker has no log files yet");
                         });
 
         Container.ExecResult logsResult =

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/joblog/JobLogUrlPortIT.java
@@ -76,8 +76,8 @@ public class JobLogUrlPortIT extends SeaTunnelEngineContainer {
     @Override
     @BeforeEach
     public void startUp() throws Exception {
-        masterServer = createServer("server", "job-log-multiport/seatunnel-master.yaml");
-        workerServer = createServer("secondServer", "job-log-multiport/seatunnel-worker.yaml");
+        masterServer = createServer("master", "job-log-multiport/seatunnel-master.yaml");
+        workerServer = createServer("worker", "job-log-multiport/seatunnel-worker.yaml");
 
         Awaitility.await()
                 .atMost(2, TimeUnit.MINUTES)

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/hazelcast.yaml
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/hazelcast.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hazelcast:
+  cluster-name: seatunnel
+  network:
+    rest-api:
+      enabled: true
+      endpoint-groups:
+        CLUSTER_WRITE:
+          enabled: true
+        DATA:
+          enabled: true
+    join:
+      tcp-ip:
+        enabled: true
+        member-list:
+          - secondServer
+          - server
+    port:
+      auto-increment: true
+      port-count: 100
+      port: 5801
+  properties:
+    hazelcast.invocation.max.retry.count: 100
+    hazelcast.invocation.retry.pause.millis: 1000
+    hazelcast.tcp.join.port.try.count: 30
+    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true
+    hazelcast.logging.type: log4j2
+    hazelcast.operation.generic.thread.count: 200

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/hazelcast.yaml
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/hazelcast.yaml
@@ -29,8 +29,8 @@ hazelcast:
       tcp-ip:
         enabled: true
         member-list:
-          - secondServer
-          - server
+          - master
+          - worker
     port:
       auto-increment: true
       port-count: 100

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/log4j2.properties
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/log4j2.properties
@@ -1,0 +1,97 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# The minimum amount of time, in seconds, that must elapse before the file configuration is checked for changes.
+monitorInterval = 60
+
+property.file_path = ${sys:seatunnel.logs.path:-/tmp/seatunnel/logs}
+property.file_name = ${sys:seatunnel.logs.file_name:-seatunnel}
+property.file_split_size = 100MB
+property.file_count = 100
+property.file_ttl = 7d
+
+rootLogger.level = INFO
+
+############################ log output to console #############################
+rootLogger.appenderRef.consoleStdout.ref = consoleStdoutAppender
+rootLogger.appenderRef.consoleStderr.ref = consoleStderrAppender
+############################ log output to console #############################
+############################ log output to file    #############################
+rootLogger.appenderRef.file.ref = routingAppender
+############################ log output to file    #############################
+
+appender.consoleStdout.name = consoleStdoutAppender
+appender.consoleStdout.type = CONSOLE
+appender.consoleStdout.target = SYSTEM_OUT
+appender.consoleStdout.layout.type = PatternLayout
+appender.consoleStdout.layout.pattern = [%X{ST-JID}] %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%-30.30c{1.}] [%t] - %m%n
+appender.consoleStdout.filter.acceptLtWarn.type = ThresholdFilter
+appender.consoleStdout.filter.acceptLtWarn.level = WARN
+appender.consoleStdout.filter.acceptLtWarn.onMatch = DENY
+appender.consoleStdout.filter.acceptLtWarn.onMismatch = ACCEPT
+
+appender.consoleStderr.name = consoleStderrAppender
+appender.consoleStderr.type = CONSOLE
+appender.consoleStderr.target = SYSTEM_ERR
+appender.consoleStderr.layout.type = PatternLayout
+appender.consoleStderr.layout.pattern = [%X{ST-JID}] %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%-30.30c{1.}] [%t] - %m%n
+appender.consoleStderr.filter.acceptGteWarn.type = ThresholdFilter
+appender.consoleStderr.filter.acceptGteWarn.level = WARN
+appender.consoleStderr.filter.acceptGteWarn.onMatch = ACCEPT
+appender.consoleStderr.filter.acceptGteWarn.onMismatch = DENY
+
+appender.routing.name = routingAppender
+appender.routing.type = Routing
+appender.routing.purge.type = IdlePurgePolicy
+appender.routing.purge.timeToLive = 60
+appender.routing.route.type = Routes
+appender.routing.route.pattern = $${ctx:ST-JID}
+appender.routing.route.system.type = Route
+appender.routing.route.system.key = $${ctx:ST-JID}
+appender.routing.route.system.ref = fileAppender
+appender.routing.route.job.type = Route
+appender.routing.route.job.appender.type = File
+appender.routing.route.job.appender.name = job-${ctx:ST-JID}
+appender.routing.route.job.appender.fileName = ${file_path}/job-${ctx:ST-JID}.log
+appender.routing.route.job.appender.layout.type = PatternLayout
+appender.routing.route.job.appender.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%-30.30c{1.}] [%t] - %m%n
+
+appender.file.name = fileAppender
+appender.file.type = RollingFile
+appender.file.fileName = ${file_path}/${file_name}.log
+appender.file.filePattern = ${file_path}/${file_name}.log.%d{yyyy-MM-dd}-%i
+appender.file.append = true
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%-30.30c{1.}] [%t] - %m%n
+appender.file.policies.type = Policies
+appender.file.policies.time.type = TimeBasedTriggeringPolicy
+appender.file.policies.time.modulate = true
+appender.file.policies.size.type = SizeBasedTriggeringPolicy
+appender.file.policies.size.size = ${file_split_size}
+appender.file.strategy.type = DefaultRolloverStrategy
+appender.file.strategy.fileIndex = nomax
+appender.file.strategy.action.type = Delete
+appender.file.strategy.action.basepath = ${file_path}
+appender.file.strategy.action.maxDepth = 1
+appender.file.strategy.action.condition.type = IfFileName
+appender.file.strategy.action.condition.glob = ${file_name}.log*
+appender.file.strategy.action.condition.nested_condition.type = IfAny
+appender.file.strategy.action.condition.nested_condition.lastModify.type = IfLastModified
+appender.file.strategy.action.condition.nested_condition.lastModify.age = ${file_ttl}
+appender.file.strategy.action.condition.nested_condition.fileCount.type = IfAccumulatedFileCount
+appender.file.strategy.action.condition.nested_condition.fileCount.exceeds = ${file_count}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/seatunnel-master.yaml
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/seatunnel-master.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+seatunnel:
+  engine:
+    history-job-expire-minutes: 1
+    backup-count: 2
+    queue-type: blockingqueue
+    print-execution-info-interval: 10
+    slot-service:
+      dynamic-slot: true
+    checkpoint:
+      interval: 300000
+      timeout: 100000
+      storage:
+        type: localfile
+        max-retained: 3
+        plugin-config:
+          namespace: /tmp/seatunnel/checkpoint_snapshot/
+    http:
+      enable-http: true
+      port: 8080
+      enable-dynamic-port: false
+    telemetry:
+      metric:
+        enabled: false
+      logs:
+        scheduled-deletion-enable: true

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/seatunnel-worker.yaml
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/job-log-multiport/seatunnel-worker.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+seatunnel:
+  engine:
+    history-job-expire-minutes: 1
+    backup-count: 2
+    queue-type: blockingqueue
+    print-execution-info-interval: 10
+    slot-service:
+      dynamic-slot: true
+    checkpoint:
+      interval: 300000
+      timeout: 100000
+      storage:
+        type: localfile
+        max-retained: 3
+        plugin-config:
+          namespace: /tmp/seatunnel/checkpoint_snapshot/
+    http:
+      enable-http: true
+      port: 8081
+      enable-dynamic-port: false
+    telemetry:
+      metric:
+        enabled: false
+      logs:
+        scheduled-deletion-enable: true

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.operation;
+
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.serializable.ClientToServerOperationDataSerializerHook;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+
+/** Returns the REST HTTP port configured on the node that executes this operation. */
+public class GetNodeHttpPortOperation extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
+
+    private int response;
+
+    @Override
+    public void run() {
+        SeaTunnelServer service = getService();
+        response = service.getSeaTunnelConfig().getEngineConfig().getHttpConfig().getPort();
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClientToServerOperationDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ClientToServerOperationDataSerializerHook.GET_NODE_HTTP_PORT_OPERATION;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperation.java
@@ -20,13 +20,9 @@ package org.apache.seatunnel.engine.server.operation;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.serializable.ClientToServerOperationDataSerializerHook;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.operationservice.Operation;
-
-import java.io.IOException;
 
 /** Returns the REST HTTP port configured on the node that executes this operation. */
 public class GetNodeHttpPortOperation extends Operation
@@ -53,15 +49,5 @@ public class GetNodeHttpPortOperation extends Operation
     @Override
     public int getClassId() {
         return ClientToServerOperationDataSerializerHook.GET_NODE_HTTP_PORT_OPERATION;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        super.writeInternal(out);
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        super.readInternal(in);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -24,7 +24,10 @@ import org.apache.seatunnel.common.utils.FileUtils;
 import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.engine.common.config.server.HttpConfig;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.operation.GetNodeHttpPortOperation;
+import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
 
+import com.hazelcast.cluster.Member;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -60,50 +63,58 @@ public class LogService extends BaseLogService {
         HttpConfig httpConfig =
                 seaTunnelServer.getSeaTunnelConfig().getEngineConfig().getHttpConfig();
         String contextPath = httpConfig.getContextPath();
-        int port = httpConfig.getPort();
 
         List<Tuple3<String, String, String>> allLogNameList = new ArrayList<>();
 
-        JsonArray systemMonitoringInformationJsonValues =
-                getSystemMonitoringInformationJsonValues();
-        systemMonitoringInformationJsonValues.forEach(
-                systemMonitoringInformation -> {
-                    String host = systemMonitoringInformation.asObject().get("host").asString();
-                    String url = "http://" + host + ":" + port + contextPath;
-                    String logUrl = url + REST_URL_GET_ALL_LOG_NAME;
+        for (Member member : nodeEngine.getHazelcastInstance().getCluster().getMembers()) {
+            String host = member.getAddress().getHost();
+            int nodeHttpPort;
+            try {
+                nodeHttpPort =
+                        (int)
+                                NodeEngineUtil.sendOperationToMemberNode(
+                                                nodeEngine,
+                                                new GetNodeHttpPortOperation(),
+                                                member.getAddress())
+                                        .get();
+            } catch (Exception e) {
+                log.warn("Failed to get HTTP port from member {}, skip.", member.getAddress(), e);
+                continue;
+            }
 
-                    String allName =
-                            httpConfig.isEnableBasicAuth()
-                                    ? sendGet(
-                                            logUrl,
-                                            httpConfig.getBasicAuthUsername(),
-                                            httpConfig.getBasicAuthPassword())
-                                    : sendGet(logUrl);
+            String url = "http://" + host + ":" + nodeHttpPort + contextPath;
+            String logUrl = url + REST_URL_GET_ALL_LOG_NAME;
 
-                    if (StringUtils.isBlank(allName)) {
-                        log.warn(
-                                "GET {} returned empty body (null/empty). Skip this node.", logUrl);
-                        return;
-                    }
+            String allName =
+                    httpConfig.isEnableBasicAuth()
+                            ? sendGet(
+                                    logUrl,
+                                    httpConfig.getBasicAuthUsername(),
+                                    httpConfig.getBasicAuthPassword())
+                            : sendGet(logUrl);
 
-                    if (log.isDebugEnabled()) {
-                        log.debug("Request: {} , Result: {}", url, allName);
-                    }
-                    ArrayNode jsonNodes = JsonUtils.parseArray(allName);
+            if (StringUtils.isBlank(allName)) {
+                log.warn("GET {} returned empty body (null/empty). Skip this node.", logUrl);
+                continue;
+            }
 
-                    jsonNodes.forEach(
-                            jsonNode -> {
-                                String fileName = jsonNode.asText();
-                                if (StringUtils.isNotBlank(jobId) && !fileName.contains(jobId)) {
-                                    return;
-                                }
-                                allLogNameList.add(
-                                        new Tuple3<>(
-                                                host + ":" + port,
-                                                url + REST_URL_LOGS + "/" + fileName,
-                                                fileName));
-                            });
-                });
+            if (log.isDebugEnabled()) {
+                log.debug("Request: {} , Result: {}", url, allName);
+            }
+            ArrayNode jsonNodes = JsonUtils.parseArray(allName);
+
+            final String nodeId = host + ":" + nodeHttpPort;
+            jsonNodes.forEach(
+                    jsonNode -> {
+                        String fileName = jsonNode.asText();
+                        if (StringUtils.isNotBlank(jobId) && !fileName.contains(jobId)) {
+                            return;
+                        }
+                        allLogNameList.add(
+                                new Tuple3<>(
+                                        nodeId, url + REST_URL_LOGS + "/" + fileName, fileName));
+                    });
+        }
 
         return allLogNameList;
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -66,7 +66,7 @@ public class LogService extends BaseLogService {
 
         List<Tuple3<String, String, String>> allLogNameList = new ArrayList<>();
 
-        for (Member member : nodeEngine.getHazelcastInstance().getCluster().getMembers()) {
+        for (Member member : nodeEngine.getClusterService().getMembers()) {
             String host = member.getAddress().getHost();
             int nodeHttpPort;
             try {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.engine.server.operation.GetJobDetailStatusOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobInfoOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobMetricsOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobStatusOperation;
+import org.apache.seatunnel.engine.server.operation.GetNodeHttpPortOperation;
 import org.apache.seatunnel.engine.server.operation.GetRunningJobMetricsOperation;
 import org.apache.seatunnel.engine.server.operation.PrintMessageOperation;
 import org.apache.seatunnel.engine.server.operation.SavePointJobOperation;
@@ -72,6 +73,7 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
     public static final int GET_JOB_CHECKPOINT_OPERATION = 12;
     public static final int GET_CHECKPOINT_OVERVIEW_OPERATION = 13;
     public static final int GET_CHECKPOINT_HISTORY_OPERATION = 14;
+    public static final int GET_NODE_HTTP_PORT_OPERATION = 15;
 
     public static final int FACTORY_ID =
             FactoryIdHelper.getFactoryId(
@@ -122,6 +124,8 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
                     return new GetCheckpointOverviewOperation();
                 case GET_CHECKPOINT_HISTORY_OPERATION:
                     return new GetCheckpointHistoryOperation();
+                case GET_NODE_HTTP_PORT_OPERATION:
+                    return new GetNodeHttpPortOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperationTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/operation/GetNodeHttpPortOperationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.operation;
+
+import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
+import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.cluster.Address;
+
+public class GetNodeHttpPortOperationTest
+        extends AbstractSeaTunnelServerTest<GetNodeHttpPortOperationTest> {
+
+    private static final int HTTP_PORT = 18085;
+
+    @Override
+    public SeaTunnelConfig loadSeaTunnelConfig() {
+        SeaTunnelConfig config = super.loadSeaTunnelConfig();
+        config.getEngineConfig().getHttpConfig().setPort(HTTP_PORT);
+        return config;
+    }
+
+    @Test
+    public void testReturnsConfiguredHttpPort() throws Exception {
+        Address localAddress = instance.getCluster().getLocalMember().getAddress();
+
+        int result =
+                (int)
+                        NodeEngineUtil.sendOperationToMemberNode(
+                                        nodeEngine, new GetNodeHttpPortOperation(), localAddress)
+                                .get();
+
+        Assertions.assertEquals(HTTP_PORT, result);
+    }
+}


### PR DESCRIPTION
Fixes #9263

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
 When calling the log list API on a master node in a cluster where nodes have different REST ports configured, all returned ogLink URLs incorrectly use the master node's REST port instead of each node's own port. This makes worker node log URLs  unreachable.                                              
                                                                                                                                   
  SeaTunnel exposes this API through two endpoints backed by the same LogService:                                                  
  - Hazelcast REST API (port 5801): GET /hazelcast/rest/maps/logs
  - Jetty REST API (port 8080 by default): GET /logs                                                                               
                                                            
  Both are affected by this bug and fixed by this PR.                                                                              
                                                                                                                                   
  Root cause: 
LogService.allLogNameList() read the HTTP port from the local (master) node's HttpConfig and applied it to every  node's URL, while only the host was fetched per-node.                                                                            
                                                                                                                                   
  Fix: 
Introduce GetNodeHttpPortOperation, a dedicated Hazelcast Operation that each node executes locally to return its own configured REST port. LogService now iterates cluster.getMembers() directly and queries each member's port via this Operation, so every logLink URL is assembled with the correct host and port.                                                                  
                                                            

                                                            
  // Before — master port applied to all nodes            
```java                                                                                             
  int port = httpConfig.getPort();  // always master's port                                                                                            
  getSystemMonitoringInformationJsonValues().forEach(info -> {                                                                                         
      String host = info.asObject().get("host").asString();                                                                                            
      String url = "http://" + host + ":" + port + contextPath;  // worker gets master port
  });      
```                                                                                                                                            
                                                                                                                                                       
  // After — each node reports its own port  
```java 
  for (Member member : nodeEngine.getClusterService().getMembers()) {                                                                
      String host = member.getAddress().getHost();                                                                                                     
      int nodeHttpPort = (int) NodeEngineUtil
              .sendOperationToMemberNode(nodeEngine, new GetNodeHttpPortOperation(), member.getAddress())                                              
              .get();                                                                                                                                  
      String url = "http://" + host + ":" + nodeHttpPort + contextPath;  // correct per-node port                                                    
  }
```
             

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
  Yes. In clusters where nodes are configured with different REST ports, the logLink field in log list API responses previously pointed to wrong ports for worker nodes, making the links unreachable. After this fix, each logLink uses the correct port of the  node that owns the log file.
                                                                                                                                   
  This affects both the Hazelcast REST API (/hazelcast/rest/maps/logs) and the Jetty REST API (/logs), as both share the same LogService implementation.
                                                                                                                                   

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
**Unit test** — `GetNodeHttpPortOperationTest` (in-process, single node):                                                                            
  Overrides the configured HTTP port to `18085`, sends `GetNodeHttpPortOperation` to                                                                 
  the local member via `NodeEngineUtil.sendOperationToMemberNode`, and asserts the                                                                     
  returned value equals `18085`. Verifies that the Operation correctly reads its own                                                                   
  node's `SeaTunnelConfig`.                                                                                                                            
                                                                                                                                                       
  **E2E test** — `JobLogUrlPortIT` (Testcontainers, 2-node cluster):                                                                                   
 Starts a cluster where the master uses REST port 8080 and the worker uses 8081. Log files are generated automatically on node
  startup — no job submission is required.                                                                                         
                                                            
  1. Waits for log files to appear on both nodes.                                                                                  
  2. Calls GET /logs?format=JSON on the master and asserts that both nodes are represented in the response (all-node coverage  check).                                                                                                                          
  3. For every logLink URL in the response, runs curl from inside the master container and asserts HTTP 200. A wrong port would result in connection refused

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)