### PR TITLE
[Build][Deps] Support JDK23 lombok annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <javax.servlet.jap.version>2.1</javax.servlet.jap.version>
         <hadoop.binary.version>2.7</hadoop.binary.version>
         <jackson.version>2.13.3</jackson.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
         <commons-compress.version>1.20</commons-compress.version>
         <avro.version>1.11.1</avro.version>
         <skip.pmd.check>false</skip.pmd.check>
@@ -873,6 +873,18 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.google.auto.service</groupId>
+                            <artifactId>auto-service</artifactId>
+                            <version>${auto-service.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## What does this PR do?

Fix JDK23 build compatibility for modules that rely on lombok-generated constructors, getters, and loggers.

This change:
- upgrades `lombok.version` from `1.18.24` to `1.18.36`
- adds lombok to `maven-compiler-plugin` `annotationProcessorPaths`

## Why is this needed?

On JDK23, the `connector-cdc-base` module fails during `compile` / `testCompile` because lombok annotation processing is not applied.

Typical failures include missing generated getters, constructors, and `log` fields.

## How was this verified?

Ran in a JDK23 environment:

```bash
./mvnw spotless:apply
./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-base \
  -Dgit.skip=true -Dmaven.gitcommitid.skip=true \
  -Dtest=HybridSplitAssignerTest test
```

The targeted CDC module build and test now pass successfully under JDK23.