### PR TITLE
[Improve][Transform-V2] Migrate FieldEncrypt validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.encrypt;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -38,10 +39,17 @@ public class FieldEncryptTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(FieldEncryptTransformConfig.FIELDS)
-                .required(FieldEncryptTransformConfig.KEY)
+                .required(
+                        FieldEncryptTransformConfig.FIELDS,
+                        Conditions.notEmpty(FieldEncryptTransformConfig.FIELDS))
+                .required(
+                        FieldEncryptTransformConfig.KEY,
+                        Conditions.notBlank(FieldEncryptTransformConfig.KEY))
                 .optional(FieldEncryptTransformConfig.ALGORITHM)
                 .optional(FieldEncryptTransformConfig.MODE)
+                .optional(
+                        FieldEncryptTransformConfig.MAX_FIELD_LENGTH,
+                        Conditions.greaterThan(FieldEncryptTransformConfig.MAX_FIELD_LENGTH, 0))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.encrypt;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class FieldEncryptTransformFactoryTest {
+
+    private final OptionRule rule = new FieldEncryptTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("fields", Arrays.asList("password", "ssn"));
+        cfg.put("key", "1234567890abcdef");
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingKeyFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("key");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testBlankKeyFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("key", "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthZeroFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", 0);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthNegativeFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", -1);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthPositiveValid() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", 1024);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate FieldEncrypt imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `FieldEncryptTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="FieldEncryptTransformFactoryTest" -DfailIfNoTests=false
```