### PR TITLE
[Feature][Doris] Support VARIANT source and sink mapping

### DIFF
--- a/docs/en/connectors/sink/Doris.md
+++ b/docs/en/connectors/sink/Doris.md
@@ -172,6 +172,7 @@ You can use the following placeholders
 | ARRAY           | ARRAY                                   |
 | MAP             | MAP                                     |
 | JSON            | STRING                                  |
+| VARIANT         | STRING                                  |
 | HLL             | Not supported yet                       |
 | BITMAP          | Not supported yet                       |
 | QUANTILE_STATE  | Not supported yet                       |
@@ -180,6 +181,9 @@ You can use the following placeholders
 #### Supported import data formats
 
 The supported formats include CSV and JSON
+
+When writing to Doris `VARIANT` columns from SeaTunnel `STRING` fields, the field value should be a
+valid JSON document.
 
 ## Tuning Guide
 Appropriately increasing the value of `sink.buffer-size` and `doris.batch.size` can increase the write performance.

--- a/docs/en/connectors/source/Doris.md
+++ b/docs/en/connectors/source/Doris.md
@@ -54,6 +54,8 @@ Used to read data from Apache Doris.
 | FLOAT                                | FLOAT                                                                                                                                               |
 | DOUBLE                               | DOUBLE                                                                                                                                              |
 | CHAR<br/>VARCHAR<br/>STRING<br/>TEXT | STRING                                                                                                                                              |
+| JSON                                 | STRING                                                                                                                                              |
+| VARIANT                              | STRING                                                                                                                                              |
 | DATE                                 | DATE                                                                                                                                                |
 | DATETIME<br/>DATETIME(p)             | TIMESTAMP                                                                                                                                           |
 | ARRAY                                | ARRAY                                                                                                                                               |

--- a/docs/zh/connectors/sink/Doris.md
+++ b/docs/zh/connectors/sink/Doris.md
@@ -169,6 +169,7 @@ CREATE TABLE IF NOT EXISTS `${database}`.`${table_name}`
 | ARRAY          | ARRAY                                   |
 | MAP            | MAP                                     |
 | JSON           | STRING                                  |
+| VARIANT        | STRING                                  |
 | HLL            | 尚不支持                                    |
 | BITMAP         | 尚不支持                                    |
 | QUANTILE_STATE | 尚不支持                                    |
@@ -177,6 +178,8 @@ CREATE TABLE IF NOT EXISTS `${database}`.`${table_name}`
 #### 支持的导入数据格式
 
 支持的格式包括 CSV 和 JSON。
+
+当从 SeaTunnel `STRING` 字段写入 Doris `VARIANT` 列时，字段值需要是合法的 JSON 文档。
 
 ## 调优指南
 适当增加`sink.buffer-size`和`doris.batch.size`的值可以提高写性能。

--- a/docs/zh/connectors/source/Doris.md
+++ b/docs/zh/connectors/source/Doris.md
@@ -54,6 +54,8 @@ import ChangeLog from '../changelog/connector-doris.md';
 | FLOAT                                | FLOAT                                                                                                                                               |
 | DOUBLE                               | DOUBLE                                                                                                                                              |
 | CHAR<br/>VARCHAR<br/>STRING<br/>TEXT | STRING                                                                                                                                              |
+| JSON                                 | STRING                                                                                                                                              |
+| VARIANT                              | STRING                                                                                                                                              |
 | DATE                                 | DATE                                                                                                                                                |
 | DATETIME<br/>DATETIME(p)             | TIMESTAMP                                                                                                                                           |
 | ARRAY                                | ARRAY                                                                                                                                               |

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
@@ -75,6 +75,7 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
 
     public static final String DORIS_JSON = "JSON";
     public static final String DORIS_JSONB = "JSONB";
+    public static final String DORIS_VARIANT = "VARIANT";
 
     public static final Long DEFAULT_PRECISION = 9L;
     public static final Long MAX_PRECISION = 38L;
@@ -184,6 +185,7 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
                 break;
             case DORIS_STRING:
             case DORIS_JSON:
+            case DORIS_VARIANT:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(MAX_STRING_LENGTH);
                 break;

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV2.java
@@ -283,6 +283,12 @@ public class DorisTypeConverterV2 extends AbstractDorisTypeConverter {
             builder.dataType(DORIS_JSON);
             return;
         }
+        if (column.getSourceType() != null
+                && column.getSourceType().equalsIgnoreCase(DORIS_VARIANT)) {
+            builder.columnType(DORIS_VARIANT);
+            builder.dataType(DORIS_VARIANT);
+            return;
+        }
 
         super.sampleReconvertString(column, builder);
     }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
@@ -318,6 +318,21 @@ public class DorisTypeConvertorV1Test {
     }
 
     @Test
+    public void testConvertVariant() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("variant")
+                        .dataType("variant")
+                        .build();
+        Column column = DorisTypeConverterV1.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(DorisTypeConverterV1.MAX_STRING_LENGTH, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+    }
+
+    @Test
     public void testConvertDate() {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder().name("test").columnType("date").dataType("date").build();

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
@@ -311,6 +311,21 @@ public class DorisTypeConvertorV2Test {
     }
 
     @Test
+    public void testConvertVariant() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("variant")
+                        .dataType("variant")
+                        .build();
+        Column column = DorisTypeConverterV2.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(DorisTypeConverterV2.MAX_STRING_LENGTH, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+    }
+
+    @Test
     public void testConvertDate() {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder().name("test").columnType("date").dataType("date").build();
@@ -855,6 +870,19 @@ public class DorisTypeConvertorV2Test {
         Assertions.assertEquals(column.getName(), typeDefine.getName());
         Assertions.assertEquals(DorisTypeConverterV2.DORIS_JSON, typeDefine.getColumnType());
         Assertions.assertEquals(DorisTypeConverterV2.DORIS_JSON, typeDefine.getDataType());
+
+        column =
+                PhysicalColumn.builder()
+                        .name("test")
+                        .dataType(BasicType.STRING_TYPE)
+                        .columnLength(null)
+                        .sourceType(DorisTypeConverterV2.DORIS_VARIANT)
+                        .build();
+
+        typeDefine = DorisTypeConverterV2.INSTANCE.reconvert(column);
+        Assertions.assertEquals(column.getName(), typeDefine.getName());
+        Assertions.assertEquals(DorisTypeConverterV2.DORIS_VARIANT, typeDefine.getColumnType());
+        Assertions.assertEquals(DorisTypeConverterV2.DORIS_VARIANT, typeDefine.getDataType());
 
         column =
                 PhysicalColumn.builder()

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/DorisCatalogUtilTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/DorisCatalogUtilTest.java
@@ -18,11 +18,13 @@
 package org.apache.seatunnel.connectors.doris.util;
 
 import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
 import org.apache.seatunnel.api.table.converter.TypeConverter;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.connectors.doris.datatype.DorisTypeConverterFactory;
+import org.apache.seatunnel.connectors.doris.datatype.DorisTypeConverterV2;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,5 +70,22 @@ public class DorisCatalogUtilTest {
         String result = DorisCatalogUtil.columnToDorisType(column, typeConverter);
 
         assertEquals("`col1` VARCHAR NOT NULL ", result);
+    }
+
+    @Test
+    void returnsVariantTypeWhenSourceTypeIsVariant() {
+        Column column =
+                PhysicalColumn.builder()
+                        .name("col1")
+                        .dataType(BasicType.STRING_TYPE)
+                        .sourceType(DorisTypeConverterV2.DORIS_VARIANT)
+                        .nullable(true)
+                        .build();
+        TypeConverter<BasicTypeDefine> typeConverter =
+                DorisTypeConverterFactory.getTypeConverter("Doris version Doris-2.0.0");
+
+        String result = DorisCatalogUtil.columnToDorisType(column, typeConverter);
+
+        assertEquals("`col1` VARIANT NULL ", result);
     }
 }


### PR DESCRIPTION
## What changed
- add Doris `VARIANT` to source type conversion and map it to SeaTunnel `STRING`
- preserve `VARIANT` during Doris sink type reconvert so auto-created sink tables keep the column type
- document `VARIANT` support in Doris source/sink docs and add unit tests for source/sink type mapping

## Why
SeaTunnel could not read Doris `VARIANT` columns, and sink auto-DDL could not keep `VARIANT` when writing back to Doris.

## Validation
- `git push origin corgy/dev-doris-variant-source`
- local module tests were not runnable in this environment because the `3.0.0-SNAPSHOT` dependency chain for `connector-doris` was unavailable