### PR TITLE
[Improve][Transform-V2] Migrate Split validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.split;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,10 +37,11 @@ public class SplitTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
-                        SplitTransformConfig.KEY_SEPARATOR,
-                        SplitTransformConfig.KEY_SPLIT_FIELD,
-                        SplitTransformConfig.KEY_OUTPUT_FIELDS)
+                .required(SplitTransformConfig.KEY_SEPARATOR)
+                .required(SplitTransformConfig.KEY_SPLIT_FIELD)
+                .required(
+                        SplitTransformConfig.KEY_OUTPUT_FIELDS,
+                        Conditions.notEmpty(SplitTransformConfig.KEY_OUTPUT_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/split/SplitTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/split/SplitTransformFactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.split;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class SplitTransformFactoryTest {
+
+    private final OptionRule rule = new SplitTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("separator", " ");
+        cfg.put("split_field", "name");
+        cfg.put("output_fields", Arrays.asList("first_name", "last_name"));
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingSeparatorFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("separator");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingSplitFieldFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("split_field");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("output_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("output_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate Split imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `SplitTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="SplitTransformFactoryTest" -DfailIfNoTests=false
```