### PR TITLE
[Bugfix][Zeta]Fix the problem of scientific notation when restApi obtains read and write rate

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -71,6 +71,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -778,7 +779,15 @@ public abstract class BaseService {
                     if (value instanceof Map) {
                         members.add(key, metricsToJsonObject((Map<String, Object>) value));
                     } else {
-                        members.add(key, value.toString());
+                        String strValue;
+                        if (value instanceof Float
+                                || value instanceof Double
+                                || value instanceof BigDecimal) {
+                            strValue = new BigDecimal(value.toString()).toPlainString();
+                        } else {
+                            strValue = value.toString();
+                        }
+                        members.add(key, strValue);
                     }
                 });
         return members;

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -376,6 +377,26 @@ public class BaseServiceTableMetricsTest {
         Assertions.assertNotNull(tableSinkCount);
         Assertions.assertEquals(1L, tableSinkCount.get("Sink[0].fake.user_table"));
         Assertions.assertEquals(2L, tableSinkCount.get("Sink[1].fake.user_table"));
+    }
+
+    @Test
+    public void testMetricsToJsonObjectForSpecialNumber() {
+        // test double
+        Double doubleNumber = 85210718.2630262;
+        String doubleNumberStr = doubleNumber.toString();
+        Assertions.assertTrue(doubleNumberStr.contains("E"));
+        Assertions.assertEquals(
+                new BigDecimal(doubleNumber.toString()).toPlainString(), "85210718.2630262");
+        // test float
+        Float floatNumber = 85210718.263026f;
+        String floatNumberStr = floatNumber.toString();
+        Assertions.assertTrue(floatNumberStr.contains("E"));
+        Assertions.assertFalse(
+                new BigDecimal(floatNumber.toString()).toPlainString().contains("E"));
+        // test BigDecimal
+        BigDecimal bigDecimalNumber = new BigDecimal("85210718.2630262");
+        Assertions.assertEquals(
+                new BigDecimal(bigDecimalNumber.toString()).toPlainString(), "85210718.2630262");
     }
 
     private JobDAGInfo createDAGInfoWithMultipleSinks() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.lang.reflect.Method;
@@ -397,6 +398,49 @@ public class BaseServiceTableMetricsTest {
         BigDecimal bigDecimalNumber = new BigDecimal("85210718.2630262");
         Assertions.assertEquals(
                 new BigDecimal(bigDecimalNumber.toString()).toPlainString(), "85210718.2630262");
+    }
+
+    @Test
+    public void testMetricsToJsonObjectConvertsLargeNumbersToPlainString() throws Exception {
+        Method metricsToJsonObjectMethod =
+                BaseService.class.getDeclaredMethod("metricsToJsonObject", Map.class);
+        metricsToJsonObjectMethod.setAccessible(true);
+
+        Map<String, Object> metricsMap = new HashMap<>();
+        metricsMap.put("SourceReceivedQPS", 85210718.2630262);
+        metricsMap.put("SinkWriteQPS", 99999999.999);
+        metricsMap.put("FloatValue", 85210718.263026f);
+        metricsMap.put("LongValue", 123456789L);
+        metricsMap.put("IntValue", 42);
+
+        // Nested map to test recursive conversion
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("NestedQPS", 77777777.777);
+        metricsMap.put("NestedMetrics", nestedMap);
+
+        JsonObject result =
+                (JsonObject) metricsToJsonObjectMethod.invoke(jobInfoService, metricsMap);
+        String jsonString = result.toString();
+
+        // Verify plain string format is present
+        Assertions.assertTrue(
+                jsonString.contains("85210718.2630262"),
+                "JSON should contain plain number format without scientific notation");
+        Assertions.assertTrue(
+                jsonString.contains("99999999.999"),
+                "JSON should contain large decimal in plain format");
+        Assertions.assertTrue(
+                jsonString.contains("77777777.777"),
+                "JSON should contain nested value in plain format");
+
+        // Verify NO scientific notation (no "E" in the output)
+        Assertions.assertFalse(
+                jsonString.contains("E"),
+                "JSON should NOT contain scientific notation (letter 'E')");
+
+        // Verify integer values are also present
+        Assertions.assertTrue(jsonString.contains("123456789"), "JSON should contain long value");
+        Assertions.assertTrue(jsonString.contains("42"), "JSON should contain int value");
     }
 
     private JobDAGInfo createDAGInfoWithMultipleSinks() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceTableMetricsTest.java
@@ -381,27 +381,10 @@ public class BaseServiceTableMetricsTest {
     }
 
     @Test
-    public void testMetricsToJsonObjectForSpecialNumber() {
-        // test double
-        Double doubleNumber = 85210718.2630262;
-        String doubleNumberStr = doubleNumber.toString();
-        Assertions.assertTrue(doubleNumberStr.contains("E"));
-        Assertions.assertEquals(
-                new BigDecimal(doubleNumber.toString()).toPlainString(), "85210718.2630262");
-        // test float
-        Float floatNumber = 85210718.263026f;
-        String floatNumberStr = floatNumber.toString();
-        Assertions.assertTrue(floatNumberStr.contains("E"));
-        Assertions.assertFalse(
-                new BigDecimal(floatNumber.toString()).toPlainString().contains("E"));
-        // test BigDecimal
-        BigDecimal bigDecimalNumber = new BigDecimal("85210718.2630262");
-        Assertions.assertEquals(
-                new BigDecimal(bigDecimalNumber.toString()).toPlainString(), "85210718.2630262");
-    }
-
-    @Test
     public void testMetricsToJsonObjectConvertsLargeNumbersToPlainString() throws Exception {
+        Double doubleValue = 85210718.2630262;
+        Assertions.assertTrue(doubleValue.toString().contains("E"));
+
         Method metricsToJsonObjectMethod =
                 BaseService.class.getDeclaredMethod("metricsToJsonObject", Map.class);
         metricsToJsonObjectMethod.setAccessible(true);
@@ -411,36 +394,12 @@ public class BaseServiceTableMetricsTest {
         metricsMap.put("SinkWriteQPS", 99999999.999);
         metricsMap.put("FloatValue", 85210718.263026f);
         metricsMap.put("LongValue", 123456789L);
-        metricsMap.put("IntValue", 42);
-
-        // Nested map to test recursive conversion
-        Map<String, Object> nestedMap = new HashMap<>();
-        nestedMap.put("NestedQPS", 77777777.777);
-        metricsMap.put("NestedMetrics", nestedMap);
+        metricsMap.put("BigDecimalValue", new BigDecimal("6.752132322232343E7"));
 
         JsonObject result =
                 (JsonObject) metricsToJsonObjectMethod.invoke(jobInfoService, metricsMap);
         String jsonString = result.toString();
-
-        // Verify plain string format is present
-        Assertions.assertTrue(
-                jsonString.contains("85210718.2630262"),
-                "JSON should contain plain number format without scientific notation");
-        Assertions.assertTrue(
-                jsonString.contains("99999999.999"),
-                "JSON should contain large decimal in plain format");
-        Assertions.assertTrue(
-                jsonString.contains("77777777.777"),
-                "JSON should contain nested value in plain format");
-
-        // Verify NO scientific notation (no "E" in the output)
-        Assertions.assertFalse(
-                jsonString.contains("E"),
-                "JSON should NOT contain scientific notation (letter 'E')");
-
-        // Verify integer values are also present
-        Assertions.assertTrue(jsonString.contains("123456789"), "JSON should contain long value");
-        Assertions.assertTrue(jsonString.contains("42"), "JSON should contain int value");
+        Assertions.assertFalse(jsonString.contains("E"));
     }
 
     private JobDAGInfo createDAGInfoWithMultipleSinks() {


### PR DESCRIPTION
Fix the problem of scientific notation when restApi obtains read and write rate.
The repair effect is shown in the screenshot:
<img width="1163" height="716" alt="image" src="https://github.com/user-attachments/assets/31a94f53-c235-490e-8a56-156dce8a5780" />

close:https://github.com/apache/seatunnel/issues/10823