### PR TITLE
[Docs][Zeta] Fix incorrect config key name in slot-allocation-strateg…

### DIFF
--- a/docs/en/engines/zeta/slot-allocation-strategy.md
+++ b/docs/en/engines/zeta/slot-allocation-strategy.md
@@ -4,7 +4,7 @@ Slot allocation strategy is an important part of SeaTunnel Engine, which determi
 
 **Configuration method:**
 
-Set the parameter `slot-allocation-strategy`, optional values are `RANDOM`, `SYSTEM_LOAD`, `SLOT_RATIO`.
+Set the parameter `slot-allocate-strategy`, optional values are `RANDOM`, `SYSTEM_LOAD`, `SLOT_RATIO`.
 
 Example:
 
@@ -12,7 +12,7 @@ Example:
 seatunnel:
   engine:
     slot-service:
-      slot-allocation-strategy: RANDOM
+      slot-allocate-strategy: RANDOM
 ```
 
 ## RANDOM (default value)

--- a/docs/zh/engines/zeta/slot-allocation-strategy.md
+++ b/docs/zh/engines/zeta/slot-allocation-strategy.md
@@ -8,14 +8,14 @@ Slot分配策略是SeaTunnel Engine的一个重要组成部分，它决定了Sea
 
 **配置方法：**
 
-设置参数`slot-allocation-strategy`, 可选值有`RANDOM`, `SYSTEM_LOAD`, `SLOT_RATIO`。
+设置参数`slot-allocate-strategy`, 可选值有`RANDOM`, `SYSTEM_LOAD`, `SLOT_RATIO`。
 
 例：
 ```yaml
 seatunnel:
   engine:
     slot-service:
-      slot-allocation-strategy: RANDOM
+      slot-allocate-strategy: RANDOM
 ...
 ```
 


### PR DESCRIPTION

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
  Fix incorrect config key name in slot-allocation-strategy documentation.

  The docs used `slot-allocation-strategy` but the actual config key parsed by `YamlSeaTunnelDomConfigProcessor` is `slot-allocate-strategy`. 
Using the wrong key causes the setting to be silently ignored (logs `Unrecognized element`) and falls back to the default `RANDOM` strategy.


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
  Yes. Users who followed the documentation and configured `slot-allocation-strategy` would have had their setting silently ignored. The correct key is `slot-allocate-strategy`, consistent with `ServerConfigOptions.MasterServerConfigOptions.SLOT_ALLOCATE_STRATEGY`.


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

  Verified by reading the parser code in `YamlSeaTunnelDomConfigProcessor.java` (line 108)  
  and the key definition in `ServerConfigOptions.java` (line 195). Documentation-only change,  no code logic modified.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [X] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
