### PR TITLE
[Fix][Connectors-v2] connector-typesense Not imported in seatunnel-dist

### DIFF
--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -582,6 +582,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-typesense</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-selectdb-cloud</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>


### PR DESCRIPTION
### Purpose of this pull request

`connector-typesense` was missing from `seatunnel-dist/pom.xml`, so the binary dist did not include the plugin. **Change:** add `connector-typesense` as a `provided` dependency there (same pattern as other connectors).

### Does this PR introduce _any_ user-facing change?

No breaking change. Users installing from the SeaTunnel dist package can obtain and run the Typesense Source/Sink as documented instead of building or copying the JAR manually.

### How was this patch tested?

- `./mvnw -q -DskipTests verify` (or `package` the `seatunnel-dist` module) and confirm the built distribution contains `connector-typesense` under the expected connectors/plugins path.
- Optional smoke: run a minimal job referencing `Typesense` after `install-plugin` from the produced dist.
