### PR TITLE
[Improve][Connector-V2] Enhance JDBC chunk splitter logging

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/ChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/ChunkSplitter.java
@@ -143,7 +143,7 @@ public abstract class ChunkSplitter implements AutoCloseable, Serializable {
         if (connection.getAutoCommit() != autoCommit) {
             connection.setAutoCommit(autoCommit);
         }
-        log.debug("Prepared statement: {}", sql);
+        log.info("Prepared statement: {}", sql);
         return jdbcDialect.creatPreparedStatement(connection, sql, fetchSize);
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitter.java
@@ -903,16 +903,31 @@ public class DynamicChunkSplitter extends ChunkSplitter {
                 statement.setObject(i + 1, splitEnd[i]);
                 statement.setObject(i + 1 + splitKeyNumbers, splitEnd[i]);
             }
+            log.info(
+                    "Dynamic split (first) - params: [{}={}, {}={}]",
+                    1,
+                    splitEnd[0],
+                    2,
+                    splitEnd[0]);
         } else if (isLastSplit) {
             for (int i = 0; i < splitKeyNumbers; i++) {
                 statement.setObject(i + 1, splitStart[i]);
             }
+            log.info("Dynamic split (last) - params: [{}={}]", 1, splitStart[0]);
         } else {
             for (int i = 0; i < splitKeyNumbers; i++) {
                 statement.setObject(i + 1, splitStart[i]);
                 statement.setObject(i + 1 + splitKeyNumbers, splitEnd[i]);
                 statement.setObject(i + 1 + 2 * splitKeyNumbers, splitEnd[i]);
             }
+            log.info(
+                    "Dynamic split (middle) - params: [{}={}, {}={}, {}={}]",
+                    1,
+                    splitStart[0],
+                    2,
+                    splitEnd[0],
+                    3,
+                    splitEnd[0]);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/FixedChunkSplitter.java
@@ -341,6 +341,7 @@ public class FixedChunkSplitter extends ChunkSplitter {
             throws SQLException {
         PreparedStatement statement = createPreparedStatement(split.getSplitQuery());
         statement.setInt(1, (Integer) split.getSplitStart());
+        log.info("String column split - param[1]: {}", split.getSplitStart());
         return statement;
     }
 
@@ -410,6 +411,12 @@ public class FixedChunkSplitter extends ChunkSplitter {
                 jdbcNumericBetweenParametersProvider.getParameterValues();
         List<JdbcSourceSplit> splits = new ArrayList<>(table.getPartitionNumber());
         for (int i = 0; i < parameterValues.length; i++) {
+            log.info(
+                    "Number column split - params: [{}={}, {}={}]",
+                    1,
+                    parameterValues[i][0],
+                    2,
+                    parameterValues[i][1]);
             JdbcSourceSplit split =
                     new JdbcSourceSplit(
                             table.getTablePath(),


### PR DESCRIPTION
### Purpose of this pull request

This PR syncs the logging enhancement from zhangshenghang/seatunnel#11 to Apache SeaTunnel.

It adds INFO logs for JDBC chunk splitting to make generated prepared SQL and split parameters easier to inspect when troubleshooting dynamic, string, and numeric splitting.

### Does this PR introduce _any_ user-facing change?

Yes. It adds additional INFO-level logs for JDBC chunk splitting. Connector behavior is unchanged.

### How was this patch tested?

Ran:

```
./mvnw spotless:apply
```

Build verification was not run per sync request.

### Check list

- [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
- [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
- [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
- [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
