### PR TITLE
[Fix][Core] Fix seatunnel.cmd crash before 10 AM due to %time% leadin…

### DIFF
--- a/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.cmd
+++ b/seatunnel-core/seatunnel-starter/src/main/bin/seatunnel.cmd
@@ -86,7 +86,9 @@ if exist "%CONF_DIR%\log4j2_client.properties" (
             set datetime=%%A
             set ndate=!datetime:~0,4!!datetime:~4,2!!datetime:~6,2!
         )
-        set "JAVA_OPTS=!JAVA_OPTS! -Dseatunnel.logs.file_name=seatunnel-starter-client-!ndate!-!time:~0,2!!time:~3,2!!time:~6,2!!ntime:~0,6!"
+        set "timestamp=!time:~0,2!!time:~3,2!!time:~6,2!!ntime:~0,6!"
+        set "timestamp=!timestamp: =0!"
+        set "JAVA_OPTS=!JAVA_OPTS! -Dseatunnel.logs.file_name=seatunnel-starter-client-!ndate!-!timestamp!"
     ) else (
         set "JAVA_OPTS=!JAVA_OPTS! -Dseatunnel.logs.file_name=seatunnel-starter-client"
     )


### PR DESCRIPTION
close #10805

On Windows, %time% returns a leading space instead of a leading zero
for hours before 10 AM (e.g., " 9:38:04" instead of "09:38:04").

When running in local mode (-m local), the script generates a
timestamp-based log file name using %time% substring extraction.
The leading space gets embedded into JAVA_OPTS, causing the final
Java command to be split incorrectly:

  java ... -Dseatunnel.logs.file_name=seatunnel-starter-client-20260427- 93804 93804 -cp ...

Java interprets the bare number "93804" as the main class, resulting
in ClassNotFoundException.

Fix by concatenating the time parts into a timestamp variable first,
then replacing all spaces with "0" before embedding it into JAVA_OPTS.

This only affects seatunnel.cmd (Windows). seatunnel-cluster.cmd and
seatunnel-connector.cmd are not affected as they use fixed log file names.


<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)