### PR TITLE
[Fix][Zeta] Fix checkpoint barrier trigger test race

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointBarrierTriggerErrorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointBarrierTriggerErrorTest.java
@@ -51,6 +51,7 @@ public class CheckpointBarrierTriggerErrorTest extends AbstractSeaTunnelServerTe
     @Test
     public void testCheckpointBarrierTriggerError()
             throws NoSuchFieldException, IllegalAccessException {
+        COUNTER.set(0);
         long jobId = System.currentTimeMillis();
         startJob(jobId, CONF_PATH);
 
@@ -62,11 +63,10 @@ public class CheckpointBarrierTriggerErrorTest extends AbstractSeaTunnelServerTe
                                         JobStatus.RUNNING));
 
         CheckpointManager spiedCheckpointManager = spy(getCheckpointManager(jobId));
-        setCheckpointManager(spiedCheckpointManager);
-
         doAnswer(this::mockException)
                 .when(spiedCheckpointManager)
                 .sendOperationToMemberNode(Mockito.any(CheckpointBarrierTriggerOperation.class));
+        setCheckpointManager(spiedCheckpointManager);
 
         await().atMost(120000, TimeUnit.MILLISECONDS)
                 .untilAsserted(


### PR DESCRIPTION
### Purpose
Fix a race in `CheckpointBarrierTriggerErrorTest` where the spied `CheckpointManager` was installed before Mockito stubbing was completed. A running checkpoint thread could invoke the spy during stubbing and trigger `UnfinishedStubbing`.

### Changes
- Configure the spy before replacing the checkpoint manager used by the running coordinator.
- Reset the test counter at the start of the test so repeated executions are deterministic.

### Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`