### PR TITLE
Split unrelated client summary and Pulsar E2E follow-ups from PR 10491

### DIFF
--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/ClientExecuteCommand.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/ClientExecuteCommand.java
@@ -288,8 +288,10 @@ public class ClientExecuteCommand implements Command<ClientCommandArgs> {
                                 "Total Write Count",
                                 jobMetricsSummary.getSinkWriteCount(),
                                 "Total Failed Count",
-                                jobMetricsSummary.getSourceReadCount()
-                                        - jobMetricsSummary.getSinkWriteCount()));
+                                Math.max(
+                                        0,
+                                        jobMetricsSummary.getSourceReadCount()
+                                                - jobMetricsSummary.getSinkWriteCount())));
             }
             closeClient();
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/CanalToPulsarIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/CanalToPulsarIT.java
@@ -34,7 +34,12 @@ import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.Schema;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -251,6 +256,31 @@ public class CanalToPulsarIT extends TestSuiteBase implements TestResource {
         }
     }
 
+    private void waitForCanalDataInTopic() throws IOException, PulsarClientException {
+        String topicFullName = "persistent://public/default/" + TOPIC;
+        try (PulsarClient pulsarClient =
+                        PulsarClient.builder()
+                                .serviceUrl(
+                                        String.format(
+                                                "pulsar://%s:%s",
+                                                PULSAR_CONTAINER.getHost(),
+                                                PULSAR_CONTAINER.getMappedPort(PULSAR_BROKER_PORT)))
+                                .build();
+                Reader<byte[]> reader =
+                        pulsarClient
+                                .newReader(Schema.BYTES)
+                                .topic(topicFullName)
+                                .startMessageId(MessageId.earliest)
+                                .create()) {
+            Message<byte[]> message = reader.readNext(5, TimeUnit.SECONDS);
+            Assertions.assertNotNull(message, "Canal has not yet forwarded data to topic " + TOPIC);
+            LOG.info(
+                    "Detected Canal data in topic {} with message id {}",
+                    TOPIC,
+                    message.getMessageId());
+        }
+    }
+
     @BeforeAll
     @Override
     public void startUp() throws ClassNotFoundException, InterruptedException {
@@ -275,8 +305,13 @@ public class CanalToPulsarIT extends TestSuiteBase implements TestResource {
                 .untilAsserted(this::waitForTopicCreated);
         // before ddl, the pulsar_canal connector should be started
         inventoryDatabase.createAndInitialize();
-        // wait pulsar get data from canal server
-        Thread.sleep(10 * 1000);
+        // wait for Canal server to forward data to Pulsar topic
+        given().ignoreExceptions()
+                .await()
+                .atLeast(100, TimeUnit.MILLISECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.MINUTES)
+                .untilAsserted(this::waitForCanalDataInTopic);
         LOG.info("The fourth stage: Starting PostgresSQL container...");
         createPostgreSQLContainer();
         Startables.deepStart(Stream.of(POSTGRESQL_CONTAINER)).join();


### PR DESCRIPTION
## Summary
- move two changes unrelated to stain trace out of #10491
- avoid negative failed-count output in client summary
- wait for Canal data to arrive in Pulsar before continuing the Pulsar E2E flow

## Validation
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true spotless:apply`
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -Dspotless.check.skip=true -f seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/pom.xml -Dtest=CanalToPulsarIT -Dsurefire.failIfNoSpecifiedTests=false test` (blocked by missing local Docker / `/var/run/docker.sock`)
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -Dspotless.check.skip=true -f seatunnel-core/seatunnel-starter/pom.xml -DskipTests package` (blocked by existing upstream `DryRun` compile issue in `ClientCommandArgs`, unrelated to this one-line change)

## Notes
- This PR is intentionally draft because it only exists to keep #10491 focused.