### PR TITLE
[Fix][Zeta] Reuse job info during restore

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -816,7 +816,7 @@ public class CoordinatorService {
                         seaTunnelServer);
 
         try {
-            jobMaster.init(runningJobInfoIMap.get(jobId).getInitializationTimestamp(), true);
+            jobMaster.init(jobInfo.getInitializationTimestamp(), true);
         } catch (Exception e) {
             throw new SeaTunnelEngineException(String.format("Job id %s init failed", jobId), e);
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server;
 
+import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
@@ -26,6 +27,7 @@ import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.core.job.JobInfo;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
@@ -44,13 +46,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.mockito.Mockito;
 
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.IMap;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import lombok.extern.slf4j.Slf4j;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -66,6 +71,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doThrow;
 
 @Slf4j
 public class CoordinatorServiceTest {
@@ -698,6 +704,15 @@ public class CoordinatorServiceTest {
         return new JobInformation(coordinatorServiceTest, coordinatorService, jobId);
     }
 
+    private void invokeRestoreJobFromMasterActiveSwitch(
+            CoordinatorService coordinatorService, long jobId, JobInfo jobInfo) throws Exception {
+        Method method =
+                CoordinatorService.class.getDeclaredMethod(
+                        "restoreJobFromMasterActiveSwitch", Long.class, JobInfo.class);
+        method.setAccessible(true);
+        method.invoke(coordinatorService, jobId, jobInfo);
+    }
+
     @Test
     public void testClearCoordinatorService() {
         JobInformation jobInformation =
@@ -747,6 +762,67 @@ public class CoordinatorServiceTest {
                                 thread ->
                                         thread.getName().startsWith("pending-job-schedule-runner"))
                         .count());
+    }
+
+    @Test
+    void testRestoreUsesProvidedJobInfoInitializationTimestamp() throws Exception {
+        HazelcastInstanceImpl instance =
+                createHazelcastInstanceWithJoinPortTryCount(
+                        TestUtils.getClusterName(
+                                "CoordinatorServiceTest_testRestoreUsesProvidedJobInfoInitializationTimestamp"),
+                        100);
+        try {
+            SeaTunnelServer server =
+                    instance.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+            CoordinatorService coordinatorService = server.getCoordinatorService();
+            await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> Assertions.assertTrue(coordinatorService.isCoordinatorActive()));
+
+            Long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            long initializationTimestamp = 100L;
+            LogicalDag logicalDag =
+                    TestUtils.createTestLogicalPlan(
+                            "stream_fake_to_console.conf",
+                            "restore-job-info-initialization-timestamp-test",
+                            jobId);
+            JobImmutableInformation jobImmutableInformation =
+                    new JobImmutableInformation(
+                            jobId,
+                            "Test",
+                            instance.getSerializationService(),
+                            logicalDag,
+                            Collections.emptyList(),
+                            Collections.emptyList());
+            JobInfo jobInfo =
+                    new JobInfo(
+                            initializationTimestamp,
+                            instance.getSerializationService().toData(jobImmutableInformation));
+
+            IMap<Long, JobInfo> runningJobInfoIMap =
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+            IMap<Object, Object> runningJobStateIMap =
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+            runningJobInfoIMap.put(jobId, jobInfo);
+            runningJobStateIMap.put(jobId, JobStatus.RUNNING);
+
+            IMap<Long, JobInfo> spiedRunningJobInfoIMap = Mockito.spy(runningJobInfoIMap);
+            doThrow(new RetryableHazelcastException("loading"))
+                    .when(spiedRunningJobInfoIMap)
+                    .get(jobId);
+            ReflectionUtils.setField(
+                    coordinatorService, "runningJobInfoIMap", spiedRunningJobInfoIMap);
+            try {
+                invokeRestoreJobFromMasterActiveSwitch(coordinatorService, jobId, jobInfo);
+            } finally {
+                ReflectionUtils.setField(
+                        coordinatorService, "runningJobInfoIMap", runningJobInfoIMap);
+            }
+
+            Assertions.assertTrue(coordinatorService.getPendingJobQueue().contains(jobId));
+        } finally {
+            instance.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Purpose of this pull request
Fix Zeta job restore after an active-master switch by reusing the `JobInfo` that was already fetched with retry protection. This avoids a second direct `runningJobInfoIMap.get(jobId)` read when passing the initialization timestamp to `JobMaster.init(...)`.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- `./mvnw spotless:apply`

### Check list
- [x] No new Jar package is introduced
- [x] Documentation update is not required
- [x] `incompatible-changes.md` update is not required
- [x] Connector metadata updates are not required