### PR TITLE
[Improve][Transform-V2] Migrate DynamicCompile validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.dynamiccompile;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,17 +37,16 @@ public class DynamicCompileTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
-                        DynamicCompileTransformConfig.COMPILE_LANGUAGE,
-                        DynamicCompileTransformConfig.COMPILE_PATTERN)
+                .required(DynamicCompileTransformConfig.COMPILE_LANGUAGE)
+                .optional(DynamicCompileTransformConfig.COMPILE_PATTERN)
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.SOURCE_CODE,
-                        DynamicCompileTransformConfig.SOURCE_CODE)
+                        Conditions.notBlank(DynamicCompileTransformConfig.SOURCE_CODE))
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.ABSOLUTE_PATH,
-                        DynamicCompileTransformConfig.ABSOLUTE_PATH)
+                        Conditions.notBlank(DynamicCompileTransformConfig.ABSOLUTE_PATH))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.dynamiccompile;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class DynamicCompileTransformFactoryTest {
+
+    private final OptionRule rule = new DynamicCompileTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidSourceCodeConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "public class Transform {}");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidAbsolutePathConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "ABSOLUTE_PATH");
+        cfg.put("absolute_path", "/tmp/Transform.java");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingCompileLanguageFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "public class Transform {}");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testSourceCodeBlankFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testAbsolutePathBlankFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "ABSOLUTE_PATH");
+        cfg.put("absolute_path", "  ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate DynamicCompile imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `DynamicCompileTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="DynamicCompileTransformFactoryTest" -DfailIfNoTests=false
```