### PR TITLE
[Bug] [Postgres-CDC] Fix snapshot table schema lookup

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTask.java
@@ -166,10 +166,38 @@ public class PostgresSnapshotSplitReadTask
         EventDispatcher.SnapshotReceiver snapshotReceiver =
                 dispatcher.getSnapshotChangeEventReceiver();
         log.debug("Snapshotting table {}", tableId);
-        TableId newTableId = new TableId(null, tableId.schema(), tableId.table());
-        createDataEventsForTable(
-                snapshotContext, snapshotReceiver, databaseSchema.tableFor(newTableId));
+        createDataEventsForTable(snapshotContext, snapshotReceiver, resolveTable(tableId));
         snapshotReceiver.completeSnapshot();
+    }
+
+    private Table resolveTable(TableId tableId) {
+        TableId tableIdWithoutCatalog = new TableId(null, tableId.schema(), tableId.table());
+        Table table = databaseSchema.tableFor(tableIdWithoutCatalog);
+        if (table != null) {
+            return table;
+        }
+
+        String catalog = tableId.catalog();
+        if (catalog == null || catalog.isEmpty()) {
+            catalog = connectorConfig.databaseName();
+        }
+        if (catalog == null || catalog.isEmpty()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Cannot find table schema for table %s. Tried table id: %s.",
+                            tableId, tableIdWithoutCatalog));
+        }
+
+        TableId tableIdWithCatalog = new TableId(catalog, tableId.schema(), tableId.table());
+        table = databaseSchema.tableFor(tableIdWithCatalog);
+        if (table != null) {
+            return table;
+        }
+
+        throw new IllegalStateException(
+                String.format(
+                        "Cannot find table schema for table %s. Tried table ids: %s and %s.",
+                        tableId, tableIdWithoutCatalog, tableIdWithCatalog));
     }
 
     /** Dispatches the data change events for the records of a single table. */

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTaskTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/snapshot/PostgresSnapshotSplitReadTaskTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader.snapshot;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PostgresSnapshotSplitReadTaskTest {
+
+    @Test
+    public void testResolveTableFallsBackToCatalogQualifiedTableId() throws Exception {
+        TableId tableIdWithoutCatalog = new TableId(null, "public", "users");
+        TableId tableIdWithCatalog = new TableId("traffic", "public", "users");
+        Table table = table(tableIdWithCatalog);
+
+        PostgresSchema databaseSchema = mock(PostgresSchema.class);
+        when(databaseSchema.tableFor(tableIdWithoutCatalog)).thenReturn(null);
+        when(databaseSchema.tableFor(tableIdWithCatalog)).thenReturn(table);
+
+        Table resolvedTable =
+                resolveTable(
+                        newSnapshotSplitReadTask(
+                                mock(PostgresConnectorConfig.class), databaseSchema),
+                        tableIdWithCatalog);
+
+        Assertions.assertSame(table, resolvedTable);
+    }
+
+    @Test
+    public void testResolveTableFallsBackToConfiguredDatabaseName() throws Exception {
+        TableId tableIdWithoutCatalog = new TableId(null, "public", "users");
+        TableId tableIdWithCatalog = new TableId("traffic", "public", "users");
+        Table table = table(tableIdWithCatalog);
+
+        PostgresConnectorConfig connectorConfig = mock(PostgresConnectorConfig.class);
+        when(connectorConfig.databaseName()).thenReturn("traffic");
+
+        PostgresSchema databaseSchema = mock(PostgresSchema.class);
+        when(databaseSchema.tableFor(tableIdWithoutCatalog)).thenReturn(null);
+        when(databaseSchema.tableFor(tableIdWithCatalog)).thenReturn(table);
+
+        Table resolvedTable =
+                resolveTable(
+                        newSnapshotSplitReadTask(connectorConfig, databaseSchema),
+                        tableIdWithoutCatalog);
+
+        Assertions.assertSame(table, resolvedTable);
+    }
+
+    private static PostgresSnapshotSplitReadTask newSnapshotSplitReadTask(
+            PostgresConnectorConfig connectorConfig, PostgresSchema databaseSchema) {
+        return new PostgresSnapshotSplitReadTask(
+                connectorConfig,
+                null,
+                mock(SnapshotProgressListener.class),
+                databaseSchema,
+                null,
+                null,
+                null);
+    }
+
+    private static Table resolveTable(PostgresSnapshotSplitReadTask task, TableId tableId)
+            throws Exception {
+        Method method =
+                PostgresSnapshotSplitReadTask.class.getDeclaredMethod(
+                        "resolveTable", TableId.class);
+        method.setAccessible(true);
+        return (Table) method.invoke(task, tableId);
+    }
+
+    private static Table table(TableId tableId) {
+        return Table.editor()
+                .tableId(tableId)
+                .addColumn(Column.editor().name("id").type("int4").create())
+                .create();
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fix Postgres-CDC snapshot table schema lookup when the PostgreSQL JDBC driver returns a catalog value from `DatabaseMetaData`.

Starting with pgjdbc 42.7.5, `DatabaseMetaData#getTables` and `getColumns` may return the database name in `TABLE_CAT`. This follows the pgjdbc change described as `Fix PgDatabaseMetaData implementation of catalog as param and return value` in pgjdbc PR #3390.

With the same metadata test against a Docker PostgreSQL database named `traffic`:

```text
pgjdbc 42.4.3:
getTables:  TABLE_CAT=null,    TABLE_SCHEM=public, TABLE_NAME=users
getColumns: TABLE_CAT=null,    TABLE_SCHEM=public, TABLE_NAME=users

pgjdbc 42.7.5:
getTables:  TABLE_CAT=traffic, TABLE_SCHEM=public, TABLE_NAME=users
getColumns: TABLE_CAT=traffic, TABLE_SCHEM=public, TABLE_NAME=users
```

The current Postgres snapshot reader always looks up the Debezium table schema with a catalog-less `TableId`:

```java
new TableId(null, tableId.schema(), tableId.table())
```

That works with the old metadata shape, but when Debezium stores the table schema as `database.schema.table`, `databaseSchema.tableFor(...)` returns `null`. The next snapshot read path calls `table.id()` and fails with a `NullPointerException` in `PostgresSnapshotSplitReadTask#createDataEventsForTable`.

This patch keeps the old catalog-less lookup first for existing environments, then falls back to a catalog-aware `TableId` using the `SnapshotSplit` catalog or the configured database name. The generated PostgreSQL snapshot SQL is not changed because `PostgresUtils#quoteSchemaAndTable` still uses only schema and table names.


### Does this PR introduce _any_ user-facing change?

Yes. Postgres-CDC snapshot startup can now resolve the table schema when pgjdbc returns the database name as `TABLE_CAT`, avoiding a snapshot read `NullPointerException` for tables such as `traffic.public.users`.


### How was this patch tested?

Added a focused unit test for the snapshot schema lookup fallback:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home \
PATH=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/bin:$PATH \
./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres \
  -Dskip.spotless=true -Dtest=PostgresSnapshotSplitReadTaskTest test
```

Result: `BUILD SUCCESS`, `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home \
PATH=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/bin:$PATH \
./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres \
  -DskipTests -Dskip.spotless=true compile
```

Result: `BUILD SUCCESS`.

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home \
PATH=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/bin:$PATH \
./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres \
  spotless:check -DskipTests
```

Result: `BUILD SUCCESS`.

I also tried compiling the module with upstream dependencies:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home \
PATH=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/bin:$PATH \
./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres -am \
  -DskipTests -Dskip.spotless=true compile
```

This failed before reaching the Postgres-CDC module, in `seatunnel-config-shade`, because the shaded `org.apache.seatunnel.shade.com.typesafe.config.*` classes were not found in this local checkout.


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
