### PR TITLE
[Improve][Transform-V2] Migrate Replace validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.transform.replace;
 
-import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
@@ -32,7 +31,6 @@ import lombok.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -49,19 +47,9 @@ public class ReplaceTransform extends AbstractCatalogSupportMapTransform {
     public ReplaceTransform(
             @NonNull ReadonlyConfig config, @NonNull CatalogTable inputCatalogTable) {
         super(inputCatalogTable);
-        validateConflictingReplaceFieldKeys(config);
-        this.replaceFields.addAll(
-                getRequiredOption(config, ReplaceTransformConfig.KEY_REPLACE_FIELDS));
-
-        if (replaceFields.isEmpty()) {
-            throw TransformCommonError.validationFailed(
-                    String.format(
-                            "Option '%s' must not be empty.",
-                            ReplaceTransformConfig.KEY_REPLACE_FIELDS.key()));
-        }
-
-        this.pattern = getRequiredOption(config, ReplaceTransformConfig.KEY_PATTERN);
-        this.replacement = getRequiredOption(config, ReplaceTransformConfig.KEY_REPLACEMENT);
+        this.replaceFields.addAll(config.get(ReplaceTransformConfig.KEY_REPLACE_FIELDS));
+        this.pattern = config.get(ReplaceTransformConfig.KEY_PATTERN);
+        this.replacement = config.get(ReplaceTransformConfig.KEY_REPLACEMENT);
         this.isRegex = config.get(ReplaceTransformConfig.KEY_IS_REGEX);
         this.replaceFirst = config.get(ReplaceTransformConfig.KEY_REPLACE_FIRST);
         this.regexPattern = initializeRegexPattern();
@@ -71,22 +59,6 @@ public class ReplaceTransform extends AbstractCatalogSupportMapTransform {
     @Override
     public String getPluginName() {
         return PLUGIN_NAME;
-    }
-
-    private void validateConflictingReplaceFieldKeys(ReadonlyConfig config) {
-        Map<String, Object> sourceMap = config.getSourceMap();
-        if (sourceMap.containsKey("replace_field") && sourceMap.containsKey("replace_fields")) {
-            throw TransformCommonError.validationFailed(
-                    "Options 'replace_field' and 'replace_fields' cannot be configured together.");
-        }
-    }
-
-    private <T> T getRequiredOption(ReadonlyConfig config, Option<T> option) {
-        return config.getOptional(option)
-                .orElseThrow(
-                        () ->
-                                TransformCommonError.validationFailed(
-                                        String.format("Option '%s' is required.", option.key())));
     }
 
     private void initializeFieldIndexes() {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.replace;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,10 +37,11 @@ public class ReplaceTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
+                .required(
                         ReplaceTransformConfig.KEY_REPLACE_FIELDS,
-                        ReplaceTransformConfig.KEY_PATTERN,
-                        ReplaceTransformConfig.KEY_REPLACEMENT)
+                        Conditions.notEmpty(ReplaceTransformConfig.KEY_REPLACE_FIELDS))
+                .required(ReplaceTransformConfig.KEY_PATTERN)
+                .required(ReplaceTransformConfig.KEY_REPLACEMENT)
                 .optional(ReplaceTransformConfig.KEY_IS_REGEX)
                 .optional(ReplaceTransformConfig.KEY_REPLACE_FIRST)
                 .optional(TransformCommonOptions.MULTI_TABLES)

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.replace;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class ReplaceTransformFactoryTest {
+
+    private final OptionRule rule = new ReplaceTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("replace_fields", Arrays.asList("name"));
+        cfg.put("pattern", "old");
+        cfg.put("replacement", "new");
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingReplaceFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("replace_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyReplaceFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("replace_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingPatternFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("pattern");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingReplacementFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("replacement");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testFallbackKeyValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("replace_field", "name");
+        cfg.put("pattern", "old");
+        cfg.put("replacement", "new");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate Replace imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `ReplaceTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="ReplaceTransformFactoryTest" -DfailIfNoTests=false
```