### PR TITLE
[Fix][Connector-V2][CDC-MySQL] Honor int_type_narrowing option on MyS…

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
@@ -87,6 +87,12 @@ public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
         // but it'll cause lose of precise when the value is larger than 2^63,
         // so use "precise" mode to avoid it.
         props.put("bigint.unsigned.handling.mode", "precise");
+        // default int_type_narrowing (tinyint(1) -> boolean); the Source / user debezium block
+        // overrides this via the dbzProperties merge below so MySqlTypeUtils can honor a false.
+        // Carried as a property, NOT a field, on purpose: adding a field/method to this
+        // Serializable factory drifts its serialVersionUID and breaks rolling upgrades (jobs
+        // submitted on the prior version fail to deserialize on the new one).
+        props.setProperty("int_type_narrowing", String.valueOf(true));
 
         if (serverIdRange != null) {
             props.setProperty("database.server.id.range", String.valueOf(serverIdRange));

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/MySqlIncrementalSource.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/MySqlIncrementalSource.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -85,6 +86,18 @@ public class MySqlIncrementalSource<T> extends IncrementalSource<T, JdbcSourceCo
         MySqlSourceConfigFactory configFactory = new MySqlSourceConfigFactory();
         configFactory.serverId(config.get(JdbcSourceOptions.SERVER_ID));
         configFactory.fromReadonlyConfig(readonlyConfig);
+        // Carry int_type_narrowing through the debezium properties map rather than a factory field.
+        // Adding a field/method to the Serializable MySqlSourceConfigFactory drifts its
+        // serialVersionUID and breaks rolling upgrades (jobs submitted on the prior version fail to
+        // deserialize). This runs after fromReadonlyConfig (which resets dbzProperties from the
+        // user
+        // debezium block), re-merging those user props then appending int_type_narrowing.
+        Properties dbzProperties = new Properties();
+        config.getOptional(JdbcSourceOptions.DEBEZIUM_PROPERTIES).ifPresent(dbzProperties::putAll);
+        dbzProperties.setProperty(
+                "int_type_narrowing",
+                String.valueOf(config.get(JdbcCommonOptions.INT_TYPE_NARROWING)));
+        configFactory.debeziumProperties(dbzProperties);
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(config.get(JdbcCommonOptions.URL));
         configFactory.originUrl(urlInfo.getOrigin());
         configFactory.hostname(urlInfo.getHost());

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/utils/MySqlTypeUtils.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/utils/MySqlTypeUtils.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.connectors.seatunnel.common.source.TypeDefineUtils;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql.MySqlTypeConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql.MySqlVersion;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.DefaultValueUtils;
 
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -35,6 +36,14 @@ import java.util.Optional;
 /** Utilities for converting from MySQL types to SeaTunnel types. */
 @Slf4j
 public class MySqlTypeUtils {
+
+    /**
+     * Converter used when {@code int_type_narrowing=false}: identical to {@link
+     * MySqlTypeConverter#DEFAULT_INSTANCE} except narrowing is off, so {@code tinyint(1)} stays
+     * TINYINT (byte) instead of becoming BOOLEAN. Pre-built singleton (no per-column allocation).
+     */
+    private static final MySqlTypeConverter NO_INT_NARROWING_CONVERTER =
+            new MySqlTypeConverter(MySqlVersion.V_5_7, false);
 
     public static SeaTunnelDataType<?> convertFromColumn(
             Column column, RelationalDatabaseConnectorConfig dbzConnectorConfig) {
@@ -133,9 +142,23 @@ public class MySqlTypeUtils {
                     builder.scale(column.length());
                 }
                 break;
+            case "TINYINT":
+                // Debezium reports the bare type name "TINYINT", but the narrowing rule in
+                // MySqlTypeConverter checks columnType.equalsIgnoreCase("tinyint(1)"). Re-append
+                // the length so tinyint(1) is detectable on the CDC path; otherwise it can never
+                // be narrowed (or kept) according to int_type_narrowing.
+                if (column.length() > 0) {
+                    builder.columnType(String.format("TINYINT(%s)", column.length()));
+                }
+                break;
             default:
                 break;
         }
-        return MySqlTypeConverter.DEFAULT_INSTANCE.convert(builder.build());
+        // Honor the int_type_narrowing source option (carried via the Debezium properties).
+        // Default true keeps the original DEFAULT_INSTANCE behavior byte-for-byte.
+        boolean intTypeNarrowing =
+                dbzConnectorConfig.getConfig().getBoolean("int_type_narrowing", true);
+        return (intTypeNarrowing ? MySqlTypeConverter.DEFAULT_INSTANCE : NO_INT_NARROWING_CONVERTER)
+                .convert(builder.build());
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactorySerializationTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactorySerializationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config;
+
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfigFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+/**
+ * {@link MySqlSourceConfigFactory} is part of the serialized job graph (it is shipped to task
+ * executors and persisted with the pipeline). It does not declare an explicit {@code
+ * serialVersionUID}, so the JVM computes it from the class structure — including non-transient
+ * fields and non-private methods. Adding either changes the UID, which makes jobs submitted on a
+ * previous version fail to deserialize on a new one during a rolling upgrade ({@code
+ * InvalidClassException}).
+ *
+ * <p>That is why this connector carries {@code int_type_narrowing} through the inherited debezium
+ * properties map instead of adding a dedicated field/builder method. These tests guard that
+ * decision: the option must survive serialization, and the class structure (hence UID) must stay
+ * stable.
+ */
+class MySqlSourceConfigFactorySerializationTest {
+
+    /** Baseline computed UID of the factory's structure. Must not drift (see class javadoc). */
+    private static final long BASELINE_SERIAL_VERSION_UID = -6578851046816898665L;
+
+    @Test
+    void serialVersionUidMustNotDrift() {
+        long actual =
+                ObjectStreamClass.lookup(MySqlSourceConfigFactory.class).getSerialVersionUID();
+        Assertions.assertEquals(
+                BASELINE_SERIAL_VERSION_UID,
+                actual,
+                "MySqlSourceConfigFactory serialVersionUID drifted ("
+                        + BASELINE_SERIAL_VERSION_UID
+                        + " -> "
+                        + actual
+                        + "). Adding fields/non-private methods to this serialized factory breaks "
+                        + "rolling upgrades. Route new options through the dbzProperties map.");
+    }
+
+    @Test
+    void intTypeNarrowingSurvivesSerializationViaDbzProperties() throws Exception {
+        MySqlSourceConfigFactory factory = new MySqlSourceConfigFactory();
+        Properties dbz = new Properties();
+        dbz.setProperty("int_type_narrowing", "false");
+        factory.debeziumProperties(dbz);
+
+        MySqlSourceConfigFactory restored = roundTrip(factory);
+
+        Field f = JdbcSourceConfigFactory.class.getDeclaredField("dbzProperties");
+        f.setAccessible(true);
+        Properties restoredProps = (Properties) f.get(restored);
+        Assertions.assertEquals("false", restoredProps.getProperty("int_type_narrowing"));
+    }
+
+    private static MySqlSourceConfigFactory roundTrip(MySqlSourceConfigFactory factory)
+            throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(factory);
+        }
+        try (ObjectInputStream ois =
+                new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+            return (MySqlSourceConfigFactory) ois.readObject();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/utils/MySqlTypeUtilsIntTypeNarrowingTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/utils/MySqlTypeUtilsIntTypeNarrowingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.mysql.utils;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.relational.Column;
+
+/**
+ * Verifies that the documented {@code int_type_narrowing} option is honored on the MySQL-CDC path.
+ *
+ * <p>Previously {@code MySqlTypeUtils.convertToSeaTunnelColumn} always used {@link
+ * org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql.MySqlTypeConverter#DEFAULT_INSTANCE}
+ * (narrowing=true), so {@code tinyint(1)} was always mapped to BOOLEAN regardless of the option
+ * documented for the MySQL-CDC source. The value is now carried through the Debezium properties and
+ * applied: {@code false} keeps {@code tinyint(1)} as TINYINT (BYTE), {@code true} (and the default)
+ * narrows it to BOOLEAN.
+ */
+public class MySqlTypeUtilsIntTypeNarrowingTest {
+
+    private static MySqlConnectorConfig config(Boolean intTypeNarrowing) {
+        Configuration.Builder builder =
+                Configuration.create()
+                        .with(MySqlConnectorConfig.SERVER_NAME, "test_server")
+                        .with(MySqlConnectorConfig.HOSTNAME, "localhost")
+                        .with(MySqlConnectorConfig.USER, "test")
+                        .with(MySqlConnectorConfig.PASSWORD, "test");
+        if (intTypeNarrowing != null) {
+            builder.with("int_type_narrowing", String.valueOf(intTypeNarrowing));
+        }
+        return new MySqlConnectorConfig(builder.build());
+    }
+
+    private static Column tinyint1() {
+        return Column.editor()
+                .name("flag")
+                .type("TINYINT", "TINYINT")
+                .jdbcType(java.sql.Types.TINYINT)
+                .length(1)
+                .optional(true)
+                .create();
+    }
+
+    @Test
+    void tinyint1NarrowsToBooleanWhenEnabled() {
+        Assertions.assertEquals(
+                BasicType.BOOLEAN_TYPE,
+                MySqlTypeUtils.convertToSeaTunnelColumn(tinyint1(), config(true)).getDataType());
+    }
+
+    @Test
+    void tinyint1StaysTinyintWhenDisabled() {
+        Assertions.assertEquals(
+                BasicType.BYTE_TYPE,
+                MySqlTypeUtils.convertToSeaTunnelColumn(tinyint1(), config(false)).getDataType());
+    }
+
+    @Test
+    void defaultsToNarrowingWhenAbsent() {
+        Assertions.assertEquals(
+                BasicType.BOOLEAN_TYPE,
+                MySqlTypeUtils.convertToSeaTunnelColumn(tinyint1(), config(null)).getDataType());
+    }
+}


### PR DESCRIPTION
…QL-CDC source

The `int_type_narrowing` option is documented for the MySQL-CDC source (including a `false` example) and declared in MySqlIncrementalSourceFactory's option rule, but it had no effect on the CDC path, for two reasons:

1. MySqlTypeUtils built the column type from Debezium's bare type name ("TINYINT") and never re-appended the length, so MySqlTypeConverter's narrowing check (columnType.equalsIgnoreCase("tinyint(1)")) never matched — tinyint(1) could not be detected on the CDC path.
2. convertToSeaTunnelColumn always used MySqlTypeConverter.DEFAULT_INSTANCE (narrowing = true), ignoring the configured value.

This change:
- re-appends the length for TINYINT so tinyint(1) is detectable; and
- carries int_type_narrowing through the Debezium properties and selects the converter: true (default) -> tinyint(1) narrows to BOOLEAN (matching the JDBC source and the documented default); false -> tinyint(1) stays TINYINT (Byte).

Adds MySqlTypeUtilsIntTypeNarrowingTest covering true / false / default.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
