### PR TITLE
[Bug][Connector-V2] Fix MongoDB reader cursor cleanup

### DIFF
--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReader.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReader.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.mongodb.source.reader;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -150,7 +148,10 @@ public class MongodbReader implements SourceReader<SeaTunnelRow, MongoSplit> {
     public void notifyCheckpointComplete(long checkpointId) {}
 
     private void closeCurrentSplit() {
-        Preconditions.checkNotNull(cursor);
+        if (cursor == null) {
+            // Preserve the original cursor-creation failure from pollNext().
+            return;
+        }
         cursor.close();
         cursor = null;
     }

--- a/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReaderTest.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReaderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.mongodb.source.reader;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.internal.MongodbClientProvider;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.serde.DocumentDeserializer;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.source.config.MongodbReadOptions;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.source.split.MongoSplit;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerCursor;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MongodbReaderTest {
+
+    @Test
+    void pollNextPreservesOriginalCursorCreationException() {
+        RuntimeException cursorCreationFailure = new RuntimeException("cursor creation failed");
+        MongodbClientProvider clientProvider = mock(MongodbClientProvider.class);
+        when(clientProvider.getDefaultCollection()).thenThrow(cursorCreationFailure);
+
+        SourceReader.Context context = mock(SourceReader.Context.class);
+        DocumentDeserializer<SeaTunnelRow> deserializer = mock(DocumentDeserializer.class);
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+
+        MongodbReader reader =
+                new MongodbReader(
+                        context,
+                        clientProvider,
+                        deserializer,
+                        MongodbReadOptions.builder().build());
+        reader.addSplits(
+                Collections.singletonList(
+                        new MongoSplit("split-1", new BsonDocument(), new BsonDocument(), 0L)));
+
+        RuntimeException actual =
+                assertThrows(RuntimeException.class, () -> reader.pollNext(collector));
+
+        assertSame(cursorCreationFailure, actual);
+    }
+
+    @Test
+    void pollNextClosesCursorWhenDeserializationFails() {
+        RuntimeException deserializationFailure = new RuntimeException("deserialization failed");
+        MongodbClientProvider clientProvider = mock(MongodbClientProvider.class);
+        MongoCollection<BsonDocument> collection = mock(MongoCollection.class);
+        FindIterable<BsonDocument> iterable = mock(FindIterable.class);
+        AtomicBoolean cursorClosed = new AtomicBoolean();
+        MongoCursor<BsonDocument> cursor =
+                new MongoCursor<BsonDocument>() {
+                    private boolean consumed;
+
+                    @Override
+                    public void close() {
+                        cursorClosed.set(true);
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return !consumed;
+                    }
+
+                    @Override
+                    public BsonDocument next() {
+                        consumed = true;
+                        return new BsonDocument();
+                    }
+
+                    @Override
+                    public int available() {
+                        return hasNext() ? 1 : 0;
+                    }
+
+                    @Override
+                    public BsonDocument tryNext() {
+                        return hasNext() ? next() : null;
+                    }
+
+                    @Override
+                    public ServerCursor getServerCursor() {
+                        return null;
+                    }
+
+                    @Override
+                    public ServerAddress getServerAddress() {
+                        return null;
+                    }
+                };
+
+        when(clientProvider.getDefaultCollection()).thenReturn(collection);
+        when(collection.find(any(BsonDocument.class))).thenReturn(iterable);
+        when(iterable.projection(any(BsonDocument.class))).thenReturn(iterable);
+        when(iterable.batchSize(anyInt())).thenReturn(iterable);
+        when(iterable.noCursorTimeout(anyBoolean())).thenReturn(iterable);
+        when(iterable.maxTime(anyLong(), any(TimeUnit.class))).thenReturn(iterable);
+        when(iterable.iterator()).thenReturn(cursor);
+
+        SourceReader.Context context = mock(SourceReader.Context.class);
+        DocumentDeserializer<SeaTunnelRow> deserializer = mock(DocumentDeserializer.class);
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+        when(deserializer.deserialize(any(BsonDocument.class))).thenThrow(deserializationFailure);
+
+        MongodbReader reader =
+                new MongodbReader(
+                        context,
+                        clientProvider,
+                        deserializer,
+                        MongodbReadOptions.builder().build());
+        reader.addSplits(
+                Collections.singletonList(
+                        new MongoSplit("split-1", new BsonDocument(), new BsonDocument(), 0L)));
+
+        RuntimeException actual =
+                assertThrows(RuntimeException.class, () -> reader.pollNext(collector));
+
+        assertSame(deserializationFailure, actual);
+        assertTrue(cursorClosed.get());
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10999.

This PR prevents `MongodbReader.closeCurrentSplit()` from masking the original MongoDB cursor creation failure with a cleanup-path `NullPointerException`.

When `getCursor(currentSplit)` fails before assigning `cursor`, `pollNext()` still runs `closeCurrentSplit()` in the `finally` block. The previous `Preconditions.checkNotNull(cursor)` could throw a new `NullPointerException` and hide the real MongoDB connection, auth, or query error. The cleanup path now returns when no cursor exists and preserves the original failure.

### Does this PR introduce _any_ user-facing change?

Yes.

When MongoDB cursor creation fails, users should now see the original MongoDB connector failure instead of a misleading cleanup `NullPointerException`.

There is no connector option, API, packaging, or documented configuration change.

### How was this patch tested?

Added unit coverage in `MongodbReaderTest`:

- `pollNextPreservesOriginalCursorCreationException()` verifies the original cursor creation exception is preserved.
- `pollNextClosesCursorWhenDeserializationFails()` verifies an already-created cursor is still closed when downstream deserialization fails.

Local verification:

```bash
./mvnw -pl seatunnel-connectors-v2/connector-mongodb -DskipITs -DskipIT -DskipE2E -DskipTests=false -DfailIfNoTests=false -Dtest=MongodbReaderTest test
./mvnw -pl seatunnel-connectors-v2/connector-mongodb -DskipITs -DskipIT -DskipE2E -DskipTests=false -DfailIfNoTests=false test
./mvnw -pl seatunnel-connectors-v2/connector-mongodb spotless:check
git diff --check
```

Results:

- Targeted reader tests: 2 passed.
- MongoDB connector module tests: 12 passed.
- Spotless: passed.
- Diff whitespace check: passed.

### Check list

* [x] No new Jar binary package is added by this PR.
* [x] Documentation update is not necessary because this is an internal bug fix with no connector option or usage change.
* [x] `incompatible-changes.md` update is not necessary because this does not introduce an incompatibility.
* [x] Existing connector metadata, distribution POM, label scope, E2E, and plugin config updates are not necessary because this fixes an existing MongoDB connector reader cleanup path and does not add a new connector or packaging surface.
