### PR TITLE
[Improve][Transform-V2] Migrate CopyField validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.copy;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -36,8 +40,15 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .bundled(CopyTransformConfig.SRC_FIELD, CopyTransformConfig.DEST_FIELD)
-                .bundled(CopyTransformConfig.FIELDS)
+                .exclusive(CopyTransformConfig.FIELDS, CopyTransformConfig.SRC_FIELD)
+                .optional(
+                        CopyTransformConfig.FIELDS,
+                        Conditions.mapNotEmpty(CopyTransformConfig.FIELDS))
+                .optional(
+                        CopyTransformConfig.SRC_FIELD,
+                        Conditions.extension(
+                                CopyTransformConfig.SRC_FIELD, new RequireDestFieldValidator()))
+                .optional(CopyTransformConfig.DEST_FIELD)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();
@@ -48,5 +59,23 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
         return () ->
                 new CopyFieldMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class RequireDestFieldValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "'dest_field' is required when 'src_field' is provided";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String value)
+                throws OptionValidationException {
+            String destField = config.get(CopyTransformConfig.DEST_FIELD);
+            if (destField == null || destField.trim().isEmpty()) {
+                throw new OptionValidationException(
+                        "'dest_field' must be provided when using 'src_field'");
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.copy;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class CopyFieldTransformFactoryTest {
+
+    private final OptionRule rule = new CopyFieldTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidFieldsMapConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, String> fields = new HashMap<>();
+        fields.put("new_col", "old_col");
+        cfg.put("fields", fields);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidSrcDestConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("src_field", "old_col");
+        cfg.put("dest_field", "new_col");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldsMapFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("fields", Collections.emptyMap());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testNeitherFieldsNorSrcFieldProvidedFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testSrcFieldWithoutDestFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("src_field", "old_col");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDestFieldWithoutSrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("dest_field", "new_col");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate CopyField imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `CopyFieldTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="CopyFieldTransformFactoryTest" -DfailIfNoTests=false
```