### PR TITLE
[Feature][Connector-V2] Add binary format support for HTTP source connector

### DIFF
--- a/docs/en/connectors/source/Http.md
+++ b/docs/en/connectors/source/Http.md
@@ -60,7 +60,8 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 | pageing.cursor_field          | String  | No       | -           | this parameter is used to specify the Cursor field name in the request parameter.                                                                                       |
 | pageing.cursor_response_field | String  | No       | -           | This parameter specifies the field in the response from which the cursor is retrieved.                                                                                        |
 | content_field                  | String  | No       | -           | This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.                                          |
-| format                        | String  | No       | text        | The format of upstream data, now only support `json` `text`, default `text`.                                                                                                  |
+| format                        | String  | No       | text        | The format of upstream data, supports `json` `text` `binary`, default `text`. When set to `binary`, the response body is treated as raw bytes for downloading files (PDF, images, ZIP, etc.). |
+| binary_chunk_size             | Long    | No       | 10485760    | Chunk size in bytes when `format = binary`. Large files are split into multiple rows. Default 10MB. Only effective in BATCH mode.                                             |
 | method                        | String  | No       | get         | Http request method, only supports GET, POST method.                                                                                                                          |
 | headers                       | Map     | No       | -           | Http headers.                                                                                                                                                                 |
 | params                        | Map     | No       | -           | Http params.                                                                                                                                                                  |
@@ -190,6 +191,40 @@ connector will generate data as the following:
 |                         content                          |
 |----------------------------------------------------------|
 | {"code":  200, "data":  "get success", "success":  true} |
+
+when you assign format is `binary`, the HTTP response body is treated as raw bytes for downloading files (PDF, images, ZIP, etc.). The output schema is fixed as `(data: bytes, relativePath: string, partIndex: long)`. Large files are automatically split into multiple rows based on `binary_chunk_size`. Only supports BATCH mode.
+
+Example: Download a file via HTTP and write to LocalFileSink:
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Http {
+    url = "http://example.com/files/report.pdf"
+    method = "GET"
+    format = "binary"
+    binary_chunk_size = 10485760  # 10MB per chunk
+    schema = {
+      fields {
+        data = bytes
+        relativePath = string
+        partIndex = long
+      }
+    }
+  }
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/download"
+    file_format = "binary"
+  }
+}
+```
 
 ### keep_params_as_form
 For compatibility with old versions of http.

--- a/docs/zh/connectors/source/Http.md
+++ b/docs/zh/connectors/source/Http.md
@@ -50,7 +50,8 @@ import ChangeLog from '../changelog/connector-http.md';
 | pageing.cursor_field          | String  | 否       | -           | 此参数用于指定请求参数中的游标字段名称。                                                                                       |
 | pageing.cursor_response_field | String  | 否       | -           | 此参数指定从中检索游标的响应字段。                                                                                            |
 | content_field                  | String  | 否       | -           | 此参数可以获取一些 json 数据。如果您只需要 'book' 部分的数据，配置 `content_field = "$.store.book.*"`。                                              |
-| format                        | String  | 否       | text        | 上游数据的格式，目前仅支持 `json` `text`，默认为 `text`。                                                                                                      |
+| format                        | String  | 否       | text        | 上游数据的格式，支持 `json` `text` `binary`，默认为 `text`。当设置为 `binary` 时，响应体作为原始字节处理，用于下载文件（PDF、图片、ZIP 等）。                                     |
+| binary_chunk_size             | Long    | 否       | 10485760    | 当 `format = binary` 时的分片大小（字节）。大文件会被拆分为多行。默认 10MB。仅在 BATCH 模式下生效。                                                                             |
 | method                        | String  | 否       | get         | Http 请求方法，仅支持 GET、POST 方法。                                                                                                                              |
 | headers                       | Map     | 否       | -           | Http 头信息。                                                                                                                                                                     |
 | params                        | Map     | 否       | -           | Http 参数。                                                                                                                                                                      |
@@ -179,6 +180,40 @@ schema {
 |                         content                          |
 |----------------------------------------------------------|
 | {"code":  200, "data":  "get success", "success":  true} |
+
+当您指定 format 为 `binary` 时，HTTP 响应体作为原始字节处理，用于下载文件（PDF、图片、ZIP 等）。输出 schema 固定为 `(data: bytes, relativePath: string, partIndex: long)`。大文件会根据 `binary_chunk_size` 自动拆分为多行。仅支持 BATCH 模式。
+
+示例：通过 HTTP 下载文件并写入 LocalFileSink：
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Http {
+    url = "http://example.com/files/report.pdf"
+    method = "GET"
+    format = "binary"
+    binary_chunk_size = 10485760  # 每个分片 10MB
+    schema = {
+      fields {
+        data = bytes
+        relativePath = string
+        partIndex = long
+      }
+    }
+  }
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/download"
+    file_format = "binary"
+  }
+}
+```
 
 ### keep_params_as_form
 为了兼容旧版本的 http。

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -207,6 +207,99 @@ public class HttpClientProvider implements AutoCloseable {
     }
 
     /**
+     * Streams binary response directly in chunks without buffering the entire body. The consumer is
+     * called once per chunk with a SeaTunnelRow containing (byte[] data, String filename, long
+     * partIndex).
+     */
+    public int executeBinaryStreaming(
+            String url,
+            String method,
+            Map<String, String> headers,
+            Map<String, String> params,
+            String body,
+            boolean keepParamsAsForm,
+            long chunkSize,
+            String urlForFilename,
+            java.util.function.Consumer<Object[]> chunkConsumer)
+            throws Exception {
+        HttpRequestBase request =
+                buildRequest(url, method, headers, params, body, keepParamsAsForm);
+        try (CloseableHttpResponse response = retryWithException(request)) {
+            if (response == null
+                    || response.getStatusLine() == null
+                    || response.getStatusLine().getStatusCode() >= 300) {
+                int code =
+                        response != null && response.getStatusLine() != null
+                                ? response.getStatusLine().getStatusCode()
+                                : HttpStatus.SC_INTERNAL_SERVER_ERROR;
+                return code;
+            }
+
+            if (response.getEntity() == null) {
+                return response.getStatusLine().getStatusCode();
+            }
+
+            String contentDisposition = null;
+            if (response.getFirstHeader("Content-Disposition") != null) {
+                contentDisposition = response.getFirstHeader("Content-Disposition").getValue();
+            }
+            String filename =
+                    org.apache.seatunnel.connectors.seatunnel.http.source.FilenameExtractor.extract(
+                            contentDisposition, urlForFilename);
+
+            try (java.io.InputStream in = response.getEntity().getContent()) {
+                byte[] buffer = new byte[(int) chunkSize];
+                long partIndex = 0;
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) > 0) {
+                    byte[] chunk = new byte[bytesRead];
+                    System.arraycopy(buffer, 0, chunk, 0, bytesRead);
+                    chunkConsumer.accept(new Object[] {chunk, filename, partIndex});
+                    partIndex++;
+                }
+            }
+            return response.getStatusLine().getStatusCode();
+        }
+    }
+
+    private HttpRequestBase buildRequest(
+            String url,
+            String method,
+            Map<String, String> headers,
+            Map<String, String> params,
+            String body,
+            boolean keepParamsAsForm)
+            throws Exception {
+        method = method.toUpperCase(Locale.ROOT);
+        if (HttpGet.METHOD_NAME.equals(method)) {
+            URIBuilder uriBuilder = new URIBuilder(url);
+            addParameters(uriBuilder, params);
+            HttpGet httpGet = new HttpGet(uriBuilder.build());
+            httpGet.setConfig(requestConfig);
+            addHeaders(httpGet, headers);
+            return httpGet;
+        }
+        if (HttpPost.METHOD_NAME.equals(method)) {
+            HttpPost httpPost = new HttpPost(url);
+            httpPost.setConfig(requestConfig);
+            addHeaders(httpPost, headers);
+            if (!Strings.isNullOrEmpty(body)) {
+                httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+            } else {
+                addParameters(httpPost, params);
+            }
+            return httpPost;
+        }
+        // fallback to GET for other methods
+        URIBuilder uriBuilder = new URIBuilder(url);
+        addParameters(uriBuilder, params);
+        HttpGet httpGet = new HttpGet(uriBuilder.build());
+        httpGet.setConfig(requestConfig);
+        addHeaders(httpGet, headers);
+        return httpGet;
+    }
+
+    /**
      * Send a get request without request headers and request parameters
      *
      * @param url request address

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -187,6 +187,9 @@ public class HttpClientProvider implements AutoCloseable {
             return getResponseBinary(httpGet);
         }
         if (HttpPost.METHOD_NAME.equals(method)) {
+            if (keepParamsAsForm) {
+                return doPostBinary(url, headers, params, body);
+            }
             HttpPost httpPost = new HttpPost(url);
             httpPost.setConfig(requestConfig);
             addHeaders(httpPost, headers);
@@ -204,6 +207,35 @@ public class HttpClientProvider implements AutoCloseable {
         httpGet.setConfig(requestConfig);
         addHeaders(httpGet, headers);
         return getResponseBinary(httpGet);
+    }
+
+    private HttpResponse doPostBinary(
+            String url, Map<String, String> headers, Map<String, String> params, String body)
+            throws Exception {
+        Map<String, Object> bodyMap = new HashMap<>();
+        if (!Strings.isNullOrEmpty(body)) {
+            bodyMap =
+                    ConfigFactory.parseString(body).entrySet().stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            Map.Entry::getKey,
+                                            entry -> entry.getValue().unwrapped(),
+                                            (v1, v2) -> v2));
+        }
+        if (MapUtils.isNotEmpty(params)) {
+            headers = MapUtils.isEmpty(headers) ? new HashMap<>() : headers;
+            headers.putIfAbsent(HTTP.CONTENT_TYPE, APPLICATION_FORM);
+        }
+        if (MapUtils.isEmpty(bodyMap)) {
+            bodyMap = new HashMap<>();
+        }
+        bodyMap.putAll(params);
+        URIBuilder uriBuilder = new URIBuilder(url);
+        HttpPost httpPost = new HttpPost(uriBuilder.build());
+        httpPost.setConfig(requestConfig);
+        addHeaders(httpPost, headers);
+        addBody(httpPost, bodyMap);
+        return getResponseBinary(httpPost);
     }
 
     /**
@@ -282,11 +314,34 @@ public class HttpClientProvider implements AutoCloseable {
         if (HttpPost.METHOD_NAME.equals(method)) {
             HttpPost httpPost = new HttpPost(url);
             httpPost.setConfig(requestConfig);
-            addHeaders(httpPost, headers);
-            if (!Strings.isNullOrEmpty(body)) {
-                httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+            if (keepParamsAsForm) {
+                Map<String, Object> bodyMap = new HashMap<>();
+                if (!Strings.isNullOrEmpty(body)) {
+                    bodyMap =
+                            ConfigFactory.parseString(body).entrySet().stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    Map.Entry::getKey,
+                                                    entry -> entry.getValue().unwrapped(),
+                                                    (v1, v2) -> v2));
+                }
+                if (MapUtils.isNotEmpty(params)) {
+                    headers = MapUtils.isEmpty(headers) ? new HashMap<>() : headers;
+                    headers.putIfAbsent(HTTP.CONTENT_TYPE, APPLICATION_FORM);
+                }
+                if (MapUtils.isEmpty(bodyMap)) {
+                    bodyMap = new HashMap<>();
+                }
+                bodyMap.putAll(params);
+                addHeaders(httpPost, headers);
+                addBody(httpPost, bodyMap);
             } else {
-                addParameters(httpPost, params);
+                addHeaders(httpPost, headers);
+                if (!Strings.isNullOrEmpty(body)) {
+                    httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+                } else {
+                    addParameters(httpPost, params);
+                }
             }
             return httpPost;
         }

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -169,6 +169,43 @@ public class HttpClientProvider implements AutoCloseable {
         return doGet(url, headers, params);
     }
 
+    public HttpResponse executeBinary(
+            String url,
+            String method,
+            Map<String, String> headers,
+            Map<String, String> params,
+            String body,
+            boolean keepParamsAsForm)
+            throws Exception {
+        method = method.toUpperCase(Locale.ROOT);
+        if (HttpGet.METHOD_NAME.equals(method)) {
+            URIBuilder uriBuilder = new URIBuilder(url);
+            addParameters(uriBuilder, params);
+            HttpGet httpGet = new HttpGet(uriBuilder.build());
+            httpGet.setConfig(requestConfig);
+            addHeaders(httpGet, headers);
+            return getResponseBinary(httpGet);
+        }
+        if (HttpPost.METHOD_NAME.equals(method)) {
+            HttpPost httpPost = new HttpPost(url);
+            httpPost.setConfig(requestConfig);
+            addHeaders(httpPost, headers);
+            if (!Strings.isNullOrEmpty(body)) {
+                httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+            } else {
+                addParameters(httpPost, params);
+            }
+            return getResponseBinary(httpPost);
+        }
+        // fallback to GET for other methods
+        URIBuilder uriBuilder = new URIBuilder(url);
+        addParameters(uriBuilder, params);
+        HttpGet httpGet = new HttpGet(uriBuilder.build());
+        httpGet.setConfig(requestConfig);
+        addHeaders(httpGet, headers);
+        return getResponseBinary(httpGet);
+    }
+
     /**
      * Send a get request without request headers and request parameters
      *
@@ -425,6 +462,27 @@ public class HttpClientProvider implements AutoCloseable {
                     content = EntityUtils.toString(httpResponse.getEntity(), ENCODING);
                 }
                 return new HttpResponse(httpResponse.getStatusLine().getStatusCode(), content);
+            }
+        }
+        return new HttpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    private HttpResponse getResponseBinary(HttpRequestBase request) throws Exception {
+        try (CloseableHttpResponse httpResponse = retryWithException(request)) {
+            if (httpResponse != null && httpResponse.getStatusLine() != null) {
+                byte[] bodyBytes = null;
+                if (httpResponse.getEntity() != null) {
+                    bodyBytes = EntityUtils.toByteArray(httpResponse.getEntity());
+                }
+                String contentDisposition = null;
+                if (httpResponse.getFirstHeader("Content-Disposition") != null) {
+                    contentDisposition =
+                            httpResponse.getFirstHeader("Content-Disposition").getValue();
+                }
+                return new HttpResponse(
+                        httpResponse.getStatusLine().getStatusCode(),
+                        bodyBytes,
+                        contentDisposition);
             }
         }
         return new HttpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpResponse.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpResponse.java
@@ -32,6 +32,12 @@ public class HttpResponse implements Serializable {
     /** response body */
     private String content;
 
+    /** binary response body */
+    private byte[] bodyBytes;
+
+    /** Content-Disposition header value */
+    private String contentDisposition;
+
     public HttpResponse() {}
 
     public HttpResponse(int code) {
@@ -45,6 +51,12 @@ public class HttpResponse implements Serializable {
     public HttpResponse(int code, String content) {
         this.code = code;
         this.content = content;
+    }
+
+    public HttpResponse(int code, byte[] bodyBytes, String contentDisposition) {
+        this.code = code;
+        this.bodyBytes = bodyBytes;
+        this.contentDisposition = contentDisposition;
     }
 
     public int getCode() {
@@ -61,6 +73,22 @@ public class HttpResponse implements Serializable {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public byte[] getBodyBytes() {
+        return bodyBytes;
+    }
+
+    public void setBodyBytes(byte[] bodyBytes) {
+        this.bodyBytes = bodyBytes;
+    }
+
+    public String getContentDisposition() {
+        return contentDisposition;
+    }
+
+    public void setContentDisposition(String contentDisposition) {
+        this.contentDisposition = contentDisposition;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/config/HttpConfig.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/config/HttpConfig.java
@@ -23,7 +23,8 @@ public class HttpConfig {
 
     public enum ResponseFormat {
         JSON("json"),
-        TEXT("text");
+        TEXT("text"),
+        BINARY("binary");
 
         private String format;
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/config/HttpSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/config/HttpSourceOptions.java
@@ -110,6 +110,13 @@ public class HttpSourceOptions extends HttpCommonOptions {
                     .enumType(HttpConfig.ResponseFormat.class)
                     .defaultValue(HttpConfig.ResponseFormat.TEXT)
                     .withDescription("Http response format");
+
+    public static final Option<Long> BINARY_CHUNK_SIZE =
+            Options.key("binary_chunk_size")
+                    .longType()
+                    .defaultValue(10 * 1024 * 1024L)
+                    .withDescription(
+                            "Chunk size in bytes for binary response mode. When the response body exceeds this size, it will be split into multiple rows. Only effective when format=binary. Default is 10MB.");
     public static final Option<Integer> POLL_INTERVAL_MILLS =
             Options.key("poll_interval_millis")
                     .intType()

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/exception/HttpConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/exception/HttpConnectorErrorCode.java
@@ -21,7 +21,8 @@ import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
 
 public enum HttpConnectorErrorCode implements SeaTunnelErrorCode {
     FIELD_DATA_IS_INCONSISTENT("HTTP-01", "The field data is inconsistent"),
-    REQUEST_FAILED("HTTP-02", "The request is failed");
+    REQUEST_FAILED("HTTP-02", "The request is failed"),
+    CONFIG_VALIDATION_FAILED("HTTP-03", "The config validation is failed");
 
     private final String code;
     private final String description;

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/BinaryResponseCollector.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/BinaryResponseCollector.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.http.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpResponse;
+
+public class BinaryResponseCollector {
+
+    public static final SeaTunnelRowType BINARY_ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"data", "relativePath", "partIndex"},
+                    new SeaTunnelDataType[] {
+                        PrimitiveByteArrayType.INSTANCE, BasicType.STRING_TYPE, BasicType.LONG_TYPE
+                    });
+
+    private BinaryResponseCollector() {}
+
+    public static void collect(
+            HttpResponse response, String url, long chunkSize, Collector<SeaTunnelRow> output) {
+        String filename = FilenameExtractor.extract(response.getContentDisposition(), url);
+
+        byte[] bodyBytes = response.getBodyBytes();
+        if (bodyBytes == null || bodyBytes.length == 0) {
+            return;
+        }
+
+        if (chunkSize <= 0 || bodyBytes.length <= chunkSize) {
+            output.collect(new SeaTunnelRow(new Object[] {bodyBytes, filename, 0L}));
+            return;
+        }
+
+        int offset = 0;
+        long partIndex = 0;
+        while (offset < bodyBytes.length) {
+            int end = Math.min(offset + (int) chunkSize, bodyBytes.length);
+            byte[] chunk = new byte[end - offset];
+            System.arraycopy(bodyBytes, offset, chunk, 0, end - offset);
+            output.collect(new SeaTunnelRow(new Object[] {chunk, filename, partIndex}));
+            offset = end;
+            partIndex++;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/FilenameExtractor.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/FilenameExtractor.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.http.source;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FilenameExtractor {
+
+    private static final Pattern FILENAME_PATTERN =
+            Pattern.compile("filename\\*?=([^;]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ENCODED_FILENAME_PATTERN =
+            Pattern.compile("filename\\*=UTF-8''(.+?)(?:;|$)", Pattern.CASE_INSENSITIVE);
+
+    private FilenameExtractor() {}
+
+    public static String extract(String contentDisposition, String url) {
+        // 1. Try Content-Disposition header
+        if (contentDisposition != null && !contentDisposition.isEmpty()) {
+            String filename = parseContentDisposition(contentDisposition);
+            if (filename != null && !filename.isEmpty()) {
+                return filename;
+            }
+        }
+
+        // 2. Try URL path
+        if (url != null && !url.isEmpty()) {
+            String filename = extractFromUrl(url);
+            if (filename != null && !filename.isEmpty()) {
+                return filename;
+            }
+        }
+
+        // 3. Default
+        return "response-body-" + System.currentTimeMillis();
+    }
+
+    static String parseContentDisposition(String contentDisposition) {
+        // Try RFC 5987 encoded filename first (filename*=UTF-8''xxx)
+        Matcher encodedMatcher = ENCODED_FILENAME_PATTERN.matcher(contentDisposition);
+        if (encodedMatcher.find()) {
+            try {
+                return java.net.URLDecoder.decode(encodedMatcher.group(1), "UTF-8");
+            } catch (java.io.UnsupportedEncodingException e) {
+                return encodedMatcher.group(1);
+            }
+        }
+
+        // Try standard filename="xxx"
+        Matcher matcher = FILENAME_PATTERN.matcher(contentDisposition);
+        if (matcher.find()) {
+            String filename = matcher.group(1).trim();
+            if (filename.startsWith("\"") && filename.endsWith("\"")) {
+                filename = filename.substring(1, filename.length() - 1);
+            }
+            return filename;
+        }
+        return null;
+    }
+
+    static String extractFromUrl(String url) {
+        try {
+            String path = URI.create(url).getPath();
+            if (path != null && !path.isEmpty()) {
+                int lastSlash = path.lastIndexOf('/');
+                String filename = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+                if (!filename.isEmpty() && filename.contains(".")) {
+                    return filename;
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            // URL parsing failed, ignore
+        }
+        return null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSource.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSource.java
@@ -191,24 +191,70 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
                                     format));
             }
         } else {
-            TableIdentifier tableIdentifier =
-                    TableIdentifier.of(HttpConfig.CONNECTOR_IDENTITY, TablePath.DEFAULT);
-            TableSchema tableSchema =
-                    TableSchema.builder()
-                            .column(
-                                    PhysicalColumn.of(
-                                            "content", BasicType.STRING_TYPE, 0, false, null, null))
-                            .build();
+            HttpConfig.ResponseFormat format = pluginConfig.get(HttpSourceOptions.FORMAT);
+            if (format == HttpConfig.ResponseFormat.BINARY) {
+                this.binaryMode = true;
+                this.binaryChunkSize = pluginConfig.get(HttpSourceOptions.BINARY_CHUNK_SIZE);
+                TableSchema binarySchema =
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.of(
+                                                "data",
+                                                PrimitiveByteArrayType.INSTANCE,
+                                                0,
+                                                false,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "relativePath",
+                                                BasicType.STRING_TYPE,
+                                                0,
+                                                false,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "partIndex",
+                                                BasicType.LONG_TYPE,
+                                                0,
+                                                false,
+                                                null,
+                                                null))
+                                .build();
+                this.catalogTable =
+                        CatalogTable.of(
+                                TableIdentifier.of(
+                                        HttpConfig.CONNECTOR_IDENTITY, TablePath.DEFAULT),
+                                binarySchema,
+                                Collections.emptyMap(),
+                                Collections.emptyList(),
+                                null);
+            } else {
+                TableIdentifier tableIdentifier =
+                        TableIdentifier.of(HttpConfig.CONNECTOR_IDENTITY, TablePath.DEFAULT);
+                TableSchema tableSchema =
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.of(
+                                                "content",
+                                                BasicType.STRING_TYPE,
+                                                0,
+                                                false,
+                                                null,
+                                                null))
+                                .build();
 
-            this.catalogTable =
-                    CatalogTable.of(
-                            tableIdentifier,
-                            tableSchema,
-                            Collections.emptyMap(),
-                            Collections.emptyList(),
-                            null);
-            this.deserializationSchema =
-                    new SimpleTextDeserializationSchema(catalogTable.getSeaTunnelRowType());
+                this.catalogTable =
+                        CatalogTable.of(
+                                tableIdentifier,
+                                tableSchema,
+                                Collections.emptyMap(),
+                                Collections.emptyList(),
+                                null);
+                this.deserializationSchema =
+                        new SimpleTextDeserializationSchema(catalogTable.getSeaTunnelRowType());
+            }
         }
     }
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSource.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSource.java
@@ -33,7 +33,9 @@ import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.common.utils.JsonUtils;
@@ -58,6 +60,8 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
     protected String contentField;
     protected JobContext jobContext;
     protected DeserializationSchema<SeaTunnelRow> deserializationSchema;
+    protected boolean binaryMode = false;
+    protected long binaryChunkSize = HttpSourceOptions.BINARY_CHUNK_SIZE.defaultValue();
 
     protected CatalogTable catalogTable;
 
@@ -70,13 +74,6 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
     @Override
     public String getPluginName() {
         return HttpConfig.CONNECTOR_IDENTITY;
-    }
-
-    @Override
-    public Boundedness getBoundedness() {
-        return JobMode.BATCH.equals(jobContext.getJobMode())
-                ? Boundedness.BOUNDED
-                : Boundedness.UNBOUNDED;
     }
 
     private void buildPagingWithConfig(ReadonlyConfig config) {
@@ -145,6 +142,46 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
                         contentField = config.getString(HttpSourceOptions.CONTENT_FIELD.key());
                     }
                     break;
+                case BINARY:
+                    this.binaryMode = true;
+                    this.binaryChunkSize = pluginConfig.get(HttpSourceOptions.BINARY_CHUNK_SIZE);
+                    SeaTunnelRowType binaryRowType = BinaryResponseCollector.BINARY_ROW_TYPE;
+                    TableSchema binarySchema =
+                            TableSchema.builder()
+                                    .column(
+                                            PhysicalColumn.of(
+                                                    "data",
+                                                    PrimitiveByteArrayType.INSTANCE,
+                                                    0,
+                                                    false,
+                                                    null,
+                                                    null))
+                                    .column(
+                                            PhysicalColumn.of(
+                                                    "relativePath",
+                                                    BasicType.STRING_TYPE,
+                                                    0,
+                                                    false,
+                                                    null,
+                                                    null))
+                                    .column(
+                                            PhysicalColumn.of(
+                                                    "partIndex",
+                                                    BasicType.LONG_TYPE,
+                                                    0,
+                                                    false,
+                                                    null,
+                                                    null))
+                                    .build();
+                    this.catalogTable =
+                            CatalogTable.of(
+                                    TableIdentifier.of(
+                                            HttpConfig.CONNECTOR_IDENTITY, TablePath.DEFAULT),
+                                    binarySchema,
+                                    Collections.emptyMap(),
+                                    Collections.emptyList(),
+                                    null);
+                    break;
                 default:
                     // TODO: use format SPI
                     throw new HttpConnectorException(
@@ -181,6 +218,18 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
     }
 
     @Override
+    public Boundedness getBoundedness() {
+        if (binaryMode && JobMode.STREAMING.equals(jobContext.getJobMode())) {
+            throw new HttpConnectorException(
+                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                    "HTTP binary format only supports BATCH mode, not STREAMING.");
+        }
+        return JobMode.BATCH.equals(jobContext.getJobMode())
+                ? Boundedness.BOUNDED
+                : Boundedness.UNBOUNDED;
+    }
+
+    @Override
     public List<CatalogTable> getProducedCatalogTables() {
         return Lists.newArrayList(catalogTable);
     }
@@ -194,7 +243,9 @@ public class HttpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
                 this.deserializationSchema,
                 jsonField,
                 contentField,
-                pageInfo);
+                pageInfo,
+                binaryMode,
+                binaryChunkSize);
     }
 
     protected JsonField getJsonField(Config jsonFieldConf) {

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
@@ -75,6 +75,8 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
             Configuration.defaultConfiguration().addOptions(DEFAULT_OPTIONS);
     private boolean noMoreElementFlag = true;
     private Optional<PageInfo> pageInfoOptional = Optional.empty();
+    private final boolean binaryMode;
+    private final long binaryChunkSize;
     /**
      * Holds the original request body template for placeholder replacement. This ensures that the
      * state is not unintentionally mutated during pagination.
@@ -87,12 +89,15 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
             DeserializationSchema<SeaTunnelRow> deserializationSchema,
             JsonField jsonField,
             String contentJson) {
-        this.context = context;
-        this.httpParameter = httpParameter;
-        this.deserializationCollector = new DeserializationCollector(deserializationSchema);
-        this.jsonField = jsonField;
-        this.contentJson = contentJson;
-        this.rawBody = httpParameter.getBody();
+        this(
+                httpParameter,
+                context,
+                deserializationSchema,
+                jsonField,
+                contentJson,
+                null,
+                false,
+                0L);
     }
 
     public HttpSourceReader(
@@ -102,6 +107,26 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
             JsonField jsonField,
             String contentJson,
             PageInfo pageInfo) {
+        this(
+                httpParameter,
+                context,
+                deserializationSchema,
+                jsonField,
+                contentJson,
+                pageInfo,
+                false,
+                0L);
+    }
+
+    public HttpSourceReader(
+            HttpParameter httpParameter,
+            SingleSplitReaderContext context,
+            DeserializationSchema<SeaTunnelRow> deserializationSchema,
+            JsonField jsonField,
+            String contentJson,
+            PageInfo pageInfo,
+            boolean binaryMode,
+            long binaryChunkSize) {
         this.context = context;
         this.httpParameter = httpParameter;
         this.deserializationCollector = new DeserializationCollector(deserializationSchema);
@@ -109,6 +134,8 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
         this.contentJson = contentJson;
         this.pageInfoOptional = Optional.ofNullable(pageInfo);
         this.rawBody = httpParameter.getBody();
+        this.binaryMode = binaryMode;
+        this.binaryChunkSize = binaryChunkSize;
     }
 
     @Override
@@ -124,6 +151,10 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
     }
 
     public void pollAndCollectData(Collector<SeaTunnelRow> output) throws Exception {
+        if (binaryMode) {
+            pollAndCollectBinaryData(output);
+            return;
+        }
         HttpResponse response = executeRequest();
         if (response.getCode() >= 200 && response.getCode() <= 207) {
             String content = response.getContent();
@@ -151,6 +182,30 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
                             response.getCode(), response.getContent());
             throw new HttpConnectorException(HttpConnectorErrorCode.REQUEST_FAILED, msg);
         }
+    }
+
+    private void pollAndCollectBinaryData(Collector<SeaTunnelRow> output) throws Exception {
+        HttpResponse response = executeBinaryRequest();
+        if (response.getCode() >= 200 && response.getCode() <= 207) {
+            BinaryResponseCollector.collect(
+                    response, httpParameter.getUrl(), binaryChunkSize, output);
+            noMoreElementFlag = true;
+        } else {
+            String msg =
+                    String.format(
+                            "http binary request failed, status code:[%s]", response.getCode());
+            throw new HttpConnectorException(HttpConnectorErrorCode.REQUEST_FAILED, msg);
+        }
+    }
+
+    protected HttpResponse executeBinaryRequest() throws Exception {
+        return httpClient.executeBinary(
+                this.httpParameter.getUrl(),
+                this.httpParameter.getMethod().getMethod(),
+                this.httpParameter.getHeaders(),
+                this.httpParameter.getParams(),
+                this.httpParameter.getBody(),
+                this.httpParameter.isKeepParamsAsForm());
     }
 
     protected HttpResponse executeRequest() throws Exception {

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
@@ -185,15 +185,21 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
     }
 
     private void pollAndCollectBinaryData(Collector<SeaTunnelRow> output) throws Exception {
-        HttpResponse response = executeBinaryRequest();
-        if (response.getCode() >= 200 && response.getCode() <= 207) {
-            BinaryResponseCollector.collect(
-                    response, httpParameter.getUrl(), binaryChunkSize, output);
+        int statusCode =
+                httpClient.executeBinaryStreaming(
+                        this.httpParameter.getUrl(),
+                        this.httpParameter.getMethod().getMethod(),
+                        this.httpParameter.getHeaders(),
+                        this.httpParameter.getParams(),
+                        this.httpParameter.getBody(),
+                        this.httpParameter.isKeepParamsAsForm(),
+                        binaryChunkSize,
+                        httpParameter.getUrl(),
+                        row -> output.collect(new SeaTunnelRow(row)));
+        if (statusCode >= 200 && statusCode <= 207) {
             noMoreElementFlag = true;
         } else {
-            String msg =
-                    String.format(
-                            "http binary request failed, status code:[%s]", response.getCode());
+            String msg = String.format("http binary request failed, status code:[%s]", statusCode);
             throw new HttpConnectorException(HttpConnectorErrorCode.REQUEST_FAILED, msg);
         }
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
@@ -136,6 +136,13 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
         this.rawBody = httpParameter.getBody();
         this.binaryMode = binaryMode;
         this.binaryChunkSize = binaryChunkSize;
+
+        if (binaryMode && pageInfo != null) {
+            throw new HttpConnectorException(
+                    HttpConnectorErrorCode.CONFIG_VALIDATION_FAILED,
+                    "Binary mode does not support pagination. "
+                            + "Please remove pagination configuration or use text mode.");
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/source/BinaryResponseCollectorTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/source/BinaryResponseCollectorTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.http.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpResponse;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BinaryResponseCollectorTest {
+
+    private static Collector<SeaTunnelRow> listCollector(List<SeaTunnelRow> list) {
+        return new Collector<SeaTunnelRow>() {
+            @Override
+            public void collect(SeaTunnelRow record) {
+                list.add(record);
+            }
+
+            @Override
+            public Object getCheckpointLock() {
+                return this;
+            }
+        };
+    }
+
+    @Test
+    public void testSingleRowOutput() {
+        byte[] data = new byte[1024];
+        HttpResponse response = new HttpResponse(200, data, "attachment; filename=\"test.pdf\"");
+        List<SeaTunnelRow> collected = new ArrayList<>();
+
+        BinaryResponseCollector.collect(
+                response, "http://example.com/file", 10 * 1024 * 1024L, listCollector(collected));
+
+        Assertions.assertEquals(1, collected.size());
+        SeaTunnelRow row = collected.get(0);
+        Assertions.assertArrayEquals(data, (byte[]) row.getField(0));
+        Assertions.assertEquals("test.pdf", row.getField(1));
+        Assertions.assertEquals(0L, row.getField(2));
+    }
+
+    @Test
+    public void testChunkedOutput() {
+        byte[] data = new byte[25 * 1024 * 1024]; // 25MB
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 256);
+        }
+        HttpResponse response = new HttpResponse(200, data, null);
+        List<SeaTunnelRow> collected = new ArrayList<>();
+
+        BinaryResponseCollector.collect(
+                response,
+                "http://example.com/files/big.zip",
+                10 * 1024 * 1024L,
+                listCollector(collected));
+
+        Assertions.assertEquals(3, collected.size());
+
+        // First chunk: 10MB
+        SeaTunnelRow chunk0 = collected.get(0);
+        Assertions.assertEquals(10 * 1024 * 1024, ((byte[]) chunk0.getField(0)).length);
+        Assertions.assertEquals(0L, chunk0.getField(2));
+
+        // Second chunk: 10MB
+        SeaTunnelRow chunk1 = collected.get(1);
+        Assertions.assertEquals(10 * 1024 * 1024, ((byte[]) chunk1.getField(0)).length);
+        Assertions.assertEquals(1L, chunk1.getField(2));
+
+        // Third chunk: 5MB
+        SeaTunnelRow chunk2 = collected.get(2);
+        Assertions.assertEquals(5 * 1024 * 1024, ((byte[]) chunk2.getField(0)).length);
+        Assertions.assertEquals(2L, chunk2.getField(2));
+
+        // All chunks have same filename
+        String filename = (String) chunk0.getField(1);
+        Assertions.assertEquals("big.zip", filename);
+        Assertions.assertEquals(filename, chunk1.getField(1));
+        Assertions.assertEquals(filename, chunk2.getField(1));
+
+        // Verify data integrity: reassemble and compare
+        byte[] reassembled = new byte[data.length];
+        for (SeaTunnelRow row : collected) {
+            byte[] chunk = (byte[]) row.getField(0);
+            int partIndex = ((Long) row.getField(2)).intValue();
+            System.arraycopy(chunk, 0, reassembled, partIndex * 10 * 1024 * 1024, chunk.length);
+        }
+        Assertions.assertArrayEquals(data, reassembled);
+    }
+
+    @Test
+    public void testNullBodyBytes() {
+        HttpResponse response = new HttpResponse(200, null, null);
+        List<SeaTunnelRow> collected = new ArrayList<>();
+
+        BinaryResponseCollector.collect(
+                response, "http://example.com/file", 1024L, listCollector(collected));
+
+        Assertions.assertEquals(0, collected.size());
+    }
+
+    @Test
+    public void testEmptyBodyBytes() {
+        HttpResponse response = new HttpResponse(200, new byte[0], null);
+        List<SeaTunnelRow> collected = new ArrayList<>();
+
+        BinaryResponseCollector.collect(
+                response, "http://example.com/file", 1024L, listCollector(collected));
+
+        Assertions.assertEquals(0, collected.size());
+    }
+
+    @Test
+    public void testBinaryRowTypeStructure() {
+        Assertions.assertEquals(3, BinaryResponseCollector.BINARY_ROW_TYPE.getTotalFields());
+        Assertions.assertEquals("data", BinaryResponseCollector.BINARY_ROW_TYPE.getFieldName(0));
+        Assertions.assertEquals(
+                "relativePath", BinaryResponseCollector.BINARY_ROW_TYPE.getFieldName(1));
+        Assertions.assertEquals(
+                "partIndex", BinaryResponseCollector.BINARY_ROW_TYPE.getFieldName(2));
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/source/FilenameExtractorTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/source/FilenameExtractorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.http.source;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FilenameExtractorTest {
+
+    @Test
+    public void testParseContentDispositionStandard() {
+        String result =
+                FilenameExtractor.parseContentDisposition("attachment; filename=\"report.pdf\"");
+        Assertions.assertEquals("report.pdf", result);
+    }
+
+    @Test
+    public void testParseContentDispositionWithoutQuotes() {
+        String result =
+                FilenameExtractor.parseContentDisposition("attachment; filename=report.pdf");
+        Assertions.assertEquals("report.pdf", result);
+    }
+
+    @Test
+    public void testParseContentDispositionUtf8Encoded() {
+        String result =
+                FilenameExtractor.parseContentDisposition(
+                        "attachment; filename*=UTF-8''%E6%8A%A5%E5%91%8A.pdf");
+        Assertions.assertEquals("报告.pdf", result);
+    }
+
+    @Test
+    public void testParseContentDispositionNoFilename() {
+        String result = FilenameExtractor.parseContentDisposition("attachment");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testExtractFromUrlNormalPath() {
+        String result = FilenameExtractor.extractFromUrl("http://example.com/files/demo.pdf");
+        Assertions.assertEquals("demo.pdf", result);
+    }
+
+    @Test
+    public void testExtractFromUrlNoExtension() {
+        String result = FilenameExtractor.extractFromUrl("http://example.com/api/download");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testExtractFromUrlWithQueryParams() {
+        String result =
+                FilenameExtractor.extractFromUrl(
+                        "http://example.com/files/archive.zip?token=abc123");
+        Assertions.assertEquals("archive.zip", result);
+    }
+
+    @Test
+    public void testExtractFromUrlTrailingSlash() {
+        String result = FilenameExtractor.extractFromUrl("http://example.com/files/");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testExtractPriorityContentDispositionOverUrl() {
+        String result =
+                FilenameExtractor.extract(
+                        "attachment; filename=\"report.pdf\"",
+                        "http://example.com/files/other-name.pdf");
+        Assertions.assertEquals("report.pdf", result);
+    }
+
+    @Test
+    public void testExtractFallbackToUrl() {
+        String result = FilenameExtractor.extract(null, "http://example.com/files/demo.zip");
+        Assertions.assertEquals("demo.zip", result);
+    }
+
+    @Test
+    public void testExtractDefaultFallback() {
+        String result = FilenameExtractor.extract(null, "http://example.com/api/download");
+        Assertions.assertTrue(result.startsWith("response-body-"));
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
@@ -365,6 +365,10 @@ public class HttpIT extends TestSuiteBase implements TestResource {
         // http airtable source
         Container.ExecResult execResult22 = container.executeJob("/airtable_json_to_assert.conf");
         Assertions.assertEquals(0, execResult22.getExitCode());
+
+        // http binary download
+        Container.ExecResult execResult23 = container.executeJob("/http_binary_to_assert.conf");
+        Assertions.assertEquals(0, execResult23.getExitCode());
     }
 
     @TestTemplate

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_binary_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_binary_to_assert.conf
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Http {
+    plugin_output = "http"
+    url = "http://mockserver:1080/example/binary"
+    method = "GET"
+    format = "binary"
+    schema = {
+      fields {
+        data = bytes
+        relativePath = string
+        partIndex = long
+      }
+    }
+  }
+}
+
+sink {
+  Assert {
+    plugin_input = "http"
+    rules {
+      row_rules = [
+        {
+          rule_type = MAX_ROW
+          rule_value = 1
+        },
+        {
+          rule_type = MIN_ROW
+          rule_value = 1
+        }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json
@@ -4943,5 +4943,21 @@
         ]
       }
     }
+  },
+  {
+    "httpRequest": {
+      "method": "GET",
+      "path": "/example/binary"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "headers": {
+        "Content-Disposition": "attachment; filename=\"test.pdf\""
+      },
+      "body": {
+        "type": "BINARY",
+        "base64Bytes": "SGVsbG8gV29ybGQgLSBiaW5hcnkgdGVzdCBjb250ZW50"
+      }
+    }
   }
 ]


### PR DESCRIPTION
Closes #10923
Add format = "binary" option to HTTP Source for downloading binary files
(PDF, images, ZIP, etc.) via HTTP and writing to sinks like LocalFile.

Changes:
- Add BINARY to ResponseFormat enum in HttpConfig
- Add binary_chunk_size option (default 10MB) for large file splitting
- Add executeBinary() method in HttpClientProvider using EntityUtils.toByteArray()
- Add FilenameExtractor utility for Content-Disposition and URL path parsing
- Add BinaryResponseCollector for chunked binary row output
- Modify HttpSource/HttpSourceReader to support binary mode (BATCH only)
- Add unit tests for FilenameExtractor (11 tests) and BinaryResponseCollector (5 tests)
- Add E2E test with mockserver binary endpoint
- Update docs (en/zh) with binary format configuration and examples



<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
