### PR TITLE
[Fix][E2E] Fix flaky jdbc-connectors-it-ddl tests with timeout tuning and DM wait strategy

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
@@ -199,7 +199,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
         given().pollDelay(Duration.ofSeconds(5))
                 .pollInterval(Duration.ofMillis(1000))
                 .await()
-                .atMost(30, TimeUnit.SECONDS)
+                .atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertEquals("RUNNING", container.getJobStatus(jobId));
@@ -231,7 +231,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
 
         // savepoint 2
         given().pollDelay(Duration.ofSeconds(5))
-                .atMost(30000, TimeUnit.MILLISECONDS)
+                .atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertEquals(
@@ -284,7 +284,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
         given().pollDelay(Duration.ofSeconds(5))
                 .pollInterval(Duration.ofMillis(1000))
                 .await()
-                .atMost(30, TimeUnit.SECONDS)
+                .atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertEquals("RUNNING", container.getJobStatus(jobId));
@@ -294,7 +294,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
     }
 
     private void assertSchemaEvolution(String sourceTable, String sinkTable) {
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
@@ -309,7 +309,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
 
         // case1 add columns with cdc data at same time
         sourceDatabase.setTemplateName("add_columns").createAndInitialize();
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
@@ -323,7 +323,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
                                                         schemaChangeCase.getSinkQueryColumns(),
                                                         schemaChangeCase.getSchemaName(),
                                                         sinkTable))));
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertIterableEquals(
@@ -368,7 +368,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
     }
 
     private void assertSchemaEvolutionForAddColumns(String sourceTable, String sinkTable) {
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
@@ -385,7 +385,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
         sourceDatabase.setTemplateName("add_columns").createAndInitialize();
         given().pollDelay(Duration.ofSeconds(5))
                 .await()
-                .atMost(120000, TimeUnit.MILLISECONDS)
+                .atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
@@ -397,7 +397,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
                                                                 schemaChangeCase.getSchemaName(),
                                                                 sinkTable)
                                                         + ORDER_BY)));
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().atMost(120, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertIterableEquals(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/DmSchemaChangeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/DmSchemaChangeIT.java
@@ -21,7 +21,10 @@ import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerLoggerFactory;
+
+import java.time.Duration;
 
 public class DmSchemaChangeIT extends AbstractSchemaChangeBaseIT {
 
@@ -70,6 +73,9 @@ public class DmSchemaChangeIT extends AbstractSchemaChangeBaseIT {
                 new GenericContainer<>(DM_IMAGE)
                         .withNetwork(NETWORK)
                         .withNetworkAliases(DM_CONTAINER_HOST)
+                        .withExposedPorts(DM_PORT)
+                        .waitingFor(Wait.forListeningPort())
+                        .withStartupTimeout(Duration.ofMinutes(5))
                         .withLogConsumer(
                                 new Slf4jLogConsumer(DockerLoggerFactory.getLogger(DM_IMAGE)));
         container.setPortBindings(Lists.newArrayList(String.format("%s:%s", DM_PORT, DM_PORT)));


### PR DESCRIPTION
### Purpose of this pull request

Fix flaky tests in `jdbc-connectors-it-ddl` E2E module by:
1. Increasing Awaitility timeouts that were too tight for CI environments
2. Adding a proper container wait strategy for Dameng (DM) database

**Root cause:**

The `SqlServerSchemaChangeIT` test intermittently fails with `ConditionTimeout` in CI:

```
Error: SqlServerSchemaChangeIT>AbstractSchemaChangeBaseIT.testMysqlCdcWithSchemaEvolutionCaseExactlyOnce:293
  ->AbstractSchemaChangeBaseIT.assertSchemaEvolution:298 » ConditionTimeout

Tests run: 6, Failures: 0, Errors: 1, Skipped: 0
```

The Awaitility timeouts in `assertSchemaEvolution` and related methods were too short (30s~60s) for CI environments where CDC data sync can be slower due to resource contention.

**Timeout changes in `AbstractSchemaChangeBaseIT`:**
- Job RUNNING status wait: 30s → 60s
- Savepoint wait: 30s → 60s
- Data sync assertions in `assertSchemaEvolution`: 60s → 120s
- Data sync assertions in `assertSchemaEvolutionForAddColumns`: 60s → 120s
- Unified time unit style from `MILLISECONDS` to `SECONDS`

**DM container fix in `DmSchemaChangeIT`:**
- Added `withExposedPorts()`, `waitingFor(Wait.forListeningPort())` and `withStartupTimeout(5min)` to ensure DM database is fully initialized before tests start

### Does this PR introduce _any_ user-facing change?

No. This change only affects E2E test stability.

### How was this patch tested?

These are test infrastructure changes. The fixes target known `ConditionTimeout` failures observed in CI (e.g. `SqlServerSchemaChangeIT.testMysqlCdcWithSchemaEvolutionCaseExactlyOnce`).
