### PR TITLE
[hotfix] [docs] Add managed Kubernetes deployment notes

### DIFF
--- a/docs/en/getting-started/kubernetes/helm.md
+++ b/docs/en/getting-started/kubernetes/helm.md
@@ -41,6 +41,21 @@ Install with another namespace.
 helm install seatunnel . -n <your namespace>
 ```
 
+For managed Kubernetes services, keep provider-specific changes in a separate values file and pass it with `-f`, for example:
+
+```bash
+helm install seatunnel . -n <your namespace> -f values-eks.yaml
+```
+
+Common managed-cluster values to review include:
+
+- image repository and `imagePullSecrets` for ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, VCR, or an OpenShift internal registry
+- ServiceAccount, RBAC, and OpenShift SecurityContextConstraint requirements for the target namespace
+- Service or Ingress annotations for the provider load balancer, subnet, certificate, and internal/external exposure model
+- object storage or PersistentVolume settings for checkpoint and state paths
+- resource requests, limits, node selectors, tolerations, and affinity rules for the node pools that should run SeaTunnel pods
+- log and metrics collection settings for the provider monitoring stack
+
 ## Submit Job
 
 The default config doesn't enable ingress, so you need forward the master restapi.

--- a/docs/en/getting-started/kubernetes/helm.md
+++ b/docs/en/getting-started/kubernetes/helm.md
@@ -49,7 +49,7 @@ helm install seatunnel . -n <your namespace> -f values-eks.yaml
 
 Common managed-cluster values to review include:
 
-- image repository and `imagePullSecrets` for ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, VCR, or an OpenShift internal registry
+- image repository and `imagePullSecrets` for ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, Volcengine Container Registry, or an OpenShift internal registry
 - ServiceAccount, RBAC, and OpenShift SecurityContextConstraint requirements for the target namespace
 - Service or Ingress annotations for the provider load balancer, subnet, certificate, and internal/external exposure model
 - object storage or PersistentVolume settings for checkpoint and state paths

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -31,7 +31,7 @@ The examples below use Minikube, but the same manifests can be adapted to manage
 
 | Area | What to verify |
 | --- | --- |
-| Image registry | Push the SeaTunnel image to a registry reachable by the cluster, such as ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, VCR, or the internal OpenShift registry. Update `image` and `imagePullSecrets` when the image is private. |
+| Image registry | Push the SeaTunnel image to a registry reachable by the cluster, such as ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, Volcengine Container Registry, or the internal OpenShift registry. Update `image` and `imagePullSecrets` when the image is private. |
 | Namespace and access | Create a dedicated namespace for SeaTunnel and bind the required ServiceAccount, Role, and RoleBinding there. OpenShift deployments may also need a SecurityContextConstraint compatible with the container user. |
 | Config and secrets | Keep non-sensitive SeaTunnel configuration in ConfigMaps and mount credentials through Secrets or the cloud provider's secret integration. Avoid putting connector credentials directly into the job ConfigMap. |
 | Connector packaging | Package commonly used connectors in the image for repeatable deployments, or mount connector libraries from a PersistentVolume or object-storage backed init step when connector sets change frequently. |

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -25,6 +25,23 @@ Take kubernetes [minikube](https://minikube.sigs.k8s.io/docs/start/) as an examp
 minikube start --kubernetes-version=v1.23.3
 ```
 
+## Managed Kubernetes Notes
+
+The examples below use Minikube, but the same manifests can be adapted to managed Kubernetes services such as Amazon EKS, Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), Alibaba Cloud ACK, Tencent TKE, Huawei Cloud CCE, Volcengine VKE, and Red Hat OpenShift. Before applying the manifests to a managed cluster, check the following platform-specific settings.
+
+| Area | What to verify |
+| --- | --- |
+| Image registry | Push the SeaTunnel image to a registry reachable by the cluster, such as ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, VCR, or the internal OpenShift registry. Update `image` and `imagePullSecrets` when the image is private. |
+| Namespace and access | Create a dedicated namespace for SeaTunnel and bind the required ServiceAccount, Role, and RoleBinding there. OpenShift deployments may also need a SecurityContextConstraint compatible with the container user. |
+| Config and secrets | Keep non-sensitive SeaTunnel configuration in ConfigMaps and mount credentials through Secrets or the cloud provider's secret integration. Avoid putting connector credentials directly into the job ConfigMap. |
+| Connector packaging | Package commonly used connectors in the image for repeatable deployments, or mount connector libraries from a PersistentVolume or object-storage backed init step when connector sets change frequently. |
+| Storage and checkpoints | Use the storage service that matches the cloud, such as S3, GCS, Azure Blob Storage, OSS, COS, OBS, TOS, or a Kubernetes PersistentVolume. Confirm that the SeaTunnel pods have both network access and credentials for the chosen checkpoint or state path. |
+| Networking | Use `ClusterIP` for in-cluster access, `LoadBalancer` or Ingress for external access, and the cloud provider's annotations when a specific load balancer type, subnet, or certificate is required. |
+| Scheduling | Set CPU and memory requests, node selectors, tolerations, or affinity rules when the cluster has mixed node pools. If cluster autoscaling is enabled, make sure worker pods have enough requested resources to trigger scale-out before jobs are submitted. |
+| Observability | Send pod logs and SeaTunnel metrics to the managed logging and monitoring stack. For example, use CloudWatch, Cloud Logging, Azure Monitor, Alibaba Cloud Log Service, Tencent CLS, Huawei LTS, Volcengine TLS, or OpenShift monitoring. |
+
+For production environments, pin the SeaTunnel image tag, keep platform-specific values in separate manifests or Helm values files, and test upgrades in a staging namespace before changing the running cluster.
+
 ## Installation
 
 ### SeaTunnel Docker Image

--- a/docs/zh/getting-started/kubernetes/helm.md
+++ b/docs/zh/getting-started/kubernetes/helm.md
@@ -42,6 +42,21 @@ helm install seatunnel .
 helm install seatunnel . -n <your namespace>
 ```
 
+对于托管 Kubernetes 服务，建议将云厂商相关的差异化配置单独维护在一个 values 文件中，并通过 `-f` 传入，例如：
+
+```bash
+helm install seatunnel . -n <your namespace> -f values-eks.yaml
+```
+
+在托管集群上常见需要复核的 values 包括：
+
+- 用于 ECR、Artifact Registry、ACR、ACK 容器镜像服务、TCR、SWR、Volcengine Container Registry 或 OpenShift 内置镜像仓库的镜像仓库地址与 `imagePullSecrets`
+- 目标命名空间对应的 ServiceAccount、RBAC，以及 OpenShift 上的 SecurityContextConstraint 要求
+- 云厂商负载均衡、子网、证书与内外网暴露模式相关的 Service 或 Ingress annotation
+- 用于 checkpoint 与 state 路径的对象存储或 PersistentVolume 配置
+- 用于运行 SeaTunnel Pod 的节点池所需的 resource request/limit、node selector、toleration 与 affinity
+- 接入云厂商监控栈的日志与指标采集配置
+
 ## 提交任务
 
 当前默认的配置没有启用ingress，所以需要使用转发命令将master的restapi端口转发出来。

--- a/docs/zh/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/zh/getting-started/kubernetes/kubernetes.mdx
@@ -25,6 +25,23 @@ import TabItem from '@theme/TabItem';
 minikube start --kubernetes-version=v1.23.3
 ```
 
+## 托管 Kubernetes 注意事项
+
+下面的示例使用 Minikube，但相同的 manifest 可以适配到各种托管 Kubernetes 服务，例如 Amazon EKS、Google Kubernetes Engine (GKE)、Azure Kubernetes Service (AKS)、阿里云 ACK、腾讯云 TKE、华为云 CCE、火山引擎 VKE 和 Red Hat OpenShift。在将 manifest 应用到托管集群之前，请按下表检查与平台相关的设置。
+
+| 项目 | 需要确认的内容 |
+| --- | --- |
+| 镜像仓库 | 将 SeaTunnel 镜像推送到集群可访问的镜像仓库，例如 ECR、Artifact Registry、ACR、ACK 容器镜像服务、TCR、SWR、Volcengine Container Registry 或 OpenShift 内置镜像仓库。当镜像为私有镜像时，需要同步更新 `image` 与 `imagePullSecrets`。 |
+| 命名空间与权限 | 为 SeaTunnel 创建专用命名空间，并在该命名空间下绑定所需的 ServiceAccount、Role 与 RoleBinding。在 OpenShift 上部署时，可能还需要配置与容器用户兼容的 SecurityContextConstraint。 |
+| 配置与密钥 | 将非敏感的 SeaTunnel 配置放入 ConfigMap，通过 Secret 或云厂商的密钥管理服务挂载凭据，避免把连接器凭据直接写入任务的 ConfigMap。 |
+| 连接器打包 | 对于稳定的部署，建议将常用连接器一并打入镜像；当连接器组合经常变更时，可以通过 PersistentVolume 或对象存储 + init 容器的方式挂载连接器依赖。 |
+| 存储与 Checkpoint | 选择与所在云相匹配的存储服务，例如 S3、GCS、Azure Blob Storage、OSS、COS、OBS、TOS，或 Kubernetes PersistentVolume。确保 SeaTunnel Pod 对所选 checkpoint / state 路径同时具有网络可达性和访问凭据。 |
+| 网络访问 | 集群内部访问使用 `ClusterIP`，外部访问使用 `LoadBalancer` 或 Ingress；当需要指定负载均衡器类型、子网或证书时，请使用对应云厂商的 annotation。 |
+| 资源调度 | 在混合节点池的集群上，按需要设置 CPU、内存 request、node selector、toleration 与 affinity；如果开启了集群自动扩缩容，请确保 worker Pod 的资源 request 足以触发节点扩容后再提交任务。 |
+| 可观测性 | 将 Pod 日志和 SeaTunnel 指标接入云厂商的日志与监控栈，例如 CloudWatch、Cloud Logging、Azure Monitor、阿里云日志服务 SLS、腾讯云 CLS、华为云 LTS、火山引擎 TLS 或 OpenShift 内置监控。 |
+
+对于生产环境，请固定 SeaTunnel 镜像 tag，把云厂商相关的 values 单独维护在独立的 manifest 或 Helm values 文件中，并在改动正在运行的集群之前，先在 staging 命名空间中验证升级。
+
 ## 安装
 
 ### SeaTunnel Docker 镜像


### PR DESCRIPTION
### Purpose of this pull request

Closes #10927.

Adds a focused managed Kubernetes notes section to the Kubernetes quickstart and Helm guide. The new docs cover the platform-specific checks users usually need before adapting the existing Minikube examples to EKS, GKE, AKS, ACK, TKE, CCE, VKE, or OpenShift.

### Does this PR introduce _any_ user-facing change?

Yes. Users deploying SeaTunnel on managed Kubernetes services now get explicit guidance for image registries, namespace/RBAC setup, ConfigMaps and Secrets, connector packaging, checkpoint/state storage, networking exposure, scheduling, and observability.

### How was this patch tested?

Documentation-only change.

Verified locally with:

```bash
git diff --check
```

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
