### PR TITLE
[Improve][Transform-V2] Migrate SQL validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
@@ -38,7 +38,7 @@ public class SQLTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(KEY_QUERY)
+                .required(KEY_QUERY)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
@@ -18,59 +18,34 @@
 package org.apache.seatunnel.transform.sql;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.table.catalog.CatalogTable;
-import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
-import org.apache.seatunnel.api.table.connector.TableTransform;
-import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
-import org.apache.seatunnel.api.table.type.BasicType;
-import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
-import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.api.transform.SeaTunnelTransform;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class SQLTransformFactoryTest {
+class SQLTransformFactoryTest {
 
-    @Test
-    public void testFactoryIdentifierAndOptionRule() {
-        SQLTransformFactory factory = new SQLTransformFactory();
-        Assertions.assertEquals(SQLTransform.PLUGIN_NAME, factory.factoryIdentifier());
+    private final OptionRule rule = new SQLTransformFactory().optionRule();
 
-        OptionRule rule = factory.optionRule();
-        // Just ensure optional keys are registered; exact contents will be validated elsewhere
-        Assertions.assertNotNull(rule);
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
     }
 
     @Test
-    public void testCreateTransformReturnsMultiCatalogTransform() {
-        SQLTransformFactory factory = new SQLTransformFactory();
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("query", "SELECT id, name FROM table1");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
 
-        SeaTunnelRowType rowType =
-                new SeaTunnelRowType(
-                        new String[] {"id", "name"},
-                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
-        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("test", rowType);
-        List<CatalogTable> tables = Collections.singletonList(catalogTable);
-
-        ReadonlyConfig config =
-                ReadonlyConfig.fromMap(
-                        Collections.singletonMap(
-                                SQLTransform.KEY_QUERY.key(), "select * from dual"));
-
-        TableTransformFactoryContext context =
-                new TableTransformFactoryContext(
-                        tables, config, Thread.currentThread().getContextClassLoader());
-
-        TableTransform<?> tableTransform = factory.createTransform(context);
-        Assertions.assertNotNull(tableTransform);
-
-        SeaTunnelTransform<?> inner = tableTransform.createTransform();
-        Assertions.assertNotNull(inner);
-        Assertions.assertTrue(inner instanceof SQLMultiCatalogFlatMapTransform);
+    @Test
+    void testMissingQueryFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
@@ -21,31 +21,78 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.connector.TableTransform;
+import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-class SQLTransformFactoryTest {
+public class SQLTransformFactoryTest {
 
-    private final OptionRule rule = new SQLTransformFactory().optionRule();
+    @Test
+    public void testFactoryIdentifierAndOptionRule() {
+        SQLTransformFactory factory = new SQLTransformFactory();
+        Assertions.assertEquals(SQLTransform.PLUGIN_NAME, factory.factoryIdentifier());
 
-    private void validate(Map<String, Object> config) {
-        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+        OptionRule rule = factory.optionRule();
+        // Just ensure optional keys are registered; exact contents will be validated elsewhere
+        Assertions.assertNotNull(rule);
     }
 
     @Test
-    void testValidConfig() {
+    public void testCreateTransformReturnsMultiCatalogTransform() {
+        SQLTransformFactory factory = new SQLTransformFactory();
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("test", rowType);
+        List<CatalogTable> tables = Collections.singletonList(catalogTable);
+
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        Collections.singletonMap(
+                                SQLTransform.KEY_QUERY.key(), "select * from dual"));
+
+        TableTransformFactoryContext context =
+                new TableTransformFactoryContext(
+                        tables, config, Thread.currentThread().getContextClassLoader());
+
+        TableTransform<?> tableTransform = factory.createTransform(context);
+        Assertions.assertNotNull(tableTransform);
+
+        SeaTunnelTransform<?> inner = tableTransform.createTransform();
+        Assertions.assertNotNull(inner);
+        Assertions.assertTrue(inner instanceof SQLMultiCatalogFlatMapTransform);
+    }
+
+    @Test
+    public void testValidConfigWithQuery() {
+        OptionRule rule = new SQLTransformFactory().optionRule();
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("query", "SELECT id, name FROM table1");
-        Assertions.assertDoesNotThrow(() -> validate(cfg));
+        Assertions.assertDoesNotThrow(
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(rule));
     }
 
     @Test
-    void testMissingQueryFails() {
+    public void testMissingQueryFails() {
+        OptionRule rule = new SQLTransformFactory().optionRule();
         Map<String, Object> cfg = new HashMap<>();
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(rule));
     }
 }


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate SQL imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `SQLTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="SQLTransformFactoryTest" -DfailIfNoTests=false
```