### PR TITLE
[Fix][Connector-V2] Respect Paimon alter table ignore flag

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalog.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalog.java
@@ -358,9 +358,12 @@ public class PaimonCatalog implements Catalog, PaimonTable {
     public void alterTable(
             Identifier identifier, SchemaChange schemaChange, boolean ignoreIfNotExists) {
         try {
-            catalog.alterTable(identifier, schemaChange, true);
+            catalog.alterTable(identifier, schemaChange, ignoreIfNotExists);
         } catch (org.apache.paimon.catalog.Catalog.TableNotExistException e) {
-            throw new CatalogException("TableNotExistException: {}", e);
+            throw new TableNotExistException(
+                    this.catalogName,
+                    TablePath.of(identifier.getDatabaseName(), identifier.getTableName()),
+                    e);
         } catch (org.apache.paimon.catalog.Catalog.ColumnAlreadyExistException e) {
             throw new CatalogException("ColumnAlreadyExistException: {}", e);
         } catch (org.apache.paimon.catalog.Catalog.ColumnNotExistException e) {
@@ -371,9 +374,12 @@ public class PaimonCatalog implements Catalog, PaimonTable {
     public void alterTable(
             Identifier identifier, List<SchemaChange> schemaChanges, boolean ignoreIfNotExists) {
         try {
-            catalog.alterTable(identifier, schemaChanges, true);
+            catalog.alterTable(identifier, schemaChanges, ignoreIfNotExists);
         } catch (org.apache.paimon.catalog.Catalog.TableNotExistException e) {
-            throw new CatalogException("TableNotExistException: {}", e);
+            throw new TableNotExistException(
+                    this.catalogName,
+                    TablePath.of(identifier.getDatabaseName(), identifier.getTableName()),
+                    e);
         } catch (org.apache.paimon.catalog.Catalog.ColumnAlreadyExistException e) {
             throw new CatalogException("ColumnAlreadyExistException: {}", e);
         } catch (org.apache.paimon.catalog.Catalog.ColumnNotExistException e) {

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogTest.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.catalog.PrimaryKey;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.catalog.exception.TableNotExistException;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.DecimalType;
@@ -31,6 +32,10 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.MapType;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -41,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -253,6 +259,27 @@ public class PaimonCatalogTest {
                         throw e;
                     }
                 });
+    }
+
+    @Test
+    public void alterTableShouldRespectIgnoreIfNotExists() {
+        Identifier identifier = Identifier.create(DATABASE_NAME, "missing_table");
+        SchemaChange change = SchemaChange.addColumn("new_column", DataTypes.STRING());
+
+        Assertions.assertThrows(
+                TableNotExistException.class,
+                () -> paimonCatalog.alterTable(identifier, change, false));
+        Assertions.assertDoesNotThrow(() -> paimonCatalog.alterTable(identifier, change, true));
+
+        Assertions.assertThrows(
+                TableNotExistException.class,
+                () ->
+                        paimonCatalog.alterTable(
+                                identifier, Collections.singletonList(change), false));
+        Assertions.assertDoesNotThrow(
+                () ->
+                        paimonCatalog.alterTable(
+                                identifier, Collections.singletonList(change), true));
     }
 
     @AfterEach


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

 The Paimon catalog wrapper ignored the `ignoreIfNotExists` argument in both `alterTable` overloads and always passed `true` to the underlying Paimon catalog. As a result, alter table operations that should fail when the target table does not exist were silently ignored.

This PR passes `ignoreIfNotExists` through correctly and maps Paimon table-not-found errors to SeaTunnel `TableNotExistException`.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

Yes. Paimon alter table operations with `ignoreIfNotExists = false` now fail when the target table does not exist, instead of being silently ignored.


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

Added unit coverage for both single `SchemaChange` and list-based `alterTable` overloads.

Ran:

  - `./mvnw -pl seatunnel-connectors-v2/connector-paimon -Dtest=PaimonCatalogTest test`
  - `./mvnw -pl seatunnel-connectors-v2/connector-paimon test`
  - `./mvnw -pl seatunnel-connectors-v2/connector-paimon spotless:check`

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
