### PR TITLE
[Docs] Fix Http source code fence

### DIFF
--- a/docs/en/connectors/source/Http.md
+++ b/docs/en/connectors/source/Http.md
@@ -590,7 +590,7 @@ source {
 the `pageing.page_type` parameter must be set to `Cursor`.
 `cursor_field` is the field name of the cursor in the request parameters.
 `cursor_response_field` is the field name denotes the name of the pagination token field in the response data, we should add this to add pageing fields into request.
-````hocon
+```hocon
 
 source {
     Http {

--- a/docs/zh/connectors/source/Http.md
+++ b/docs/zh/connectors/source/Http.md
@@ -579,7 +579,7 @@ source {
 `pageing.page_type` 参数必须设置为 `Cursor`。
 `cursor_field` 是请求参数中游标的字段名称。
 `cursor_response_field` 是响应数据中分页令牌字段的名称，我们应该将其添加到请求的分页字段中。
-````hocon
+```hocon
 
 source {
     Http {


### PR DESCRIPTION
### Purpose

Fix mismatched Markdown code fences in the Http source connector docs. The Cursor example opened with four backticks but closed with three, which caused following content to be rendered as part of the code block.

### Changes

- Fix the English Http source docs code fence
- Fix the Chinese Http source docs code fence

### Tests

- ./mvnw spotless:apply
- Not run: ./mvnw -q -DskipTests verify (docs-only change; skipped per requester)