### PR TITLE
[Fix][Zeta] Fix flaky pending job info test

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -42,6 +42,7 @@ import org.apache.seatunnel.engine.server.execution.PendingSourceState;
 import org.apache.seatunnel.engine.server.execution.TaskGroupContext;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
+import org.apache.seatunnel.engine.server.master.JobHistoryService;
 import org.apache.seatunnel.engine.server.master.JobMaster;
 import org.apache.seatunnel.engine.server.metrics.SeaTunnelMetricsContext;
 import org.apache.seatunnel.engine.server.operation.PrintMessageOperation;
@@ -944,22 +945,29 @@ public class CoordinatorServiceTest {
 
     @Test
     void testGetPendingJobInfo() {
-        JobInformation jobInformation =
-                submitJob(
-                        "CoordinatorServiceTest_testGetPendingJobInfo",
-                        "batch_fake_to_console.conf",
-                        "test_get_pending_job_info");
+        SeaTunnelServer server = Mockito.mock(SeaTunnelServer.class);
+        CoordinatorService coordinatorService = newMockCoordinatorService(server);
+        try {
+            Long jobId = 70001L;
+            JobHistoryService jobHistoryService = Mockito.mock(JobHistoryService.class);
+            ReflectionUtils.setField(coordinatorService, "jobHistoryService", jobHistoryService);
+            Mockito.when(jobHistoryService.getJobDAGInfo(jobId)).thenReturn(null);
 
-        CoordinatorService coordinatorService = jobInformation.coordinatorService;
-        Long jobId = jobInformation.jobId;
+            JobDAGInfo pendingJobDAGInfo = new JobDAGInfo();
+            pendingJobDAGInfo.setJobId(jobId);
+            JobMaster jobMaster =
+                    enqueueMockPendingJob(coordinatorService, jobId, new CountDownLatch(1));
+            Mockito.when(jobMaster.getJobDAGInfo()).thenReturn(pendingJobDAGInfo);
 
-        Assertions.assertTrue(coordinatorService.getPendingJobQueue().contains(jobId));
+            Assertions.assertTrue(coordinatorService.getPendingJobQueue().contains(jobId));
 
-        JobDAGInfo jobDAGInfo =
-                Assertions.assertDoesNotThrow(() -> coordinatorService.getJobInfo(jobId));
-        Assertions.assertEquals(jobId, jobDAGInfo.getJobId());
-
-        jobInformation.coordinatorServiceTest.shutdown();
+            JobDAGInfo jobDAGInfo =
+                    Assertions.assertDoesNotThrow(() -> coordinatorService.getJobInfo(jobId));
+            Assertions.assertSame(pendingJobDAGInfo, jobDAGInfo);
+            Assertions.assertEquals(jobId, jobDAGInfo.getJobId());
+        } finally {
+            coordinatorService.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Fix flaky `CoordinatorServiceTest.testGetPendingJobInfo`.

Related CI failure: https://github.com/QuakeWang/seatunnel/actions/runs/25901176569/job/76125357474

The old test submitted a real job and asserted that the job was still in `pendingJobQueue`. This assertion depended on a transient scheduler state because the coordinator scheduler may consume the pending job immediately after submission.

This patch makes the test deterministic by constructing a controlled pending job and verifying that `getJobInfo()` can return DAG info from the pending job path.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

No.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

```bash
git diff --check
./mvnw -pl seatunnel-engine/seatunnel-engine-server -am -Dtest=CoordinatorServiceTest#testGetPendingJobInfo -DfailIfNoTests=false -DskipIT=true -Dskip.spotless=true verify
```

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
