### PR TITLE
[Improve] [Zeta] Add observability metrics for engine state stores

### DIFF
--- a/docs/en/engines/zeta/telemetry.md
+++ b/docs/en/engines/zeta/telemetry.md
@@ -51,6 +51,19 @@ Note: All metrics both have the same labelName `cluster`, that's value is the co
 | hazelcast_partition_isClusterSafe         | Gauge | -                                                                                                                                  | Whether is cluster safe of partition                                    |
 | hazelcast_partition_isLocalMemberSafe     | Gauge | -                                                                                                                                  | Whether is local member safe of partition                               |
 
+### Engine State Store Metrics
+
+These metrics expose the basic size and local resource usage of Zeta engine state stores. The current backend is
+Hazelcast IMap, so the `backend` label value is `hazelcast`. The global entry metric is emitted by the master only.
+Local metrics are emitted by each node with the `address` label.
+
+| MetricName                                      | Type  | Labels                                                                      | DESCRIPTION                                                                 |
+|-------------------------------------------------|-------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| engine_state_store_entries                      | Gauge | **store**, engine state store name. **backend**, state store backend.        | Total entries of an engine state store. Emitted by the master only.         |
+| engine_state_store_local_owned_entries          | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local owned entries of an engine state store on this node.                  |
+| engine_state_store_local_backup_entries         | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local backup entries of an engine state store on this node.                 |
+| engine_state_store_local_heap_cost_bytes        | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local heap cost in bytes when the backend exposes it.                       |
+
 ### Thread Pool Status
 
 | MetricName                          | Type    | Labels                                                             | DESCRIPTION                                                                    |

--- a/docs/en/engines/zeta/telemetry.md
+++ b/docs/en/engines/zeta/telemetry.md
@@ -54,15 +54,21 @@ Note: All metrics both have the same labelName `cluster`, that's value is the co
 ### Engine State Store Metrics
 
 These metrics expose the basic size and local resource usage of Zeta engine state stores. The current backend is
-Hazelcast IMap, so the `backend` label value is `hazelcast`. The global entry metric is emitted by the master only.
-Local metrics are emitted by each node with the `address` label.
+Hazelcast IMap, so the `backend` label value is `hazelcast`. Local metrics are emitted by each node with the
+`address` label. To monitor the total entry count of an engine state store, aggregate
+`engine_state_store_local_owned_entries` in Prometheus.
 
 | MetricName                                      | Type  | Labels                                                                      | DESCRIPTION                                                                 |
 |-------------------------------------------------|-------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| engine_state_store_entries                      | Gauge | **store**, engine state store name. **backend**, state store backend.        | Total entries of an engine state store. Emitted by the master only.         |
 | engine_state_store_local_owned_entries          | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local owned entries of an engine state store on this node.                  |
 | engine_state_store_local_backup_entries         | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local backup entries of an engine state store on this node.                 |
 | engine_state_store_local_heap_cost_bytes        | Gauge | **address**, server instance address. **store**, state store name. **backend**, state store backend. | Local heap cost in bytes when the backend exposes it.                       |
+
+Example PromQL:
+
+```promql
+sum by (cluster, store, backend) (engine_state_store_local_owned_entries)
+```
 
 ### Thread Pool Status
 

--- a/docs/zh/engines/zeta/telemetry.md
+++ b/docs/zh/engines/zeta/telemetry.md
@@ -54,14 +54,20 @@ OpenMetrics 的指标文本
 ### 引擎状态存储指标
 
 这些指标暴露 Zeta 引擎状态存储的基础大小和本地资源使用情况。当前后端是 Hazelcast IMap，因此 `backend`
-标签值为 `hazelcast`。全局 entry 指标仅由 master 节点输出。本地指标由每个节点输出，并包含 `address` 标签。
+标签值为 `hazelcast`。本地指标由每个节点输出，并包含 `address` 标签。如需监控某个引擎状态存储的全局
+entry 总量，请在 Prometheus 中聚合 `engine_state_store_local_owned_entries`。
 
 | MetricName                                      | Type  | Labels                                                    | 描述                                      |
 |-------------------------------------------------|-------|-----------------------------------------------------------|-----------------------------------------|
-| engine_state_store_entries                      | Gauge | **store**，引擎状态存储名称。**backend**，状态存储后端。             | 引擎状态存储的全局 entry 总数，仅由 master 节点输出。 |
 | engine_state_store_local_owned_entries          | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 当前节点上该引擎状态存储的本地 owned entry 数。       |
 | engine_state_store_local_backup_entries         | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 当前节点上该引擎状态存储的本地 backup entry 数。      |
 | engine_state_store_local_heap_cost_bytes        | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 后端支持时，当前节点上该引擎状态存储的本地堆内存成本，单位为字节。 |
+
+PromQL 示例：
+
+```promql
+sum by (cluster, store, backend) (engine_state_store_local_owned_entries)
+```
 
 ### 线程池状态
 

--- a/docs/zh/engines/zeta/telemetry.md
+++ b/docs/zh/engines/zeta/telemetry.md
@@ -51,6 +51,18 @@ OpenMetrics 的指标文本
 | hazelcast_partition_isClusterSafe         | Gauge | -                                                                                                          | 分区是否安全                              |
 | hazelcast_partition_isLocalMemberSafe     | Gauge | -                                                                                                          | 本地成员是否安全                            |
 
+### 引擎状态存储指标
+
+这些指标暴露 Zeta 引擎状态存储的基础大小和本地资源使用情况。当前后端是 Hazelcast IMap，因此 `backend`
+标签值为 `hazelcast`。全局 entry 指标仅由 master 节点输出。本地指标由每个节点输出，并包含 `address` 标签。
+
+| MetricName                                      | Type  | Labels                                                    | 描述                                      |
+|-------------------------------------------------|-------|-----------------------------------------------------------|-----------------------------------------|
+| engine_state_store_entries                      | Gauge | **store**，引擎状态存储名称。**backend**，状态存储后端。             | 引擎状态存储的全局 entry 总数，仅由 master 节点输出。 |
+| engine_state_store_local_owned_entries          | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 当前节点上该引擎状态存储的本地 owned entry 数。       |
+| engine_state_store_local_backup_entries         | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 当前节点上该引擎状态存储的本地 backup entry 数。      |
+| engine_state_store_local_heap_cost_bytes        | Gauge | **address**，服务器实例地址。**store**，状态存储名称。**backend**，状态存储后端。 | 后端支持时，当前节点上该引擎状态存储的本地堆内存成本，单位为字节。 |
+
 ### 线程池状态
 
 | MetricName                          | Type    | Labels                                  | 描述                             |

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/ExportsInstanceInitializer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/ExportsInstanceInitializer.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server.telemetry.metrics;
 
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.ClusterMetricExports;
+import org.apache.seatunnel.engine.server.telemetry.metrics.exports.EngineStateStoreMetricExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.JobMetricExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.JobThreadPoolStatusExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.NodeMetricExports;
@@ -45,6 +46,8 @@ public final class ExportsInstanceInitializer {
             new JobThreadPoolStatusExports(node).register(collectorRegistry);
             // Node metrics
             new NodeMetricExports(node).register(collectorRegistry);
+            // Engine state store metrics
+            new EngineStateStoreMetricExports(node).register(collectorRegistry);
             // Cluster metrics
             new ClusterMetricExports(node).register(collectorRegistry);
             initialized = true;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.telemetry.metrics.exports;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.server.telemetry.metrics.AbstractCollector;
+
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.instance.impl.Node;
+import com.hazelcast.map.IMap;
+import com.hazelcast.map.LocalMapStats;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EngineStateStoreMetricExports extends AbstractCollector {
+
+    private static final String BACKEND = "hazelcast";
+
+    private static final List<String> ENGINE_STATE_STORES =
+            Arrays.asList(
+                    Constant.IMAP_RUNNING_JOB_INFO,
+                    Constant.IMAP_RUNNING_JOB_STATE,
+                    Constant.IMAP_STATE_TIMESTAMPS,
+                    Constant.IMAP_OWNED_SLOT_PROFILES,
+                    Constant.IMAP_RUNNING_JOB_METRICS,
+                    Constant.IMAP_FINISHED_JOB_STATE,
+                    Constant.IMAP_FINISHED_JOB_METRICS,
+                    Constant.IMAP_FINISHED_JOB_VERTEX_INFO,
+                    Constant.IMAP_CHECKPOINT_MONITOR,
+                    Constant.IMAP_CONNECTOR_JAR_REF_COUNTERS,
+                    Constant.IMAP_CHECKPOINT_ID,
+                    Constant.IMAP_PENDING_PIPELINE_CLEANUP);
+
+    public EngineStateStoreMetricExports(Node node) {
+        super(node);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        GaugeMetricFamily entries =
+                new GaugeMetricFamily(
+                        "engine_state_store_entries",
+                        "Total entries of an engine state store",
+                        clusterLabelNames("store", "backend"));
+        List<String> localLabelNames = clusterLabelNames(ADDRESS, "store", "backend");
+        GaugeMetricFamily localOwnedEntries =
+                new GaugeMetricFamily(
+                        "engine_state_store_local_owned_entries",
+                        "Local owned entries of an engine state store on this node",
+                        localLabelNames);
+        GaugeMetricFamily localBackupEntries =
+                new GaugeMetricFamily(
+                        "engine_state_store_local_backup_entries",
+                        "Local backup entries of an engine state store on this node",
+                        localLabelNames);
+        GaugeMetricFamily localHeapCostBytes =
+                new GaugeMetricFamily(
+                        "engine_state_store_local_heap_cost_bytes",
+                        "Local heap cost in bytes of an engine state store on this node",
+                        localLabelNames);
+
+        for (String storeName : ENGINE_STATE_STORES) {
+            collectStoreMetrics(
+                    storeName, entries, localOwnedEntries, localBackupEntries, localHeapCostBytes);
+        }
+
+        return Arrays.asList(entries, localOwnedEntries, localBackupEntries, localHeapCostBytes);
+    }
+
+    private void collectStoreMetrics(
+            String storeName,
+            GaugeMetricFamily entries,
+            GaugeMetricFamily localOwnedEntries,
+            GaugeMetricFamily localBackupEntries,
+            GaugeMetricFamily localHeapCostBytes) {
+        try {
+            IMap<?, ?> map = getNode().hazelcastInstance.getMap(storeName);
+            if (isMaster()) {
+                entries.addMetric(labelValues(storeName, BACKEND), map.size());
+            }
+            LocalMapStats localMapStats = map.getLocalMapStats();
+            List<String> localLabelValues = labelValues(localAddress(), storeName, BACKEND);
+            localOwnedEntries.addMetric(localLabelValues, localMapStats.getOwnedEntryCount());
+            localBackupEntries.addMetric(localLabelValues, localMapStats.getBackupEntryCount());
+            localHeapCostBytes.addMetric(localLabelValues, localMapStats.getHeapCost());
+        } catch (HazelcastInstanceNotActiveException e) {
+            getLogger(getClass())
+                    .fine(
+                            String.format(
+                                    "Skip state store metrics because Hazelcast is not active, store=%s, backend=%s",
+                                    storeName, BACKEND),
+                            e);
+        } catch (Exception e) {
+            getLogger(getClass())
+                    .warning(
+                            String.format(
+                                    "Failed to collect state store metrics, store=%s, backend=%s",
+                                    storeName, BACKEND),
+                            e);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
@@ -54,11 +54,6 @@ public class EngineStateStoreMetricExports extends AbstractCollector {
 
     @Override
     public List<MetricFamilySamples> collect() {
-        GaugeMetricFamily entries =
-                new GaugeMetricFamily(
-                        "engine_state_store_entries",
-                        "Total entries of an engine state store",
-                        clusterLabelNames("store", "backend"));
         List<String> localLabelNames = clusterLabelNames(ADDRESS, "store", "backend");
         GaugeMetricFamily localOwnedEntries =
                 new GaugeMetricFamily(
@@ -78,23 +73,19 @@ public class EngineStateStoreMetricExports extends AbstractCollector {
 
         for (String storeName : ENGINE_STATE_STORES) {
             collectStoreMetrics(
-                    storeName, entries, localOwnedEntries, localBackupEntries, localHeapCostBytes);
+                    storeName, localOwnedEntries, localBackupEntries, localHeapCostBytes);
         }
 
-        return Arrays.asList(entries, localOwnedEntries, localBackupEntries, localHeapCostBytes);
+        return Arrays.asList(localOwnedEntries, localBackupEntries, localHeapCostBytes);
     }
 
     private void collectStoreMetrics(
             String storeName,
-            GaugeMetricFamily entries,
             GaugeMetricFamily localOwnedEntries,
             GaugeMetricFamily localBackupEntries,
             GaugeMetricFamily localHeapCostBytes) {
         try {
             IMap<?, ?> map = getNode().hazelcastInstance.getMap(storeName);
-            if (isMaster()) {
-                entries.addMetric(labelValues(storeName, BACKEND), map.size());
-            }
             LocalMapStats localMapStats = map.getLocalMapStats();
             List<String> localLabelValues = labelValues(localAddress(), storeName, BACKEND);
             localOwnedEntries.addMetric(localLabelValues, localMapStats.getOwnedEntryCount());

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/metrics/MetricsApiTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/metrics/MetricsApiTest.java
@@ -55,7 +55,7 @@ public class MetricsApiTest {
                 .then()
                 .statusCode(200)
                 .body(containsString("process_start_time_seconds"))
-                .body(containsString("engine_state_store_entries"));
+                .body(containsString("engine_state_store_local_owned_entries"));
     }
 
     @AfterAll

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/metrics/MetricsApiTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/metrics/MetricsApiTest.java
@@ -54,7 +54,8 @@ public class MetricsApiTest {
         given().get("http://localhost:8080" + RestConstant.REST_URL_METRICS)
                 .then()
                 .statusCode(200)
-                .body(containsString("process_start_time_seconds"));
+                .body(containsString("process_start_time_seconds"))
+                .body(containsString("engine_state_store_entries"));
     }
 
     @AfterAll

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
@@ -53,23 +53,16 @@ class EngineStateStoreMetricExportsTest {
     }
 
     @Test
-    void collectShouldExportGlobalAndLocalStateStoreMetrics() {
+    void collectShouldExportLocalStateStoreMetrics() {
         instance =
                 SeaTunnelServerStarter.createHazelcastInstance(
-                        TestUtils.getClusterName(
-                                "EngineStateStoreMetricExportsTest_globalAndLocal"));
+                        TestUtils.getClusterName("EngineStateStoreMetricExportsTest_localMetrics"));
         await().atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> Assertions.assertTrue(instance.node.isMaster()));
         instance.getMap(Constant.IMAP_RUNNING_JOB_INFO).put(1L, "job-info");
 
         List<MetricFamilySamples> metrics =
                 new EngineStateStoreMetricExports(instance.node).collect();
-
-        Sample entries =
-                findSample(metrics, "engine_state_store_entries", Constant.IMAP_RUNNING_JOB_INFO);
-        Assertions.assertEquals(1.0, entries.value);
-        Assertions.assertEquals(Arrays.asList("cluster", "store", "backend"), entries.labelNames);
-        Assertions.assertEquals("hazelcast", labelValue(entries, "backend"));
 
         Sample ownedEntries =
                 findSample(
@@ -106,7 +99,7 @@ class EngineStateStoreMetricExportsTest {
                 new EngineStateStoreMetricExports(instance.node).collect();
 
         Set<String> exportedStores =
-                findMetricFamily(metrics, "engine_state_store_entries").samples.stream()
+                findMetricFamily(metrics, "engine_state_store_local_owned_entries").samples.stream()
                         .map(sample -> labelValue(sample, "store"))
                         .collect(Collectors.toSet());
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.telemetry.metrics.exports;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
+import org.apache.seatunnel.engine.server.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+
+@DisabledOnOs(OS.WINDOWS)
+class EngineStateStoreMetricExportsTest {
+
+    private HazelcastInstanceImpl instance;
+
+    @AfterEach
+    void afterEach() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    void collectShouldExportGlobalAndLocalStateStoreMetrics() {
+        instance =
+                SeaTunnelServerStarter.createHazelcastInstance(
+                        TestUtils.getClusterName(
+                                "EngineStateStoreMetricExportsTest_globalAndLocal"));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertTrue(instance.node.isMaster()));
+        instance.getMap(Constant.IMAP_RUNNING_JOB_INFO).put(1L, "job-info");
+
+        List<MetricFamilySamples> metrics =
+                new EngineStateStoreMetricExports(instance.node).collect();
+
+        Sample entries =
+                findSample(metrics, "engine_state_store_entries", Constant.IMAP_RUNNING_JOB_INFO);
+        Assertions.assertEquals(1.0, entries.value);
+        Assertions.assertEquals(Arrays.asList("cluster", "store", "backend"), entries.labelNames);
+        Assertions.assertEquals("hazelcast", labelValue(entries, "backend"));
+
+        Sample ownedEntries =
+                findSample(
+                        metrics,
+                        "engine_state_store_local_owned_entries",
+                        Constant.IMAP_RUNNING_JOB_INFO);
+        Assertions.assertEquals(
+                Arrays.asList("cluster", "address", "store", "backend"), ownedEntries.labelNames);
+        Assertions.assertEquals("hazelcast", labelValue(ownedEntries, "backend"));
+        Assertions.assertFalse(labelValue(ownedEntries, "address").isEmpty());
+
+        Assertions.assertNotNull(
+                findSample(
+                        metrics,
+                        "engine_state_store_local_backup_entries",
+                        Constant.IMAP_RUNNING_JOB_INFO));
+        Assertions.assertNotNull(
+                findSample(
+                        metrics,
+                        "engine_state_store_local_heap_cost_bytes",
+                        Constant.IMAP_RUNNING_JOB_INFO));
+    }
+
+    @Test
+    void collectShouldCoverAllEngineStateStores() {
+        instance =
+                SeaTunnelServerStarter.createHazelcastInstance(
+                        TestUtils.getClusterName(
+                                "EngineStateStoreMetricExportsTest_allStateStores"));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertTrue(instance.node.isMaster()));
+
+        List<MetricFamilySamples> metrics =
+                new EngineStateStoreMetricExports(instance.node).collect();
+
+        Set<String> exportedStores =
+                findMetricFamily(metrics, "engine_state_store_entries").samples.stream()
+                        .map(sample -> labelValue(sample, "store"))
+                        .collect(Collectors.toSet());
+
+        Assertions.assertEquals(
+                new HashSet<>(
+                        Arrays.asList(
+                                Constant.IMAP_RUNNING_JOB_INFO,
+                                Constant.IMAP_RUNNING_JOB_STATE,
+                                Constant.IMAP_STATE_TIMESTAMPS,
+                                Constant.IMAP_OWNED_SLOT_PROFILES,
+                                Constant.IMAP_RUNNING_JOB_METRICS,
+                                Constant.IMAP_FINISHED_JOB_STATE,
+                                Constant.IMAP_FINISHED_JOB_METRICS,
+                                Constant.IMAP_FINISHED_JOB_VERTEX_INFO,
+                                Constant.IMAP_CHECKPOINT_MONITOR,
+                                Constant.IMAP_CONNECTOR_JAR_REF_COUNTERS,
+                                Constant.IMAP_CHECKPOINT_ID,
+                                Constant.IMAP_PENDING_PIPELINE_CLEANUP)),
+                exportedStores);
+    }
+
+    private static MetricFamilySamples findMetricFamily(
+            List<MetricFamilySamples> metrics, String name) {
+        return metrics.stream()
+                .filter(metricFamilySamples -> name.equals(metricFamilySamples.name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing metric family: " + name));
+    }
+
+    private static Sample findSample(
+            List<MetricFamilySamples> metrics, String metricName, String storeName) {
+        return findMetricFamily(metrics, metricName).samples.stream()
+                .filter(sample -> storeName.equals(labelValue(sample, "store")))
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new AssertionError(
+                                        "Missing metric sample: "
+                                                + metricName
+                                                + ", store="
+                                                + storeName));
+    }
+
+    private static String labelValue(Sample sample, String labelName) {
+        int index = sample.labelNames.indexOf(labelName);
+        if (index < 0) {
+            throw new AssertionError("Missing label: " + labelName);
+        }
+        return sample.labelValues.get(index);
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
fix #10766 

This pull request adds basic observability metrics for Zeta engine state stores backed by Hazelcast `IMap`.

Main changes in this PR:
  - add a new collector `EngineStateStoreMetricExports`
  - register engine state store metrics in the existing telemetry initialization flow
  - expose basic metrics for major engine state stores, including:
    - total entries
    - local owned entries
    - local backup entries
    - local heap cost in bytes

This PR is intentionally kept within the Phase 1 scope discussed in issue #10766:
  - basic store-level metrics only
  - backend-neutral metric names with `backend="hazelcast"` label
  - no StateStore abstraction refactor
  - no special business-aware logical metrics yet

### Does this PR introduce _any_ user-facing change?

Yes.  This PR adds new user-visible telemetry metrics to the existing Zeta Prometheus metrics endpoint.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
