### PR TITLE
[Fix][Connector-V2] Fix Dameng create table with comment failed

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalog.java
@@ -108,6 +108,12 @@ public class DamengCatalog extends AbstractJdbcCatalog {
     @Override
     protected String getCreateTableSql(
             TablePath tablePath, CatalogTable table, boolean createIndex) {
+        return getCreateTableSqls(tablePath, table, createIndex).get(0);
+    }
+
+    @Override
+    protected List<String> getCreateTableSqls(
+            TablePath tablePath, CatalogTable table, boolean createIndex) {
         return new DamengCreateTableSqlBuilder(table, createIndex).build(tablePath);
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCreateTableSqlBuilder.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTy
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -52,7 +53,8 @@ public class DamengCreateTableSqlBuilder extends AbstractJdbcCreateTableSqlBuild
         this.createIndex = createIndex;
     }
 
-    public String build(TablePath tablePath) {
+    public List<String> build(TablePath tablePath) {
+        List<String> sqls = new ArrayList<>();
         StringBuilder createTableSql = new StringBuilder();
         createTableSql
                 .append("CREATE TABLE ")
@@ -90,6 +92,7 @@ public class DamengCreateTableSqlBuilder extends AbstractJdbcCreateTableSqlBuild
 
         createTableSql.append(String.join(",\n", columnSqls));
         createTableSql.append("\n)");
+        sqls.add(createTableSql.toString());
 
         List<String> commentSqls =
                 columns.stream()
@@ -100,13 +103,8 @@ public class DamengCreateTableSqlBuilder extends AbstractJdbcCreateTableSqlBuild
                                                 column, tablePath.getSchemaAndTableName("\"")))
                         .collect(Collectors.toList());
 
-        if (!commentSqls.isEmpty()) {
-            createTableSql.append(";\n");
-            createTableSql.append(String.join(";\n", commentSqls));
-            createTableSql.append(";");
-        }
-
-        return createTableSql.toString();
+        sqls.addAll(commentSqls);
+        return sqls;
     }
 
     String buildColumnSql(Column column) {
@@ -163,7 +161,7 @@ public class DamengCreateTableSqlBuilder extends AbstractJdbcCreateTableSqlBuild
         columnCommentSql
                 .append(CatalogUtils.quoteIdentifier(column.getName(), fieldIde, "\""))
                 .append(CatalogUtils.quoteIdentifier(" IS '", fieldIde))
-                .append(column.getComment())
+                .append(column.getComment().replace("'", "''"))
                 .append("'");
         return columnCommentSql.toString();
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCreateTableSqlBuilderTest.java
@@ -96,34 +96,49 @@ public class DamengCreateTableSqlBuilderTest {
                         new ArrayList<>(),
                         "User table");
 
-        String createTableSql =
+        java.util.List<String> createTableSqls =
                 new DamengCreateTableSqlBuilder(catalogTable, true).build(tablePath);
-        String expect =
+
+        Assertions.assertEquals(6, createTableSqls.size());
+        Assertions.assertTrue(createTableSqls.get(0).startsWith("CREATE TABLE"));
+
+        String regex1 = "id_\\w+";
+        String regex2 = "name_\\w+";
+        String actualCreate =
+                createTableSqls.get(0).replaceAll(regex1, "id_").replaceAll(regex2, "name_");
+        String expectCreate =
                 "CREATE TABLE \"test_schema\".\"test_table\" (\n"
                         + "\"id\" BIGINT NOT NULL,\n"
                         + "\"name\" VARCHAR2(128) NOT NULL,\n"
                         + "\"age\" INT,\n"
                         + "\"createTime\" TIMESTAMP,\n"
                         + "\"lastUpdateTime\" TIMESTAMP,\n"
-                        + "CONSTRAINT id_63d5 PRIMARY KEY (\"id\"),\n"
-                        + "\tCONSTRAINT name_49b6 UNIQUE (\"name\")\n"
-                        + ");\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"id\" IS 'id';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"name\" IS 'name';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"age\" IS 'age';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"createTime\" IS 'createTime';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"lastUpdateTime\" IS 'lastUpdateTime';";
+                        + "CONSTRAINT id_ PRIMARY KEY (\"id\"),\n"
+                        + "\tCONSTRAINT name_ UNIQUE (\"name\")\n"
+                        + ")";
+        Assertions.assertEquals(expectCreate, actualCreate);
 
-        String regex1 = "id_\\w+";
-        String regex2 = "name_\\w+";
-        String replacedStr1 = createTableSql.replaceAll(regex1, "id_").replaceAll(regex2, "name_");
-        String replacedStr2 = expect.replaceAll(regex1, "id_").replaceAll(regex2, "name_");
-        Assertions.assertEquals(replacedStr2, replacedStr1);
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"id\" IS 'id'",
+                createTableSqls.get(1));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"name\" IS 'name'",
+                createTableSqls.get(2));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"age\" IS 'age'",
+                createTableSqls.get(3));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"createTime\" IS 'createTime'",
+                createTableSqls.get(4));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"lastUpdateTime\" IS 'lastUpdateTime'",
+                createTableSqls.get(5));
 
         // skip index
-        String createTableSqlSkipIndex =
+        java.util.List<String> createTableSqlsSkipIndex =
                 new DamengCreateTableSqlBuilder(catalogTable, false).build(tablePath);
-        // create table sql is change; The old unit tests are no longer applicable
+
+        Assertions.assertEquals(6, createTableSqlsSkipIndex.size());
         String expectSkipIndex =
                 "CREATE TABLE \"test_schema\".\"test_table\" (\n"
                         + "\"id\" BIGINT NOT NULL,\n"
@@ -131,13 +146,14 @@ public class DamengCreateTableSqlBuilderTest {
                         + "\"age\" INT,\n"
                         + "\"createTime\" TIMESTAMP,\n"
                         + "\"lastUpdateTime\" TIMESTAMP\n"
-                        + ");\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"id\" IS 'id';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"name\" IS 'name';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"age\" IS 'age';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"createTime\" IS 'createTime';\n"
-                        + "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"lastUpdateTime\" IS 'lastUpdateTime';";
-        Assertions.assertEquals(expectSkipIndex, createTableSqlSkipIndex);
+                        + ")";
+        Assertions.assertEquals(expectSkipIndex, createTableSqlsSkipIndex.get(0));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"id\" IS 'id'",
+                createTableSqlsSkipIndex.get(1));
+        Assertions.assertEquals(
+                "COMMENT ON COLUMN \"test_schema\".\"test_table\".\"lastUpdateTime\" IS 'lastUpdateTime'",
+                createTableSqlsSkipIndex.get(5));
     }
 
     @Test


### PR DESCRIPTION
Close #10955
Dameng JDBC driver does not support executing multiple SQL statements
separated by semicolons in a single PreparedStatement.

The DamengCreateTableSqlBuilder now returns List<String> instead of a
single concatenated string, allowing each CREATE TABLE and COMMENT ON
statement to execute independently. This follows the same pattern as
OracleCatalog.

Also added single quote escaping in COMMENT statements.



<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
