### PR TITLE
[Docs] Fix dead issue link in connector common changelog

### DIFF
--- a/docs/en/connectors/changelog/connector-common.md
+++ b/docs/en/connectors/changelog/connector-common.md
@@ -76,7 +76,7 @@
 |[Feature][Connector-V2] Support user-defined schema for source connectors (#2392)|https://github.com/apache/seatunnel/commit/6b650bef07|2.2.0-beta|
 |Merge from dev to st-engine (#2243)|https://github.com/apache/seatunnel/commit/41e530afd5|2.3.0-beta|
 |StateT of SeaTunnelSource should extend `Serializable` (#2214)|https://github.com/apache/seatunnel/commit/8c426ef850|2.2.0-beta|
-|[Improvement][new api] refer to https://github.com/apache/incubator-seatunnel/issues/2127 (#2144)|https://github.com/apache/seatunnel/commit/e19660a049|2.2.0-beta|
+|[Improvement][new api] refer to https://github.com/apache/seatunnel/issues/2127 (#2144)|https://github.com/apache/seatunnel/commit/e19660a049|2.2.0-beta|
 |[api-draft][Optimize] Optimize module name (#2062)|https://github.com/apache/seatunnel/commit/f79e3112b1|2.2.0-beta|
 
 </details>


### PR DESCRIPTION
## What changed

- Fix the stale changelog issue link in connector common from the old incubator repository URL to the current apache/seatunnel issue URL.

## Why

- The Dead links CI job fails because docs/en/connectors/changelog/connector-common.md still points to https://github.com/apache/incubator-seatunnel/issues/2127, which now returns 404.
## Validation
- ./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true -T 3C\n- npx --yes markdown-link-check docs/en/connectors/changelog/connector-common.md\n- git diff --check
