### PR TITLE
[Fix][Connector-V2] Fix Elasticsearch connector connection pool leak …

### DIFF
--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClient.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClient.java
@@ -571,8 +571,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.CREATE_INDEX_FAILED,
                         "PUT " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.CREATE_INDEX_FAILED,
                         String.format(
@@ -595,9 +595,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.DROP_INDEX_FAILED,
                         "DELETE " + endpoint + " response null");
             }
-            // todo: if the index doesn't exist, the response status code is 200?
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.DROP_INDEX_FAILED,
                         String.format(
@@ -623,9 +622,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.CLEAR_INDEX_DATA_FAILED,
                         "POST " + endpoint + " response null");
             }
-            // todo: if the index doesn't exist, the response status code is 200?
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.CLEAR_INDEX_DATA_FAILED,
                         String.format(
@@ -849,15 +847,13 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.ADD_FIELD_FAILED,
                         "PUT " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.ADD_FIELD_FAILED,
                         String.format(
-                                "PUT %s response status code=%d, response=%s",
-                                endpoint,
-                                response.getStatusLine().getStatusCode(),
-                                EntityUtils.toString(
-                                        response.getEntity(), StandardCharsets.UTF_8)));
+                                "PUT %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(

--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClient.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClient.java
@@ -130,8 +130,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.BULK_RESPONSE_ERROR,
                         "bulk es Response is null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 JsonNode json = OBJECT_MAPPER.readTree(entity);
                 int took = json.get("took").asInt();
                 boolean errors = json.get("errors").asBoolean();
@@ -140,8 +140,9 @@ public class EsRestClient implements Closeable {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.BULK_RESPONSE_ERROR,
                         String.format(
-                                "bulk es response status=%s,request body(truncate)=%s",
-                                response,
+                                "bulk es response status=%s, response body=%s, request body(truncate)=%s",
+                                response.getStatusLine().getStatusCode(),
+                                entity,
                                 requestBody.substring(0, Math.min(1000, requestBody.length()))));
             }
         } catch (IOException e) {
@@ -316,16 +317,17 @@ public class EsRestClient implements Closeable {
                 log.warn("DELETE {} response null for scroll ID: {}", endpoint, scrollId);
                 return false;
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 JsonNode jsonNode = JsonUtils.parseObject(entity);
                 boolean succeeded = jsonNode.get("succeeded").asBoolean();
                 return succeeded;
             } else {
                 log.warn(
-                        "DELETE {} response status code={} for scroll ID: {}",
+                        "DELETE {} response status code={}, body={} for scroll ID: {}",
                         endpoint,
                         response.getStatusLine().getStatusCode(),
+                        entity,
                         scrollId);
                 return false;
             }
@@ -346,16 +348,19 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.SCROLL_REQUEST_ERROR,
                         "POST " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 ObjectNode responseJson = JsonUtils.parseObject(entity);
                 return getDocsFromSqlResponse(responseJson, columnNodes);
             } else {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.SCROLL_REQUEST_ERROR,
                         String.format(
-                                "POST %s response status code=%d,request body=%s",
-                                endpoint, response.getStatusLine().getStatusCode(), requestBody));
+                                "POST %s response status code=%d, body=%s, request body=%s",
+                                endpoint,
+                                response.getStatusLine().getStatusCode(),
+                                entity,
+                                requestBody));
             }
         } catch (IOException e) {
             throw new ElasticsearchConnectorException(
@@ -375,8 +380,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.SCROLL_REQUEST_ERROR,
                         "POST " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 ObjectNode responseJson = JsonUtils.parseObject(entity);
 
                 JsonNode shards = responseJson.get("_shards");
@@ -393,8 +398,11 @@ public class EsRestClient implements Closeable {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.SCROLL_REQUEST_ERROR,
                         String.format(
-                                "POST %s response status code=%d,request body=%s",
-                                endpoint, response.getStatusLine().getStatusCode(), requestBody));
+                                "POST %s response status code=%d, body=%s, request body=%s",
+                                endpoint,
+                                response.getStatusLine().getStatusCode(),
+                                entity,
+                                requestBody));
             }
         } catch (IOException e) {
             throw new ElasticsearchConnectorException(
@@ -502,15 +510,15 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.GET_INDEX_DOCS_COUNT_FAILED,
                         "GET " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 return JsonUtils.toList(entity, IndexDocsCount.class);
             } else {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.GET_INDEX_DOCS_COUNT_FAILED,
                         String.format(
-                                "GET %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "GET %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -528,8 +536,8 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.LIST_INDEX_FAILED,
                         "GET " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 return JsonUtils.toList(entity, Map.class).stream()
                         .map(map -> map.get("index").toString())
                         .collect(Collectors.toList());
@@ -537,8 +545,8 @@ public class EsRestClient implements Closeable {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.LIST_INDEX_FAILED,
                         String.format(
-                                "GET %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "GET %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -564,11 +572,12 @@ public class EsRestClient implements Closeable {
                         "PUT " + endpoint + " response null");
             }
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.CREATE_INDEX_FAILED,
                         String.format(
-                                "PUT %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "PUT %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -587,14 +596,13 @@ public class EsRestClient implements Closeable {
                         "DELETE " + endpoint + " response null");
             }
             // todo: if the index doesn't exist, the response status code is 200?
-            if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                return;
-            } else {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.DROP_INDEX_FAILED,
                         String.format(
-                                "DELETE %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "DELETE %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -616,14 +624,13 @@ public class EsRestClient implements Closeable {
                         "POST " + endpoint + " response null");
             }
             // todo: if the index doesn't exist, the response status code is 200?
-            if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                return;
-            } else {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.CLEAR_INDEX_DATA_FAILED,
                         String.format(
-                                "POST %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "POST %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -650,11 +657,12 @@ public class EsRestClient implements Closeable {
                         "GET " + endpoint + " response null");
             }
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.GET_INDEX_DOCS_COUNT_FAILED,
                         String.format(
-                                "GET %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "GET %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
             String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             log.info(String.format("GET %s respnse=%s", endpoint, entity));
@@ -877,16 +885,16 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.CREATE_PIT_FAILED,
                         "POST " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 JsonNode jsonNode = JsonUtils.parseObject(entity);
                 return jsonNode.get("id").asText();
             } else {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.CREATE_PIT_FAILED,
                         String.format(
-                                "POST %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "POST %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -913,16 +921,16 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.DELETE_PIT_FAILED,
                         "DELETE " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 JsonNode jsonNode = JsonUtils.parseObject(entity);
                 return jsonNode.get("succeeded").asBoolean();
             } else {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.DELETE_PIT_FAILED,
                         String.format(
-                                "DELETE %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "DELETE %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(
@@ -1010,15 +1018,15 @@ public class EsRestClient implements Closeable {
                         ElasticsearchConnectorErrorCode.SEARCH_WITH_PIT_FAILED,
                         "POST " + endpoint + " response null");
             }
+            String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                String entity = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                 return parsePointInTimeResponse(entity, pitId);
             } else {
                 throw new ElasticsearchConnectorException(
                         ElasticsearchConnectorErrorCode.SEARCH_WITH_PIT_FAILED,
                         String.format(
-                                "POST %s response status code=%d",
-                                endpoint, response.getStatusLine().getStatusCode()));
+                                "POST %s response status code=%d, body=%s",
+                                endpoint, response.getStatusLine().getStatusCode(), entity));
             }
         } catch (IOException ex) {
             throw new ElasticsearchConnectorException(

--- a/seatunnel-connectors-v2/connector-elasticsearch/src/test/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClientTest.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/test/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/client/EsRestClientTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.elasticsearch.client;
+
+import org.apache.seatunnel.connectors.seatunnel.elasticsearch.dto.BulkResponse;
+import org.apache.seatunnel.connectors.seatunnel.elasticsearch.exception.ElasticsearchConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.elasticsearch.exception.ElasticsearchConnectorException;
+
+import org.apache.http.StatusLine;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EsRestClientTest {
+
+    @Mock private RestClient mockRestClient;
+
+    // ---- bulk: non-200 path ----
+
+    @Test
+    void testBulkIncludesEsErrorBodyOnNon200Response() throws Exception {
+        Response mockResponse = mock(Response.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+        String esErrorJson = "{\"error\":{\"root_cause\":[{\"type\":\"rate_limit_exceeded\"}]}}";
+
+        when(mockRestClient.performRequest(any(Request.class))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(429);
+        when(mockResponse.getEntity())
+                .thenReturn(
+                        new org.apache.http.entity.StringEntity(
+                                esErrorJson, org.apache.http.entity.ContentType.APPLICATION_JSON));
+
+        EsRestClient client = createEsRestClient(mockRestClient);
+
+        ElasticsearchConnectorException exception =
+                Assertions.assertThrows(
+                        ElasticsearchConnectorException.class,
+                        () -> client.bulk("{\"index\":{}}\n{}\n"));
+
+        Assertions.assertEquals(
+                ElasticsearchConnectorErrorCode.BULK_RESPONSE_ERROR,
+                exception.getSeaTunnelErrorCode());
+        Assertions.assertTrue(
+                exception.getMessage().contains(esErrorJson),
+                "Error message should contain ES response body for debugging");
+    }
+
+    // ---- bulk: 200 success path ----
+
+    @Test
+    void testBulkSucceedsOn200Response() throws Exception {
+        Response mockResponse = mock(Response.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockRestClient.performRequest(any(Request.class))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        when(mockResponse.getEntity())
+                .thenReturn(
+                        new org.apache.http.entity.StringEntity(
+                                "{\"took\":1,\"errors\":false,\"items\":[]}",
+                                org.apache.http.entity.ContentType.APPLICATION_JSON));
+
+        EsRestClient client = createEsRestClient(mockRestClient);
+
+        BulkResponse result = client.bulk("{\"index\":{}}\n{}\n");
+        Assertions.assertFalse(result.isErrors());
+    }
+
+    // ---- createIndex: 200 success path (void method, must still consume entity) ----
+
+    @Test
+    void testCreateIndexConsumesEntityOn200Response() throws Exception {
+        Response mockResponse = mock(Response.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockRestClient.performRequest(any(Request.class))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        when(mockResponse.getEntity())
+                .thenReturn(
+                        new org.apache.http.entity.StringEntity(
+                                "{\"acknowledged\":true}",
+                                org.apache.http.entity.ContentType.APPLICATION_JSON));
+
+        EsRestClient client = createEsRestClient(mockRestClient);
+
+        // Should not throw — entity is consumed internally
+        Assertions.assertDoesNotThrow(() -> client.createIndex("test_index"));
+    }
+
+    // ---- createIndex: non-200 path includes ES error body ----
+
+    @Test
+    void testCreateIndexIncludesEsErrorBodyOnNon200Response() throws Exception {
+        Response mockResponse = mock(Response.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+        String esErrorJson = "{\"error\":{\"type\":\"resource_already_exists_exception\"}}";
+
+        when(mockRestClient.performRequest(any(Request.class))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(400);
+        when(mockResponse.getEntity())
+                .thenReturn(
+                        new org.apache.http.entity.StringEntity(
+                                esErrorJson, org.apache.http.entity.ContentType.APPLICATION_JSON));
+
+        EsRestClient client = createEsRestClient(mockRestClient);
+
+        ElasticsearchConnectorException exception =
+                Assertions.assertThrows(
+                        ElasticsearchConnectorException.class,
+                        () -> client.createIndex("test_index"));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains(esErrorJson),
+                "Error message should contain ES response body for debugging");
+    }
+
+    private EsRestClient createEsRestClient(RestClient restClient) throws Exception {
+        Constructor<EsRestClient> constructor =
+                EsRestClient.class.getDeclaredConstructor(RestClient.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(restClient);
+    }
+}


### PR DESCRIPTION
When Elasticsearch returns a non-200 response (e.g., 429 Too Many Requests,503 Service Unavailable), the response entity was not consumed before throwing an exception. Apache HttpClient requires the response entity to be fully consumed to release the connection back to the pool.

Without this fix, each non-200 response permanently leaks one connection.Under sustained error conditions (e.g., ES rate limiting), the poolexhausts and the connector hangs.

Fixed by reading the response entity before checking status code via EntityUtils.toString(), which both releases the connection and captures the ES error body for debugging. Applied to all 13 affected methods in EsRestClient: bulk, clearScroll, searchBySql, searchByScroll, getIndexDocsCount, listIndex, createIndex, dropIndex, clearIndexData, getFieldTypeMapping, createPointInTime, deletePointInTime, and searchWithPointInTime.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
