### PR TITLE
[Fix][Docs] Add missing auth options to Chinese Elasticsearch sink docs and remove duplicate sections in English docs

### DIFF
--- a/docs/en/connectors/sink/Elasticsearch.md
+++ b/docs/en/connectors/sink/Elasticsearch.md
@@ -161,12 +161,6 @@ sink {
 
 one bulk request max try size
 
-### vectorization_fields [array]
-fields to embeddings 
-
-### vector_dimensions [int]
-embeddings dimensions
-
 ### max_batch_size [int]
 
 batch bulk doc max size

--- a/docs/zh/connectors/sink/Elasticsearch.md
+++ b/docs/zh/connectors/sink/Elasticsearch.md
@@ -30,8 +30,12 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 | index_type             | string  | 否    |                              |
 | primary_keys           | list    | 否    |                              |
 | key_delimiter          | string  | 否    | `_`                          |
+| auth_type              | string  | 否    | basic                        |
 | username               | string  | 否    |                              |
 | password               | string  | 否    |                              |
+| auth.api_key_id        | string  | 否    | -                            |
+| auth.api_key           | string  | 否    | -                            |
+| auth.api_key_encoded   | string  | 否    | -                            |
 | max_retry_count        | int     | 否    | 3                            |
 | max_batch_size         | int     | 否    | 10                           |
 | tls_verify_certificate | boolean | 否    | true                         |
@@ -64,13 +68,86 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 
 设定复合键的分隔符（默认为 `_`），例如，如果使用 `$` 作为分隔符，那么文档的 `_id` 将呈现为 `KEY1$KEY2$KEY3` 的格式
 
-### username [string]
+## 认证
 
-x-pack 用户名
+Elasticsearch 连接器支持多种认证方式连接到安全的 Elasticsearch 集群。您可以根据 Elasticsearch 的安全配置选择合适的认证方式。
 
-### password [string]
+### auth_type [enum]
 
-x-pack 密码
+指定使用的认证方式。支持的值：
+- `basic`（默认）：使用用户名和密码的 HTTP 基本认证
+- `api_key`：使用独立的 ID 和密钥的 Elasticsearch API Key 认证
+- `api_key_encoded`：使用编码密钥的 Elasticsearch API Key 认证
+
+如果未指定，默认使用 `basic` 以保持向后兼容。
+
+### 基本认证
+
+基本认证使用 HTTP 基本认证，通过用户名和密码凭据进行认证。
+
+#### username [string]
+
+基本认证用户名（x-pack 用户名）。
+
+#### password [string]
+
+基本认证密码（x-pack 密码）。
+
+**示例：**
+```hocon
+sink {
+    Elasticsearch {
+        hosts = ["https://localhost:9200"]
+        auth_type = "basic"
+        username = "elastic"
+        password = "your_password"
+        index = "my_index"
+    }
+}
+```
+
+### API Key 认证
+
+API Key 认证提供了一种更安全的方式，使用 API 密钥对 Elasticsearch 进行认证。
+
+#### auth.api_key_id [string]
+
+Elasticsearch 生成的 API 密钥 ID。
+
+#### auth.api_key [string]
+
+Elasticsearch 生成的 API 密钥。
+
+#### auth.api_key_encoded [string]
+
+Base64 编码的 API 密钥，格式为 `base64(id:api_key)`。这是分别指定 `auth.api_key_id` 和 `auth.api_key` 的替代方式。
+
+**注意：** 可以使用 `auth.api_key_id` + `auth.api_key` 或 `auth.api_key_encoded`，但不能同时使用两者。
+
+**使用独立 ID 和密钥的示例：**
+```hocon
+sink {
+    Elasticsearch {
+        hosts = ["https://localhost:9200"]
+        auth_type = "api_key"
+        auth.api_key_id = "your_api_key_id"
+        auth.api_key = "your_api_key_secret"
+        index = "my_index"
+    }
+}
+```
+
+**使用编码密钥的示例：**
+```hocon
+sink {
+    Elasticsearch {
+        hosts = ["https://localhost:9200"]
+        auth_type = "api_key_encoded"
+        auth.api_key_encoded = "eW91cl9hcGlfa2V5X2lkOnlvdXJfYXBpX2tleV9zZWNyZXQ="
+        index = "my_index"
+    }
+}
+```
 
 ### max_retry_count [int]
 


### PR DESCRIPTION
The Chinese sink documentation was missing auth_type, auth.api_key_id,
auth.api_key, and auth.api_key_encoded options. Added the full
Authentication section with descriptions and examples, matching the
English documentation.

Also removed duplicate vectorization_fields/vector_dimensions sections
in the English sink documentation.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
