### PR TITLE
[Fix][Zeta] Stabilize coordinator restore test

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -10,8 +10,8 @@ Use these entry points first:
 
 ## What data sources and destinations does SeaTunnel support?
 SeaTunnel supports various data sources and destinations. You can find a detailed list on the following list:
-- Supported data sources (Source): [Source List](../connectors/source)
-- Supported data destinations (Sink): [Sink List](../connectors/sink)
+- Supported data sources (Source): [Source List](./connectors/source)
+- Supported data destinations (Sink): [Sink List](./connectors/sink)
 
 ## Does SeaTunnel support batch and streaming processing?
 SeaTunnel supports both batch and streaming processing modes. You can select the appropriate mode based on your specific business scenarios and needs. Batch processing is suitable for scheduled data integration tasks, while streaming processing is ideal for real-time integration and Change Data Capture (CDC).
@@ -29,7 +29,7 @@ Yes, SeaTunnel supports custom data cleansing rules. You can configure custom ru
 SeaTunnel supports incremental data integration. For example, the CDC connector allows real-time capture of data changes, which is ideal for scenarios requiring real-time data integration.
 
 ## What CDC data sources are currently supported by SeaTunnel?
-SeaTunnel currently supports MongoDB CDC, MySQL CDC, OpenGauss CDC, Oracle CDC, PostgreSQL CDC, SQL Server CDC, TiDB CDC, and more. For more details, refer to the [Source List](../connectors/source).
+SeaTunnel currently supports MongoDB CDC, MySQL CDC, OpenGauss CDC, Oracle CDC, PostgreSQL CDC, SQL Server CDC, TiDB CDC, and more. For more details, refer to the [Source List](./connectors/source).
 
 ## How do I enable permissions required for SeaTunnel CDC integration?
 Please refer to the official SeaTunnel documentation for the necessary steps to enable permissions for each connector’s CDC functionality.

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -10,8 +10,8 @@
 
 ## SeaTunnel 支持哪些数据来源和数据目的地？
 SeaTunnel 支持多种数据源来源和数据目的地，您可以在官网找到详细的列表：
-SeaTunnel 支持的数据来源(Source)列表：[Source List](../connectors/source)
-SeaTunnel 支持的数据目的地(Sink)列表：[Sink List](../connectors/sink)
+SeaTunnel 支持的数据来源(Source)列表：[Source List](./connectors/source)
+SeaTunnel 支持的数据目的地(Sink)列表：[Sink List](./connectors/sink)
 
 ## SeaTunnel 是否支持批处理和流处理？
 SeaTunnel 支持批流一体，SeaTunnel 可以设置批处理和流处理两种模式。您可以根据具体的业务场景和需求选择合适的处理模式。批处理适合定时数据同步场景，而流处理适合实时同步和数据变更捕获 (CDC) 场景。
@@ -30,7 +30,7 @@ SeaTunnel 支持自定义数据清洗规则。可以在 `transform` 模块中配
 SeaTunnel 支持增量数据同步。例如通过 CDC 连接器实现对数据库的增量同步，适用于需要实时捕获数据变更的场景。
 
 ## SeaTunnel 目前支持哪些数据源的 CDC ？
-目前支持 MongoDB CDC、MySQL CDC、Opengauss CDC、Oracle CDC、PostgreSQL CDC、Sql Server CDC、TiDB CDC等，更多请查阅[Source](../connectors/source)。
+目前支持 MongoDB CDC、MySQL CDC、Opengauss CDC、Oracle CDC、PostgreSQL CDC、Sql Server CDC、TiDB CDC等，更多请查阅[Source](./connectors/source)。
 
 ## SeaTunnel CDC 同步需要的权限如何开启？
 这样就可以了。

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceJobCleanupTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceJobCleanupTest.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
 import org.apache.seatunnel.engine.server.checkpoint.CompletedCheckpoint;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.master.JobMaster;
 import org.apache.seatunnel.engine.server.master.cleanup.JobCleanupRecord;
 import org.apache.seatunnel.engine.server.operation.SubmitJobOperation;
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
@@ -46,10 +47,12 @@ import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -493,6 +496,8 @@ class CoordinatorServiceJobCleanupTest extends AbstractSeaTunnelServerTest {
                 nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_INFO);
         IMap<Object, Object> runningJobStateIMap =
                 nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_STATE);
+        IMap<Object, Long[]> runningJobStateTimestampsIMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_STATE_TIMESTAMPS);
 
         JobInfo jobInfo =
                 new JobInfo(
@@ -513,7 +518,21 @@ class CoordinatorServiceJobCleanupTest extends AbstractSeaTunnelServerTest {
             ReflectionUtils.setField(coordinatorService, "runningJobInfoIMap", runningJobInfoIMap);
         }
 
-        Assertions.assertTrue(coordinatorService.getPendingJobQueue().contains(jobId));
+        Long[] jobStateTimestamps = runningJobStateTimestampsIMap.get(jobId);
+        Assertions.assertNotNull(jobStateTimestamps);
+        Assertions.assertEquals(
+                initializationTimestamp, jobStateTimestamps[JobStatus.INITIALIZING.ordinal()]);
+        Assertions.assertTrue(
+                coordinatorService.getPendingJobQueue().contains(jobId)
+                        || getRunningJobMasterMap(coordinatorService).containsKey(jobId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Long, JobMaster> getRunningJobMasterMap(CoordinatorService coordinatorService)
+            throws Exception {
+        Field field = CoordinatorService.class.getDeclaredField("runningJobMasterMap");
+        field.setAccessible(true);
+        return (Map<Long, JobMaster>) field.get(coordinatorService);
     }
 
     private Set<Object> stateKeys(Object... keys) {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -852,7 +852,7 @@ public class CoordinatorServiceTest {
                 createHazelcastInstanceWithJoinPortTryCount(
                         TestUtils.getClusterName(
                                 "CoordinatorServiceTest_testRestoreUsesProvidedJobInfoInitializationTimestamp"),
-                        100);
+                        1);
         try {
             SeaTunnelServer server =
                     instance.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
@@ -885,6 +885,8 @@ public class CoordinatorServiceTest {
                     instance.getMap(Constant.IMAP_RUNNING_JOB_INFO);
             IMap<Object, Object> runningJobStateIMap =
                     instance.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+            IMap<Object, Long[]> runningJobStateTimestampsIMap =
+                    instance.getMap(Constant.IMAP_STATE_TIMESTAMPS);
             runningJobInfoIMap.put(jobId, jobInfo);
             runningJobStateIMap.put(jobId, JobStatus.RUNNING);
 
@@ -901,7 +903,13 @@ public class CoordinatorServiceTest {
                         coordinatorService, "runningJobInfoIMap", runningJobInfoIMap);
             }
 
-            Assertions.assertTrue(coordinatorService.getPendingJobQueue().contains(jobId));
+            Long[] jobStateTimestamps = runningJobStateTimestampsIMap.get(jobId);
+            Assertions.assertNotNull(jobStateTimestamps);
+            Assertions.assertEquals(
+                    initializationTimestamp, jobStateTimestamps[JobStatus.INITIALIZING.ordinal()]);
+            Assertions.assertTrue(
+                    coordinatorService.getPendingJobQueue().contains(jobId)
+                            || getRunningJobMasterMap(coordinatorService).containsKey(jobId));
         } finally {
             instance.shutdown();
         }


### PR DESCRIPTION
### Purpose of this pull request

Stabilize coordinator restore tests by avoiding assertions on the transient pending queue state. A restored job can be consumed by the pending-job scheduler immediately, so the tests now verify the restored initialization timestamp and accept either pending or already scheduled state.

This also fixes FAQ connector links that were reported by the `Dead links` CI job.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- `./mvnw spotless:apply`
- `npx -y markdown-link-check@3.8.7 -c .dlc.json -q docs/en/faq.md`
- `npx -y markdown-link-check@3.8.7 -c .dlc.json -q docs/zh/faq.md`
- `git diff --check`

### Check list

- [ ] 新增 Jar 包需按 New License Guide 添加 License
- [ ] 必要时更新文档 (docs/en + docs/zh)
- [ ] 必要时更新 incompatible-changes.md
- [ ] 连接器代码需更新: plugin-mapping.properties, seatunnel-dist pom, CI label, E2E, plugin_config
