### PR TITLE
[Improve][connector-jdbc] Remove useless parameters: support_upsert_by_insert_only

### DIFF
--- a/docs/en/connectors/sink/Redshift.md
+++ b/docs/en/connectors/sink/Redshift.md
@@ -64,7 +64,7 @@ semantics (using XA transaction guarantee).
 
 ## Sink Options
 
-> Redshift sink is implemented on top of the JDBC sink. The table below focuses on the most commonly used Redshift options. For inherited advanced JDBC sink options such as `compatible_mode`, `dialect`, `is_primary_key_updated`, `support_upsert_by_insert_only`, `use_copy_statement`, `tablePrefix`, `tableSuffix`, and `create_index`, see [JDBC Sink](Jdbc.md).
+> Redshift sink is implemented on top of the JDBC sink. The table below focuses on the most commonly used Redshift options. For inherited advanced JDBC sink options such as `compatible_mode`, `dialect`, `is_primary_key_updated`, `use_copy_statement`, `tablePrefix`, `tableSuffix`, and `create_index`, see [JDBC Sink](Jdbc.md).
 
 |                   Name                    |  Type   | Required |           Default            |                                                                                                                  Description                                                                                                                   |
 |-------------------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/zh/connectors/sink/Redshift.md
+++ b/docs/zh/connectors/sink/Redshift.md
@@ -62,7 +62,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Sink 参数
 
-> Redshift Sink 基于 JDBC Sink 实现。下表聚焦于 Redshift 常用参数。对于继承自 JDBC Sink 的高级参数，例如 `compatible_mode`、`dialect`、`is_primary_key_updated`、`support_upsert_by_insert_only`、`use_copy_statement`、`tablePrefix`、`tableSuffix` 和 `create_index`，请参考 [JDBC Sink](Jdbc.md)。
+> Redshift Sink 基于 JDBC Sink 实现。下表聚焦于 Redshift 常用参数。对于继承自 JDBC Sink 的高级参数，例如 `compatible_mode`、`dialect`、`is_primary_key_updated`、`use_copy_statement`、`tablePrefix`、`tableSuffix` 和 `create_index`，请参考 [JDBC Sink](Jdbc.md)。
 
 | 名称                           | 类型    | 是否必填 |           默认值            |                                                                                                                  描述                                                                                                                   |
 |------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkConfig.java
@@ -38,7 +38,6 @@ public class JdbcSinkConfig implements Serializable {
     private List<String> primaryKeys;
     private boolean enableUpsert;
     @Builder.Default private boolean isPrimaryKeyUpdated = true;
-    private boolean supportUpsertByInsertOnly;
     private boolean useCopyStatement;
     @Builder.Default private boolean createIndex = true;
 
@@ -51,8 +50,6 @@ public class JdbcSinkConfig implements Serializable {
         config.getOptional(JdbcSinkOptions.TABLE).ifPresent(builder::table);
         builder.enableUpsert(config.get(JdbcSinkOptions.ENABLE_UPSERT));
         builder.isPrimaryKeyUpdated(config.get(JdbcSinkOptions.IS_PRIMARY_KEY_UPDATED));
-        builder.supportUpsertByInsertOnly(
-                config.get(JdbcSinkOptions.SUPPORT_UPSERT_BY_INSERT_ONLY));
         builder.simpleSql(config.get(JdbcSinkOptions.QUERY));
         builder.useCopyStatement(config.get(JdbcSinkOptions.USE_COPY_STATEMENT));
         builder.createIndex(config.get(JdbcSinkOptions.CREATE_INDEX));

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
@@ -115,12 +115,6 @@ public class JdbcSinkOptions extends JdbcCommonOptions {
                     .withDescription(
                             "is the primary key updated when performing an update operation");
 
-    public static final Option<Boolean> SUPPORT_UPSERT_BY_INSERT_ONLY =
-            Options.key("support_upsert_by_insert_only")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("support upsert by insert only");
-
     public static final Option<Boolean> USE_COPY_STATEMENT =
             Options.key("use_copy_statement")
                     .booleanType()

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilder.java
@@ -92,8 +92,7 @@ public class JdbcOutputFormatBuilder {
                                     databaseTableSchema,
                                     primaryKeys.toArray(new String[0]),
                                     jdbcSinkConfig.isEnableUpsert(),
-                                    jdbcSinkConfig.isPrimaryKeyUpdated(),
-                                    jdbcSinkConfig.isSupportUpsertByInsertOnly());
+                                    jdbcSinkConfig.isPrimaryKeyUpdated());
         }
 
         return new JdbcOutputFormat(
@@ -132,8 +131,7 @@ public class JdbcOutputFormatBuilder {
             TableSchema databaseTableSchema,
             String[] pkNames,
             boolean enableUpsert,
-            boolean isPrimaryKeyUpdated,
-            boolean supportUpsertByInsertOnly) {
+            boolean isPrimaryKeyUpdated) {
         int[] pkFields =
                 Arrays.stream(pkNames)
                         .mapToInt(tableSchema.toPhysicalRowDataType()::indexOf)
@@ -163,8 +161,7 @@ public class JdbcOutputFormatBuilder {
                         pkSchema,
                         keyExtractor,
                         enableUpsert,
-                        isPrimaryKeyUpdated,
-                        supportUpsertByInsertOnly);
+                        isPrimaryKeyUpdated);
         return new BufferReducedBatchStatementExecutor(
                 upsertExecutor, deleteExecutor, keyExtractor, Function.identity());
     }
@@ -179,12 +176,7 @@ public class JdbcOutputFormatBuilder {
             TableSchema pkTableSchema,
             Function<SeaTunnelRow, SeaTunnelRow> keyExtractor,
             boolean enableUpsert,
-            boolean isPrimaryKeyUpdated,
-            boolean supportUpsertByInsertOnly) {
-        if (supportUpsertByInsertOnly) {
-            return createInsertOnlyExecutor(
-                    dialect, database, table, tableSchema, databaseTableSchema);
-        }
+            boolean isPrimaryKeyUpdated) {
         if (enableUpsert) {
             Optional<String> upsertSQL =
                     dialect.getUpsertStatementByTableSchema(database, table, tableSchema, pkNames);
@@ -230,24 +222,6 @@ public class JdbcOutputFormatBuilder {
                         .collect(Collectors.joining(",", "(", ")"));
         String copyInSql = String.format("COPY %s %s FROM STDIN WITH CSV", table, columns);
         return new CopyManagerBatchStatementExecutor(copyInSql, tableSchema);
-    }
-
-    private static JdbcBatchStatementExecutor<SeaTunnelRow> createInsertOnlyExecutor(
-            JdbcDialect dialect,
-            String database,
-            String table,
-            TableSchema tableSchema,
-            TableSchema databaseTableSchema) {
-        return new SimpleBatchStatementExecutor(
-                connection ->
-                        FieldNamedPreparedStatement.prepareStatement(
-                                connection,
-                                dialect.getInsertIntoStatement(
-                                        database, table, tableSchema.getFieldNames()),
-                                tableSchema.getFieldNames()),
-                tableSchema,
-                databaseTableSchema,
-                dialect.getRowConverter());
     }
 
     private static JdbcBatchStatementExecutor<SeaTunnelRow> createInsertOrUpdateExecutor(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -225,7 +225,6 @@ public class JdbcSinkFactory implements TableSinkFactory {
                         JdbcSinkOptions.AUTO_COMMIT,
                         JdbcSinkOptions.PRIMARY_KEYS,
                         JdbcSinkOptions.IS_PRIMARY_KEY_UPDATED,
-                        JdbcSinkOptions.SUPPORT_UPSERT_BY_INSERT_ONLY,
                         JdbcSinkOptions.USE_COPY_STATEMENT,
                         JdbcSinkOptions.COMPATIBLE_MODE,
                         JdbcSinkOptions.ENABLE_UPSERT,


### PR DESCRIPTION
### Purpose of this pull request                                                                                                                                                                                                   
                                                                                                                                                                                                                                   
  Remove the useless parameter support_upsert_by_insert_only from JDBC sink connector.                                                                                                                                           

###  Reasons for removal:

  1. No actual functionality: This parameter does not implement the "insert-only" semantics (such as INSERT IGNORE or ON CONFLICT DO NOTHING). It simply changes the upsert executor to a plain INSERT executor, which causes
  primary key conflicts when the record already exists.
  2. Redundant complexity:
    - When primary_keys is not configured: The system uses simple INSERT directly; this parameter is not needed.
    - When primary_keys is configured: The upsert mode handles CDC operations (INSERT/UPDATE/DELETE). Setting support_upsert_by_insert_only=true causes UPDATE_AFTER operations to execute INSERT, leading to primary key violation errors.
  3. No documentation: The parameter is not documented in JdbcSink docs (only referenced in RedshiftSink as an inherited option without explanation).

  The correct way to achieve "insert-only without update" behavior is to disable upsert mode, not to use this parameter.


