### PR TITLE
[Improve][Transform-V2] Migrate TableFilter validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
@@ -18,7 +18,6 @@
 package org.apache.seatunnel.transform.table;
 
 import org.apache.seatunnel.shade.com.fasterxml.jackson.annotation.JsonAlias;
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
@@ -107,13 +106,6 @@ public class TableFilterConfig implements Serializable {
         filterConfig.setSchemaPattern(config.get(SCHEMA_PATTERN));
         filterConfig.setTablePattern(config.get(TABLE_PATTERN));
         filterConfig.setPatternMode(config.get(PATTERN_MODE));
-
-        Preconditions.checkArgument(
-                filterConfig.getDatabasePattern() != null
-                        || filterConfig.getSchemaPattern() != null
-                        || filterConfig.getTablePattern() != null
-                        || filterConfig.getPatternMode() != null,
-                "At least one of database_pattern, schema_pattern, table_pattern or pattern_mode must be specified.");
         return filterConfig;
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.table;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,8 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.regex.PatternSyntaxException;
 
 @AutoService(Factory.class)
 public class TableFilterTransformFactory implements TableTransformFactory {
@@ -38,8 +44,15 @@ public class TableFilterTransformFactory implements TableTransformFactory {
         return OptionRule.builder()
                 .optional(
                         TableFilterConfig.DATABASE_PATTERN,
+                        Conditions.extension(
+                                TableFilterConfig.DATABASE_PATTERN, new RegexValidator()))
+                .optional(
                         TableFilterConfig.SCHEMA_PATTERN,
-                        TableFilterConfig.TABLE_PATTERN)
+                        Conditions.extension(
+                                TableFilterConfig.SCHEMA_PATTERN, new RegexValidator()))
+                .optional(
+                        TableFilterConfig.TABLE_PATTERN,
+                        Conditions.extension(TableFilterConfig.TABLE_PATTERN, new RegexValidator()))
                 .optional(TableFilterConfig.PATTERN_MODE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
@@ -51,5 +64,27 @@ public class TableFilterTransformFactory implements TableTransformFactory {
         return () ->
                 new TableFilterMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class RegexValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "must be a valid regular expression";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String value)
+                throws OptionValidationException {
+            if (value == null || value.isEmpty()) {
+                return true;
+            }
+            try {
+                java.util.regex.Pattern.compile(value);
+                return true;
+            } catch (PatternSyntaxException e) {
+                throw new OptionValidationException(
+                        String.format("Invalid regex pattern '%s': %s", value, e.getDescription()));
+            }
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/table/TableFilterTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/table/TableFilterTransformFactoryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.table;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class TableFilterTransformFactoryTest {
+
+    private final OptionRule rule = new TableFilterTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidWithTablePattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("table_pattern", "user_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidWithDatabasePattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("database_pattern", "prod_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidWithSchemaPattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("schema_pattern", "public");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidDatabasePatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("database_pattern", "[unclosed");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidSchemaPatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("schema_pattern", "(missing_paren");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidTablePatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("table_pattern", "*invalid");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testPatternModeWithTablePatternValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("pattern_mode", "EXCLUDE");
+        cfg.put("table_pattern", "tmp_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate TableFilter imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `TableFilterTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="TableFilterTransformFactoryTest" -DfailIfNoTests=false
```