### PR TITLE
[Improve][connector-starrocks] Improved starrocks source enumerator splits allocation algorithm for subtasks

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceState.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceState.java
@@ -33,4 +33,5 @@ public class StarRocksSourceState implements Serializable {
     private static final long serialVersionUID = -147928488869915694L;
     private Map<Integer, List<StarRocksSourceSplit>> pendingSplit;
     private final ConcurrentLinkedQueue<String> pendingTables;
+    private int assignCount;
 }

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StartRocksSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StartRocksSourceSplitEnumerator.java
@@ -29,11 +29,13 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -46,6 +48,7 @@ public class StartRocksSourceSplitEnumerator
 
     private final Object stateLock = new Object();
     private final Context<StarRocksSourceSplit> context;
+    private final AtomicInteger assignCount = new AtomicInteger(0);
 
     public StartRocksSourceSplitEnumerator(
             SourceSplitEnumerator.Context<StarRocksSourceSplit> context,
@@ -147,8 +150,15 @@ public class StartRocksSourceSplitEnumerator
 
     private void addPendingSplit(Collection<StarRocksSourceSplit> splits) {
         int readerCount = context.currentParallelism();
-        for (StarRocksSourceSplit split : splits) {
-            int ownerReader = getSplitOwner(split.splitId(), readerCount);
+
+        List<StarRocksSourceSplit> sortedSplits =
+                splits.stream()
+                        .sorted(Comparator.comparing(StarRocksSourceSplit::getSplitId))
+                        .collect(Collectors.toList());
+
+        assignCount.set(0);
+        for (StarRocksSourceSplit split : sortedSplits) {
+            int ownerReader = getSplitOwner(assignCount.getAndIncrement(), readerCount);
             log.info("Assigning {} to {} reader.", split.getSplitId(), ownerReader);
             pendingSplit.computeIfAbsent(ownerReader, r -> new ArrayList<>()).add(split);
         }
@@ -191,7 +201,7 @@ public class StartRocksSourceSplitEnumerator
         return sourceSplits;
     }
 
-    private static int getSplitOwner(String tp, int numReaders) {
-        return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+    private static int getSplitOwner(int assignCount, int numReaders) {
+        return assignCount % numReaders;
     }
 }

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StartRocksSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StartRocksSourceSplitEnumerator.java
@@ -48,6 +48,7 @@ public class StartRocksSourceSplitEnumerator
 
     private final Object stateLock = new Object();
     private final Context<StarRocksSourceSplit> context;
+    // Keeps round-robin assignment global across tables and restore.
     private final AtomicInteger assignCount = new AtomicInteger(0);
 
     public StartRocksSourceSplitEnumerator(
@@ -74,6 +75,7 @@ public class StartRocksSourceSplitEnumerator
         if (sourceState != null) {
             this.pendingSplit.putAll(sourceState.getPendingSplit());
             this.pendingTables.addAll(sourceState.getPendingTables());
+            this.assignCount.set(sourceState.getAssignCount());
         }
     }
 
@@ -102,7 +104,7 @@ public class StartRocksSourceSplitEnumerator
     public void addSplitsBack(List<StarRocksSourceSplit> splits, int subtaskId) {
         log.debug("Add back splits {} to StartRocksSourceSplitEnumerator.", splits);
         if (!splits.isEmpty()) {
-            addPendingSplit(splits);
+            addPendingSplit(splits, subtaskId);
             assignSplit(Collections.singletonList(subtaskId));
         }
     }
@@ -123,7 +125,7 @@ public class StartRocksSourceSplitEnumerator
     @Override
     public StarRocksSourceState snapshotState(long checkpointId) {
         synchronized (stateLock) {
-            return new StarRocksSourceState(pendingSplit, pendingTables);
+            return new StarRocksSourceState(pendingSplit, pendingTables, assignCount.get());
         }
     }
 
@@ -156,12 +158,15 @@ public class StartRocksSourceSplitEnumerator
                         .sorted(Comparator.comparing(StarRocksSourceSplit::getSplitId))
                         .collect(Collectors.toList());
 
-        assignCount.set(0);
         for (StarRocksSourceSplit split : sortedSplits) {
             int ownerReader = getSplitOwner(assignCount.getAndIncrement(), readerCount);
             log.info("Assigning {} to {} reader.", split.getSplitId(), ownerReader);
             pendingSplit.computeIfAbsent(ownerReader, r -> new ArrayList<>()).add(split);
         }
+    }
+
+    private void addPendingSplit(Collection<StarRocksSourceSplit> splits, int ownerReader) {
+        pendingSplit.computeIfAbsent(ownerReader, r -> new ArrayList<>()).addAll(splits);
     }
 
     private void assignSplit(Collection<Integer> readers) {

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceSplitEnumeratorTest.java
@@ -17,10 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.starrocks.source;
 
-import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.api.event.EventListener;
-import org.apache.seatunnel.api.source.SourceEvent;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SourceConfig;
 
@@ -34,12 +31,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class StarRocksSourceSplitEnumeratorTest {
 
     @Test
     public void shouldBalanceSplitsEvenlyAcrossReaders() throws Exception {
-        TestingContext context = new TestingContext(4);
+        Map<Integer, List<StarRocksSourceSplit>> assignments = new HashMap<>();
+        SourceSplitEnumerator.Context<StarRocksSourceSplit> context = createContext(4, assignments);
         StartRocksSourceSplitEnumerator enumerator =
                 new StartRocksSourceSplitEnumerator(
                         context, new SourceConfig(ReadonlyConfig.fromMap(configMap())));
@@ -60,6 +67,89 @@ public class StarRocksSourceSplitEnumeratorTest {
         Assertions.assertEquals(2, pendingSplits.get(3).size());
     }
 
+    @Test
+    public void shouldBalanceSingleSplitTablesAcrossReadersInRun() {
+        Map<Integer, List<StarRocksSourceSplit>> assignments = new HashMap<>();
+        SourceSplitEnumerator.Context<StarRocksSourceSplit> context = createContext(3, assignments);
+        StartRocksSourceSplitEnumerator enumerator =
+                spy(
+                        new StartRocksSourceSplitEnumerator(
+                                context,
+                                new SourceConfig(ReadonlyConfig.fromMap(configMap())),
+                                new StarRocksSourceState(
+                                        new HashMap<>(),
+                                        new ConcurrentLinkedQueue<>(
+                                                new ArrayList<String>() {
+                                                    {
+                                                        add("table_0");
+                                                        add("table_1");
+                                                        add("table_2");
+                                                    }
+                                                }),
+                                        0)));
+
+        doReturn(Collections.singletonList(buildSplit("split-0")))
+                .when(enumerator)
+                .getStarRocksSourceSplit("table_0");
+        doReturn(Collections.singletonList(buildSplit("split-1")))
+                .when(enumerator)
+                .getStarRocksSourceSplit("table_1");
+        doReturn(Collections.singletonList(buildSplit("split-2")))
+                .when(enumerator)
+                .getStarRocksSourceSplit("table_2");
+
+        enumerator.run();
+
+        Assertions.assertEquals(1, getAssignedSplitCount(assignments, 0));
+        Assertions.assertEquals(1, getAssignedSplitCount(assignments, 1));
+        Assertions.assertEquals(1, getAssignedSplitCount(assignments, 2));
+    }
+
+    @Test
+    public void shouldReassignReturnedSplitsToOriginalReader() {
+        Map<Integer, List<StarRocksSourceSplit>> assignments = new HashMap<>();
+        SourceSplitEnumerator.Context<StarRocksSourceSplit> context = createContext(3, assignments);
+        StartRocksSourceSplitEnumerator enumerator =
+                new StartRocksSourceSplitEnumerator(
+                        context, new SourceConfig(ReadonlyConfig.fromMap(configMap())));
+
+        enumerator.addSplitsBack(buildSplits(3), 2);
+
+        Assertions.assertEquals(0, getAssignedSplitCount(assignments, 0));
+        Assertions.assertEquals(0, getAssignedSplitCount(assignments, 1));
+        Assertions.assertEquals(3, getAssignedSplitCount(assignments, 2));
+
+        StarRocksSourceState state = enumerator.snapshotState(1L);
+        Assertions.assertTrue(state.getPendingSplit().isEmpty());
+    }
+
+    @Test
+    public void shouldContinueRoundRobinAfterRestore() {
+        Map<Integer, List<StarRocksSourceSplit>> assignments = new HashMap<>();
+        SourceSplitEnumerator.Context<StarRocksSourceSplit> context = createContext(3, assignments);
+        String remainingTable = "table_after_restore";
+        StartRocksSourceSplitEnumerator enumerator =
+                spy(
+                        new StartRocksSourceSplitEnumerator(
+                                context,
+                                new SourceConfig(ReadonlyConfig.fromMap(configMap())),
+                                new StarRocksSourceState(
+                                        new HashMap<>(),
+                                        new ConcurrentLinkedQueue<>(
+                                                Collections.singletonList(remainingTable)),
+                                        1)));
+
+        doReturn(Collections.singletonList(buildSplit("split-after-restore")))
+                .when(enumerator)
+                .getStarRocksSourceSplit(remainingTable);
+
+        enumerator.run();
+
+        Assertions.assertEquals(0, getAssignedSplitCount(assignments, 0));
+        Assertions.assertEquals(1, getAssignedSplitCount(assignments, 1));
+        Assertions.assertEquals(0, getAssignedSplitCount(assignments, 2));
+    }
+
     private Map<String, Object> configMap() {
         Map<String, Object> config = new HashMap<>();
         config.put("nodeUrls", Collections.singletonList("localhost:8030"));
@@ -74,46 +164,46 @@ public class StarRocksSourceSplitEnumeratorTest {
     private List<StarRocksSourceSplit> buildSplits(int size) {
         List<StarRocksSourceSplit> splits = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            splits.add(new StarRocksSourceSplit(null, "split-" + i));
+            splits.add(buildSplit("split-" + i));
         }
         return splits;
     }
 
-    private static class TestingContext
-            implements SourceSplitEnumerator.Context<StarRocksSourceSplit> {
-        private final int parallelism;
+    private StarRocksSourceSplit buildSplit(String splitId) {
+        return new StarRocksSourceSplit(null, splitId);
+    }
 
-        private TestingContext(int parallelism) {
-            this.parallelism = parallelism;
+    private SourceSplitEnumerator.Context<StarRocksSourceSplit> createContext(
+            int parallelism, Map<Integer, List<StarRocksSourceSplit>> assignments) {
+        @SuppressWarnings("unchecked")
+        SourceSplitEnumerator.Context<StarRocksSourceSplit> context =
+                mock(SourceSplitEnumerator.Context.class);
+        when(context.currentParallelism()).thenReturn(parallelism);
+        when(context.registeredReaders()).thenReturn(createReaders(parallelism));
+        doAnswer(
+                        invocation -> {
+                            int subtaskId = invocation.getArgument(0);
+                            List<StarRocksSourceSplit> splits = invocation.getArgument(1);
+                            assignments
+                                    .computeIfAbsent(subtaskId, ignored -> new ArrayList<>())
+                                    .addAll(splits);
+                            return null;
+                        })
+                .when(context)
+                .assignSplit(anyInt(), anyList());
+        return context;
+    }
+
+    private Set<Integer> createReaders(int parallelism) {
+        Set<Integer> readers = new java.util.LinkedHashSet<>();
+        for (int i = 0; i < parallelism; i++) {
+            readers.add(i);
         }
+        return readers;
+    }
 
-        @Override
-        public int currentParallelism() {
-            return parallelism;
-        }
-
-        @Override
-        public Set<Integer> registeredReaders() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public void assignSplit(int subtaskId, List<StarRocksSourceSplit> splits) {}
-
-        @Override
-        public void signalNoMoreSplits(int subtask) {}
-
-        @Override
-        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
-
-        @Override
-        public MetricsContext getMetricsContext() {
-            return null;
-        }
-
-        @Override
-        public EventListener getEventListener() {
-            return null;
-        }
+    private int getAssignedSplitCount(
+            Map<Integer, List<StarRocksSourceSplit>> assignments, int subtaskId) {
+        return assignments.getOrDefault(subtaskId, Collections.emptyList()).size();
     }
 }

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/source/StarRocksSourceSplitEnumeratorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.starrocks.source;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SourceConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class StarRocksSourceSplitEnumeratorTest {
+
+    @Test
+    public void shouldBalanceSplitsEvenlyAcrossReaders() throws Exception {
+        TestingContext context = new TestingContext(4);
+        StartRocksSourceSplitEnumerator enumerator =
+                new StartRocksSourceSplitEnumerator(
+                        context, new SourceConfig(ReadonlyConfig.fromMap(configMap())));
+
+        Method addPendingSplit =
+                StartRocksSourceSplitEnumerator.class.getDeclaredMethod(
+                        "addPendingSplit", java.util.Collection.class);
+        addPendingSplit.setAccessible(true);
+        addPendingSplit.invoke(enumerator, buildSplits(10));
+
+        StarRocksSourceState state = enumerator.snapshotState(1L);
+        Map<Integer, List<StarRocksSourceSplit>> pendingSplits = state.getPendingSplit();
+
+        Assertions.assertEquals(4, pendingSplits.size());
+        Assertions.assertEquals(3, pendingSplits.get(0).size());
+        Assertions.assertEquals(3, pendingSplits.get(1).size());
+        Assertions.assertEquals(2, pendingSplits.get(2).size());
+        Assertions.assertEquals(2, pendingSplits.get(3).size());
+    }
+
+    private Map<String, Object> configMap() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("nodeUrls", Collections.singletonList("localhost:8030"));
+        config.put("username", "root");
+        config.put("password", "");
+        config.put("database", "test_db");
+        config.put("table", "test_table");
+        config.put("table_list", Collections.emptyList());
+        return config;
+    }
+
+    private List<StarRocksSourceSplit> buildSplits(int size) {
+        List<StarRocksSourceSplit> splits = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            splits.add(new StarRocksSourceSplit(null, "split-" + i));
+        }
+        return splits;
+    }
+
+    private static class TestingContext
+            implements SourceSplitEnumerator.Context<StarRocksSourceSplit> {
+        private final int parallelism;
+
+        private TestingContext(int parallelism) {
+            this.parallelism = parallelism;
+        }
+
+        @Override
+        public int currentParallelism() {
+            return parallelism;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<StarRocksSourceSplit> splits) {}
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {}
+
+        @Override
+        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Similar to pr #9108, improving starrocks source enumerator splits allocation algorithm for subtasks and add UT.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
