### PR TITLE
[Fix][Transform-V2] Prevent input row mutation in ReplaceTransform

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
@@ -123,14 +123,16 @@ public class ReplaceTransform extends AbstractCatalogSupportMapTransform {
 
     @Override
     protected SeaTunnelRow transformRow(SeaTunnelRow inputRow) {
+        SeaTunnelRow outputRow = inputRow.copy();
+
         for (int index : replaceFieldIndexes) {
-            Object value = inputRow.getField(index);
+            Object value = outputRow.getField(index);
             if (value == null) {
                 continue;
             }
-            inputRow.setField(index, applyReplacement(value.toString()));
+            outputRow.setField(index, applyReplacement(value.toString()));
         }
-        return inputRow;
+        return outputRow;
     }
 
     private String applyReplacement(String value) {

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformTest.java
@@ -268,4 +268,37 @@ class ReplaceTransformTest {
         Assertions.assertEquals("abcNUMdef456", output.getField(1));
         Assertions.assertEquals("xyzNUMuvw012", output.getField(2));
     }
+
+    @Test
+    void testReplaceDoesNotMutateInputRowForFanOut() {
+        Map<String, Object> phoneReplaceConfig = new HashMap<>();
+        phoneReplaceConfig.put("replace_field", "title");
+        phoneReplaceConfig.put(ReplaceTransformConfig.KEY_PATTERN.key(), "1");
+        phoneReplaceConfig.put(ReplaceTransformConfig.KEY_REPLACEMENT.key(), "a");
+
+        Map<String, Object> nameReplaceConfig = new HashMap<>();
+        nameReplaceConfig.put("replace_field", "name");
+        nameReplaceConfig.put(ReplaceTransformConfig.KEY_PATTERN.key(), "before");
+        nameReplaceConfig.put(ReplaceTransformConfig.KEY_REPLACEMENT.key(), "after");
+
+        ReplaceTransform phoneReplaceTransform =
+                new ReplaceTransform(ReadonlyConfig.fromMap(phoneReplaceConfig), catalogTable);
+        ReplaceTransform nameReplaceTransform =
+                new ReplaceTransform(ReadonlyConfig.fromMap(nameReplaceConfig), catalogTable);
+
+        SeaTunnelRow input = new SeaTunnelRow(new Object[] {1, "before name", "17111999384"});
+
+        SeaTunnelRow phoneOutput = phoneReplaceTransform.transformRow(input);
+        SeaTunnelRow nameOutput = nameReplaceTransform.transformRow(input);
+
+        Assertions.assertEquals("a7aaa999384", phoneOutput.getField(2));
+        Assertions.assertEquals("after name", nameOutput.getField(1));
+
+        // The sibling transform branch should still see the original title value.
+        Assertions.assertEquals("17111999384", nameOutput.getField(2));
+
+        // ReplaceTransform should not mutate the shared input row.
+        Assertions.assertEquals("before name", input.getField(1));
+        Assertions.assertEquals("17111999384", input.getField(2));
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/apache/seatunnel/issues/10620

### Purpose of this pull request

Fix ReplaceTransform to avoid mutating the input SeaTunnelRow directly.

Previously, ReplaceTransform updated fields on the input row and returned the same row instance. In a fan-out transform graph, this could contaminate sibling transform branches because they may observe the row already modified by another branch.

This change copies the input row before applying replacements, so each ReplaceTransform output is isolated from the shared upstream row.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

A regression test was added to cover the fan-out style case.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
