### PR TITLE
[Fix][Doc] Fix OpenAI API key documentation link

### DIFF
--- a/docs/en/transforms/llm.md
+++ b/docs/en/transforms/llm.md
@@ -96,7 +96,7 @@ of `/v1/chat/completions` endpoint.
 ### api_key
 
 The API key to use for the model provider.
-If you use OpenAI model, please refer https://platform.openai.com/docs/api-reference/api-keys of how to get the API key.
+If you use OpenAI model, please refer https://help.openai.com/en/articles/4936850-how-to-create-and-use-an-api-key for how to get the API key.
 
 ### api_path
 

--- a/docs/zh/transforms/llm.md
+++ b/docs/zh/transforms/llm.md
@@ -93,7 +93,7 @@ transform {
 ### api_key
 
 用于模型提供者的 API 密钥。
-如果使用 OpenAI 模型，请参考 https://platform.openai.com/docs/api-reference/api-keys 文档的如何获取 API 密钥。
+如果使用 OpenAI 模型，请参考 https://help.openai.com/en/articles/4936850-how-to-create-and-use-an-api-key 文档了解如何获取 API 密钥。
 
 ### api_path
 


### PR DESCRIPTION
### Purpose of this pull request
Fix the outdated OpenAI API key documentation link in the LLM transform docs. The old API reference URL now returns 404, so this patch points both English and Chinese docs to the current OpenAI Help Center article for creating and using an API key.

### Does this PR introduce _any_ user-facing change?
Yes. Documentation now links to the current OpenAI API key help article.

### How was this patch tested?
- Ran `./mvnw spotless:apply`
- Ran `git diff --check -- docs/en/transforms/llm.md docs/zh/transforms/llm.md`
- Skipped compile/build verification per request because this is a documentation-only link fix.

### Check list
- [x] No new Jar package is introduced
- [x] Documentation updated in docs/en and docs/zh
- [x] No incompatible change is introduced
- [x] Connector release metadata is not affected