### PR TITLE
[Fix][Connector-V2] Fix Cassandra null timestamp conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/util/TypeConvertUtil.java
+++ b/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/util/TypeConvertUtil.java
@@ -44,6 +44,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -181,9 +182,8 @@ public class TypeConvertUtil {
                     fields[i] = row.getLocalDate(i);
                     break;
                 case ProtocolConstants.DataType.TIMESTAMP:
-                    fields[i] =
-                            Timestamp.from(Objects.requireNonNull(row.getInstant(i)))
-                                    .toLocalDateTime();
+                    Instant instant = row.getInstant(i);
+                    fields[i] = instant == null ? null : Timestamp.from(instant).toLocalDateTime();
                     break;
                 case ProtocolConstants.DataType.BLOB:
                     fields[i] =

--- a/seatunnel-connectors-v2/connector-cassandra/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/util/TypeConvertUtilTest.java
+++ b/seatunnel-connectors-v2/connector-cassandra/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/util/TypeConvertUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cassandra.util;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TypeConvertUtilTest {
+
+    @Test
+    void testBuildSeaTunnelRowKeepsNullTimestamp() {
+        Row row = mock(Row.class);
+        ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
+        ColumnDefinition columnDefinition = mock(ColumnDefinition.class);
+
+        when(row.size()).thenReturn(1);
+        when(row.getColumnDefinitions()).thenReturn(columnDefinitions);
+        when(columnDefinitions.get(0)).thenReturn(columnDefinition);
+        when(columnDefinition.getType()).thenReturn(DataTypes.TIMESTAMP);
+        when(row.getInstant(0)).thenReturn(null);
+
+        SeaTunnelRow seaTunnelRow = TypeConvertUtil.buildSeaTunnelRow(row);
+
+        Assertions.assertNull(seaTunnelRow.getField(0));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #9849.

Cassandra `timestamp` columns can be null. The current conversion path calls `Objects.requireNonNull(row.getInstant(i))`, so a null timestamp from Cassandra fails with `NullPointerException` before the row reaches downstream connectors.

This patch keeps null timestamp values as null, and only converts non-null `Instant` values to `LocalDateTime`.

### Does this PR introduce _any_ user-facing change?

No. It only fixes null handling for Cassandra timestamp columns.

### How was this patch tested?

- `./mvnw -pl seatunnel-connectors-v2/connector-cassandra -Dtest=TypeConvertUtilTest#testBuildSeaTunnelRowKeepsNullTimestamp test`
- `./mvnw -pl seatunnel-connectors-v2/connector-cassandra test`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
