### PR TITLE
[Feature][Connector-V2] Add OceanBase CDC source connector

### DIFF
--- a/config/plugin_config
+++ b/config/plugin_config
@@ -24,6 +24,7 @@ connector-amazondynamodb
 connector-assert
 connector-cassandra
 connector-cdc-mysql
+connector-cdc-oceanbase
 connector-cdc-mongodb
 connector-cdc-sqlserver
 connector-cdc-postgres

--- a/docs/en/connectors/changelog/connector-cdc-oceanbase.md
+++ b/docs/en/connectors/changelog/connector-cdc-oceanbase.md
@@ -1,0 +1,6 @@
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+
+</details>

--- a/docs/en/connectors/source/OceanBase-CDC.md
+++ b/docs/en/connectors/source/OceanBase-CDC.md
@@ -1,0 +1,117 @@
+import ChangeLog from '../changelog/connector-cdc-oceanbase.md';
+
+# OceanBase CDC
+
+> OceanBase CDC source connector
+
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+> Flink <br/>
+
+## Key features
+
+- [ ] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+
+## Description
+
+The first delivery of the OceanBase CDC connector targets the stable OceanBase MySQL compatible
+path backed by OceanBase Binlog Service.
+
+To keep the implementation narrow and restart-safe, `OceanBase-CDC` reuses SeaTunnel's
+`MySQL-CDC` incremental runtime for:
+
+- snapshot + incremental capture
+- checkpoint / restore handling
+- multi-table CDC row semantics
+- schema change propagation supported by `MySQL-CDC`
+
+OceanBase Oracle compatible mode is not supported in this first delivery.
+
+## Supported DataSource Info
+
+| Datasource | Supported versions | Driver | Url | Notes |
+| --- | --- | --- | --- | --- |
+| OceanBase CE / OceanBase EE (MySQL compatible mode) | OceanBase deployments that expose a MySQL-compatible snapshot endpoint and OceanBase Binlog Service | `com.mysql.cj.jdbc.Driver` | `jdbc:mysql://localhost:2881/test` | Requires OceanBase Binlog Service |
+
+## Using Dependency
+
+### Install Jdbc Driver
+
+#### For Flink Engine
+
+> 1. You need to ensure that the [MySQL JDBC driver](https://mvnrepository.com/artifact/mysql/mysql-connector-java) has been placed in `${SEATUNNEL_HOME}/plugins/`.
+
+#### For SeaTunnel Zeta Engine
+
+> 1. You need to ensure that the [MySQL JDBC driver](https://mvnrepository.com/artifact/mysql/mysql-connector-java) has been placed in `${SEATUNNEL_HOME}/lib/`.
+
+## OceanBase Preparation
+
+Before using `OceanBase-CDC`, make sure the monitored tenant satisfies these requirements:
+
+1. OceanBase runs in MySQL compatible mode for the captured tables.
+2. [OceanBase Binlog Service](https://en.oceanbase.com/docs/common-ocp-10000000002168919) is deployed and enabled for incremental subscription.
+3. The JDBC `url` points to a MySQL-compatible endpoint that SeaTunnel can use for snapshot reads.
+4. The configured account can read the captured tables and subscribe to incremental changes.
+
+## Source Options
+
+`OceanBase-CDC` intentionally reuses the same option contract as `MySQL-CDC`.
+
+Please refer to [MySQL CDC Source Options](./MySQL-CDC.md#source-options) for the complete option
+list.
+
+### OceanBase-specific constraints
+
+- Use a MySQL-compatible JDBC URL such as `jdbc:mysql://host:2881/database`.
+- Use the MySQL JDBC driver `com.mysql.cj.jdbc.Driver`.
+- The first delivery supports explicitly configured tables only through `table-names`,
+  `table-pattern`, and `table-names-config`.
+- Startup modes, checkpoint / restore semantics, and schema evolution behavior are the same as
+  `MySQL-CDC`.
+
+## Task Example
+
+### Simple
+
+> Support multi-table reading from OceanBase MySQL compatible mode
+
+```
+env {
+  execution.parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  OceanBase-CDC {
+    plugin_output = "oceanbase_cdc"
+    username = "root"
+    password = "123456"
+    url = "jdbc:mysql://127.0.0.1:2881/inventory"
+    database-names = ["inventory"]
+    table-names = ["inventory.orders", "inventory.customers"]
+    server-time-zone = "Asia/Shanghai"
+    startup.mode = "initial"
+    exactly_once = true
+  }
+}
+
+transform {
+
+}
+
+sink {
+  Console {}
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-cdc-oceanbase.md
+++ b/docs/zh/connectors/changelog/connector-cdc-oceanbase.md
@@ -1,0 +1,6 @@
+<details><summary> Change Log </summary>
+
+| 变更 | Commit | 版本 |
+| --- | --- | --- |
+
+</details>

--- a/docs/zh/connectors/source/OceanBase-CDC.md
+++ b/docs/zh/connectors/source/OceanBase-CDC.md
@@ -1,0 +1,115 @@
+import ChangeLog from '../changelog/connector-cdc-oceanbase.md';
+
+# OceanBase CDC
+
+> OceanBase CDC 源连接器
+
+## 支持这些引擎
+
+> SeaTunnel Zeta<br/>
+> Flink <br/>
+
+## 主要功能
+
+- [ ] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户定义的拆分](../../introduction/concepts/connector-v2-features.md)
+
+## 描述
+
+OceanBase CDC 首个交付版本只覆盖稳定、可验证的 OceanBase MySQL 兼容模式路径，并依赖
+OceanBase Binlog Service 提供增量订阅能力。
+
+为了把实现范围控制在最小且确保重启恢复语义可靠，`OceanBase-CDC` 直接复用 SeaTunnel
+现有 `MySQL-CDC` 的增量运行时，包括：
+
+- 全量快照 + 增量读取
+- checkpoint / restore 处理
+- 多表 CDC 行语义
+- `MySQL-CDC` 已支持的模式演进能力
+
+本次首批交付暂不支持 OceanBase Oracle 兼容模式的增量 CDC。
+
+## 支持的数据源信息
+
+| 数据源 | 支持版本 | 驱动 | URL | 说明 |
+| --- | --- | --- | --- | --- |
+| OceanBase CE / OceanBase EE（MySQL 兼容模式） | 暴露 MySQL 兼容快照读取端点，并开启 OceanBase Binlog Service 的部署 | `com.mysql.cj.jdbc.Driver` | `jdbc:mysql://localhost:2881/test` | 依赖 OceanBase Binlog Service |
+
+## 依赖使用
+
+### 安装 JDBC 驱动
+
+#### 对于 Flink 引擎
+
+> 1. 你需要确保 [MySQL JDBC 驱动](https://mvnrepository.com/artifact/mysql/mysql-connector-java) 已经放在 `${SEATUNNEL_HOME}/plugins/` 目录下。
+
+#### 对于 SeaTunnel Zeta 引擎
+
+> 1. 你需要确保 [MySQL JDBC 驱动](https://mvnrepository.com/artifact/mysql/mysql-connector-java) 已经放在 `${SEATUNNEL_HOME}/lib/` 目录下。
+
+## OceanBase 前置准备
+
+在使用 `OceanBase-CDC` 之前，请确保被采集租户满足以下条件：
+
+1. OceanBase 运行在 MySQL 兼容模式。
+2. [OceanBase Binlog Service](https://en.oceanbase.com/docs/common-ocp-10000000002168919) 已部署并开启增量订阅能力。
+3. JDBC `url` 指向 SeaTunnel 可用于快照读取的 MySQL 兼容端点。
+4. 配置账号同时具备快照读取和增量订阅所需权限。
+
+## 源端可选项
+
+`OceanBase-CDC` 有意复用了 `MySQL-CDC` 的完整参数契约。
+
+完整参数请直接参考 [MySQL CDC 源端参数](./MySQL-CDC.md#配置参数选项)。
+
+### OceanBase 特有约束
+
+- JDBC URL 需要使用 MySQL 兼容写法，例如 `jdbc:mysql://host:2881/database`。
+- JDBC 驱动固定使用 MySQL 驱动 `com.mysql.cj.jdbc.Driver`。
+- 首批版本只支持显式配置的表，即通过 `table-names`、`table-pattern`、
+  `table-names-config` 指定采集范围。
+- 启动模式、checkpoint / restore 语义、模式演进行为与 `MySQL-CDC` 保持一致。
+
+## 任务示例
+
+### 简单示例
+
+> 读取 OceanBase MySQL 兼容模式下的多张表
+
+```
+env {
+  execution.parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  OceanBase-CDC {
+    plugin_output = "oceanbase_cdc"
+    username = "root"
+    password = "123456"
+    url = "jdbc:mysql://127.0.0.1:2881/inventory"
+    database-names = ["inventory"]
+    table-names = ["inventory.orders", "inventory.customers"]
+    server-time-zone = "Asia/Shanghai"
+    startup.mode = "initial"
+    exactly_once = true
+  }
+}
+
+transform {
+
+}
+
+sink {
+  Console {}
+}
+```
+
+## 变更日志
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -107,6 +107,7 @@ seatunnel.sink.Doris = connector-doris
 seatunnel.source.Maxcompute = connector-maxcompute
 seatunnel.sink.Maxcompute = connector-maxcompute
 seatunnel.source.MySQL-CDC = connector-cdc-mysql
+seatunnel.source.OceanBase-CDC = connector-cdc-oceanbase
 seatunnel.source.MongoDB-CDC = connector-cdc-mongodb
 seatunnel.source.TiDB-CDC = connector-cdc-tidb
 seatunnel.sink.S3Redshift = connector-s3-redshift

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>connector-cdc</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-cdc-oceanbase</artifactId>
+    <name>SeaTunnel : Connectors V2 : CDC : OceanBase</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-cdc-base</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-cdc-mysql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSource.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSource.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oceanbase.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.MySqlIncrementalSource;
+
+import java.util.List;
+
+/**
+ * OceanBase CDC source for the first delivery path that targets OceanBase MySQL compatible mode.
+ *
+ * <p>The connector intentionally reuses the MySQL CDC runtime because OceanBase Binlog Service
+ * exposes a MySQL-compatible change-log interface, which keeps snapshot, incremental, checkpoint,
+ * and restore semantics aligned with the existing MySQL connector.
+ *
+ * @param <T> emitted record type
+ */
+public class OceanBaseIncrementalSource<T> extends MySqlIncrementalSource<T> {
+
+    /** Stable plugin identifier used by SeaTunnel config and plugin discovery. */
+    static final String IDENTIFIER = "OceanBase-CDC";
+
+    /**
+     * Create an OceanBase CDC source backed by the MySQL CDC runtime.
+     *
+     * @param options connector options
+     * @param catalogTables tables discovered or restored for the source
+     */
+    public OceanBaseIncrementalSource(ReadonlyConfig options, List<CatalogTable> catalogTables) {
+        super(options, catalogTables);
+    }
+
+    /**
+     * Expose the OceanBase-specific plugin name while reusing MySQL-compatible internals.
+     *
+     * @return OceanBase CDC plugin name
+     */
+    @Override
+    public String getPluginName() {
+        return IDENTIFIER;
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSourceFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oceanbase.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceTableConfig;
+import org.apache.seatunnel.connectors.cdc.base.option.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.option.SourceOptions;
+import org.apache.seatunnel.connectors.cdc.base.utils.CatalogTableUtils;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config.MySqlSourceConfigFactory;
+import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.MySqlIncrementalSourceFactory;
+
+import com.google.auto.service.AutoService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Factory for the OceanBase CDC source.
+ *
+ * <p>The first implementation deliberately wraps the MySQL CDC connector because that is the stable
+ * and testable path already adopted by Flink CDC for OceanBase Binlog Service.
+ */
+@AutoService(Factory.class)
+@Slf4j
+public class OceanBaseIncrementalSourceFactory extends MySqlIncrementalSourceFactory {
+
+    /**
+     * Return the identifier used in SeaTunnel source config.
+     *
+     * @return OceanBase CDC identifier
+     */
+    @Override
+    public String factoryIdentifier() {
+        return OceanBaseIncrementalSource.IDENTIFIER;
+    }
+
+    /**
+     * Return the concrete source class used for OceanBase CDC jobs.
+     *
+     * @return OceanBase CDC source class
+     */
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return OceanBaseIncrementalSource.class;
+    }
+
+    /**
+     * Restore the source by reusing MySQL-compatible table discovery and checkpoint merge logic.
+     *
+     * @param context source factory context
+     * @param restoreTables restored table structures from checkpoint state
+     * @param <T> emitted record type
+     * @param <SplitT> split type
+     * @param <StateT> state type
+     * @return restorable OceanBase CDC table source
+     */
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> restoreSource(
+                    TableSourceFactoryContext context, List<CatalogTable> restoreTables) {
+        return () -> {
+            try {
+                Class.forName("com.mysql.cj.jdbc.Driver");
+            } catch (Exception e) {
+                log.warn("Failed to load JDBC driver com.mysql.cj.jdbc.Driver ", e);
+            }
+            ReadonlyConfig config = context.getOptions();
+            List<CatalogTable> catalogTables =
+                    CatalogTableUtil.getCatalogTables(config, context.getClassLoader());
+            boolean enableSchemaChange =
+                    context.getOptions()
+                            .getOptional(SourceOptions.SCHEMA_CHANGES_ENABLED)
+                            .orElse(
+                                    context.getOptions()
+                                            .getOptional(SourceOptions.DEBEZIUM_PROPERTIES)
+                                            .map(
+                                                    e ->
+                                                            e.getOrDefault(
+                                                                    MySqlSourceConfigFactory
+                                                                            .SCHEMA_CHANGE_KEY,
+                                                                    SourceOptions
+                                                                            .SCHEMA_CHANGES_ENABLED
+                                                                            .defaultValue()
+                                                                            .toString()))
+                                            .map(Boolean::parseBoolean)
+                                            .orElse(
+                                                    SourceOptions.SCHEMA_CHANGES_ENABLED
+                                                            .defaultValue()));
+            if (!restoreTables.isEmpty() && enableSchemaChange) {
+                catalogTables = mergeTableStruct(catalogTables, restoreTables);
+            }
+
+            Optional<List<JdbcSourceTableConfig>> tableConfigs =
+                    context.getOptions().getOptional(JdbcSourceOptions.TABLE_NAMES_CONFIG);
+            if (tableConfigs.isPresent()) {
+                catalogTables =
+                        CatalogTableUtils.mergeCatalogTableConfig(
+                                catalogTables,
+                                tableConfigs.get(),
+                                text -> TablePath.of(text, false));
+            }
+            return (SeaTunnelSource<T, SplitT, StateT>)
+                    new OceanBaseIncrementalSource<>(config, catalogTables);
+        };
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oceanbase/source/OceanBaseIncrementalSourceFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.oceanbase.source;
+
+import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.source.MySqlIncrementalSourceFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the OceanBase CDC wrapper contract that differentiates it from the reused MySQL CDC
+ * implementation.
+ */
+public class OceanBaseIncrementalSourceFactoryTest {
+
+    /** Verify the OceanBase wrapper uses a dedicated factory identifier for plugin discovery. */
+    @Test
+    public void testFactoryIdentifier() {
+        Assertions.assertEquals(
+                "OceanBase-CDC", new OceanBaseIncrementalSourceFactory().factoryIdentifier());
+    }
+
+    /** Verify the wrapper keeps the MySQL factory inheritance so restore logic stays aligned. */
+    @Test
+    public void testFactoryInheritance() {
+        Assertions.assertEquals(
+                MySqlIncrementalSourceFactory.class,
+                OceanBaseIncrementalSourceFactory.class.getSuperclass());
+    }
+
+    /** Verify the factory returns the OceanBase wrapper source instead of the raw MySQL source. */
+    @Test
+    public void testSourceClass() {
+        Assertions.assertEquals(
+                OceanBaseIncrementalSource.class,
+                new OceanBaseIncrementalSourceFactory().getSourceClass());
+    }
+}

--- a/seatunnel-connectors-v2/connector-cdc/pom.xml
+++ b/seatunnel-connectors-v2/connector-cdc/pom.xml
@@ -32,6 +32,7 @@
     <modules>
         <module>connector-cdc-base</module>
         <module>connector-cdc-mysql</module>
+        <module>connector-cdc-oceanbase</module>
         <module>connector-cdc-sqlserver</module>
         <module>connector-cdc-mongodb</module>
         <module>connector-cdc-postgres</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -528,6 +528,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-cdc-oceanbase</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-cdc-oracle</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>


### PR DESCRIPTION
## What does this PR do?
This PR adds the first delivery of `OceanBase-CDC` by reusing the existing MySQL CDC runtime, following the current Flink CDC OceanBase implementation for OceanBase Binlog Service and MySQL-compatible mode.

Main changes:
- add the new `connector-cdc-oceanbase` module with the OceanBase wrapper source and factory
- register plugin mapping and dist packaging
- add English and Chinese source docs plus changelog entries

Closes #11049.

## Does this PR introduce any user-facing change?
Yes. It adds a new source plugin named `OceanBase-CDC`.

## How was this patch tested?
- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase -am -DskipTests verify`
- `./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-oceanbase -am -Dtest=OceanBaseIncrementalSourceFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -q -DskipTests verify`

Validation notes:
- No reusable prebuilt modules or artifacts were intentionally reused; validations were run from the current worktree.
- A real OceanBase Binlog Service end-to-end runtime path is not available in this repository today, so that scope was not revalidated in this run.
- The first delivery only targets OceanBase MySQL-compatible mode with OceanBase Binlog Service. Oracle-compatible mode remains out of scope.
