### PR TITLE
[Improve][Transform-V2] Migrate JsonPath validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.jsonpath;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,9 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
 
 @AutoService(Factory.class)
 public class JsonPathTransformFactory implements TableTransformFactory {
@@ -36,7 +43,13 @@ public class JsonPathTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(JsonPathTransformConfig.COLUMNS)
+                .required(
+                        JsonPathTransformConfig.COLUMNS,
+                        Conditions.notEmpty(JsonPathTransformConfig.COLUMNS)
+                                .and(
+                                        Conditions.extension(
+                                                JsonPathTransformConfig.COLUMNS,
+                                                new ColumnsValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
@@ -47,5 +60,45 @@ public class JsonPathTransformFactory implements TableTransformFactory {
     public TableTransform createTransform(TableTransformFactoryContext context) {
         return () ->
                 new JsonPathMultiCatalogTransform(context.getCatalogTables(), context.getOptions());
+    }
+
+    static class ColumnsValidator implements ConditionExtension<List<Map<String, Object>>> {
+        @Override
+        public String description() {
+            return "each column entry must contain non-empty 'path' and 'dest_field'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            for (int i = 0; i < value.size(); i++) {
+                Map<String, Object> entry = value.get(i);
+                Object path = entry.get("path");
+                if (path == null
+                        || (path instanceof String && ((String) path).trim().isEmpty())
+                        || (path instanceof List && ((List<?>) path).isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'path' must not be null or empty", i));
+                }
+                Object srcField = entry.get("src_field");
+                if (srcField == null
+                        || (srcField instanceof String && ((String) srcField).trim().isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'src_field' must not be null or empty", i));
+                }
+                Object destField = entry.get("dest_field");
+                if (destField == null
+                        || (destField instanceof String && ((String) destField).trim().isEmpty())
+                        || (destField instanceof List && ((List<?>) destField).isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: 'dest_field' must not be null or empty", i));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.jsonpath;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class JsonPathTransformFactoryTest {
+
+    private final OptionRule rule = new JsonPathTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> columnEntry(String path, String srcField, String destField) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", path);
+        entry.put("src_field", srcField);
+        entry.put("dest_field", destField);
+        return entry;
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("$.data.name", "raw", "name")));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullPathFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("src_field", "raw");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptyDestFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("src_field", "raw");
+        entry.put("dest_field", "");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithMissingSrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptySrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("src_field", "");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate JsonPath imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `JsonPathTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="JsonPathTransformFactoryTest" -DfailIfNoTests=false
```