### PR TITLE
[Fix][CI] Pin azure/setup-helm to approved SHA

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
         id: install
       - name: Lint Chart
         run: helm lint deploy/kubernetes/seatunnel


### PR DESCRIPTION
### Purpose of this pull request

Fix post-merge CI startup failures caused by the ASF GitHub Actions allowlist policy:
https://github.com/apache/seatunnel/actions/runs/25513725736

The workflow currently uses `azure/setup-helm@v4.3.0`, but this tag is not allowed by [the ASF approved action patterns](https://github.com/apache/infrastructure-actions/blob/main/actions.yml). The ASF allowlist already includes `azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4`, which corresponds to `v4.3.1`.

This PR updates the workflow to use the approved pinned SHA. This also updates `azure/setup-helm` from `v4.3.0` to the approved `v4.3.1` commit.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
