### PR TITLE
[Improve][CI] Add CI changes step timeout of 20m

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -126,7 +126,7 @@ jobs:
 
   changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     outputs:
       api: ${{ steps.filter.outputs.api }}
       engine: ${{ steps.filter.outputs.engine }}


### PR DESCRIPTION
### Purpose of this pull request

Add a 20-minute timeout-minutes to the CI changes step to prevent it from hanging indefinitely when fetch-depth: 2000 checkout or path filtering stalls on GitHub-hosted runners.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
The changes step has been observed to exceed 10 minutes on GitHub-hosted runners due to fetch-depth: 2000 checkout latency. A 20-minute timeout provides 2× margin over the observed worst case while preventing indefinite hangs.
