### PR TITLE
[Feature][Connector-V2][MongoDB-CDC] Support latest-offset startup mode without initial snapshot

### DIFF
--- a/docs/en/connectors/source/MongoDB-CDC.md
+++ b/docs/en/connectors/source/MongoDB-CDC.md
@@ -127,8 +127,41 @@ For specific types in MongoDB, we use Extended JSON format to map them to Seatun
 | poll.await.time.ms                 | Long   | No       | 1000    | The amount of time to wait before checking for new results on the change stream.                                                                                                                                                                                            |
 | heartbeat.interval.ms              | String | No       | 0       | The length of time in milliseconds between sending heartbeat messages. Use 0 to disable.                                                                                                                                                                                    |
 | incremental.snapshot.chunk.size.mb | Long   | No       | 64      | The chunk size mb of incremental snapshot.                                                                                                                                                                                                                                  |
+| startup.mode                       | Enum   | No       | INITIAL | Optional startup mode for MongoDB CDC consumer, valid enumerations are `initial`, `latest` and `timestamp`. See the [Startup Mode](#startup-mode) section below.                                                                                                            |
+| startup.timestamp                  | Long   | No       | -       | Start from the specified epoch timestamp (in milliseconds). Only used when `startup.mode` is `timestamp`.                                                                                                                                                                   |
 | exactly_once                       | Boolean| No       | false   | Enable exactly once semantic. Enabling this may cause an out-of-memory risk during the large table snapshot stage in recovery.                                                                                                                                              |
 | common-options                     |        | No       | -       | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                                                                          |
+
+### Startup Mode
+
+The `startup.mode` option controls where the connector starts reading when a job is submitted:
+
+- `initial` (default): reads a snapshot of the monitored collections first, then switches to the change stream.
+- `latest`: skips the snapshot entirely and starts from the latest change-stream position, so only changes made after the job starts are captured. Snapshot-related options such as `incremental.snapshot.chunk.size.mb` are ignored in this mode.
+- `timestamp`: skips the snapshot and starts reading the change stream from the position given by `startup.timestamp`.
+
+When a job is restored from a checkpoint or savepoint, it resumes from the checkpointed change-stream position regardless of `startup.mode`, so a restart never falls back to a new snapshot.
+
+For example, to consume only changes made after the job starts:
+
+```hocon
+source {
+  MongoDB-CDC {
+    hosts = "mongo0:27017"
+    database = ["inventory"]
+    collection = ["inventory.products"]
+    startup.mode = "latest"
+    schema = {
+      fields {
+        "_id" : string,
+        "name" : string,
+        "description" : string,
+        "weight" : string
+      }
+    }
+  }
+}
+```
 
 ### Tips
 

--- a/docs/zh/connectors/source/MongoDB-CDC.md
+++ b/docs/zh/connectors/source/MongoDB-CDC.md
@@ -127,8 +127,41 @@ db.grantRolesToUser("<USER_NAME>", ["<ROLE_NAME>"])
 | poll.await.time.ms                 | Long   | 否       | 1000  | 在检查更改流上的新结果之前等待的时间量。                                                                  |
 | heartbeat.interval.ms              | String | 否       | 0     | 发送心跳消息之间的时间长度（毫秒）。使用0禁用。                                                              |
 | incremental.snapshot.chunk.size.mb | Long   | 否       | 64    | 增量快照的块大小（mb）。                                                                         |
+| startup.mode                       | Enum   | 否       | INITIAL | MongoDB CDC 消费者的可选启动模式，有效枚举为 `initial`、`latest` 和 `timestamp`。详见下方[启动模式](#启动模式)章节。      |
+| startup.timestamp                  | Long   | 否       | -     | 从指定的纪元时间戳（毫秒）开始消费。仅在 `startup.mode` 为 `timestamp` 时使用。                                  |
 | exactly_once                       | Boolean| 否       | false | 启用精确一次语义，若开启在大表快照阶段恢复时会有内存溢出风险。                                                       |
 | common-options                     |        | 否       | -     | 源插件常用参数，请参考 [Source Common Options](../common-options/source-common-options.md)                      |
+
+### 启动模式
+
+`startup.mode` 选项控制作业提交时连接器从哪里开始读取：
+
+- `initial`（默认）：先读取所监视集合的快照，然后切换到变更流。
+- `latest`：完全跳过快照，从最新的变更流位置开始，只捕获作业启动之后产生的变更。在该模式下，与快照相关的选项（如 `incremental.snapshot.chunk.size.mb`）将被忽略。
+- `timestamp`：跳过快照，从 `startup.timestamp` 指定的位置开始读取变更流。
+
+当作业从检查点或保存点恢复时，无论 `startup.mode` 为何值，都会从检查点记录的变更流位置继续消费，重启不会回退到重新执行快照。
+
+例如，只消费作业启动之后产生的变更：
+
+```hocon
+source {
+  MongoDB-CDC {
+    hosts = "mongo0:27017"
+    database = ["inventory"]
+    collection = ["inventory.products"]
+    startup.mode = "latest"
+    schema = {
+      fields {
+        "_id" : string,
+        "name" : string,
+        "description" : string,
+        "weight" : string
+      }
+    }
+  }
+}
+```
 
 ### 提示
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbIncrementalSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbIncrementalSourceOptions.java
@@ -136,11 +136,15 @@ public class MongodbIncrementalSourceOptions extends SourceOptions implements Ta
             Options.key(SourceOptions.STARTUP_MODE_KEY)
                     .singleChoice(
                             StartupMode.class,
-                            Arrays.asList(StartupMode.INITIAL, StartupMode.TIMESTAMP))
+                            Arrays.asList(
+                                    StartupMode.INITIAL, StartupMode.LATEST, StartupMode.TIMESTAMP))
                     .defaultValue(StartupMode.INITIAL)
                     .withDescription(
-                            "Optional startup mode for CDC source, valid enumerations are "
-                                    + "\"initial\", \"earliest\", \"latest\", \"timestamp\"\n or \"specific\"");
+                            "Optional startup mode for MongoDB CDC source, valid enumerations are "
+                                    + "\"initial\", \"latest\" or \"timestamp\". "
+                                    + "\"initial\": reads a snapshot of the monitored collections first and then switches to the change stream. "
+                                    + "\"latest\": skips the snapshot entirely and starts from the latest change-stream position, so only changes made after the job starts are captured. "
+                                    + "\"timestamp\": skips the snapshot and starts reading the change stream from the position given by \"startup.timestamp\".");
 
     public static final SingleChoiceOption<StopMode> STOP_MODE =
             Options.key(SourceOptions.STOP_MODE_KEY)

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbSourceConfigProvider.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbSourceConfigProvider.java
@@ -111,6 +111,7 @@ public class MongodbSourceConfigProvider {
         public Builder startupOptions(StartupConfig startupOptions) {
             this.startupOptions = Objects.requireNonNull(startupOptions);
             if (startupOptions.getStartupMode() != StartupMode.INITIAL
+                    && startupOptions.getStartupMode() != StartupMode.LATEST
                     && startupOptions.getStartupMode() != StartupMode.TIMESTAMP) {
                 throw new MongodbConnectorException(
                         ILLEGAL_ARGUMENT,

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/test/java/mongodb/source/MongodbIncrementalSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/test/java/mongodb/source/MongodbIncrementalSourceFactoryTest.java
@@ -23,6 +23,9 @@ import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
 import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.MongodbIncrementalSourceFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.config.MongodbSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.config.MongodbSourceConfigProvider;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.exception.MongodbConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.source.offset.ChangeStreamOffset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.source.offset.ChangeStreamOffsetFactory;
 
@@ -52,6 +55,30 @@ public class MongodbIncrementalSourceFactoryTest {
                                             StartupMode.TIMESTAMP),
                                     ((SingleChoiceOption<StartupMode>) option).getOptionValues());
                         });
+    }
+
+    @Test
+    public void testSourceConfigBuilderAcceptsLatestStartupMode() {
+        // Regression for the real source-assembly path: the builder used to reject
+        // StartupMode.LATEST at runtime even though the option rule advertised it.
+        MongodbSourceConfig config =
+                MongodbSourceConfigProvider.newBuilder()
+                        .hosts("localhost:27017")
+                        .startupOptions(new StartupConfig(StartupMode.LATEST, null, null, null))
+                        .validate()
+                        .create(0);
+
+        Assertions.assertEquals(StartupMode.LATEST, config.getStartupConfig().getStartupMode());
+    }
+
+    @Test
+    public void testSourceConfigBuilderRejectsUnsupportedStartupMode() {
+        Assertions.assertThrows(
+                MongodbConnectorException.class,
+                () ->
+                        MongodbSourceConfigProvider.newBuilder()
+                                .startupOptions(
+                                        new StartupConfig(StartupMode.EARLIEST, null, null, null)));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/test/java/mongodb/source/MongodbIncrementalSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/test/java/mongodb/source/MongodbIncrementalSourceFactoryTest.java
@@ -18,9 +18,13 @@
 package mongodb.source;
 
 import org.apache.seatunnel.api.configuration.SingleChoiceOption;
+import org.apache.seatunnel.connectors.cdc.base.config.StartupConfig;
 import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
 import org.apache.seatunnel.connectors.cdc.base.option.StartupMode;
+import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.MongodbIncrementalSourceFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.source.offset.ChangeStreamOffset;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mongodb.source.offset.ChangeStreamOffsetFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,7 +38,7 @@ public class MongodbIncrementalSourceFactoryTest {
     }
 
     @Test
-    public void testWithUnsupportedStartUpMode() {
+    public void testSupportedStartUpModes() {
         MongodbIncrementalSourceFactory mongodbIncrementalSourceFactory =
                 new MongodbIncrementalSourceFactory();
         mongodbIncrementalSourceFactory.optionRule().getOptionalOptions().stream()
@@ -42,8 +46,24 @@ public class MongodbIncrementalSourceFactoryTest {
                 .forEach(
                         (option) -> {
                             Assertions.assertIterableEquals(
-                                    Arrays.asList(StartupMode.INITIAL, StartupMode.TIMESTAMP),
+                                    Arrays.asList(
+                                            StartupMode.INITIAL,
+                                            StartupMode.LATEST,
+                                            StartupMode.TIMESTAMP),
                                     ((SingleChoiceOption<StartupMode>) option).getOptionValues());
                         });
+    }
+
+    @Test
+    public void testLatestStartupModeResolvesToLatestChangeStreamOffset() {
+        StartupConfig startupConfig = new StartupConfig(StartupMode.LATEST, null, null, null);
+
+        Offset startupOffset = startupConfig.getStartupOffset(new ChangeStreamOffsetFactory());
+
+        Assertions.assertInstanceOf(ChangeStreamOffset.class, startupOffset);
+        // The latest offset is a current-time change-stream position, not a resume token from a
+        // snapshot: starting here means only changes made after the job starts are consumed.
+        Assertions.assertNotNull(((ChangeStreamOffset) startupOffset).getTimestamp());
+        Assertions.assertNull(((ChangeStreamOffset) startupOffset).getResumeToken());
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Closes #11051. Related user report: #9511.

Adds an explicit `latest` startup mode to `MongoDB-CDC`, so a job can skip the initial snapshot and consume only changes made after it starts.

### What changed

**Option (`MongodbIncrementalSourceOptions`)**
- `startup.mode` now accepts `latest` (choices: `initial`, `latest`, `timestamp` — was `initial`, `timestamp`).
- Fixed the stale description, which advertised `earliest`/`specific` values the connector never accepted; it now describes exactly what each supported mode does.

**Why no runtime changes were needed**

The cdc-base runtime already implements the requested semantics — this connector just never exposed the mode:

- `IncrementalSource#createEnumerator` routes any non-`INITIAL` mode to `IncrementalSplitAssigner` (stream-only), so the snapshot/copy phase is skipped entirely.
- `StartupConfig#getStartupOffset(LATEST)` resolves the start position through `ChangeStreamOffsetFactory#latest()`, which MongoDB-CDC already implements (current change-stream position).
- Restore goes through the same checkpoint path: an `IncrementalPhaseState` checkpoint restores into `IncrementalSplitAssigner`, so a restarted job resumes from the checkpointed change-stream position and never falls back into a snapshot.

**Tests (`MongodbIncrementalSourceFactoryTest`)**
- Updated the option-rule test to assert the supported startup modes are exactly `initial`, `latest`, `timestamp`.
- New test proving `StartupMode.LATEST` resolves through `ChangeStreamOffsetFactory` to a `ChangeStreamOffset` positioned at the current time (timestamp set, no resume token) — i.e. "new changes only".

**Docs (EN + ZH)**
- Documented `startup.mode` and `startup.timestamp` in the options table (they were previously undocumented).
- Added a "Startup Mode" section explaining the three modes, checkpoint/restore behavior, and a `startup.mode = "latest"` example job.

### Scope notes (matching the issue's non-goals)

- No dynamic newly-added collection discovery, no new metadata keys.
- `earliest` is intentionally **not** exposed: `ChangeStreamOffsetFactory#earliest()` currently returns the current timestamp (same as `latest`), so advertising it would be misleading.

### Verification

- `mvn test -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb` — 17/17 passing (JDK 11).
- `mvn spotless:apply` clean.

### Check list

* [x] Code changed are covered with tests, or it does not need tests for reason
* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs