### PR TITLE
[Feature][Connector-Fake] Migrate validation to OptionRule

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/OptionRule.java
@@ -373,6 +373,17 @@ public class OptionRule {
         }
 
         /**
+         * Adds value constraints for options that are already registered by another rule, such as
+         * an exclusive option.
+         */
+        public Builder valueConstraint(
+                @NonNull Condition<?> condition1, @NonNull Condition<?>... conditions) {
+            this.valueConstraints.add(condition1);
+            Collections.addAll(this.valueConstraints, conditions);
+            return this;
+        }
+
+        /**
          * Conditional value constraints: when {@code conditionalOption == expectValue}, the given
          * conditions must hold.
          */

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionRuleTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/OptionRuleTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.seatunnel.api.configuration.OptionTest.TEST_MODE;
@@ -374,6 +375,43 @@ public class OptionRuleTest {
         assertEquals(1, extRule.getValueConstraints().size());
         assertEquals(
                 ConditionOperator.EXTENSION, extRule.getValueConstraints().get(0).getOperator());
+
+        ConditionExtension<String> topicPatternExt =
+                new ConditionExtension<String>() {
+                    @Override
+                    public String description() {
+                        return "must start with topic-";
+                    }
+
+                    @Override
+                    public boolean evaluate(ReadonlyConfig config, String value) {
+                        return value != null && value.startsWith("topic-");
+                    }
+                };
+        OptionRule exclusiveExtRule =
+                OptionRule.builder()
+                        .exclusive(TEST_TOPIC_PATTERN, TEST_TOPIC)
+                        .valueConstraint(Conditions.extension(TEST_TOPIC_PATTERN, topicPatternExt))
+                        .build();
+        assertEquals(1, exclusiveExtRule.getValueConstraints().size());
+        assertEquals(
+                ConditionOperator.EXTENSION,
+                exclusiveExtRule.getValueConstraints().get(0).getOperator());
+        assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(
+                                        ReadonlyConfig.fromMap(
+                                                Collections.singletonMap(
+                                                        TEST_TOPIC_PATTERN.key(), "invalid")))
+                                .validate(exclusiveExtRule));
+        assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(
+                                        ReadonlyConfig.fromMap(
+                                                Collections.singletonMap(
+                                                        TEST_TOPIC_PATTERN.key(), "topic-valid")))
+                                .validate(exclusiveExtRule));
 
         // test extension with null extension throws
         assertThrows(IllegalArgumentException.class, () -> Conditions.extension(TEST_NUM, null));

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
@@ -20,9 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.fake.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
-import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.common.utils.JsonUtils;
-import org.apache.seatunnel.connectors.seatunnel.fake.exception.FakeConnectorException;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -218,243 +216,20 @@ public class FakeConfig implements Serializable {
         readonlyConfig.getOptional(AUTO_INCREMENT_ENABLED).ifPresent(builder::autoIncrementEnabled);
         readonlyConfig.getOptional(AUTO_INCREMENT_START).ifPresent(builder::autoIncrementStart);
 
-        readonlyConfig
-                .getOptional(TINYINT_MIN)
-                .ifPresent(
-                        tinyintMin -> {
-                            if (tinyintMin < TINYINT_MIN.defaultValue()
-                                    || tinyintMin > TINYINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        TINYINT_MIN.key()
-                                                + " should >= "
-                                                + TINYINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + TINYINT_MAX.defaultValue());
-                            }
-                            builder.tinyintMin(tinyintMin);
-                        });
-
-        readonlyConfig
-                .getOptional(TINYINT_MAX)
-                .ifPresent(
-                        tinyintMax -> {
-                            if (tinyintMax < TINYINT_MIN.defaultValue()
-                                    || tinyintMax > TINYINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        TINYINT_MAX.key()
-                                                + " should >= "
-                                                + TINYINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + TINYINT_MAX.defaultValue());
-                            }
-                            builder.tinyintMax(tinyintMax);
-                        });
-
-        readonlyConfig
-                .getOptional(SMALLINT_MIN)
-                .ifPresent(
-                        smallintMin -> {
-                            if (smallintMin < SMALLINT_MIN.defaultValue()
-                                    || smallintMin > SMALLINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        SMALLINT_MIN.key()
-                                                + " should >= "
-                                                + SMALLINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + SMALLINT_MAX.defaultValue());
-                            }
-                            builder.smallintMin(smallintMin);
-                        });
-
-        readonlyConfig
-                .getOptional(SMALLINT_MAX)
-                .ifPresent(
-                        smallintMax -> {
-                            if (smallintMax < SMALLINT_MIN.defaultValue()
-                                    || smallintMax > SMALLINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        SMALLINT_MAX.key()
-                                                + " should >= "
-                                                + SMALLINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + SMALLINT_MAX.defaultValue());
-                            }
-                            builder.smallintMax(smallintMax);
-                        });
-
-        readonlyConfig
-                .getOptional(INT_MIN)
-                .ifPresent(
-                        intMin -> {
-                            if (intMin < INT_MIN.defaultValue()
-                                    || intMin > INT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        INT_MIN.key()
-                                                + " should >= "
-                                                + INT_MIN.defaultValue()
-                                                + " and <= "
-                                                + INT_MAX.defaultValue());
-                            }
-                            builder.intMin(intMin);
-                        });
-
-        readonlyConfig
-                .getOptional(INT_MAX)
-                .ifPresent(
-                        intMax -> {
-                            if (intMax < INT_MIN.defaultValue()
-                                    || intMax > INT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        INT_MAX.key()
-                                                + " should >= "
-                                                + INT_MIN.defaultValue()
-                                                + " and <= "
-                                                + INT_MAX.defaultValue());
-                            }
-                            builder.intMax(intMax);
-                        });
-
-        readonlyConfig
-                .getOptional(BIGINT_MIN)
-                .ifPresent(
-                        bigintMin -> {
-                            if (bigintMin < BIGINT_MIN.defaultValue()
-                                    || bigintMin > BIGINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        BIGINT_MIN.key()
-                                                + " should >= "
-                                                + BIGINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + BIGINT_MAX.defaultValue());
-                            }
-                            builder.bigintMin(bigintMin);
-                        });
-
-        readonlyConfig
-                .getOptional(BIGINT_MAX)
-                .ifPresent(
-                        bigintMax -> {
-                            if (bigintMax < BIGINT_MIN.defaultValue()
-                                    || bigintMax > BIGINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        BIGINT_MAX.key()
-                                                + " should >= "
-                                                + BIGINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + BIGINT_MAX.defaultValue());
-                            }
-                            builder.bigintMax(bigintMax);
-                        });
-
-        readonlyConfig
-                .getOptional(FLOAT_MIN)
-                .ifPresent(
-                        floatMin -> {
-                            if (floatMin < FLOAT_MIN.defaultValue()
-                                    || floatMin > FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        FLOAT_MIN.key()
-                                                + " should >= "
-                                                + FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + FLOAT_MAX.defaultValue());
-                            }
-                            builder.floatMin(floatMin);
-                        });
-
-        readonlyConfig
-                .getOptional(FLOAT_MAX)
-                .ifPresent(
-                        floatMax -> {
-                            if (floatMax < FLOAT_MIN.defaultValue()
-                                    || floatMax > FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        FLOAT_MAX.key()
-                                                + " should >= "
-                                                + FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + FLOAT_MAX.defaultValue());
-                            }
-                            builder.floatMax(floatMax);
-                        });
-
-        readonlyConfig
-                .getOptional(DOUBLE_MIN)
-                .ifPresent(
-                        doubleMin -> {
-                            if (doubleMin < DOUBLE_MIN.defaultValue()
-                                    || doubleMin > DOUBLE_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        DOUBLE_MIN.key()
-                                                + " should >= "
-                                                + DOUBLE_MIN.defaultValue()
-                                                + " and <= "
-                                                + DOUBLE_MAX.defaultValue());
-                            }
-                            builder.doubleMin(doubleMin);
-                        });
-
-        readonlyConfig
-                .getOptional(DOUBLE_MAX)
-                .ifPresent(
-                        doubleMax -> {
-                            if (doubleMax < DOUBLE_MIN.defaultValue()
-                                    || doubleMax > DOUBLE_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        DOUBLE_MAX.key()
-                                                + " should >= "
-                                                + DOUBLE_MIN.defaultValue()
-                                                + " and <= "
-                                                + DOUBLE_MAX.defaultValue());
-                            }
-                            builder.doubleMax(doubleMax);
-                        });
-
-        readonlyConfig
-                .getOptional(VECTOR_FLOAT_MIN)
-                .ifPresent(
-                        vectorFloatMin -> {
-                            if (vectorFloatMin < VECTOR_FLOAT_MIN.defaultValue()
-                                    || vectorFloatMin > VECTOR_FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        VECTOR_FLOAT_MIN.key()
-                                                + " should >= "
-                                                + VECTOR_FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + VECTOR_FLOAT_MAX.defaultValue());
-                            }
-                            builder.vectorFloatMin(vectorFloatMin);
-                        });
-
-        readonlyConfig
-                .getOptional(VECTOR_FLOAT_MAX)
-                .ifPresent(
-                        vectorFloatMax -> {
-                            if (vectorFloatMax < VECTOR_FLOAT_MIN.defaultValue()
-                                    || vectorFloatMax > VECTOR_FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        VECTOR_FLOAT_MAX.key()
-                                                + " should >= "
-                                                + VECTOR_FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + VECTOR_FLOAT_MAX.defaultValue());
-                            }
-                            builder.vectorFloatMax(vectorFloatMax);
-                        });
+        readonlyConfig.getOptional(TINYINT_MIN).ifPresent(builder::tinyintMin);
+        readonlyConfig.getOptional(TINYINT_MAX).ifPresent(builder::tinyintMax);
+        readonlyConfig.getOptional(SMALLINT_MIN).ifPresent(builder::smallintMin);
+        readonlyConfig.getOptional(SMALLINT_MAX).ifPresent(builder::smallintMax);
+        readonlyConfig.getOptional(INT_MIN).ifPresent(builder::intMin);
+        readonlyConfig.getOptional(INT_MAX).ifPresent(builder::intMax);
+        readonlyConfig.getOptional(BIGINT_MIN).ifPresent(builder::bigintMin);
+        readonlyConfig.getOptional(BIGINT_MAX).ifPresent(builder::bigintMax);
+        readonlyConfig.getOptional(FLOAT_MIN).ifPresent(builder::floatMin);
+        readonlyConfig.getOptional(FLOAT_MAX).ifPresent(builder::floatMax);
+        readonlyConfig.getOptional(DOUBLE_MIN).ifPresent(builder::doubleMin);
+        readonlyConfig.getOptional(DOUBLE_MAX).ifPresent(builder::doubleMax);
+        readonlyConfig.getOptional(VECTOR_FLOAT_MIN).ifPresent(builder::vectorFloatMin);
+        readonlyConfig.getOptional(VECTOR_FLOAT_MAX).ifPresent(builder::vectorFloatMax);
 
         readonlyConfig.getOptional(STRING_FAKE_MODE).ifPresent(builder::stringFakeMode);
         readonlyConfig.getOptional(TINYINT_FAKE_MODE).ifPresent(builder::tinyintFakeMode);

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
@@ -20,9 +20,9 @@ package org.apache.seatunnel.connectors.seatunnel.fake.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
-
+import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.common.utils.JsonUtils;
-
+import org.apache.seatunnel.connectors.seatunnel.fake.exception.FakeConnectorException;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -220,58 +220,241 @@ public class FakeConfig implements Serializable {
 
         readonlyConfig
                 .getOptional(TINYINT_MIN)
-                .ifPresent(builder::tinyintMin);
-
+                .ifPresent(
+                        tinyintMin -> {
+                            if (tinyintMin < TINYINT_MIN.defaultValue()
+                                    || tinyintMin > TINYINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        TINYINT_MIN.key()
+                                                + " should >= "
+                                                + TINYINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + TINYINT_MAX.defaultValue());
+                            }
+                            builder.tinyintMin(tinyintMin);
+                        });
 
         readonlyConfig
                 .getOptional(TINYINT_MAX)
-                .ifPresent(builder::tinyintMax);
+                .ifPresent(
+                        tinyintMax -> {
+                            if (tinyintMax < TINYINT_MIN.defaultValue()
+                                    || tinyintMax > TINYINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        TINYINT_MAX.key()
+                                                + " should >= "
+                                                + TINYINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + TINYINT_MAX.defaultValue());
+                            }
+                            builder.tinyintMax(tinyintMax);
+                        });
 
         readonlyConfig
                 .getOptional(SMALLINT_MIN)
-                .ifPresent(builder::smallintMin);
+                .ifPresent(
+                        smallintMin -> {
+                            if (smallintMin < SMALLINT_MIN.defaultValue()
+                                    || smallintMin > SMALLINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        SMALLINT_MIN.key()
+                                                + " should >= "
+                                                + SMALLINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + SMALLINT_MAX.defaultValue());
+                            }
+                            builder.smallintMin(smallintMin);
+                        });
+
         readonlyConfig
                 .getOptional(SMALLINT_MAX)
-                .ifPresent(builder::smallintMax);
+                .ifPresent(
+                        smallintMax -> {
+                            if (smallintMax < SMALLINT_MIN.defaultValue()
+                                    || smallintMax > SMALLINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        SMALLINT_MAX.key()
+                                                + " should >= "
+                                                + SMALLINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + SMALLINT_MAX.defaultValue());
+                            }
+                            builder.smallintMax(smallintMax);
+                        });
 
         readonlyConfig
                 .getOptional(INT_MIN)
-                .ifPresent(builder::intMin);
+                .ifPresent(
+                        intMin -> {
+                            if (intMin < INT_MIN.defaultValue()
+                                    || intMin > INT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        INT_MIN.key()
+                                                + " should >= "
+                                                + INT_MIN.defaultValue()
+                                                + " and <= "
+                                                + INT_MAX.defaultValue());
+                            }
+                            builder.intMin(intMin);
+                        });
 
         readonlyConfig
                 .getOptional(INT_MAX)
-                .ifPresent(builder::intMax);
+                .ifPresent(
+                        intMax -> {
+                            if (intMax < INT_MIN.defaultValue()
+                                    || intMax > INT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        INT_MAX.key()
+                                                + " should >= "
+                                                + INT_MIN.defaultValue()
+                                                + " and <= "
+                                                + INT_MAX.defaultValue());
+                            }
+                            builder.intMax(intMax);
+                        });
 
         readonlyConfig
                 .getOptional(BIGINT_MIN)
-                .ifPresent(builder::bigintMin);
+                .ifPresent(
+                        bigintMin -> {
+                            if (bigintMin < BIGINT_MIN.defaultValue()
+                                    || bigintMin > BIGINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        BIGINT_MIN.key()
+                                                + " should >= "
+                                                + BIGINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + BIGINT_MAX.defaultValue());
+                            }
+                            builder.bigintMin(bigintMin);
+                        });
 
         readonlyConfig
                 .getOptional(BIGINT_MAX)
-                .ifPresent(builder::bigintMax);
+                .ifPresent(
+                        bigintMax -> {
+                            if (bigintMax < BIGINT_MIN.defaultValue()
+                                    || bigintMax > BIGINT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        BIGINT_MAX.key()
+                                                + " should >= "
+                                                + BIGINT_MIN.defaultValue()
+                                                + " and <= "
+                                                + BIGINT_MAX.defaultValue());
+                            }
+                            builder.bigintMax(bigintMax);
+                        });
 
         readonlyConfig
                 .getOptional(FLOAT_MIN)
-                .ifPresent(builder::floatMin);
+                .ifPresent(
+                        floatMin -> {
+                            if (floatMin < FLOAT_MIN.defaultValue()
+                                    || floatMin > FLOAT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        FLOAT_MIN.key()
+                                                + " should >= "
+                                                + FLOAT_MIN.defaultValue()
+                                                + " and <= "
+                                                + FLOAT_MAX.defaultValue());
+                            }
+                            builder.floatMin(floatMin);
+                        });
 
         readonlyConfig
                 .getOptional(FLOAT_MAX)
-                .ifPresent(builder::floatMax);
+                .ifPresent(
+                        floatMax -> {
+                            if (floatMax < FLOAT_MIN.defaultValue()
+                                    || floatMax > FLOAT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        FLOAT_MAX.key()
+                                                + " should >= "
+                                                + FLOAT_MIN.defaultValue()
+                                                + " and <= "
+                                                + FLOAT_MAX.defaultValue());
+                            }
+                            builder.floatMax(floatMax);
+                        });
 
         readonlyConfig
                 .getOptional(DOUBLE_MIN)
-                .ifPresent(builder::doubleMin);
+                .ifPresent(
+                        doubleMin -> {
+                            if (doubleMin < DOUBLE_MIN.defaultValue()
+                                    || doubleMin > DOUBLE_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        DOUBLE_MIN.key()
+                                                + " should >= "
+                                                + DOUBLE_MIN.defaultValue()
+                                                + " and <= "
+                                                + DOUBLE_MAX.defaultValue());
+                            }
+                            builder.doubleMin(doubleMin);
+                        });
 
         readonlyConfig
                 .getOptional(DOUBLE_MAX)
-                .ifPresent(builder::doubleMax);
+                .ifPresent(
+                        doubleMax -> {
+                            if (doubleMax < DOUBLE_MIN.defaultValue()
+                                    || doubleMax > DOUBLE_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        DOUBLE_MAX.key()
+                                                + " should >= "
+                                                + DOUBLE_MIN.defaultValue()
+                                                + " and <= "
+                                                + DOUBLE_MAX.defaultValue());
+                            }
+                            builder.doubleMax(doubleMax);
+                        });
 
         readonlyConfig
                 .getOptional(VECTOR_FLOAT_MIN)
-                .ifPresent(builder::vectorFloatMin);
+                .ifPresent(
+                        vectorFloatMin -> {
+                            if (vectorFloatMin < VECTOR_FLOAT_MIN.defaultValue()
+                                    || vectorFloatMin > VECTOR_FLOAT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        VECTOR_FLOAT_MIN.key()
+                                                + " should >= "
+                                                + VECTOR_FLOAT_MIN.defaultValue()
+                                                + " and <= "
+                                                + VECTOR_FLOAT_MAX.defaultValue());
+                            }
+                            builder.vectorFloatMin(vectorFloatMin);
+                        });
+
         readonlyConfig
                 .getOptional(VECTOR_FLOAT_MAX)
-                .ifPresent(builder::vectorFloatMax);
+                .ifPresent(
+                        vectorFloatMax -> {
+                            if (vectorFloatMax < VECTOR_FLOAT_MIN.defaultValue()
+                                    || vectorFloatMax > VECTOR_FLOAT_MAX.defaultValue()) {
+                                throw new FakeConnectorException(
+                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                                        VECTOR_FLOAT_MAX.key()
+                                                + " should >= "
+                                                + VECTOR_FLOAT_MIN.defaultValue()
+                                                + " and <= "
+                                                + VECTOR_FLOAT_MAX.defaultValue());
+                            }
+                            builder.vectorFloatMax(vectorFloatMax);
+                        });
 
         readonlyConfig.getOptional(STRING_FAKE_MODE).ifPresent(builder::stringFakeMode);
         readonlyConfig.getOptional(TINYINT_FAKE_MODE).ifPresent(builder::tinyintFakeMode);

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/config/FakeConfig.java
@@ -20,9 +20,9 @@ package org.apache.seatunnel.connectors.seatunnel.fake.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
-import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+
 import org.apache.seatunnel.common.utils.JsonUtils;
-import org.apache.seatunnel.connectors.seatunnel.fake.exception.FakeConnectorException;
+
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -220,241 +220,58 @@ public class FakeConfig implements Serializable {
 
         readonlyConfig
                 .getOptional(TINYINT_MIN)
-                .ifPresent(
-                        tinyintMin -> {
-                            if (tinyintMin < TINYINT_MIN.defaultValue()
-                                    || tinyintMin > TINYINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        TINYINT_MIN.key()
-                                                + " should >= "
-                                                + TINYINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + TINYINT_MAX.defaultValue());
-                            }
-                            builder.tinyintMin(tinyintMin);
-                        });
+                .ifPresent(builder::tinyintMin);
+
 
         readonlyConfig
                 .getOptional(TINYINT_MAX)
-                .ifPresent(
-                        tinyintMax -> {
-                            if (tinyintMax < TINYINT_MIN.defaultValue()
-                                    || tinyintMax > TINYINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        TINYINT_MAX.key()
-                                                + " should >= "
-                                                + TINYINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + TINYINT_MAX.defaultValue());
-                            }
-                            builder.tinyintMax(tinyintMax);
-                        });
+                .ifPresent(builder::tinyintMax);
 
         readonlyConfig
                 .getOptional(SMALLINT_MIN)
-                .ifPresent(
-                        smallintMin -> {
-                            if (smallintMin < SMALLINT_MIN.defaultValue()
-                                    || smallintMin > SMALLINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        SMALLINT_MIN.key()
-                                                + " should >= "
-                                                + SMALLINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + SMALLINT_MAX.defaultValue());
-                            }
-                            builder.smallintMin(smallintMin);
-                        });
-
+                .ifPresent(builder::smallintMin);
         readonlyConfig
                 .getOptional(SMALLINT_MAX)
-                .ifPresent(
-                        smallintMax -> {
-                            if (smallintMax < SMALLINT_MIN.defaultValue()
-                                    || smallintMax > SMALLINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        SMALLINT_MAX.key()
-                                                + " should >= "
-                                                + SMALLINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + SMALLINT_MAX.defaultValue());
-                            }
-                            builder.smallintMax(smallintMax);
-                        });
+                .ifPresent(builder::smallintMax);
 
         readonlyConfig
                 .getOptional(INT_MIN)
-                .ifPresent(
-                        intMin -> {
-                            if (intMin < INT_MIN.defaultValue()
-                                    || intMin > INT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        INT_MIN.key()
-                                                + " should >= "
-                                                + INT_MIN.defaultValue()
-                                                + " and <= "
-                                                + INT_MAX.defaultValue());
-                            }
-                            builder.intMin(intMin);
-                        });
+                .ifPresent(builder::intMin);
 
         readonlyConfig
                 .getOptional(INT_MAX)
-                .ifPresent(
-                        intMax -> {
-                            if (intMax < INT_MIN.defaultValue()
-                                    || intMax > INT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        INT_MAX.key()
-                                                + " should >= "
-                                                + INT_MIN.defaultValue()
-                                                + " and <= "
-                                                + INT_MAX.defaultValue());
-                            }
-                            builder.intMax(intMax);
-                        });
+                .ifPresent(builder::intMax);
 
         readonlyConfig
                 .getOptional(BIGINT_MIN)
-                .ifPresent(
-                        bigintMin -> {
-                            if (bigintMin < BIGINT_MIN.defaultValue()
-                                    || bigintMin > BIGINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        BIGINT_MIN.key()
-                                                + " should >= "
-                                                + BIGINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + BIGINT_MAX.defaultValue());
-                            }
-                            builder.bigintMin(bigintMin);
-                        });
+                .ifPresent(builder::bigintMin);
 
         readonlyConfig
                 .getOptional(BIGINT_MAX)
-                .ifPresent(
-                        bigintMax -> {
-                            if (bigintMax < BIGINT_MIN.defaultValue()
-                                    || bigintMax > BIGINT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        BIGINT_MAX.key()
-                                                + " should >= "
-                                                + BIGINT_MIN.defaultValue()
-                                                + " and <= "
-                                                + BIGINT_MAX.defaultValue());
-                            }
-                            builder.bigintMax(bigintMax);
-                        });
+                .ifPresent(builder::bigintMax);
 
         readonlyConfig
                 .getOptional(FLOAT_MIN)
-                .ifPresent(
-                        floatMin -> {
-                            if (floatMin < FLOAT_MIN.defaultValue()
-                                    || floatMin > FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        FLOAT_MIN.key()
-                                                + " should >= "
-                                                + FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + FLOAT_MAX.defaultValue());
-                            }
-                            builder.floatMin(floatMin);
-                        });
+                .ifPresent(builder::floatMin);
 
         readonlyConfig
                 .getOptional(FLOAT_MAX)
-                .ifPresent(
-                        floatMax -> {
-                            if (floatMax < FLOAT_MIN.defaultValue()
-                                    || floatMax > FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        FLOAT_MAX.key()
-                                                + " should >= "
-                                                + FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + FLOAT_MAX.defaultValue());
-                            }
-                            builder.floatMax(floatMax);
-                        });
+                .ifPresent(builder::floatMax);
 
         readonlyConfig
                 .getOptional(DOUBLE_MIN)
-                .ifPresent(
-                        doubleMin -> {
-                            if (doubleMin < DOUBLE_MIN.defaultValue()
-                                    || doubleMin > DOUBLE_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        DOUBLE_MIN.key()
-                                                + " should >= "
-                                                + DOUBLE_MIN.defaultValue()
-                                                + " and <= "
-                                                + DOUBLE_MAX.defaultValue());
-                            }
-                            builder.doubleMin(doubleMin);
-                        });
+                .ifPresent(builder::doubleMin);
 
         readonlyConfig
                 .getOptional(DOUBLE_MAX)
-                .ifPresent(
-                        doubleMax -> {
-                            if (doubleMax < DOUBLE_MIN.defaultValue()
-                                    || doubleMax > DOUBLE_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        DOUBLE_MAX.key()
-                                                + " should >= "
-                                                + DOUBLE_MIN.defaultValue()
-                                                + " and <= "
-                                                + DOUBLE_MAX.defaultValue());
-                            }
-                            builder.doubleMax(doubleMax);
-                        });
+                .ifPresent(builder::doubleMax);
 
         readonlyConfig
                 .getOptional(VECTOR_FLOAT_MIN)
-                .ifPresent(
-                        vectorFloatMin -> {
-                            if (vectorFloatMin < VECTOR_FLOAT_MIN.defaultValue()
-                                    || vectorFloatMin > VECTOR_FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        VECTOR_FLOAT_MIN.key()
-                                                + " should >= "
-                                                + VECTOR_FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + VECTOR_FLOAT_MAX.defaultValue());
-                            }
-                            builder.vectorFloatMin(vectorFloatMin);
-                        });
-
+                .ifPresent(builder::vectorFloatMin);
         readonlyConfig
                 .getOptional(VECTOR_FLOAT_MAX)
-                .ifPresent(
-                        vectorFloatMax -> {
-                            if (vectorFloatMax < VECTOR_FLOAT_MIN.defaultValue()
-                                    || vectorFloatMax > VECTOR_FLOAT_MAX.defaultValue()) {
-                                throw new FakeConnectorException(
-                                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
-                                        VECTOR_FLOAT_MAX.key()
-                                                + " should >= "
-                                                + VECTOR_FLOAT_MIN.defaultValue()
-                                                + " and <= "
-                                                + VECTOR_FLOAT_MAX.defaultValue());
-                            }
-                            builder.vectorFloatMax(vectorFloatMax);
-                        });
+                .ifPresent(builder::vectorFloatMax);
 
         readonlyConfig.getOptional(STRING_FAKE_MODE).ifPresent(builder::stringFakeMode);
         readonlyConfig.getOptional(TINYINT_FAKE_MODE).ifPresent(builder::tinyintFakeMode);

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
@@ -37,8 +37,12 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterOrEqual;
+import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.ARRAY_SIZE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BINARY_VECTOR_DIMENSION;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BYTES_LENGTH;
@@ -46,15 +50,23 @@ import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOp
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DATE_MONTH_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DATE_YEAR_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.MAP_SIZE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.ROWS;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.ROW_NUM;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SPLIT_NUM;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SPLIT_READ_INTERVAL;
@@ -64,24 +76,12 @@ import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOp
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TIME_MINUTE_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TIME_SECOND_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_FAKE_MODE;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_DIMENSION;
-import static org.apache.seatunnel.api.configuration.util.Conditions.greaterOrEqual;
-import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MIN;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MAX;
-import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_FLOAT_MIN;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_FLOAT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_FLOAT_MIN;
 
 @AutoService(Factory.class)
 public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRunValidation {
@@ -94,7 +94,6 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .exclusive(ConnectorCommonOptions.TABLE_CONFIGS, ConnectorCommonOptions.SCHEMA)
-
                 .optional(
                         STRING_FAKE_MODE,
                         TINYINT_FAKE_MODE,
@@ -118,10 +117,6 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
                         TIME_HOUR_TEMPLATE,
                         TIME_MINUTE_TEMPLATE,
                         TIME_SECOND_TEMPLATE)
-
-
-
-
                 .conditional(STRING_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, STRING_TEMPLATE)
                 .conditional(
                         TINYINT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, TINYINT_TEMPLATE)
@@ -131,121 +126,67 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
                 .conditional(BIGINT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, BIGINT_TEMPLATE)
                 .conditional(FLOAT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, FLOAT_TEMPLATE)
                 .conditional(DOUBLE_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, DOUBLE_TEMPLATE)
-                 .optional(
-                TINYINT_MIN,
-                greaterOrEqual(TINYINT_MIN, TINYINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        TINYINT_MIN,
-                                        TINYINT_MAX.defaultValue())))
-
-                 .optional(
-                TINYINT_MAX,
-                greaterOrEqual(TINYINT_MAX, TINYINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        TINYINT_MAX,
-                                        TINYINT_MAX.defaultValue())))
-
-
                 .optional(
-                SMALLINT_MIN,
-                greaterOrEqual(SMALLINT_MIN, SMALLINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        SMALLINT_MIN,
-                                        SMALLINT_MAX.defaultValue())))
-
-
-                 .optional(
-                SMALLINT_MAX,
-                greaterOrEqual(SMALLINT_MAX, SMALLINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        SMALLINT_MAX,
-                                        SMALLINT_MAX.defaultValue())))
-
-                 .optional(
-                INT_MIN,
-                greaterOrEqual(INT_MIN, INT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        INT_MIN,
-                                        INT_MAX.defaultValue())))
-
-                 .optional(
-                INT_MAX,
-                greaterOrEqual(INT_MAX, INT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        INT_MAX,
-                                        INT_MAX.defaultValue())))
-
-                 .optional(
-                BIGINT_MIN,
-                greaterOrEqual(BIGINT_MIN, BIGINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        BIGINT_MIN,
-                                        BIGINT_MAX.defaultValue())))
-
-                 .optional(
-                BIGINT_MAX,
-                greaterOrEqual(BIGINT_MAX, BIGINT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        BIGINT_MAX,
-                                        BIGINT_MAX.defaultValue())))
-
-                 .optional(
-                FLOAT_MIN,
-                greaterOrEqual(FLOAT_MIN, FLOAT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        FLOAT_MIN,
-                                        FLOAT_MAX.defaultValue())))
-                 .optional(
-                FLOAT_MAX,
-                greaterOrEqual(FLOAT_MAX, FLOAT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        FLOAT_MAX,
-                                        FLOAT_MAX.defaultValue())))
-
-                 .optional(
-                DOUBLE_MIN,
-                greaterOrEqual(DOUBLE_MIN, DOUBLE_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        DOUBLE_MIN,
-                                        DOUBLE_MAX.defaultValue())))
-                 .optional(
-                DOUBLE_MAX,
-                greaterOrEqual(DOUBLE_MAX, DOUBLE_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        DOUBLE_MAX,
-                                        DOUBLE_MAX.defaultValue())))
-
-                 .optional(
-                VECTOR_FLOAT_MIN,
-                greaterOrEqual(VECTOR_FLOAT_MIN, VECTOR_FLOAT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        VECTOR_FLOAT_MIN,
-                                        VECTOR_FLOAT_MAX.defaultValue())))
-                 .optional(
-                VECTOR_FLOAT_MAX,
-                greaterOrEqual(VECTOR_FLOAT_MAX, VECTOR_FLOAT_MIN.defaultValue())
-                        .and(
-                                lessOrEqual(
-                                        VECTOR_FLOAT_MAX,
-                                        VECTOR_FLOAT_MAX.defaultValue())))
-
-
-        .build();
-
-
+                        TINYINT_MIN,
+                        greaterOrEqual(TINYINT_MIN, TINYINT_MIN.defaultValue())
+                                .and(lessOrEqual(TINYINT_MIN, TINYINT_MAX.defaultValue())))
+                .optional(
+                        TINYINT_MAX,
+                        greaterOrEqual(TINYINT_MAX, TINYINT_MIN.defaultValue())
+                                .and(lessOrEqual(TINYINT_MAX, TINYINT_MAX.defaultValue())))
+                .optional(
+                        SMALLINT_MIN,
+                        greaterOrEqual(SMALLINT_MIN, SMALLINT_MIN.defaultValue())
+                                .and(lessOrEqual(SMALLINT_MIN, SMALLINT_MAX.defaultValue())))
+                .optional(
+                        SMALLINT_MAX,
+                        greaterOrEqual(SMALLINT_MAX, SMALLINT_MIN.defaultValue())
+                                .and(lessOrEqual(SMALLINT_MAX, SMALLINT_MAX.defaultValue())))
+                .optional(
+                        INT_MIN,
+                        greaterOrEqual(INT_MIN, INT_MIN.defaultValue())
+                                .and(lessOrEqual(INT_MIN, INT_MAX.defaultValue())))
+                .optional(
+                        INT_MAX,
+                        greaterOrEqual(INT_MAX, INT_MIN.defaultValue())
+                                .and(lessOrEqual(INT_MAX, INT_MAX.defaultValue())))
+                .optional(
+                        BIGINT_MIN,
+                        greaterOrEqual(BIGINT_MIN, BIGINT_MIN.defaultValue())
+                                .and(lessOrEqual(BIGINT_MIN, BIGINT_MAX.defaultValue())))
+                .optional(
+                        BIGINT_MAX,
+                        greaterOrEqual(BIGINT_MAX, BIGINT_MIN.defaultValue())
+                                .and(lessOrEqual(BIGINT_MAX, BIGINT_MAX.defaultValue())))
+                .optional(
+                        FLOAT_MIN,
+                        greaterOrEqual(FLOAT_MIN, FLOAT_MIN.defaultValue())
+                                .and(lessOrEqual(FLOAT_MIN, FLOAT_MAX.defaultValue())))
+                .optional(
+                        FLOAT_MAX,
+                        greaterOrEqual(FLOAT_MAX, FLOAT_MIN.defaultValue())
+                                .and(lessOrEqual(FLOAT_MAX, FLOAT_MAX.defaultValue())))
+                .optional(
+                        DOUBLE_MIN,
+                        greaterOrEqual(DOUBLE_MIN, DOUBLE_MIN.defaultValue())
+                                .and(lessOrEqual(DOUBLE_MIN, DOUBLE_MAX.defaultValue())))
+                .optional(
+                        DOUBLE_MAX,
+                        greaterOrEqual(DOUBLE_MAX, DOUBLE_MIN.defaultValue())
+                                .and(lessOrEqual(DOUBLE_MAX, DOUBLE_MAX.defaultValue())))
+                .optional(
+                        VECTOR_FLOAT_MIN,
+                        greaterOrEqual(VECTOR_FLOAT_MIN, VECTOR_FLOAT_MIN.defaultValue())
+                                .and(
+                                        lessOrEqual(
+                                                VECTOR_FLOAT_MIN, VECTOR_FLOAT_MAX.defaultValue())))
+                .optional(
+                        VECTOR_FLOAT_MAX,
+                        greaterOrEqual(VECTOR_FLOAT_MAX, VECTOR_FLOAT_MIN.defaultValue())
+                                .and(
+                                        lessOrEqual(
+                                                VECTOR_FLOAT_MAX, VECTOR_FLOAT_MAX.defaultValue())))
+                .build();
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.fake.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
@@ -35,8 +39,10 @@ import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.extension;
 import static org.apache.seatunnel.api.configuration.util.Conditions.greaterOrEqual;
 import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.ARRAY_SIZE;
@@ -186,7 +192,48 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
                                 .and(
                                         lessOrEqual(
                                                 VECTOR_FLOAT_MAX, VECTOR_FLOAT_MAX.defaultValue())))
+                .valueConstraint(
+                        extension(
+                                ConnectorCommonOptions.TABLE_CONFIGS,
+                                new TableConfigsValidationExtension()))
                 .build();
+    }
+
+    private static final class TableConfigsValidationExtension
+            implements ConditionExtension<List<Map<String, Object>>> {
+
+        @Override
+        public String description() {
+            return "each tables_configs entry must satisfy the FakeSource option rules";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> tableConfigs)
+                throws OptionValidationException {
+            if (tableConfigs == null) {
+                return true;
+            }
+            OptionRule childRule = new FakeSourceFactory().optionRule();
+            for (int index = 0; index < tableConfigs.size(); index++) {
+                Map<String, Object> childConfig = tableConfigs.get(index);
+                if (childConfig == null) {
+                    throw new OptionValidationException(
+                            "Invalid tables_configs[%s]: child config must not be null", index);
+                }
+                if (childConfig.containsKey(ConnectorCommonOptions.TABLE_CONFIGS.key())) {
+                    throw new OptionValidationException(
+                            "Invalid tables_configs[%s]: nested tables_configs is not supported",
+                            index);
+                }
+                try {
+                    ConfigValidator.of(ReadonlyConfig.fromMap(childConfig)).validate(childRule);
+                } catch (OptionValidationException e) {
+                    throw new OptionValidationException(
+                            "Invalid tables_configs[%s]: %s", index, e.getRawMessage());
+                }
+            }
+            return true;
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-fake/src/main/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeSourceFactory.java
@@ -66,6 +66,22 @@ import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOp
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_FAKE_MODE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_TEMPLATE;
 import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_DIMENSION;
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterOrEqual;
+import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.TINYINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.SMALLINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.INT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.BIGINT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.FLOAT_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.DOUBLE_MAX;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_FLOAT_MIN;
+import static org.apache.seatunnel.connectors.seatunnel.fake.config.FakeSourceOptions.VECTOR_FLOAT_MAX;
 
 @AutoService(Factory.class)
 public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRunValidation {
@@ -78,6 +94,7 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .exclusive(ConnectorCommonOptions.TABLE_CONFIGS, ConnectorCommonOptions.SCHEMA)
+
                 .optional(
                         STRING_FAKE_MODE,
                         TINYINT_FAKE_MODE,
@@ -101,6 +118,10 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
                         TIME_HOUR_TEMPLATE,
                         TIME_MINUTE_TEMPLATE,
                         TIME_SECOND_TEMPLATE)
+
+
+
+
                 .conditional(STRING_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, STRING_TEMPLATE)
                 .conditional(
                         TINYINT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, TINYINT_TEMPLATE)
@@ -110,7 +131,121 @@ public class FakeSourceFactory implements TableSourceFactory, SupportSourceDryRu
                 .conditional(BIGINT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, BIGINT_TEMPLATE)
                 .conditional(FLOAT_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, FLOAT_TEMPLATE)
                 .conditional(DOUBLE_FAKE_MODE, FakeSourceOptions.FakeMode.TEMPLATE, DOUBLE_TEMPLATE)
-                .build();
+                 .optional(
+                TINYINT_MIN,
+                greaterOrEqual(TINYINT_MIN, TINYINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        TINYINT_MIN,
+                                        TINYINT_MAX.defaultValue())))
+
+                 .optional(
+                TINYINT_MAX,
+                greaterOrEqual(TINYINT_MAX, TINYINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        TINYINT_MAX,
+                                        TINYINT_MAX.defaultValue())))
+
+
+                .optional(
+                SMALLINT_MIN,
+                greaterOrEqual(SMALLINT_MIN, SMALLINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        SMALLINT_MIN,
+                                        SMALLINT_MAX.defaultValue())))
+
+
+                 .optional(
+                SMALLINT_MAX,
+                greaterOrEqual(SMALLINT_MAX, SMALLINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        SMALLINT_MAX,
+                                        SMALLINT_MAX.defaultValue())))
+
+                 .optional(
+                INT_MIN,
+                greaterOrEqual(INT_MIN, INT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        INT_MIN,
+                                        INT_MAX.defaultValue())))
+
+                 .optional(
+                INT_MAX,
+                greaterOrEqual(INT_MAX, INT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        INT_MAX,
+                                        INT_MAX.defaultValue())))
+
+                 .optional(
+                BIGINT_MIN,
+                greaterOrEqual(BIGINT_MIN, BIGINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        BIGINT_MIN,
+                                        BIGINT_MAX.defaultValue())))
+
+                 .optional(
+                BIGINT_MAX,
+                greaterOrEqual(BIGINT_MAX, BIGINT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        BIGINT_MAX,
+                                        BIGINT_MAX.defaultValue())))
+
+                 .optional(
+                FLOAT_MIN,
+                greaterOrEqual(FLOAT_MIN, FLOAT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        FLOAT_MIN,
+                                        FLOAT_MAX.defaultValue())))
+                 .optional(
+                FLOAT_MAX,
+                greaterOrEqual(FLOAT_MAX, FLOAT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        FLOAT_MAX,
+                                        FLOAT_MAX.defaultValue())))
+
+                 .optional(
+                DOUBLE_MIN,
+                greaterOrEqual(DOUBLE_MIN, DOUBLE_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        DOUBLE_MIN,
+                                        DOUBLE_MAX.defaultValue())))
+                 .optional(
+                DOUBLE_MAX,
+                greaterOrEqual(DOUBLE_MAX, DOUBLE_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        DOUBLE_MAX,
+                                        DOUBLE_MAX.defaultValue())))
+
+                 .optional(
+                VECTOR_FLOAT_MIN,
+                greaterOrEqual(VECTOR_FLOAT_MIN, VECTOR_FLOAT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        VECTOR_FLOAT_MIN,
+                                        VECTOR_FLOAT_MAX.defaultValue())))
+                 .optional(
+                VECTOR_FLOAT_MAX,
+                greaterOrEqual(VECTOR_FLOAT_MAX, VECTOR_FLOAT_MIN.defaultValue())
+                        .and(
+                                lessOrEqual(
+                                        VECTOR_FLOAT_MAX,
+                                        VECTOR_FLOAT_MAX.defaultValue())))
+
+
+        .build();
+
+
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/config/MultipleTableFakeSourceConfigTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/config/MultipleTableFakeSourceConfigTest.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.connectors.seatunnel.fake.exception.FakeConnectorException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,31 +40,5 @@ class MultipleTableFakeSourceConfigTest {
         MultipleTableFakeSourceConfig multipleTableFakeSourceConfig =
                 new MultipleTableFakeSourceConfig(readonlyConfig);
         Assertions.assertEquals(2, multipleTableFakeSourceConfig.getFakeConfigs().size());
-    }
-
-    @Test
-    void invalidTinyintMinInTablesConfigsShouldFail() {
-        String configStr =
-                "FakeSource {\n"
-                        + "  tables_configs = [\n"
-                        + "    {\n"
-                        + "      tinyint.min = 200\n"
-                        + "      schema = {\n"
-                        + "        table = \"fake.table1\"\n"
-                        + "        fields {\n"
-                        + "          c_tinyint = tinyint\n"
-                        + "        }\n"
-                        + "      }\n"
-                        + "    }\n"
-                        + "  ]\n"
-                        + "}";
-
-        Config config = ConfigFactory.parseString(configStr);
-
-        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(config.getConfig("FakeSource"));
-
-        Assertions.assertThrows(
-                FakeConnectorException.class,
-                () -> new MultipleTableFakeSourceConfig(readonlyConfig));
     }
 }

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/config/MultipleTableFakeSourceConfigTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/config/MultipleTableFakeSourceConfigTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.fake.exception.FakeConnectorException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,5 +41,31 @@ class MultipleTableFakeSourceConfigTest {
         MultipleTableFakeSourceConfig multipleTableFakeSourceConfig =
                 new MultipleTableFakeSourceConfig(readonlyConfig);
         Assertions.assertEquals(2, multipleTableFakeSourceConfig.getFakeConfigs().size());
+    }
+
+    @Test
+    void invalidTinyintMinInTablesConfigsShouldFail() {
+        String configStr =
+                "FakeSource {\n"
+                        + "  tables_configs = [\n"
+                        + "    {\n"
+                        + "      tinyint.min = 200\n"
+                        + "      schema = {\n"
+                        + "        table = \"fake.table1\"\n"
+                        + "        fields {\n"
+                        + "          c_tinyint = tinyint\n"
+                        + "        }\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  ]\n"
+                        + "}";
+
+        Config config = ConfigFactory.parseString(configStr);
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(config.getConfig("FakeSource"));
+
+        Assertions.assertThrows(
+                FakeConnectorException.class,
+                () -> new MultipleTableFakeSourceConfig(readonlyConfig));
     }
 }

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeFactoryTest.java
@@ -17,13 +17,32 @@
 
 package org.apache.seatunnel.connectors.seatunnel.fake.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class FakeFactoryTest {
 
     @Test
     void optionRule() {
         Assertions.assertNotNull((new FakeSourceFactory()).optionRule());
+    }
+
+    @Test
+    void invalidTinyintMinShouldFailValidation() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("tinyint.min", 200);
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(new FakeSourceFactory().optionRule()));
     }
 }

--- a/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-fake/src/test/java/org/apache/seatunnel/connectors/seatunnel/fake/source/FakeFactoryTest.java
@@ -20,10 +20,12 @@ package org.apache.seatunnel.connectors.seatunnel.fake.source;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,11 +40,48 @@ public class FakeFactoryTest {
     void invalidTinyintMinShouldFailValidation() {
         Map<String, Object> config = new HashMap<>();
         config.put("tinyint.min", 200);
+        config.put(ConnectorCommonOptions.SCHEMA.key(), schema());
 
-        Assertions.assertThrows(
-                OptionValidationException.class,
-                () ->
-                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
-                                .validate(new FakeSourceFactory().optionRule()));
+        OptionValidationException exception =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(exception.getRawMessage().contains("tinyint.min"));
+    }
+
+    @Test
+    void invalidTinyintMinInTablesConfigsShouldFailValidation() {
+        Map<String, Object> childConfig = new HashMap<>();
+        childConfig.put("tinyint.min", 200);
+        childConfig.put(ConnectorCommonOptions.SCHEMA.key(), schema());
+        Map<String, Object> config = new HashMap<>();
+        config.put(
+                ConnectorCommonOptions.TABLE_CONFIGS.key(), Collections.singletonList(childConfig));
+
+        OptionValidationException exception =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(exception.getRawMessage().contains("tables_configs[0]"));
+        Assertions.assertTrue(exception.getRawMessage().contains("tinyint.min"));
+    }
+
+    @Test
+    void validTinyintMinInTablesConfigsShouldPassValidation() {
+        Map<String, Object> childConfig = new HashMap<>();
+        childConfig.put("tinyint.min", 100);
+        childConfig.put(ConnectorCommonOptions.SCHEMA.key(), schema());
+        Map<String, Object> config = new HashMap<>();
+        config.put(
+                ConnectorCommonOptions.TABLE_CONFIGS.key(), Collections.singletonList(childConfig));
+
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    private static void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                .validate(new FakeSourceFactory().optionRule());
+    }
+
+    private static Map<String, Object> schema() {
+        return Collections.singletonMap("table", "fake.table");
     }
 }


### PR DESCRIPTION
Migrate connector-fake configuration validation from imperative runtime checks to declarative OptionRule + Conditions.

What I changed
Added declarative validation rules in FakeSourceFactory.
Migrated range validations for:
TINYINT_MIN/MAX
SMALLINT_MIN/MAX
INT_MIN/MAX
BIGINT_MIN/MAX
FLOAT_MIN/MAX
DOUBLE_MIN/MAX
VECTOR_FLOAT_MIN/MAX
Removed corresponding runtime validation checks from FakeConfig.
Preserved existing validation behavior.
Related Issue

Part of the declarative validation migration tracking issue.

Claimed item: connector-fake

Verification
git diff --check passed.
Attempted local compilation of connector-fake.
Build was blocked by snapshot dependency resolution (seatunnel-shade artifact unavailable), unrelated to connector-fake changes.