### PR TITLE
[Fix][seatunnel-translation-base] Remove connector-specific test dependencies from translation base

### DIFF
--- a/seatunnel-translation/seatunnel-translation-base/pom.xml
+++ b/seatunnel-translation/seatunnel-translation-base/pom.xml
@@ -31,18 +31,5 @@
             <artifactId>seatunnel-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.seatunnel</groupId>
-            <artifactId>connector-file-base</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.seatunnel</groupId>
-            <artifactId>connector-doris</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/seatunnel-translation/seatunnel-translation-base/src/test/java/org/apache/seatunnel/translation/source/ParallelSourceTest.java
+++ b/seatunnel-translation/seatunnel-translation-base/src/test/java/org/apache/seatunnel/translation/source/ParallelSourceTest.java
@@ -17,178 +17,277 @@
 
 package org.apache.seatunnel.translation.source;
 
-import org.apache.seatunnel.shade.com.google.common.collect.Maps;
-
-import org.apache.seatunnel.api.table.catalog.TablePath;
-import org.apache.seatunnel.connectors.doris.config.DorisSourceConfig;
-import org.apache.seatunnel.connectors.doris.rest.PartitionDefinition;
-import org.apache.seatunnel.connectors.doris.rest.RestService;
-import org.apache.seatunnel.connectors.doris.source.DorisSource;
-import org.apache.seatunnel.connectors.doris.source.DorisSourceTable;
-import org.apache.seatunnel.connectors.doris.source.reader.DorisSourceReader;
-import org.apache.seatunnel.connectors.doris.source.split.DorisSourceSplit;
-import org.apache.seatunnel.connectors.seatunnel.file.source.BaseFileSource;
-import org.apache.seatunnel.connectors.seatunnel.file.source.split.FileSourceSplit;
-import org.apache.seatunnel.connectors.seatunnel.file.source.split.FileSourceSplitEnumerator;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
-import lombok.extern.slf4j.Slf4j;
-
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.mockito.ArgumentMatchers.any;
-
-@Slf4j
-public class ParallelSourceTest {
+class ParallelSourceTest {
 
     @Test
-    void fileParallelSourceSplitEnumeratorTest() throws Exception {
-        int fileSize = 15;
+    void shouldDistributeSplitsAcrossParallelReaders() throws Exception {
+        int splitCount = 15;
         int parallelism = 4;
+        List<MockSplit> splits =
+                IntStream.range(0, splitCount)
+                        .mapToObj(i -> new MockSplit("split-" + i))
+                        .collect(Collectors.toList());
 
-        List<String> filePaths = new ArrayList<>();
-        for (int i = 0; i < fileSize; i++) {
-            filePaths.add("file" + i + ".txt");
-        }
-        BaseFileSource baseFileSource = Mockito.spy(BaseFileSource.class);
+        MockSource source = new MockSource(splits);
+        Map<Integer, List<MockSplit>> assignedSplits = new LinkedHashMap<>();
 
-        Set<FileSourceSplit> splitSet = new HashSet<>();
-        for (int i = 0; i < parallelism; i++) {
-
-            ParallelEnumeratorContext<FileSourceSplit> context =
-                    Mockito.mock(ParallelEnumeratorContext.class);
-
-            Mockito.when(context.currentParallelism()).thenReturn(parallelism);
-
-            FileSourceSplitEnumerator fileSourceSplitEnumerator =
-                    new FileSourceSplitEnumerator(context, filePaths);
-
-            Mockito.when(baseFileSource.createEnumerator(any()))
-                    .thenReturn(fileSourceSplitEnumerator);
-
-            ParallelSource parallelSource =
-                    new ParallelSource(
-                            baseFileSource, null, parallelism, "parallel-source-test" + i, i);
-
+        for (int subtaskId = 0; subtaskId < parallelism; subtaskId++) {
+            ParallelSource<String, MockSplit, Integer> parallelSource =
+                    new ParallelSource<>(
+                            source, null, parallelism, "parallel-source-test", subtaskId);
             parallelSource.open();
             parallelSource.splitEnumerator.run();
 
-            ArgumentCaptor<Integer> subtaskId = ArgumentCaptor.forClass(Integer.class);
-            ArgumentCaptor<List> split = ArgumentCaptor.forClass(List.class);
-
-            Mockito.verify(context, Mockito.times(parallelism))
-                    .assignSplit(subtaskId.capture(), split.capture());
-
-            List<Integer> subTaskAllValues = subtaskId.getAllValues();
-            List<List> splitAllValues = split.getAllValues();
-
-            Assertions.assertEquals(i, subTaskAllValues.get(i));
-            Assertions.assertEquals(
-                    allocateFiles(i, parallelism, fileSize), splitAllValues.get(i).size());
-
-            splitSet.addAll(splitAllValues.get(i));
+            assignedSplits.put(subtaskId, parallelSource.reader.snapshotState(0L));
+            parallelSource.close();
         }
 
-        // Check that there are no duplicate file assign
-        Assertions.assertEquals(splitSet.size(), fileSize);
+        int totalAssigned = assignedSplits.values().stream().mapToInt(List::size).sum();
+        Assertions.assertEquals(splitCount, totalAssigned);
+
+        List<String> splitIds =
+                assignedSplits.values().stream()
+                        .flatMap(List::stream)
+                        .map(MockSplit::splitId)
+                        .sorted()
+                        .collect(Collectors.toList());
+        Assertions.assertEquals(
+                splits.stream().map(MockSplit::splitId).sorted().collect(Collectors.toList()),
+                splitIds);
+
+        for (int subtaskId = 0; subtaskId < parallelism; subtaskId++) {
+            Assertions.assertEquals(
+                    expectedSplitCount(subtaskId, parallelism, splitCount),
+                    assignedSplits.get(subtaskId).size());
+        }
     }
 
     @Test
-    public void dorisParallelSourceSplitEnumeratorTest() throws Exception {
-        int parallelism = 4;
-        int partitionNums = 30;
+    void shouldRestoreReaderSplitsFromCheckpointState() throws Exception {
+        MockSource source = new MockSource(Collections.emptyList());
+        Map<Integer, List<byte[]>> restoredState = new HashMap<>();
+        restoredState.put(-1, Collections.singletonList(toBytes(Integer.valueOf(7))));
+        restoredState.put(0, Collections.singletonList(toBytes(new MockSplit("restored-split-0"))));
 
-        DorisSourceConfig dorisSourceConfig = Mockito.mock(DorisSourceConfig.class);
-        DorisSourceTable dorisSourceTable = Mockito.mock(DorisSourceTable.class);
+        ParallelSource<String, MockSplit, Integer> parallelSource =
+                new ParallelSource<>(source, restoredState, 4, "parallel-source-restore", 0);
+        parallelSource.open();
+        parallelSource.splitEnumerator.run();
 
-        Map<TablePath, DorisSourceTable> dorisSourceTableMap = Maps.newHashMap();
-        dorisSourceTableMap.put(new TablePath("default", null, "default_table"), dorisSourceTable);
+        Assertions.assertEquals(
+                Collections.singletonList("restored-split-0"),
+                parallelSource.reader.snapshotState(0L).stream()
+                        .map(MockSplit::splitId)
+                        .sorted()
+                        .collect(Collectors.toList()));
 
-        DorisSource dorisSource = new DorisSource(dorisSourceConfig, dorisSourceTableMap);
+        MockSplitEnumerator restoredEnumerator = source.lastRestoredEnumerator;
+        Assertions.assertNotNull(restoredEnumerator);
+        Assertions.assertEquals(Integer.valueOf(7), restoredEnumerator.restoredState);
 
-        MockedStatic<RestService> restServiceMockedStatic = Mockito.mockStatic(RestService.class);
-        restServiceMockedStatic
-                .when(() -> RestService.findPartitions(any(), any(), any()))
-                .thenReturn(buildPartitionDefinitions(partitionNums));
+        parallelSource.close();
+    }
 
-        Set<DorisSourceSplit> splitSet = new HashSet<>();
-        for (int i = 0; i < parallelism; i++) {
-            ParallelSource parallelSource =
-                    new ParallelSource(
-                            dorisSource, null, parallelism, "parallel-doris-source" + i, i);
-            parallelSource.open();
+    private static int expectedSplitCount(int subtaskId, int parallelism, int splitCount) {
+        int splitsPerReader = splitCount / parallelism;
+        int remainder = splitCount % parallelism;
+        return subtaskId < remainder ? splitsPerReader + 1 : splitsPerReader;
+    }
 
-            // execute file allocation process
-            parallelSource.splitEnumerator.run();
-            List<DorisSourceSplit> sourceSplits =
-                    ((DorisSourceReader) parallelSource.reader).snapshotState(0);
-            log.info(
-                    "parallel source{} splits => {}",
-                    i + 1,
-                    sourceSplits.stream()
-                            .map(DorisSourceSplit::splitId)
-                            .collect(Collectors.toList()));
+    private static byte[] toBytes(Serializable value) throws IOException {
+        return new org.apache.seatunnel.api.serialization.DefaultSerializer<Serializable>()
+                .serialize(value);
+    }
 
-            Assertions.assertEquals(
-                    allocateFiles(i, parallelism, partitionNums), sourceSplits.size());
+    private static final class MockSource implements SeaTunnelSource<String, MockSplit, Integer> {
 
-            // collect all splits
-            splitSet.addAll(sourceSplits);
+        private final List<MockSplit> splits;
+        private MockSplitEnumerator lastRestoredEnumerator;
+
+        private MockSource(List<MockSplit> splits) {
+            this.splits = splits;
         }
 
-        Assertions.assertEquals(splitSet.size(), partitionNums);
+        @Override
+        public Boundedness getBoundedness() {
+            return Boundedness.BOUNDED;
+        }
+
+        @Override
+        public SourceReader<String, MockSplit> createReader(SourceReader.Context readerContext) {
+            return new MockReader();
+        }
+
+        @Override
+        public SourceSplitEnumerator<MockSplit, Integer> createEnumerator(
+                SourceSplitEnumerator.Context<MockSplit> enumeratorContext) {
+            return new MockSplitEnumerator(enumeratorContext, splits, null);
+        }
+
+        @Override
+        public SourceSplitEnumerator<MockSplit, Integer> restoreEnumerator(
+                SourceSplitEnumerator.Context<MockSplit> enumeratorContext,
+                Integer checkpointState) {
+            lastRestoredEnumerator =
+                    new MockSplitEnumerator(
+                            enumeratorContext, Collections.emptyList(), checkpointState);
+            return lastRestoredEnumerator;
+        }
+
+        @Override
+        public String getPluginName() {
+            return "mock-source";
+        }
     }
 
-    private List<PartitionDefinition> buildPartitionDefinitions(int partitionNUms) {
+    private static final class MockSplitEnumerator
+            implements SourceSplitEnumerator<MockSplit, Integer> {
 
-        List<PartitionDefinition> partitions = new ArrayList<>();
+        private final SourceSplitEnumerator.Context<MockSplit> context;
+        private final Map<Integer, List<MockSplit>> pendingSplits = new HashMap<>();
+        private final Integer restoredState;
+        private final AtomicInteger assignCount = new AtomicInteger(0);
 
-        String beAddressPrefix = "doris-be-";
+        private MockSplitEnumerator(
+                SourceSplitEnumerator.Context<MockSplit> context,
+                List<MockSplit> splits,
+                Integer restoredState) {
+            this.context = context;
+            this.restoredState = restoredState;
+            addPendingSplits(splits);
+        }
 
-        IntStream.range(0, partitionNUms)
-                .forEach(
-                        i -> {
-                            PartitionDefinition partitionDefinition =
-                                    new PartitionDefinition(
-                                            "default",
-                                            "default_table",
-                                            beAddressPrefix + i,
-                                            new HashSet<>(i),
-                                            "QUERY_PLAN");
+        @Override
+        public void open() {}
 
-                            partitions.add(partitionDefinition);
-                        });
+        @Override
+        public void run() {
+            assignSplits(context.registeredReaders());
+            context.registeredReaders().forEach(context::signalNoMoreSplits);
+        }
 
-        return partitions;
+        private static int getSplitOwner(int assignCount, int parallelism) {
+            return assignCount % parallelism;
+        }
+
+        private void assignSplits(Iterable<Integer> readers) {
+            for (Integer reader : readers) {
+                List<MockSplit> assigned = pendingSplits.remove(reader);
+                if (assigned != null && !assigned.isEmpty()) {
+                    context.assignSplit(reader, assigned);
+                }
+            }
+        }
+
+        private void addPendingSplits(List<MockSplit> splits) {
+            int parallelism = context.currentParallelism();
+            List<MockSplit> orderedSplits =
+                    splits.stream()
+                            .sorted((left, right) -> left.splitId().compareTo(right.splitId()))
+                            .collect(Collectors.toList());
+            for (MockSplit split : orderedSplits) {
+                int ownerReader = getSplitOwner(assignCount.getAndIncrement(), parallelism);
+                pendingSplits.computeIfAbsent(ownerReader, key -> new ArrayList<>()).add(split);
+            }
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void addSplitsBack(List<MockSplit> splits, int subtaskId) {
+            pendingSplits.computeIfAbsent(subtaskId, key -> new ArrayList<>()).addAll(splits);
+        }
+
+        @Override
+        public int currentUnassignedSplitSize() {
+            return pendingSplits.values().stream().mapToInt(List::size).sum();
+        }
+
+        @Override
+        public void handleSplitRequest(int subtaskId) {}
+
+        @Override
+        public void registerReader(int subtaskId) {}
+
+        @Override
+        public Integer snapshotState(long checkpointId) {
+            return restoredState;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) {}
     }
 
-    /**
-     * calculate the number of files assigned each time
-     *
-     * @param id id
-     * @param parallelism parallelism
-     * @param fileSize file size
-     * @return
-     */
-    public int allocateFiles(int id, int parallelism, int fileSize) {
-        int filesPerIteration = fileSize / parallelism;
-        int remainder = fileSize % parallelism;
+    private static final class MockReader implements SourceReader<String, MockSplit> {
 
-        if (id < remainder) {
-            return filesPerIteration + 1;
-        } else {
-            return filesPerIteration;
+        private final List<MockSplit> splits = new ArrayList<>();
+
+        @Override
+        public void open() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void pollNext(Collector<String> output) {}
+
+        @Override
+        public List<MockSplit> snapshotState(long checkpointId) {
+            return new ArrayList<>(splits);
+        }
+
+        @Override
+        public void addSplits(List<MockSplit> splits) {
+            this.splits.addAll(splits);
+        }
+
+        @Override
+        public void handleNoMoreSplits() {}
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) {}
+    }
+
+    private static final class MockSplit implements SourceSplit {
+
+        private final String splitId;
+
+        private MockSplit(String splitId) {
+            this.splitId = splitId;
+        }
+
+        @Override
+        public String splitId() {
+            return splitId;
         }
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
This PR removes `connector-file-base` and `connector-doris` test dependencies from `seatunnel-translation-base` and rewrites `ParallelSourceTest` to use a generic mock source.

The updated test still verifies the common round-robin split assignment behavior used by connectors, but no longer depends on concrete connector modules. This reduces unnecessary Maven reactor expansion in incremental IT builds and keeps translation-base test scope isolated.

  Main changes

  - Remove `connector-file-base` and `connector-doris` test dependencies from `seatunnel-translation-base`
  - Refactor `ParallelSourceTest` to use `MockSource / MockSplitEnumerator`
  - Align mock split assignment semantics with the global round-robin strategy used in source enumerators

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
