### PR TITLE
[Fix][Connector-V2][SqlServer CDC] Fix SQL Server CDC DDL history query LSN boundary causing schema events to be lost

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -136,7 +136,7 @@ public class SqlServerConnection extends JdbcConnection {
                     + " ddl_lsn,"
                     + " ddl_time"
                     + " FROM [#db].cdc.ddl_history"
-                    + " WHERE ddl_lsn > ? AND ddl_lsn <= ?"
+                    + " WHERE ddl_lsn >= ? AND ddl_lsn <= ?"
                     + " ORDER BY ddl_lsn ASC";
     private static final String OPENING_QUOTING_CHARACTER = "[";
     private static final String CLOSING_QUOTING_CHARACTER = "]";


### PR DESCRIPTION
### Purpose of this pull request
This PR fixes a critical correctness issue in the SQL Server CDC connector where DDL schema events can be lost due to inconsistent LSN boundary semantics between the main data reading window and the DDL history query.

Related PR: https://github.com/apache/seatunnel/pull/10890
Related Issue: https://github.com/apache/seatunnel/issues/10969

**Problem**

The issue was introduced in PR #10890 which added DDL history querying functionality. The implementation created a semantic mismatch:

- Main data reading window: Uses a closed interval `[fromLsn, toLsn]`
- Explicitly documented in code comments as "reading interval is inclusive"
- `fromLsn` is set to `lastProcessedPosition.getCommitLsn()` for initial/recovery scenarios
- `incrementLsn()` is called in steady-state to advance position
- DDL history query before this fix: Used a left-open interval `(fromLsn, toLsn]`
 ```sql
 WHERE ddl_lsn > ? AND ddl_lsn <= ?
 ```

**Solution**

Change the DDL history query to use a closed interval matching the main reading window:

```diff
- WHERE ddl_lsn > ? AND ddl_lsn <= ?
+ WHERE ddl_lsn >= ? AND ddl_lsn <= ?
```

### Does this PR introduce _any_ user-facing change?
Yes, this is a minimal patch.

### How was this patch tested?
`SqlServerCDCIT`.`testWithSchemaEvolution` tests it.


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
