### PR TITLE
[Fix][Connector-V2][Http] Stop cursor pagination when cursor does not advance

### DIFF
--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
@@ -404,9 +404,17 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
                 if (cursorList != null && !cursorList.isEmpty()) {
                     newCursor = cursorList.get(0);
                 }
+                boolean cursorNotAdvanced =
+                        !Strings.isNullOrEmpty(newCursor)
+                                && Objects.equals(pageInfo.getCursor(), newCursor);
                 pageInfo.setCursor(newCursor);
-                // if not present cursor, then no more data
-                noMoreElementFlag = Strings.isNullOrEmpty(newCursor);
+                // if not present cursor or cursor not advanced, then no more data
+                noMoreElementFlag = Strings.isNullOrEmpty(newCursor) || cursorNotAdvanced;
+                if (cursorNotAdvanced) {
+                    log.warn(
+                            "HTTP cursor pagination stopped because cursor [{}] did not advance",
+                            newCursor);
+                }
             } else {
                 // if not set page pagination is default
                 // Determine whether the task is completed by specifying the presence of the 'total

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/HttpSourceReaderInternalPollNextTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/HttpSourceReaderInternalPollNextTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.seatunnel.connectors.seatunnel.http;
 
+import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
@@ -37,15 +38,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HttpSourceReaderInternalPollNextTest {
@@ -132,6 +137,46 @@ public class HttpSourceReaderInternalPollNextTest {
                 JsonUtils.toMap(JsonUtils.stringToJsonNode(httpParameter.getBody()));
         Assertions.assertEquals("2", bodyMap.get("page"));
         Assertions.assertEquals(10, bodyMap.get("limit"));
+        httpSourceReader.close();
+    }
+
+    @Test
+    @Timeout(5)
+    public void testCursorPaginationStopsWhenCursorDoesNotAdvance() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger();
+        when(context.getBoundedness()).thenReturn(Boundedness.BOUNDED);
+        when(httpClientProvider.execute(
+                        anyString(), anyString(), any(), any(), any(), anyBoolean()))
+                .thenAnswer(
+                        invocation -> {
+                            if (requestCount.incrementAndGet() == 1) {
+                                when(httpResponse.getContent())
+                                        .thenReturn(
+                                                "{\"data\":[{\"key1\":\"v1\",\"key2\":\"v2\"}],"
+                                                        + "\"next\":\"cursor-1\"}");
+                            } else {
+                                when(httpResponse.getContent())
+                                        .thenReturn("{\"data\":[],\"next\":\"cursor-1\"}");
+                            }
+                            when(httpResponse.getCode()).thenReturn(200);
+                            return httpResponse;
+                        });
+
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setPageType(HttpPaginationType.CURSOR.getCode());
+        pageInfo.setPageCursorResponseField("$.next");
+
+        httpSourceReader =
+                new HttpSourceReader(
+                        httpParameter, context, deserializationSchema, null, "$.data", pageInfo);
+        httpSourceReader.open();
+        httpSourceReader.setHttpClient(httpClientProvider);
+        httpSourceReader.internalPollNext(collector);
+
+        Assertions.assertEquals(2, requestCount.get());
+        verify(context).signalNoMoreElement();
+        verify(httpClientProvider, times(2))
+                .execute(anyString(), anyString(), any(), any(), any(), anyBoolean());
         httpSourceReader.close();
     }
 


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10929.

This PR stops HTTP cursor pagination when a response returns the same non-empty cursor as the previous request. The existing cursor path only stopped when the next cursor was empty, so APIs that signal the terminal page by repeating the final cursor could keep polling without progress.

### Does this PR introduce _any_ user-facing change?

Yes. HTTP cursor pagination now stops when the cursor does not advance, avoiding repeated requests for cursor APIs that return the final cursor again at end-of-data.

### How was this patch tested?

- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 MAVEN_OPTS=-Xmx1536m ./mvnw -B -pl seatunnel-connectors-v2/connector-http/connector-http-base -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true spotless:apply`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 MAVEN_OPTS=-Xmx1536m ./mvnw -B -U -pl seatunnel-connectors-v2/connector-http/connector-http-base -Dtest=org.apache.seatunnel.connectors.seatunnel.http.HttpSourceReaderInternalPollNextTest -DfailIfNoTests=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true test`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
