### PR TITLE
[Fix][CDC] Avoid replaying completed snapshot splits after restore

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
@@ -219,7 +219,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     public void addSplits(Collection<SourceSplitBase> splits) {
         for (SourceSplitBase split : splits) {
             SnapshotSplit snapshotSplit = split.asSnapshotSplit();
-            if (isAlreadyCompletedSnapshotSplit(snapshotSplit)) {
+            if (hasCheckpointedCompletionState(snapshotSplit)) {
                 LOG.info(
                         "Ignore add-back for completed snapshot split {}, keep checkpointed completion state",
                         snapshotSplit.splitId());
@@ -290,7 +290,14 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         return noMoreSplits() && assignedSplits.size() == splitCompletedOffsets.size();
     }
 
-    private boolean isAlreadyCompletedSnapshotSplit(SnapshotSplit snapshotSplit) {
+    /**
+     * Returns whether the restored split already has durable completion state in the checkpoint.
+     *
+     * <p>We can safely skip add-back only when the checkpoint persisted both the original
+     * assignment and the finished watermark. If either side is missing, the split still needs to be
+     * replayed after restore so the enumerator can rebuild the missing completion state.
+     */
+    private boolean hasCheckpointedCompletionState(SnapshotSplit snapshotSplit) {
         return snapshotSplit.isSnapshotReadFinished()
                 && assignedSplits.containsKey(snapshotSplit.splitId())
                 && splitCompletedOffsets.containsKey(snapshotSplit.splitId());

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssigner.java
@@ -218,11 +218,18 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     @Override
     public void addSplits(Collection<SourceSplitBase> splits) {
         for (SourceSplitBase split : splits) {
-            remainingSplits.add(split.asSnapshotSplit());
+            SnapshotSplit snapshotSplit = split.asSnapshotSplit();
+            if (isAlreadyCompletedSnapshotSplit(snapshotSplit)) {
+                LOG.info(
+                        "Ignore add-back for completed snapshot split {}, keep checkpointed completion state",
+                        snapshotSplit.splitId());
+                continue;
+            }
+            remainingSplits.add(snapshotSplit);
             // we should remove the add-backed splits from the assigned list, because they are
             // failed
-            assignedSplits.remove(split.splitId());
-            splitCompletedOffsets.remove(split.splitId());
+            assignedSplits.remove(snapshotSplit.splitId());
+            splitCompletedOffsets.remove(snapshotSplit.splitId());
         }
     }
 
@@ -281,6 +288,12 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
      */
     private boolean allSplitsCompleted() {
         return noMoreSplits() && assignedSplits.size() == splitCompletedOffsets.size();
+    }
+
+    private boolean isAlreadyCompletedSnapshotSplit(SnapshotSplit snapshotSplit) {
+        return snapshotSplit.isSnapshotReadFinished()
+                && assignedSplits.containsKey(snapshotSplit.splitId())
+                && splitCompletedOffsets.containsKey(snapshotSplit.splitId());
     }
 
     @VisibleForTesting

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
@@ -84,6 +84,36 @@ public class SnapshotSplitAssignerTest {
         Assertions.assertTrue(splitAssigner.waitingForCompletedSplits());
     }
 
+    @Test
+    public void testRestoreAfterCheckpointedCompletionShouldKeepFinishedSplitOutOfReplayQueue() {
+        SnapshotSplit finishedSplit = createFinishedSnapshotSplit("db1.table1.2");
+        Map<String, SnapshotSplit> assignedSplits = new HashMap<>();
+        assignedSplits.put(finishedSplit.splitId(), finishedSplit);
+        SnapshotSplitAssigner<?> runningAssigner =
+                createRestoredSnapshotSplitAssigner(assignedSplits, new HashMap<>());
+
+        runningAssigner.onCompletedSplits(
+                Collections.singletonList(createWatermark(finishedSplit)));
+        SnapshotPhaseState checkpointState = runningAssigner.snapshotState(13L);
+
+        SnapshotSplitAssigner<?> restoredAssigner =
+                createRestoredSnapshotSplitAssigner(
+                        checkpointState.getAssignedSplits(),
+                        checkpointState.getSplitCompletedOffsets());
+
+        restoredAssigner.addSplits(Collections.singletonList(finishedSplit));
+
+        SnapshotPhaseState restoredState = restoredAssigner.snapshotState(14L);
+        Assertions.assertTrue(restoredState.getRemainingSplits().isEmpty());
+        Assertions.assertEquals(
+                Collections.singleton(finishedSplit.splitId()),
+                restoredState.getAssignedSplits().keySet());
+        Assertions.assertEquals(
+                Collections.singleton(finishedSplit.splitId()),
+                restoredState.getSplitCompletedOffsets().keySet());
+        Assertions.assertFalse(restoredAssigner.waitingForCompletedSplits());
+    }
+
     private SnapshotSplitAssigner<?> createRestoredSnapshotSplitAssigner(
             Map<String, SnapshotSplit> assignedSplits,
             Map<String, SnapshotSplitWatermark> completedOffsets) {
@@ -115,6 +145,13 @@ public class SnapshotSplitAssignerTest {
                 null,
                 new TestOffset(1L),
                 new TestOffset(2L));
+    }
+
+    private SnapshotSplitWatermark createWatermark(SnapshotSplit finishedSplit) {
+        return new SnapshotSplitWatermark(
+                finishedSplit.splitId(),
+                finishedSplit.getLowWatermark(),
+                finishedSplit.getHighWatermark());
     }
 
     private static final class TestOffset extends Offset {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.SnapshotPhaseState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SnapshotSplitAssignerTest {
+
+    @Test
+    public void testAddSplitsShouldKeepCompletedFinishedSplitOutOfRemainingQueue() {
+        SnapshotSplit finishedSplit = createFinishedSnapshotSplit("db1.table1.1");
+        Map<String, SnapshotSplit> assignedSplits = new HashMap<>();
+        assignedSplits.put(finishedSplit.splitId(), finishedSplit);
+        Map<String, SnapshotSplitWatermark> completedOffsets = new HashMap<>();
+        completedOffsets.put(
+                finishedSplit.splitId(),
+                new SnapshotSplitWatermark(
+                        finishedSplit.splitId(),
+                        finishedSplit.getLowWatermark(),
+                        finishedSplit.getHighWatermark()));
+
+        SnapshotSplitAssigner<?> splitAssigner =
+                createRestoredSnapshotSplitAssigner(assignedSplits, completedOffsets);
+
+        splitAssigner.addSplits(Collections.singletonList(finishedSplit));
+
+        SnapshotPhaseState state = splitAssigner.snapshotState(11L);
+        Assertions.assertTrue(state.getRemainingSplits().isEmpty());
+        Assertions.assertEquals(
+                Collections.singleton(finishedSplit.splitId()), state.getAssignedSplits().keySet());
+        Assertions.assertEquals(
+                Collections.singleton(finishedSplit.splitId()),
+                state.getSplitCompletedOffsets().keySet());
+        Assertions.assertFalse(splitAssigner.waitingForCompletedSplits());
+
+        splitAssigner.notifyCheckpointComplete(11L);
+        Assertions.assertTrue(splitAssigner.isCompleted());
+    }
+
+    @Test
+    public void testAddSplitsShouldReplayFinishedSplitWithoutCompletedWatermark() {
+        SnapshotSplit finishedSplit = createFinishedSnapshotSplit("db1.table1.1");
+        Map<String, SnapshotSplit> assignedSplits = new HashMap<>();
+        assignedSplits.put(finishedSplit.splitId(), finishedSplit);
+
+        SnapshotSplitAssigner<?> splitAssigner =
+                createRestoredSnapshotSplitAssigner(assignedSplits, new HashMap<>());
+
+        splitAssigner.addSplits(Collections.singletonList(finishedSplit));
+
+        SnapshotPhaseState state = splitAssigner.snapshotState(12L);
+        Assertions.assertEquals(1, state.getRemainingSplits().size());
+        Assertions.assertEquals(
+                finishedSplit.splitId(), state.getRemainingSplits().get(0).splitId());
+        Assertions.assertTrue(state.getAssignedSplits().isEmpty());
+        Assertions.assertTrue(state.getSplitCompletedOffsets().isEmpty());
+        Assertions.assertTrue(splitAssigner.waitingForCompletedSplits());
+    }
+
+    private SnapshotSplitAssigner<?> createRestoredSnapshotSplitAssigner(
+            Map<String, SnapshotSplit> assignedSplits,
+            Map<String, SnapshotSplitWatermark> completedOffsets) {
+        SnapshotPhaseState checkpointState =
+                new SnapshotPhaseState(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        assignedSplits,
+                        completedOffsets,
+                        false,
+                        Collections.emptyList(),
+                        false,
+                        true);
+        SplitAssigner.Context<?> context =
+                new SplitAssigner.Context<>(
+                        null,
+                        Collections.singleton(TableId.parse("db1.table1")),
+                        checkpointState.getAssignedSplits(),
+                        checkpointState.getSplitCompletedOffsets());
+        return new SnapshotSplitAssigner<>(context, 10, checkpointState, null);
+    }
+
+    private SnapshotSplit createFinishedSnapshotSplit(String splitId) {
+        return new SnapshotSplit(
+                splitId,
+                TableId.parse("db1.table1"),
+                null,
+                null,
+                null,
+                new TestOffset(1L),
+                new TestOffset(2L),
+                false,
+                null,
+                null);
+    }
+
+    private static final class TestOffset extends Offset {
+        private static final long serialVersionUID = 1L;
+
+        private TestOffset(long value) {
+            this.offset = Collections.singletonMap("pos", String.valueOf(value));
+        }
+
+        @Override
+        public int compareTo(Offset other) {
+            return Long.compare(
+                    Long.parseLong(this.offset.get("pos")),
+                    Long.parseLong(other.getOffset().get("pos")));
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/SnapshotSplitAssignerTest.java
@@ -114,10 +114,7 @@ public class SnapshotSplitAssignerTest {
                 null,
                 null,
                 new TestOffset(1L),
-                new TestOffset(2L),
-                false,
-                null,
-                null);
+                new TestOffset(2L));
     }
 
     private static final class TestOffset extends Offset {


### PR DESCRIPTION
## Summary
- skip add-back for snapshot splits that are already finished and checkpointed in enumerator state
- preserve checkpointed completion state so snapshot phase can advance to incremental phase after restore
- add focused tests for completed+checkpointed vs finished-but-uncheckpointed snapshot split restore paths

## Background
During CDC snapshot failover, `SnapshotSplitAssigner#addSplits` can re-enqueue a snapshot split that has already finished reading and whose completion watermark has already been checkpointed. That can keep the snapshot phase from completing and block the job from entering incremental reading.

## Verification
- `./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-base -am -nsu -Dgit.skip=true -Dmaven.gitcommitid.skip=true spotless:apply`
- attempted targeted tests for `SnapshotSplitAssignerTest,HybridSplitAssignerTest`, but the clean `dev` checkout currently hits unrelated compile failures before those tests can complete