### PR TITLE
[Fix][Connector-V2] Fix nested ROW type conversion crash in Paimon connector

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowConverter.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowConverter.java
@@ -58,6 +58,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -338,7 +339,9 @@ public class RowConverter {
                     SeaTunnelDataType<?> rowType = seaTunnelRowType.getFieldType(i);
                     InternalRow row =
                             rowData.getRow(i, ((SeaTunnelRowType) rowType).getTotalFields());
-                    objects[i] = convert(row, (SeaTunnelRowType) rowType, tableSchema);
+                    TableSchema nestedSchema =
+                            extractNestedSchema(tableSchema.fields().get(i).type());
+                    objects[i] = convert(row, (SeaTunnelRowType) rowType, nestedSchema);
                     break;
                 default:
                     throw CommonError.unsupportedDataType(
@@ -480,13 +483,11 @@ public class RowConverter {
                 case ROW:
                     SeaTunnelDataType<?> rowType = seaTunnelRowType.getFieldType(i);
                     Object row = fieldValue;
+                    TableSchema nestedSchema = extractNestedSchema(sinkTotalFields.get(i).type());
                     InternalRow paimonRow =
-                            reconvert(
-                                    (SeaTunnelRow) row,
-                                    (SeaTunnelRowType) rowType,
-                                    sinkTableSchema);
+                            reconvert((SeaTunnelRow) row, (SeaTunnelRowType) rowType, nestedSchema);
                     RowType paimonRowType =
-                            RowTypeConverter.reconvert((SeaTunnelRowType) rowType, sinkTableSchema);
+                            RowTypeConverter.reconvert((SeaTunnelRowType) rowType, nestedSchema);
                     binaryWriter.writeRow(i, paimonRow, new InternalRowSerializer(paimonRowType));
                     break;
                 default:
@@ -497,6 +498,18 @@ public class RowConverter {
             }
         }
         return binaryRow;
+    }
+
+    private static TableSchema extractNestedSchema(DataType nestedType) {
+        RowType nestedRowType = (RowType) nestedType;
+        return new TableSchema(
+                0,
+                nestedRowType.getFields(),
+                nestedRowType.getFieldCount(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                null);
     }
 
     private static void checkCanWriteWithSchema(

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/RowConverterTest.java
@@ -43,6 +43,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.serializer.InternalArraySerializer;
 import org.apache.paimon.data.serializer.InternalMapSerializer;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -366,5 +367,112 @@ public class RowConverterTest {
                         throw e;
                     }
                 });
+    }
+
+    @Test
+    public void nestedRowPaimonToSeaTunnel() {
+        // Top-level: c_int INT, c_string STRING, c_nested ROW<a INT, b STRING>
+        RowType nestedRowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING()},
+                        new String[] {"a", "b"});
+
+        RowType topLevelRowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING(), nestedRowType},
+                        new String[] {"c_int", "c_string", "c_nested"});
+
+        TableSchema tableSchema =
+                new TableSchema(
+                        0,
+                        TableSchema.newFields(topLevelRowType),
+                        topLevelRowType.getFieldCount(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        "");
+
+        // Build nested Paimon row
+        BinaryRow nestedBinaryRow = new BinaryRow(2);
+        BinaryRowWriter nestedWriter = new BinaryRowWriter(nestedBinaryRow);
+        nestedWriter.writeInt(0, 42);
+        nestedWriter.writeString(1, BinaryString.fromString("world"));
+
+        // Build top-level Paimon row
+        BinaryRow binaryRow = new BinaryRow(3);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        writer.writeInt(0, 1);
+        writer.writeString(1, BinaryString.fromString("hello"));
+        writer.writeRow(2, nestedBinaryRow, new InternalRowSerializer(nestedRowType));
+
+        // SeaTunnel types
+        SeaTunnelRowType seaTunnelNestedType =
+                new SeaTunnelRowType(
+                        new String[] {"a", "b"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        SeaTunnelRowType seaTunnelTopLevelType =
+                new SeaTunnelRowType(
+                        new String[] {"c_int", "c_string", "c_nested"},
+                        new SeaTunnelDataType[] {
+                            BasicType.INT_TYPE, BasicType.STRING_TYPE, seaTunnelNestedType
+                        });
+
+        // Convert Paimon → SeaTunnel
+        SeaTunnelRow result = RowConverter.convert(binaryRow, seaTunnelTopLevelType, tableSchema);
+
+        Assertions.assertEquals(1, result.getField(0));
+        Assertions.assertEquals("hello", result.getField(1));
+        SeaTunnelRow nestedResult = (SeaTunnelRow) result.getField(2);
+        Assertions.assertEquals(42, nestedResult.getField(0));
+        Assertions.assertEquals("world", nestedResult.getField(1));
+    }
+
+    @Test
+    public void nestedRowSeaTunnelToPaimon() {
+        // Top-level: c_int INT, c_string STRING, c_nested ROW<a INT, b STRING>
+        RowType nestedRowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING()},
+                        new String[] {"a", "b"});
+
+        RowType topLevelRowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING(), nestedRowType},
+                        new String[] {"c_int", "c_string", "c_nested"});
+
+        TableSchema tableSchema =
+                new TableSchema(
+                        0,
+                        TableSchema.newFields(topLevelRowType),
+                        topLevelRowType.getFieldCount(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        "");
+
+        // SeaTunnel types
+        SeaTunnelRowType seaTunnelNestedType =
+                new SeaTunnelRowType(
+                        new String[] {"a", "b"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        SeaTunnelRowType seaTunnelTopLevelType =
+                new SeaTunnelRowType(
+                        new String[] {"c_int", "c_string", "c_nested"},
+                        new SeaTunnelDataType[] {
+                            BasicType.INT_TYPE, BasicType.STRING_TYPE, seaTunnelNestedType
+                        });
+
+        SeaTunnelRow nestedRow = new SeaTunnelRow(new Object[] {42, "world"});
+        SeaTunnelRow topLevelRow = new SeaTunnelRow(new Object[] {1, "hello", nestedRow});
+
+        // Convert SeaTunnel → Paimon (would throw before fix due to field count mismatch)
+        InternalRow result =
+                RowConverter.reconvert(topLevelRow, seaTunnelTopLevelType, tableSchema);
+
+        Assertions.assertEquals(1, result.getInt(0));
+        Assertions.assertEquals("hello", result.getString(1).toString());
+        InternalRow nestedResult = result.getRow(2, 2);
+        Assertions.assertEquals(42, nestedResult.getInt(0));
+        Assertions.assertEquals("world", nestedResult.getString(1).toString());
     }
 }


### PR DESCRIPTION
RowConverter.convert() and RowConverter.reconvert() passed the top-level TableSchema to recursive calls when handling nested ROW types, causing a field count mismatch error (nested fields != top-level fields).

Extract the nested RowType from the current field and construct a matching TableSchema for each recursive call. Add unit tests for both read and write paths with nested ROW types.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
