### PR TITLE
Update collaborator chl-wxp to DanielLeens in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,7 +34,7 @@ github:
     - elt
   collaborators:
     - ricky2129
-    - chl-wxp
+    - DanielLeens
     - LiJie20190102
     - yzeng1618
     - fcb-xiaobo


### PR DESCRIPTION
## What changes were proposed in this pull request?
Considering that chl-wxp is a committer now, so update `.asf.yaml` collaborators list: replace `chl-wxp` with `DanielLeens`.

## Why are the changes needed?

Update the GitHub collaborator username from `chl-wxp` to `DanielLeens`.

## Does this PR introduce _any_ user-facing change?

No. This is a configuration-only change to the ASF repository settings.