### PR TITLE
[Fix][Docs] Fix zh user page link

### DIFF
--- a/docs/zh/introduction/about.md
+++ b/docs/zh/introduction/about.md
@@ -74,7 +74,7 @@ SeaTunnel 使用的默认引擎是 [SeaTunnel Zeta Engine](../engines/zeta/about
 
 ## 谁在使用 SeaTunnel
 
-SeaTunnel 拥有大量用户。 您可以在[用户](https://seatunnel.apache.org/user)中找到有关他们的更多信息.  
+SeaTunnel 拥有大量用户。 您可以在[用户](https://seatunnel.apache.org/zh-CN/user)中找到有关他们的更多信息.
 
 ## 展望
 


### PR DESCRIPTION
## Purpose

Fix the Chinese docs About page user link so it navigates to the Chinese user page instead of the English user page.

## Changes

- Update the zh About page user link from `https://seatunnel.apache.org/user` to `https://seatunnel.apache.org/zh-CN/user`.

## Verification

- `curl -I -L https://seatunnel.apache.org/zh-CN/user` returns 200.
- `./mvnw spotless:apply` passed.
- `git diff --check` passed.
- `./mvnw -q -DskipTests verify` was not run to completion per requester instruction.
