### PR TITLE
[BUG][Connector-V2][MaxCompute] Fix Maxcompute source split stategy

### DIFF
--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplit.java
@@ -43,6 +43,6 @@ public class MaxcomputeSourceSplit implements SourceSplit {
 
     @Override
     public String splitId() {
-        return tablePath.toString() + "_" + index;
+        return tablePath.toString() + "_" + index + "_" + rowStart;
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
@@ -124,7 +124,6 @@ public class MaxcomputeSourceSplitEnumerator
             if (sourceTableInfo.getSplitRow() != null && sourceTableInfo.getSplitRow() > 0) {
                 splitRow = sourceTableInfo.getSplitRow();
             }
-            int splitIndex = 0;
             for (int i = 0; i < numReaders; i++) {
                 int readerStart = i * splitRowNum;
                 int readerEnd = (int) Math.min((i + 1) * splitRowNum, recordCount);
@@ -134,7 +133,7 @@ public class MaxcomputeSourceSplitEnumerator
                                     num,
                                     Math.min(splitRow, readerEnd - num),
                                     sourceTableInfo.getCatalogTable().getTablePath(),
-                                    splitIndex));
+                                    i));
                 }
             }
             assignedSplits.forEach(splits::remove);

--- a/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MaxcomputeSourceSplitTest {
+
+    @Test
+    public void testSplitIdUniquenessAndIndexDistribution() {
+        int numReaders = 5;
+        long recordCount = 105000;
+        int splitRow = 10000;
+
+        int splitRowNum = (int) Math.ceil((double) recordCount / numReaders); // 21000
+        TablePath tablePath = TablePath.of("test_db", "test_schema", "test_table");
+
+        Set<String> splitIds = new HashSet<>();
+        int[] indexCounts = new int[numReaders];
+        int totalSplits = 0;
+
+        // Simulate the inner logic of MaxcomputeSourceSplitEnumerator.discoverySplits
+        for (int i = 0; i < numReaders; i++) {
+            int readerStart = i * splitRowNum;
+            int readerEnd = (int) Math.min((i + 1) * splitRowNum, recordCount);
+            for (int num = readerStart; num < readerEnd; num += splitRow) {
+                MaxcomputeSourceSplit split =
+                        new MaxcomputeSourceSplit(
+                                num, Math.min(splitRow, readerEnd - num), tablePath, i);
+
+                // Verify splitId uniqueness
+                Assertions.assertTrue(
+                        splitIds.add(split.splitId()),
+                        "Duplicate splitId found: " + split.splitId());
+
+                // Verify index assigned to the split matches the reader index
+                Assertions.assertEquals(i, split.getIndex());
+
+                indexCounts[i]++;
+                totalSplits++;
+            }
+        }
+
+        Assertions.assertTrue(totalSplits == 15);
+
+        // Verify index distribution:
+        // Record count 105000 / 5 readers = 21000 splits per reader.
+        // Split row is 10000. Loop steps: 0, 10000, 20000. So 3 splits per reader.
+        for (int i = 0; i < numReaders; i++) {
+            Assertions.assertEquals(3, indexCounts[i], "Reader " + i + " split count mismatch!");
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

This PR fixes a critical bug in MaxcomputeSourceSplitEnumerator that caused all data splits to be assigned to Reader 0 when running the MaxCompute Source connector with parallelism > 1.

Root Cause — Two Bugs Working Together:

Bug 1: Wrong index variable in split assignment loop (MaxcomputeSourceSplitEnumerator.java)

The split enumeration loop correctly iterates over numReaders (one iteration per parallel reader). However, it was using a dead local variable splitIndex (always 0) instead of the loop variable i when constructing each MaxcomputeSourceSplit. As a result, every sub-split was tagged as belonging to reader 0, causing the entire dataset to be routed to a single reader.

Bug 2: Non-unique splitId() causing engine-level deduplication (MaxcomputeSourceSplit.java)

The splitId() method returned tablePath + "_" + index. Since all sub-splits within a table shared the same index=0 (due to Bug 1), they all had the identical split ID. The SeaTunnel engine uses the split ID to de-duplicate splits; so even after fixing Bug 1, identical IDs would still cause splits to be collapsed. The fix appends rowStart to the ID to make each sub-split uniquely identifiable:

### Does this PR introduce _any_ user-facing change?

Yes. Previously, running MaxCompute Source with parallelism > 1 silently degraded to single-reader performance (all work routed to reader 0). After this fix, the workload is correctly distributed across all configured parallel readers as expected.

### How was this patch tested?

Manually verified on an Alibaba Cloud ECS instance by running a MaxCompute → Kafka job with parallelism = 12. Confirmed from the logs that splits were assigned and processed by all 12 readers instead of reader 0 only.
mvn spotless:apply and mvn -q -DskipTests verify passed.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)