### PR TITLE
[Improve][Connector-V2] Upgrade kudu-client from 1.11.1 to 1.15.0

### DIFF
--- a/seatunnel-connectors-v2/connector-kudu/pom.xml
+++ b/seatunnel-connectors-v2/connector-kudu/pom.xml
@@ -30,7 +30,7 @@
     <name>SeaTunnel : Connectors V2 : Kudu</name>
 
     <properties>
-        <kudu.version>1.11.1</kudu.version>
+        <kudu.version>1.15.0</kudu.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
     </properties>
 

--- a/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
+++ b/seatunnel-connectors-v2/connector-kudu/src/main/java/org/apache/seatunnel/connectors/seatunnel/kudu/catalog/KuduCatalog.java
@@ -43,7 +43,6 @@ import org.apache.kudu.Type;
 import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduTable;
-import org.apache.kudu.shaded.com.google.common.collect.Lists;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,7 +100,7 @@ public class KuduCatalog implements Catalog {
 
     @Override
     public List<String> listDatabases() throws CatalogException {
-        return Lists.newArrayList(getDefaultDatabase());
+        return Collections.singletonList(getDefaultDatabase());
     }
 
     @Override


### PR DESCRIPTION
### Purpose of this pull request

Upgrade `kudu-client` from 1.11.1 to 1.15.0 to fix Flink 1.15+ compatibility.

Kudu client 1.11.1 shades Netty 3 (`org.apache.kudu.shaded.org.jboss.netty`), which conflicts with Flink 1.15+'s classpath at runtime, causing `NoClassDefFoundError: org/apache/kudu/shaded/org/jboss/netty/util/internal/ExecutorUtil`. This results in Flink tasks entering an infinite slot allocation/release loop — the job never starts and hangs until CI timeout (60 min).

Kudu client 1.12.0+ migrated to Netty 4 ([KUDU-1438](https://github.com/apache/kudu/commit/57dda5d)), which is compatible with Flink 1.15+. Version 1.15.0 is chosen to match the Kudu server image (`apache/kudu:1.15.0`) used in E2E tests.

### Changes

- `connector-kudu/pom.xml`: bump `kudu.version` from `1.11.1` to `1.15.0`
- `KuduCatalog.java`: replace `org.apache.kudu.shaded.com.google.common.collect.Lists.newArrayList()` with `Collections.singletonList()` — the old code referenced Kudu's internal shaded Guava, which is not a public API and may change across versions

### Risk assessment

- **API compatibility**: Kudu officially guarantees API/ABI compatibility from 1.11 → 1.15. All Kudu APIs used in the connector (`KuduClient`, `KuduTable`, `KuduSession`, `KuduScanner`, `Schema`, `Type`, etc.) are stable public interfaces with no breaking changes.
- **Wire compatibility**: Kudu 1.15 client can connect to servers running Kudu 1.0 or later.
- **Shading**: 1.15.0 shades Netty 4 instead of Netty 3, which is the intended fix. The shaded jar is larger but should not introduce new conflicts since Flink/Spark already use Netty 4.

### Does this PR introduce _any_ user-facing change?

No direct user-facing change. Fixes a runtime `NoClassDefFoundError` when running Kudu connector on Flink 1.15+.

### How was this patch tested?

```bash
./mvnw compile -pl seatunnel-connectors-v2/connector-kudu -am -DskipTests
./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kudu-e2e -DskipUT -DskipIT=false verify
```
