### PR TITLE
[Chore] Reduce dev branch required approving reviews to 1

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,7 +54,7 @@ github:
         strict: true
       required_pull_request_reviews:
         dismiss_stale_reviews: true
-        required_approving_review_count: 2
+        required_approving_review_count: 1
 
 notifications:
   commits:      commits@seatunnel.apache.org


### PR DESCRIPTION
## What Changed
- lower `github.protected_branches.dev.required_pull_request_reviews.required_approving_review_count` from `2` to `1` in `.asf.yaml`

## Why
- According to the discussion in dev mail https://lists.apache.org/thread/wqpsjzodzslzt47527gc52bvgd6dqy7d
- align the ASF GitHub repository settings so PRs targeting `dev` only require one approval before merge


