### PR TITLE
[Docs] Add connector FAQ writing guidelines

### DIFF
--- a/docs/en/developer/contribute-plugin.md
+++ b/docs/en/developer/contribute-plugin.md
@@ -2,6 +2,21 @@
 
 If you want to contribute Connector-V2, use the internal docs below as the main entry path, then read the repository guide for module-level details.
 
+## Writing Connector FAQ Sections
+
+When you add or update connector FAQ sections, treat them as a navigation layer, not a second
+source of truth.
+
+- Keep exact option names, defaults, and full behavior details in the connector option table and
+  detailed sections.
+- In FAQ answers, prefer short answers plus links or explicit pointers to the existing sections on
+  the same page.
+- If a FAQ mentions a connector option, verify the spelling and behavior against the current
+  connector doc and code before merging.
+- If a point depends on passthrough properties or upstream system behavior, label it explicitly
+  instead of presenting it as a standard SeaTunnel connector option.
+- Keep English and Chinese FAQ scope aligned.
+
 - [Contribution Path](./contribution-path.md)
 - [How to Create Your Connector](./how-to-create-your-connector.md)
 - [Source Connector Development](./source-connector-development.md)

--- a/docs/zh/developer/contribute-plugin.md
+++ b/docs/zh/developer/contribute-plugin.md
@@ -2,6 +2,16 @@
 
 如果你想贡献 Connector-V2，建议优先沿着站内文档入口进入，再结合仓库中的 Connector-V2 指南查看模块级细节。
 
+## 编写 Connector FAQ 的要求
+
+新增或更新 connector FAQ 时，应把 FAQ 当作“导航层”，而不是另一套独立事实源。
+
+- 精确的配置项名称、默认值和完整行为说明，应保留在 connector 的 option 表和详细章节中。
+- FAQ 答案优先写成“短答 + 指向现有章节”，不要在 FAQ 中再复制一套完整配置矩阵。
+- 只要 FAQ 提到 connector 配置项，合入前就必须对照当前 connector 文档和源码核对拼写与语义。
+- 如果某个结论依赖 passthrough 属性或上游数据库 / 消息系统本身的行为，必须明确标注，不能把它包装成 SeaTunnel 标准 connector 配置项。
+- 英文和中文 FAQ 的覆盖范围应保持一致。
+
 - [贡献路径](./contribution-path.md)
 - [开发自己的 Connector](./how-to-create-your-connector.md)
 - [Source Connector 开发指南](./source-connector-development.md)


### PR DESCRIPTION
## What This PR Does
- Add a small contributor guideline for writing connector FAQ sections.
- Clarify that FAQ should stay a navigation layer instead of becoming a second source of truth.
- Require contributors to verify option names and behavior against the current connector docs and code.

## Why
Recent connector FAQ work showed that FAQ sections can easily drift from existing option tables and detailed docs. This PR makes the expected writing pattern explicit for future connector doc updates.

## Validation
- `./mvnw spotless:apply`
- `npx -y markdown-link-check -c .dlc.json -q docs/en/developer/contribute-plugin.md docs/zh/developer/contribute-plugin.md`
- `./mvnw -B -T 1 clean test -D"license.skipAddThirdParty"=true -pl seatunnel-ci-tools -Dtest=AllFileSpecificationCheckTest -DfailIfNoTests=false --no-snapshot-updates`

## Scope
- `docs/en/developer/contribute-plugin.md`
- `docs/zh/developer/contribute-plugin.md`
