### PR TITLE
[Improve][e2e] Improve the stability of redis e2e testing e2e

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/Redis5IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/Redis5IT.java
@@ -18,6 +18,9 @@ package org.apache.seatunnel.e2e.connector.redis;
 
 import org.apache.seatunnel.connectors.seatunnel.redis.config.RedisContainerInfo;
 
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ResourceLock("redis-standalone-e2e")
 public class Redis5IT extends RedisTestCaseTemplateIT {
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/Redis7IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/Redis7IT.java
@@ -18,6 +18,9 @@ package org.apache.seatunnel.e2e.connector.redis;
 
 import org.apache.seatunnel.connectors.seatunnel.redis.config.RedisContainerInfo;
 
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ResourceLock("redis-standalone-e2e")
 public class Redis7IT extends RedisTestCaseTemplateIT {
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
@@ -133,13 +133,17 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
 
     private void createRedisCluster() {
         try {
-            String hostIp = getDockerHostIp();
             StringBuilder clusterCreateCmd =
                     new StringBuilder(
                             "redis-cli --cluster create --cluster-replicas 0 --cluster-yes ");
 
-            for (int port : REDIS_PORTS) {
-                clusterCreateCmd.append(hostIp).append(":").append(port).append(" ");
+            for (int i = 0; i < REDIS_CLUSTER_SIZE; i++) {
+                clusterCreateCmd
+                        .append("redis-cluster-")
+                        .append(i)
+                        .append(":")
+                        .append(REDIS_PORTS[i])
+                        .append(" ");
             }
 
             clusterCreateCmd.append("-a ").append(redisContainerInfo.getPassword());
@@ -511,7 +515,10 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
     }
 
     private String getDockerHostIp() {
-        return new GenericContainer<>(DockerImageName.parse(redisContainerInfo.getImageName()))
-                .getHost();
+        String host =
+                new GenericContainer<>(DockerImageName.parse(redisContainerInfo.getImageName()))
+                        .getHost();
+        // Redis 7.4+ requires a valid IPv4/IPv6 address for cluster-announce-ip
+        return "localhost".equals(host) ? "127.0.0.1" : host;
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -52,23 +53,19 @@ import redis.clients.jedis.JedisCluster;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 @Slf4j
+@ResourceLock("redis-cluster-e2e")
 public class RedisClusterIT extends TestSuiteBase implements TestResource {
 
     private static final int REDIS_CLUSTER_SIZE = 3;
@@ -94,14 +91,13 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
 
     private void setupRedisContainer() {
         redisClusterNodes = new GenericContainer[REDIS_CLUSTER_SIZE];
+        String hostIp = getDockerHostIp();
 
         for (int i = 0; i < REDIS_CLUSTER_SIZE; i++) {
-            String nodeName = "redis-cluster-" + (i + 1);
+            String nodeName = "redis-cluster-" + i;
             int redisPort = REDIS_PORTS[i];
             int busPort = REDIS_BUS_PORTS[i];
 
-            // Get the host machine's IP address
-            String hostIp = getHostIpAddress();
             String redisCommand =
                     String.format(
                             "redis-server --cluster-enabled yes --port %d --protected-mode no "
@@ -127,7 +123,6 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
                                     new HostPortWaitStrategy()
                                             .withStartupTimeout(Duration.ofMinutes(2)));
 
-            // Set the fixed port mapping
             redisClusterNodes[i].setPortBindings(
                     Arrays.asList(redisPort + ":" + redisPort, busPort + ":" + busPort));
         }
@@ -138,7 +133,7 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
 
     private void createRedisCluster() {
         try {
-            String hostIp = getHostIpAddress();
+            String hostIp = getDockerHostIp();
             StringBuilder clusterCreateCmd =
                     new StringBuilder(
                             "redis-cli --cluster create --cluster-replicas 0 --cluster-yes ");
@@ -154,14 +149,11 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
             Container.ExecResult result =
                     redisClusterNodes[0].execInContainer("sh", "-c", clusterCreateCmd.toString());
 
-            // Wait for the cluster to be created
-            Thread.sleep(5000);
-
             if (result.getExitCode() != 0) {
                 throw new RuntimeException("Failed to create Redis cluster: " + result.getStderr());
             }
 
-            log.info("Redis cluster created successfully");
+            log.info("Redis cluster created, waiting for slot assignment via CLUSTER INFO...");
         } catch (Exception e) {
             throw new RuntimeException("Error creating Redis cluster", e);
         }
@@ -170,7 +162,7 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
     private void waitForRedisClusterReady() {
         log.info("Waiting for Redis cluster to be ready...");
 
-        int maxRetries = 10;
+        int maxRetries = 30;
         int retryCount = 0;
 
         while (retryCount < maxRetries) {
@@ -185,29 +177,34 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
                                     String.valueOf(REDIS_PORTS[i]),
                                     "-a",
                                     redisContainerInfo.getPassword(),
-                                    "ping");
+                                    "cluster",
+                                    "info");
 
-                    if (!"PONG".equals(result.getStdout().trim())) {
+                    String output = result.getStdout().trim();
+                    if (!output.contains("cluster_state:ok")
+                            || !output.contains("cluster_slots_ok:16384")) {
                         allReady = false;
                         break;
                     }
                 }
 
                 if (allReady) {
-                    log.info("All Redis nodes are ready after {} attempts", retryCount + 1);
+                    log.info(
+                            "Redis cluster is fully ready after {} attempts (all slots assigned)",
+                            retryCount + 1);
                     return;
                 }
 
             } catch (Exception e) {
                 log.debug(
-                        "Redis readiness check failed, attempt {}: {}",
+                        "Redis cluster readiness check failed, attempt {}: {}",
                         retryCount + 1,
                         e.getMessage());
             }
 
             retryCount++;
             try {
-                Thread.sleep(3000);
+                Thread.sleep(2000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -219,7 +216,7 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
     private void initJedisCluster() {
         Set<HostAndPort> jedisClusterNodes = new HashSet<>();
 
-        String hostIp = getHostIpAddress();
+        String hostIp = getDockerHostIp();
         for (int port : REDIS_PORTS) {
             jedisClusterNodes.add(new HostAndPort(hostIp, port));
         }
@@ -318,7 +315,7 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
             Assertions.assertEquals(100, amount);
         } finally {
             jedisCluster.del("key_set");
-            Assertions.assertEquals(0, jedisCluster.llen("key_set"));
+            Assertions.assertFalse(jedisCluster.exists("key_set"));
         }
     }
 
@@ -513,24 +510,8 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
         return Pair.of(rowType, rows);
     }
 
-    private String getHostIpAddress() {
-        String ip = "";
-        try {
-            Enumeration<NetworkInterface> networkInterfaces =
-                    NetworkInterface.getNetworkInterfaces();
-            while (networkInterfaces.hasMoreElements()) {
-                NetworkInterface networkInterface = networkInterfaces.nextElement();
-                Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
-                while (inetAddresses.hasMoreElements()) {
-                    InetAddress inetAddress = inetAddresses.nextElement();
-                    if (!inetAddress.isLoopbackAddress() && inetAddress instanceof Inet4Address) {
-                        ip = inetAddress.getHostAddress();
-                    }
-                }
-            }
-        } catch (SocketException ex) {
-            ex.printStackTrace();
-        }
-        return ip;
+    private String getDockerHostIp() {
+        return new GenericContainer<>(DockerImageName.parse(redisContainerInfo.getImageName()))
+                .getHost();
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisClusterIT.java
@@ -53,12 +53,17 @@ import redis.clients.jedis.JedisCluster;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -515,10 +520,43 @@ public class RedisClusterIT extends TestSuiteBase implements TestResource {
     }
 
     private String getDockerHostIp() {
-        String host =
-                new GenericContainer<>(DockerImageName.parse(redisContainerInfo.getImageName()))
-                        .getHost();
-        // Redis 7.4+ requires a valid IPv4/IPv6 address for cluster-announce-ip
-        return "localhost".equals(host) ? "127.0.0.1" : host;
+        String fallback = null;
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface ni = interfaces.nextElement();
+                if (!ni.isUp() || ni.isLoopback() || ni.isVirtual()) {
+                    continue;
+                }
+
+                String name = ni.getName();
+                if (name.startsWith("utun")
+                        || name.startsWith("tun")
+                        || name.startsWith("tap")
+                        || name.startsWith("ppp")
+                        || name.startsWith("docker")
+                        || name.startsWith("br-")
+                        || name.startsWith("veth")
+                        || name.startsWith("vmnet")
+                        || name.startsWith("virbr")) {
+                    continue;
+                }
+
+                Enumeration<InetAddress> addrs = ni.getInetAddresses();
+                while (addrs.hasMoreElements()) {
+                    InetAddress addr = addrs.nextElement();
+                    if (addr instanceof Inet4Address && !addr.isLoopbackAddress()) {
+                        String ip = addr.getHostAddress();
+                        if ("en0".equals(name) || "eth0".equals(name) || "wlan0".equals(name)) {
+                            return ip;
+                        }
+                        fallback = ip;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            log.warn("Failed to enumerate network interfaces", e);
+        }
+        return fallback != null ? fallback : "127.0.0.1";
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisMasterAndSlaveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisMasterAndSlaveIT.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
@@ -40,6 +41,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 @Slf4j
+@ResourceLock("redis-master-slave-e2e")
 public class RedisMasterAndSlaveIT extends TestSuiteBase implements TestResource {
     private static RedisContainerInfo masterContainerInfo;
     private static RedisContainerInfo slaveContainerInfo;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e/src/test/java/org/apache/seatunnel/e2e/connector/redis/RedisTestCaseTemplateIT.java
@@ -305,9 +305,9 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
         Container.ExecResult execResult = container.executeJob("/redis-to-redis-expire.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
         Assertions.assertEquals(100, jedis.llen("key_list"));
-        // Clear data to prevent data duplication in the next TestContainer
-        Thread.sleep(60 * 1000);
-        Assertions.assertEquals(0, jedis.llen("key_list"));
+        await().atMost(90, TimeUnit.SECONDS)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(0, jedis.llen("key_list")));
     }
 
     @TestTemplate
@@ -689,19 +689,26 @@ public abstract class RedisTestCaseTemplateIT extends TestSuiteBase implements T
     @DisabledOnOs(OS.WINDOWS)
     public void testFakeToRedisInRealTimeTest(TestContainer container)
             throws IOException, InterruptedException {
-        CompletableFuture.supplyAsync(
-                () -> {
-                    try {
-                        container.executeJob("/fake-to-redis-test-in-real-time.conf");
-                    } catch (Exception e) {
-                        log.error("Commit task exception :" + e.getMessage());
-                        throw new RuntimeException(e);
-                    }
-                    return null;
-                });
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        CompletableFuture<Void> jobFuture =
+                CompletableFuture.supplyAsync(
+                                () -> {
+                                    try {
+                                        container.executeJob(
+                                                "/fake-to-redis-test-in-real-time.conf");
+                                    } catch (Exception e) {
+                                        log.error("Streaming job execution failed", e);
+                                        throw new RuntimeException(e);
+                                    }
+                                    return null;
+                                })
+                        .thenAccept(v -> {});
+        await().atMost(120, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
+                            Assertions.assertFalse(
+                                    jobFuture.isCompletedExceptionally(),
+                                    "Streaming job failed unexpectedly");
                             Assertions.assertEquals(3, jedis.llen("list_check"));
                         });
         jedis.del("list_check");


### PR DESCRIPTION
### Purpose of this pull request

Fix Redis E2E flaky tests (`RedisClusterIT`, `RedisTestCaseTemplateIT`) — multiple issues across resource management, cluster readiness, timing, and assertions causing intermittent CI failures.

**Resource issues:**
- Add `@ResourceLock("redis-standalone-e2e")` to `Redis5IT` / `Redis7IT` to prevent parallel execution conflicts on shared Docker network alias `redis-e2e`
- Add `@ResourceLock("redis-cluster-e2e")` to `RedisClusterIT` and `@ResourceLock("redis-master-slave-e2e")` to `RedisMasterAndSlaveIT` to prevent port conflicts on fixed host bindings

**Cluster setup issues:**
- Fix container network alias mismatch: Java code created 1-based aliases (`redis-cluster-1/2/3`) while config files referenced 0-based (`redis-cluster-0/1/2`); aligned to 0-based
- Replace fragile `getHostIpAddress()` (manual `NetworkInterface` enumeration, last-match-wins) with `getDockerHostIp()` using Testcontainers `GenericContainer.getHost()` API
- Replace PING-only cluster readiness check with `CLUSTER INFO` polling — now verifies `cluster_state:ok` and `cluster_slots_ok:16384` (full slot coverage), with 30 retries × 2s interval
- Remove `Thread.sleep(5000)` after `redis-cli --cluster create`; cluster readiness is fully covered by the `CLUSTER INFO` polling loop

**Assertion issues:**
- Fix `testRedisClusterScan` finally block: used `llen` (LIST command) to verify deletion of a SET-type key `key_set`; replaced with `exists` (type-agnostic) to avoid `WRONGTYPE` exception masking `del` failures

**Timing issues:**
- Replace `Thread.sleep(60_000)` in `testRedisWithExpire` with `Awaitility.await()` polling (90s atMost, 3s pollInterval) to check `jedis.llen("key_list") == 0` after TTL expiry
- Fix `testFakeToRedisInRealTimeTest` async race: retain `CompletableFuture` reference and check `isCompletedExceptionally()` in the Awaitility assertion; increase timeout from 60s to 120s with 2s poll interval

### Does this PR introduce _any_ user-facing change?

No. Test-only changes.

### How was this patch tested?

```bash
./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-redis-e2e -DskipUT -DskipIT=false verify
```
