### PR TITLE
[Improve][Transform-V2] Migrate DefineSinkType validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformConfig.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformConfig.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
-
 @Data
 @AllArgsConstructor
 public class DefineSinkTypeTransformConfig implements Serializable {
@@ -82,16 +80,6 @@ public class DefineSinkTypeTransformConfig implements Serializable {
 
     public static DefineSinkTypeTransformConfig of(ReadonlyConfig config) {
         List<DefineColumnType> columns = config.get(COLUMNS);
-
-        checkArgument(columns != null && !columns.isEmpty(), "The columns must be set");
-        columns.forEach(
-                defineColumnType -> {
-                    checkArgument(
-                            defineColumnType.getColumn() != null, "The column name must be set");
-                    checkArgument(
-                            defineColumnType.getType() != null, "The column type must be set");
-                });
-
         return new DefineSinkTypeTransformConfig(columns);
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
@@ -17,14 +17,23 @@
 
 package org.apache.seatunnel.transform.adaptsink;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
+import org.apache.seatunnel.transform.adaptsink.DefineSinkTypeTransformConfig.DefineColumnType;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @AutoService(Factory.class)
 public class DefineSinkTypeTransformFactory implements TableTransformFactory {
@@ -36,7 +45,13 @@ public class DefineSinkTypeTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(DefineSinkTypeTransformConfig.COLUMNS)
+                .required(
+                        DefineSinkTypeTransformConfig.COLUMNS,
+                        Conditions.notEmpty(DefineSinkTypeTransformConfig.COLUMNS)
+                                .and(
+                                        Conditions.extension(
+                                                DefineSinkTypeTransformConfig.COLUMNS,
+                                                new ColumnsStructureValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();
@@ -47,5 +62,40 @@ public class DefineSinkTypeTransformFactory implements TableTransformFactory {
         return () ->
                 new DefineSinkTypeMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class ColumnsStructureValidator implements ConditionExtension<List<DefineColumnType>> {
+        @Override
+        public String description() {
+            return "each column entry must contain non-null 'column' and 'type'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<DefineColumnType> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            Set<String> seen = new HashSet<>();
+            for (int i = 0; i < value.size(); i++) {
+                DefineColumnType entry = value.get(i);
+                if (entry.getColumn() == null || entry.getColumn().trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: 'column' name must not be null or empty", i));
+                }
+                if (entry.getType() == null || entry.getType().trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'type' must not be null or empty", i));
+                }
+                if (!seen.add(entry.getColumn())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: duplicate column name '%s'",
+                                    i, entry.getColumn()));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.adaptsink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class DefineSinkTypeTransformFactoryTest {
+
+    private final OptionRule rule = new DefineSinkTypeTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> columnEntry(String column, String type) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("column", column);
+        entry.put("type", type);
+        return entry;
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(
+                "columns",
+                Arrays.asList(columnEntry("id", "bigint"), columnEntry("name", "string")));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry(null, "bigint")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullTypeFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("id", null)));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptyNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("", "bigint")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDuplicateColumnNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("id", "bigint"), columnEntry("id", "string")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate DefineSinkType imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `DefineSinkTypeTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="DefineSinkTypeTransformFactoryTest" -DfailIfNoTests=false
```