### PR TITLE
[Improve][e2e] Stabilize jdbc e2e assertions and waits ﻿

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
@@ -107,7 +107,7 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
 
         given().ignoreExceptions()
                 .await()
-                .atMost(30, TimeUnit.SECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
@@ -149,7 +149,7 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
 
         given().ignoreExceptions()
                 .await()
-                .atMost(30, TimeUnit.SECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
@@ -179,7 +179,8 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
     }
 
     @TestTemplate
-    public void testBatchIntervalWithBatchSize1(TestContainer container) throws SQLException {
+    public void testBatchIntervalWithBatchSize1(TestContainer container)
+            throws SQLException, InterruptedException {
         AtomicBoolean jobFinished = new AtomicBoolean(false);
 
         CompletableFuture<Container.ExecResult> jobFuture =
@@ -197,7 +198,7 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
 
         given().ignoreExceptions()
                 .await()
-                .atMost(30, TimeUnit.SECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
@@ -216,28 +217,20 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
                         });
 
         int firstCount = getSinkRowCount("sink_batch_interval_bs1");
-        given().ignoreExceptions()
-                .await()
-                .atMost(30, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertFalse(
-                                    jobFinished.get(),
-                                    "Job should still be running for second poll");
-                            int secondCount = getSinkRowCount("sink_batch_interval_bs1");
-                            log.info(
-                                    "batch_size=1 incremental check: firstCount={}, secondCount={}",
-                                    firstCount,
-                                    secondCount);
-                            Assertions.assertTrue(
-                                    secondCount > firstCount,
-                                    "Row count should keep growing with batch_size=1 (per-row flush), "
-                                            + "firstCount="
-                                            + firstCount
-                                            + ", secondCount="
-                                            + secondCount);
-                        });
+        Thread.sleep(5000);
+        Assertions.assertFalse(jobFinished.get(), "Job should still be running for second poll");
+        int secondCount = getSinkRowCount("sink_batch_interval_bs1");
+        log.info(
+                "batch_size=1 incremental check: firstCount={}, secondCount={}",
+                firstCount,
+                secondCount);
+        Assertions.assertTrue(
+                secondCount > firstCount,
+                "Row count should keep growing with batch_size=1 (per-row flush), "
+                        + "firstCount="
+                        + firstCount
+                        + ", secondCount="
+                        + secondCount);
 
         Container.ExecResult result = jobFuture.join();
         Assertions.assertEquals(0, result.getExitCode(), result.getStderr());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
@@ -179,8 +179,7 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
     }
 
     @TestTemplate
-    public void testBatchIntervalWithBatchSize1(TestContainer container)
-            throws SQLException, InterruptedException {
+    public void testBatchIntervalWithBatchSize1(TestContainer container) throws SQLException {
         AtomicBoolean jobFinished = new AtomicBoolean(false);
 
         CompletableFuture<Container.ExecResult> jobFuture =
@@ -217,20 +216,27 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
                         });
 
         int firstCount = getSinkRowCount("sink_batch_interval_bs1");
-        Thread.sleep(5000);
-        Assertions.assertFalse(jobFinished.get(), "Job should still be running for second poll");
-        int secondCount = getSinkRowCount("sink_batch_interval_bs1");
-        log.info(
-                "batch_size=1 incremental check: firstCount={}, secondCount={}",
-                firstCount,
-                secondCount);
-        Assertions.assertTrue(
-                secondCount > firstCount,
-                "Row count should keep growing with batch_size=1 (per-row flush), "
-                        + "firstCount="
-                        + firstCount
-                        + ", secondCount="
-                        + secondCount);
+        given().ignoreExceptions()
+                .await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertFalse(
+                                    jobFinished.get(), "Job should still be running for second poll");
+                            int secondCount = getSinkRowCount("sink_batch_interval_bs1");
+                            log.info(
+                                    "batch_size=1 incremental check: firstCount={}, secondCount={}",
+                                    firstCount,
+                                    secondCount);
+                            Assertions.assertTrue(
+                                    secondCount > firstCount,
+                                    "Row count should keep growing with batch_size=1 (per-row flush), "
+                                            + "firstCount="
+                                            + firstCount
+                                            + ", secondCount="
+                                            + secondCount);
+                        });
 
         Container.ExecResult result = jobFuture.join();
         Assertions.assertEquals(0, result.getExitCode(), result.getStderr());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkBatchIntervalIT.java
@@ -223,7 +223,8 @@ public class JdbcSinkBatchIntervalIT extends TestSuiteBase implements TestResour
                 .untilAsserted(
                         () -> {
                             Assertions.assertFalse(
-                                    jobFinished.get(), "Job should still be running for second poll");
+                                    jobFinished.get(),
+                                    "Job should still be running for second poll");
                             int secondCount = getSinkRowCount("sink_batch_interval_bs1");
                             log.info(
                                     "batch_size=1 incremental check: firstCount={}, secondCount={}",

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPostgresIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPostgresIT.java
@@ -188,7 +188,8 @@ public class JdbcPostgresIT extends TestSuiteBase implements TestResource {
                     + "json_col,\n"
                     + "jsonb_col,\n"
                     + " cast(xml_col as varchar) \n"
-                    + "from pg_e2e_source_table";
+                    + "from pg_e2e_source_table\n"
+                    + "order by gid";
     private static final String SINK_SQL =
             "select\n"
                     + "  gid,\n"
@@ -226,7 +227,8 @@ public class JdbcPostgresIT extends TestSuiteBase implements TestResource {
                     + "   jsonb_col,\n"
                     + "  cast(xml_col as varchar) \n"
                     + "from\n"
-                    + "  pg_e2e_sink_table";
+                    + "  pg_e2e_sink_table\n"
+                    + "order by gid";
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkCDCChangelogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcSinkCDCChangelogIT.java
@@ -111,7 +111,9 @@ public class JdbcSinkCDCChangelogIT extends TestSuiteBase implements TestResourc
                         postgreSQLContainer.getUsername(),
                         postgreSQLContainer.getPassword())) {
             try (Statement statement = connection.createStatement();
-                    ResultSet resultSet = statement.executeQuery("select * from sink")) {
+                    ResultSet resultSet =
+                            statement.executeQuery(
+                                    "select pk_id, name, score from sink order by pk_id")) {
                 while (resultSet.next()) {
                     List<Object> row =
                             Arrays.asList(
@@ -125,7 +127,7 @@ public class JdbcSinkCDCChangelogIT extends TestSuiteBase implements TestResourc
         Set<List<Object>> expected =
                 Stream.<List<Object>>of(Arrays.asList(1L, "A_1", 100), Arrays.asList(3L, "C", 100))
                         .collect(Collectors.toSet());
-        Assertions.assertIterableEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
         try (Connection connection =
                 DriverManager.getConnection(
                         postgreSQLContainer.getJdbcUrl(),

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/resources/jdbc_postgres_source_and_sink.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-3/src/test/resources/jdbc_postgres_source_and_sink.conf
@@ -29,7 +29,7 @@ source{
         query ="""select gid, uuid_col, text_col, varchar_col, char_one_col, char_col, boolean_col, smallint_col, integer_col, bigint_col, decimal_col, numeric_col, real_col, double_precision_col,
                          smallserial_col, serial_col, bigserial_col, date_col, timestamp_col, timestamp_tz_col, bpchar_col, age, name, point, linestring, polygon_colums, multipoint,
                          multilinestring, multipolygon, geometrycollection, geog, json_col, jsonb_col,xml_col from pg_e2e_source_table"""
-      partition_column = "varchar_col"
+      partition_column = "gid"
       partition_num = 2
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCloudberryIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCloudberryIT.java
@@ -159,8 +159,11 @@ public class JdbcCloudberryIT extends AbstractJdbcIT {
     protected void beforeStartUP() {
         log.info("Setting up Apache Cloudberry...");
         try {
-            // Wait for container to start
-            Thread.sleep(5000);
+            given().ignoreExceptions()
+                    .await()
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .atMost(30, TimeUnit.SECONDS)
+                    .until(() -> dbServer != null && dbServer.isRunning());
             // Switch to gpadmin user and start database
             Container.ExecResult execResult =
                     dbServer.execInContainer("bash", "-c", "su - gpadmin -c 'gpstart -a'");
@@ -178,7 +181,7 @@ public class JdbcCloudberryIT extends AbstractJdbcIT {
                             "bash", "-c", "su - gpadmin -c 'psql -c \"SELECT version();\"'");
             log.info("Apache Cloudberry version: {}", execResult.getStdout());
 
-        } catch (InterruptedException | IOException e) {
+        } catch (IOException e) {
             log.error("Failed to initialize Apache Cloudberry", e);
             throw new RuntimeException("Failed to initialize Apache Cloudberry", e);
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCloudberryIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcCloudberryIT.java
@@ -181,7 +181,7 @@ public class JdbcCloudberryIT extends AbstractJdbcIT {
                             "bash", "-c", "su - gpadmin -c 'psql -c \"SELECT version();\"'");
             log.info("Apache Cloudberry version: {}", execResult.getStdout());
 
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             log.error("Failed to initialize Apache Cloudberry", e);
             throw new RuntimeException("Failed to initialize Apache Cloudberry", e);
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDorisdbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDorisdbIT.java
@@ -189,12 +189,11 @@ public class JdbcDorisdbIT extends TestSuiteBase implements TestResource {
         dorisServer.setPortBindings(Lists.newArrayList(String.format("%s:%s", PORT, DOCKER_PORT)));
         Startables.deepStart(Stream.of(dorisServer)).join();
         log.info("Doris container started");
-        // wait to add BE
-        Thread.sleep(600000);
         // wait for doris fully start
         given().ignoreExceptions()
                 .await()
-                .atMost(600, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.SECONDS)
+                .atMost(1200, TimeUnit.SECONDS)
                 .untilAsserted(this::initializeJdbcConnection);
         initializeJdbcTable();
         batchInsertData();

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcIrisIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcIrisIT.java
@@ -442,7 +442,13 @@ public class JdbcIrisIT extends AbstractJdbcIT {
     @Override
     Pair<String[], List<SeaTunnelRow>> initTestData() {
         List<SeaTunnelRow> rows = new ArrayList<>();
+        LocalDate baseDate = LocalDate.of(2024, 1, 1);
+        LocalTime baseTime = LocalTime.of(8, 0, 0);
+        LocalDateTime baseDateTime = LocalDateTime.of(2024, 1, 1, 8, 0, 0);
         for (int i = 1; i <= GEN_ROWS; i++) {
+            LocalDate rowDate = baseDate.plusDays(i);
+            LocalTime rowTime = baseTime.plusSeconds(i);
+            LocalDateTime rowDateTime = baseDateTime.plusSeconds(i);
             SeaTunnelRow row =
                     new SeaTunnelRow(
                             new Object[] {
@@ -463,9 +469,9 @@ public class JdbcIrisIT extends AbstractJdbcIT {
                                 "*",
                                 String.valueOf(i),
                                 String.valueOf(i),
-                                Date.valueOf(LocalDate.now()),
-                                Timestamp.valueOf(LocalDateTime.now()),
-                                Timestamp.valueOf(LocalDateTime.now()),
+                                Date.valueOf(rowDate),
+                                Timestamp.valueOf(rowDateTime),
+                                Timestamp.valueOf(rowDateTime),
                                 BigDecimal.valueOf(i, 0),
                                 BigDecimal.valueOf(i, 0),
                                 BigDecimal.valueOf(i, 2),
@@ -512,20 +518,20 @@ public class JdbcIrisIT extends AbstractJdbcIT {
                                 "1",
                                 "1",
                                 "1.111",
-                                Time.valueOf(LocalTime.now()),
+                                Time.valueOf(rowTime),
                                 "10".getBytes(),
                                 Double.parseDouble("1.11"),
                                 Long.valueOf(i),
-                                Timestamp.valueOf(LocalDateTime.now()),
+                                Timestamp.valueOf(rowDateTime),
                                 i,
                                 i,
                                 i,
                                 "F4526E29-8B4A-4449-AA90-2A7DF971F221",
                                 String.valueOf(i),
-                                Time.valueOf(LocalTime.now()),
-                                Time.valueOf(LocalTime.now()),
-                                Timestamp.valueOf(LocalDateTime.now()),
-                                Timestamp.valueOf(LocalDateTime.now()),
+                                Time.valueOf(rowTime),
+                                Time.valueOf(rowTime),
+                                Timestamp.valueOf(rowDateTime),
+                                Timestamp.valueOf(rowDateTime),
                                 i,
                                 i,
                                 "3E8B5AC7-D63A-4202-83E1-A576EBE11557",

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMySqlSaveModeCatalogIT.java
@@ -50,7 +50,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.given;
 
 @Slf4j
 public class JdbcMySqlSaveModeCatalogIT extends TestSuiteBase implements TestResource {
@@ -154,6 +157,11 @@ public class JdbcMySqlSaveModeCatalogIT extends TestSuiteBase implements TestRes
     @BeforeAll
     public void startUp() throws Exception {
         initContainer();
+        given().ignoreExceptions()
+                .await()
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(this::assertMySqlReady);
         initializeJdbcTable();
     }
 
@@ -274,6 +282,13 @@ public class JdbcMySqlSaveModeCatalogIT extends TestSuiteBase implements TestRes
                 mysql_container.getJdbcUrl(),
                 mysql_container.getUsername(),
                 mysql_container.getPassword());
+    }
+
+    private void assertMySqlReady() throws SQLException {
+        try (Connection connection = getJdbcMySqlConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeQuery("SELECT 1");
+        }
     }
 
     private void initializeJdbcTable() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlSplitIT.java
@@ -661,6 +661,7 @@ public class JdbcMysqlSplitIT extends TestSuiteBase implements TestResource {
                 }
             } catch (Exception e) {
                 LOG.error("Error splitting on column {}: {}", charColumn, e.getMessage(), e);
+                Assertions.fail("Error splitting on column " + charColumn, e);
             }
         }
 
@@ -720,6 +721,7 @@ public class JdbcMysqlSplitIT extends TestSuiteBase implements TestResource {
                 }
             } catch (Exception e) {
                 LOG.error("Error splitting on column {}: {}", charColumn, e.getMessage(), e);
+                Assertions.fail("Error splitting on column " + charColumn, e);
             }
         }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
@@ -35,7 +35,6 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Driver;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -116,17 +115,9 @@ public class JdbcPrestoIT extends AbstractJdbcIT {
                 .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
-                            try (Statement statement = connection.createStatement();
-                                    ResultSet rs =
-                                            statement.executeQuery(
-                                                    "SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'")) {
-                                rs.next();
-                                int activeNodes = rs.getInt(1);
-                                if (activeNodes < 1) {
-                                    throw new RuntimeException(
-                                            "Waiting for active Presto worker nodes, current: "
-                                                    + activeNodes);
-                                }
+                            try (Statement statement = connection.createStatement()) {
+                                statement.execute(
+                                        "CREATE TABLE IF NOT EXISTS memory.default._readiness_probe (id INTEGER)");
                             }
                         });
         this.connection.setAutoCommit(false);

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
@@ -39,6 +39,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.given;
 
 @Slf4j
 public class JdbcPrestoIT extends AbstractJdbcIT {
@@ -106,21 +109,17 @@ public class JdbcPrestoIT extends AbstractJdbcIT {
 
         this.connection = driver.connect(jdbcUrl, props);
 
-        // maybe the Presto server is still initializing
-        int tryTimes = 5;
-        for (int i = 0; i < tryTimes; i++) {
-            try (Statement statement = connection.createStatement()) {
-                statement.executeQuery(" select 1 ");
-                break;
-            } catch (SQLException ignored) {
-                log.info("the Presto server is still initializing. wait it ");
-            }
-            try {
-                Thread.sleep(15 * 1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
+        // Wait until Presto is ready to execute SQL instead of fixed sleep retries.
+        given().ignoreExceptions()
+                .await()
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(90, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            try (Statement statement = connection.createStatement()) {
+                                statement.executeQuery("select 1");
+                            }
+                        });
         this.connection.setAutoCommit(false);
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcPrestoIT.java
@@ -35,6 +35,7 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Driver;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -109,18 +110,44 @@ public class JdbcPrestoIT extends AbstractJdbcIT {
 
         this.connection = driver.connect(jdbcUrl, props);
 
-        // Wait until Presto is ready to execute SQL instead of fixed sleep retries.
         given().ignoreExceptions()
                 .await()
                 .pollInterval(2, TimeUnit.SECONDS)
-                .atMost(90, TimeUnit.SECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
-                            try (Statement statement = connection.createStatement()) {
-                                statement.executeQuery("select 1");
+                            try (Statement statement = connection.createStatement();
+                                    ResultSet rs =
+                                            statement.executeQuery(
+                                                    "SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'")) {
+                                rs.next();
+                                int activeNodes = rs.getInt(1);
+                                if (activeNodes < 1) {
+                                    throw new RuntimeException(
+                                            "Waiting for active Presto worker nodes, current: "
+                                                    + activeNodes);
+                                }
                             }
                         });
         this.connection.setAutoCommit(false);
+    }
+
+    @Override
+    protected void createNeededTables() {
+        try (Statement statement = connection.createStatement()) {
+            String createTemplate = jdbcCase.getCreateSql();
+            String createSource =
+                    String.format(
+                            createTemplate,
+                            buildTableInfoWithSchema(
+                                    jdbcCase.getDatabase(),
+                                    jdbcCase.getSchema(),
+                                    jdbcCase.getSourceTable()));
+            statement.execute(createSource);
+        } catch (Exception exception) {
+            log.error(ExceptionUtils.getMessage(exception));
+            throw new SeaTunnelRuntimeException(JdbcITErrorCode.CREATE_TABLE_FAILED, exception);
+        }
     }
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
@@ -35,7 +35,6 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Driver;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -116,17 +115,9 @@ public class JdbcTrinoIT extends AbstractJdbcIT {
                 .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
-                            try (Statement statement = connection.createStatement();
-                                    ResultSet rs =
-                                            statement.executeQuery(
-                                                    "SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'")) {
-                                rs.next();
-                                int activeNodes = rs.getInt(1);
-                                if (activeNodes < 1) {
-                                    throw new RuntimeException(
-                                            "Waiting for active Trino worker nodes, current: "
-                                                    + activeNodes);
-                                }
+                            try (Statement statement = connection.createStatement()) {
+                                statement.execute(
+                                        "CREATE TABLE IF NOT EXISTS memory.default._readiness_probe (id INTEGER)");
                             }
                         });
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
@@ -35,6 +35,7 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Driver;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -109,15 +110,23 @@ public class JdbcTrinoIT extends AbstractJdbcIT {
 
         this.connection = driver.connect(jdbcUrl, props);
 
-        // Wait until Trino is ready to execute SQL instead of fixed sleep retries.
         given().ignoreExceptions()
                 .await()
                 .pollInterval(2, TimeUnit.SECONDS)
-                .atMost(90, TimeUnit.SECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
-                            try (Statement statement = connection.createStatement()) {
-                                statement.executeQuery("select 1");
+                            try (Statement statement = connection.createStatement();
+                                    ResultSet rs =
+                                            statement.executeQuery(
+                                                    "SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'")) {
+                                rs.next();
+                                int activeNodes = rs.getInt(1);
+                                if (activeNodes < 1) {
+                                    throw new RuntimeException(
+                                            "Waiting for active Trino worker nodes, current: "
+                                                    + activeNodes);
+                                }
                             }
                         });
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcTrinoIT.java
@@ -39,6 +39,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.given;
 
 @Slf4j
 public class JdbcTrinoIT extends AbstractJdbcIT {
@@ -106,21 +109,17 @@ public class JdbcTrinoIT extends AbstractJdbcIT {
 
         this.connection = driver.connect(jdbcUrl, props);
 
-        // maybe the TRINO  server is still initializing
-        int tryTimes = 5;
-        for (int i = 0; i < tryTimes; i++) {
-            try (Statement statement = connection.createStatement()) {
-                statement.executeQuery(" select 1 ");
-                break;
-            } catch (SQLException ignored) {
-                log.info("the Trino server is still initializing. wait it ");
-            }
-            try {
-                Thread.sleep(15 * 1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
+        // Wait until Trino is ready to execute SQL instead of fixed sleep retries.
+        given().ignoreExceptions()
+                .await()
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(90, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            try (Statement statement = connection.createStatement()) {
+                                statement.executeQuery("select 1");
+                            }
+                        });
     }
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcXuguIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcXuguIT.java
@@ -175,7 +175,13 @@ public class JdbcXuguIT extends AbstractJdbcIT {
     @Override
     Pair<String[], List<SeaTunnelRow>> initTestData() {
         List<SeaTunnelRow> rows = new ArrayList<>();
+        LocalDate baseDate = LocalDate.of(2024, 1, 1);
+        LocalTime baseTime = LocalTime.of(9, 0, 0);
+        LocalDateTime baseDateTime = LocalDateTime.of(2024, 1, 1, 9, 0, 0);
         for (int i = 0; i < 100; i++) {
+            LocalDate rowDate = baseDate.plusDays(i);
+            LocalTime rowTime = baseTime.plusSeconds(i);
+            LocalDateTime rowDateTime = baseDateTime.plusSeconds(i);
             SeaTunnelRow row =
                     new SeaTunnelRow(
                             new Object[] {
@@ -193,12 +199,12 @@ public class JdbcXuguIT extends AbstractJdbcIT {
                                 String.format("f1_%s", i),
                                 String.format("f1_%s", i),
                                 String.format("f1_%s", i),
-                                Date.valueOf(LocalDate.now()),
-                                Time.valueOf(LocalTime.now()),
-                                new Timestamp(System.currentTimeMillis()),
-                                Timestamp.valueOf(LocalDateTime.now()),
-                                Time.valueOf(LocalTime.now()),
-                                new Timestamp(System.currentTimeMillis()),
+                                Date.valueOf(rowDate),
+                                Time.valueOf(rowTime),
+                                Timestamp.valueOf(rowDateTime),
+                                Timestamp.valueOf(rowDateTime),
+                                Time.valueOf(rowTime),
+                                Timestamp.valueOf(rowDateTime),
                                 null,
                                 null,
                                 null,

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
@@ -154,10 +154,23 @@ public class MetalakeIT extends SeaTunnelContainer {
                         + " --no-check-certificate"
                         + "&& mkdir -p /tmp/gravitino && cd /tmp/gravitino && curl -C - --retry 5 -L -k -o gravitino-0.9.1-bin.tar.gz https://dlcdn.apache.org/gravitino/0.9.1/gravitino-0.9.1-bin.tar.gz && tar -zxvf gravitino-0.9.1-bin.tar.gz && cd /tmp/gravitino/gravitino-0.9.1-bin && ./bin/gravitino.sh start");
 
+        given().ignoreExceptions()
+                .await()
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(180, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Container.ExecResult result =
+                                    server.execInContainer(
+                                            "bash",
+                                            "-c",
+                                            "curl -sf 'http://127.0.0.1:8090/api/metalakes' >/dev/null");
+                            Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+                        });
         server.execInContainer(
                 "bash",
                 "-c",
-                "sleep 60 && curl -L 'http://127.0.0.1:8090/api/metalakes' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_metalake\",\"comment\":\"for metalake test\",\"properties\":{}}'"
+                "curl -L 'http://127.0.0.1:8090/api/metalakes' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_metalake\",\"comment\":\"for metalake test\",\"properties\":{}}'"
                         + "&& curl -L 'http://127.0.0.1:8090/api/metalakes/test_metalake/catalogs' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_catalog\",\"type\":\"relational\",\"provider\":\"jdbc-mysql\",\"comment\":\"for metalake test\",\"properties\":{\"jdbc-driver\":\"com.mysql.cj.jdbc.Driver\",\"jdbc-url\":\"jdbc:mysql://mysql-e2e:3306/seatunnel?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true\",\"jdbc-user\":\"root\",\"jdbc-password\":\"Abc!@#135_seatunnel\"}}'");
 
         dbServer = initContainer().withImagePullPolicy(PullPolicy.alwaysPull());
@@ -334,7 +347,7 @@ public class MetalakeIT extends SeaTunnelContainer {
 
             connection.commit();
         } catch (Exception exception) {
-            exception.printStackTrace();
+            throw new RuntimeException("Create MetalakeIT tables failed", exception);
         }
     }
 
@@ -355,7 +368,7 @@ public class MetalakeIT extends SeaTunnelContainer {
 
             connection.commit();
         } catch (Exception exception) {
-            exception.printStackTrace();
+            throw new RuntimeException("Insert MetalakeIT test data failed", exception);
         }
     }
 


### PR DESCRIPTION
### Purpose of this pull request

Improve JDBC E2E stability and reduce flaky failures in part-1/3/5/7 by:
- replacing order-sensitive checks with deterministic assertions
- replacing time-variant test data with fixed values
- replacing `Thread.sleep` with condition-based waits (`Awaitility`)
- making hidden setup/assertion failures fail fast

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Ran affected JDBC E2E tests in part-1/3/5/7 locally.
- Re-ran key flaky-related cases to verify better stability.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)