### PR TITLE
fix typesense add missing import for MULTI_TABLE_SINK_REPLICA to pass…

### DIFF
--- a/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.typesense.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.connector.TableSink;
@@ -50,6 +51,7 @@ public class TypesenseSinkFactory implements TableSinkFactory {
                 .optional(TypesenseSinkOptions.KEY_DELIMITER)
                 .optional(TypesenseSinkOptions.MAX_BATCH_SIZE)
                 .optional(TypesenseSinkOptions.MAX_RETRY_COUNT)
+                .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .build();
     }
 


### PR DESCRIPTION
### Purpose of this pull request

`ConnectorSpecificationCheckTest` (in `seatunnel-dist`) requires sinks that implement `SupportMultiTableSink` to declare `SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA` in `optionRule()` optional options. `TypesenseSinkFactory` did not, which failed CI once `connector-typesense` is picked up by the dist check. **Change:** add that optional to `TypesenseSinkFactory#optionRule()`, consistent with other sinks.

**CI failure before fix** (`ConnectorSpecificationCheckTest#testAllConnectorImplementFactoryWithUpToDateMethod`):

```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
org.opentest4j.AssertionFailedError: Please add `SinkCommonOptions.MULTI_TABLE_SINK_REPLICA` optional into the `optionRule` method optional of `TypesenseSinkFactory` ==> expected: <true> but was: <false>
	at org.apache.seatunnel.api.connector.ConnectorSpecificationCheckTest.checkSupportMultiTableSink(ConnectorSpecificationCheckTest.java:185)
	at org.apache.seatunnel.api.connector.ConnectorSpecificationCheckTest.testAllConnectorImplementFactoryWithUpToDateMethod(ConnectorSpecificationCheckTest.java:172)
```

### Does this PR introduce _any_ user-facing change?

No. This satisfies the specification check only; `MULTI_TABLE_SINK_REPLICA` is an existing shared optional; default behavior is unchanged unless you rely on that option like other sinks.

### How was this patch tested?

- `./mvnw -B -T 1 -Dlicense.skipAddThirdParty=true -Dskip.ui=false --no-snapshot-updates test -DskipUT=false -DskipIT=true -pl :seatunnel-dist`
