### PR TITLE
[Fix][Kafka] Reduce default reader_cache_queue_size from 1024 to 2 to prevent OOM

### DIFF
--- a/docs/en/connectors/source/Kafka.md
+++ b/docs/en/connectors/source/Kafka.md
@@ -59,12 +59,29 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 | protobuf_message_name               | String                                                                     | No       | -                        | Effective when the format is set to protobuf, specifies the Message name                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | protobuf_schema                     | String                                                                     | No       | -                        | Effective when the format is set to protobuf, specifies the Schema definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | strip_schema_registry_header        | Boolean                                                                    | No       | false                    | Effective when the format is set to protobuf. Whether to strip the Confluent Schema Registry wire format header (magic byte, schema id and message indexes) before protobuf deserialization. This option is useful when consuming Protobuf messages that were encoded using Confluent Schema Registry. When enabled, the connector will try to detect and remove the Schema Registry header before parsing the Protobuf message. If the header is not detected, it will fall back to standard Protobuf deserialization.                                                                                                                                                                                                                                                                    |
-| reader_cache_queue_size             | Integer                                                                     | No       | 1024                     | The reader shard cache queue is used to cache the data corresponding to the shards. The size of the shard cache depends on the number of shards obtained by each reader, rather than the amount of data in each shard.                                                                                                                                                                                                                                                                                            |
+| reader_cache_queue_size             | Integer                                                                     | No       | 2                        | The capacity of the fetcher-to-reader element queue. Each element is one `consumer.poll()` batch, not a single message. See [reader_cache_queue_size](#reader_cache_queue_size) for details. |
 | is_native                           | Boolean                                                                     | No       | false                    | Supports retaining the source information of the record.
 
 > On restore from checkpoint or savepoint, Kafka Source resumes from the checkpointed split offsets.
 > `start_mode` and consumer-group offsets are only used for the first startup or for newly
 > discovered partitions that do not have checkpointed state yet.
+
+### reader_cache_queue_size
+
+The maximum number of poll-result batches that the connector buffers between the fetcher thread and the reader thread.
+
+:::tip
+
+Each element in the queue is one complete `consumer.poll()` result, which may contain up to `max.poll.records` (default 500) messages.
+When back-pressure occurs downstream, the queue may fill up, and the upper bound of messages held in memory is `reader_cache_queue_size × max.poll.records`.
+
+:::
+
+:::caution
+
+When consuming large messages, a high value can lead to excessive heap usage. If you observe memory pressure, reduce this value or lower `kafka.max.poll.records`.
+
+:::
 
 ### debezium_record_table_filter
 

--- a/docs/zh/connectors/source/Kafka.md
+++ b/docs/zh/connectors/source/Kafka.md
@@ -59,11 +59,28 @@ import ChangeLog from '../changelog/connector-kafka.md';
 | protobuf_message_name               | String                              | 否    | -                            | 当格式设置为 protobuf 时有效，指定消息名称。                                                                                                                                                                                                                                                                                                    |
 | protobuf_schema                     | String                              | 否    | -                            | 当格式设置为 protobuf 时有效，指定 Schema 定义。                                                                                                                                                                                                                                                                                              |
 | strip_schema_registry_header        | Boolean                             | 否    | false                        | 当格式设置为 protobuf 时有效。是否在 Protobuf 反序列化之前去除 Confluent Schema Registry 线格式头部（magic byte、schema id 和 message indexes）。当消费使用 Confluent Schema Registry 编码的 Protobuf 消息时，此选项非常有用。启用后，连接器将尝试在解析 Protobuf 消息之前检测并删除 Schema Registry 头部。如果未检测到头部，它将回退到标准的 Protobuf 反序列化。                                                                                                                                                                                                                                                                                              |
-| reader_cache_queue_size             | Integer                             | 否    | 1024                         | Reader分片缓存队列，用于缓存分片对应的数据。占用大小取决于每个reader得到的分片量，而不是每个分片的数据量。                                                                                                                                                                                                                                                                    |
+| reader_cache_queue_size             | Integer                             | 否    | 2                            | Fetcher 与 Reader 线程之间缓冲队列的容量。每个元素是一次 `consumer.poll()` 的整批结果，而非单条消息。详见 [reader_cache_queue_size](#reader_cache_queue_size)。 |
 | is_native                           | Boolean                             | No   | false                        | 支持保留record的源信息。                                                                                                                                                                                                                                                                                                                |
 
 > 从 checkpoint 或 savepoint 恢复时，Kafka Source 会优先使用 checkpoint 中保存的 split offset。
 > `start_mode` 和 consumer group offset 只在首次启动，或为尚未存在 checkpoint 状态的新发现分区初始化位点时生效。
+
+### reader_cache_queue_size
+
+连接器在 Fetcher 线程和 Reader 线程之间缓冲的 poll 结果批次的最大数量。
+
+:::tip
+
+队列中的每个元素是一次完整的 `consumer.poll()` 结果，最多包含 `max.poll.records`（默认 500）条消息。
+当下游产生背压时，队列可能被填满，此时驻留在内存中的消息数上限为 `reader_cache_queue_size × max.poll.records`。
+
+:::
+
+:::caution
+
+当消费的消息体较大时，过高的值会导致堆内存占用过高。如果观察到内存压力，请减小此值或降低 `kafka.max.poll.records`。
+
+:::
 
 ### debezium_record_table_filter
 

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/config/KafkaSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/config/KafkaSourceOptions.java
@@ -44,8 +44,11 @@ public class KafkaSourceOptions extends KafkaBaseOptions {
     public static final Option<Integer> READER_CACHE_QUEUE_SIZE =
             Options.key("reader_cache_queue_size")
                     .intType()
-                    .defaultValue(1024)
-                    .withDescription("The size of reader queue.");
+                    .defaultValue(2)
+                    .withDescription(
+                            "The capacity of the fetcher-to-reader element queue. "
+                                    + "Each element is one consumer.poll() batch, not a single message. "
+                                    + "Actual buffered messages ≈ this value × max.poll.records.");
 
     public static final Option<Boolean> COMMIT_ON_CHECKPOINT =
             Options.key("commit_on_checkpoint")


### PR DESCRIPTION
Closes https://github.com/apache/seatunnel/issues/10953

## Purpose

The Kafka source connector's internal element queue (`LinkedBlockingQueue`) between the fetcher thread and the reader thread uses a default capacity of 1024. Each element in the queue is one complete `consumer.poll()` batch (up to `max.poll.records` = 500 messages), not a single message. Under back-pressure, the queue fills up and can consume gigabytes of heap, causing Full GC and OOM.

## Changes

- **`KafkaSourceOptions.java`**: Change default value of `reader_cache_queue_size` from 1024 to 2. Update description to clarify the semantics.
- **`docs/en/connectors/source/Kafka.md`**: Add dedicated `reader_cache_queue_size` section explaining the batch-based queue semantics and memory implications.
- **`docs/zh/connectors/source/Kafka.md`**: Same as above in Chinese.

## Why 2?

- Each queue element holds one full `consumer.poll()` result, 2 elements are sufficient to keep the fetcher-reader pipeline saturated without idle gaps.
- With `max.poll.records = 500` and 12 KB messages, worst-case memory drops from ~6 GB (1024) to ~12 MB (2).
