### PR TITLE
[Improve][Transform-V2] Migrate DataValidator validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.validator;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,9 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.seatunnel.transform.validator.DataValidatorTransformConfig.FIELD_RULES;
 
@@ -40,7 +47,10 @@ public class DataValidatorTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(FIELD_RULES)
+                .required(
+                        FIELD_RULES,
+                        Conditions.notEmpty(FIELD_RULES)
+                                .and(Conditions.extension(FIELD_RULES, new FieldRulesValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
@@ -52,5 +62,40 @@ public class DataValidatorTransformFactory implements TableTransformFactory {
     public TableTransform createTransform(TableTransformFactoryContext context) {
         return () ->
                 new DataValidatorTransform(context.getOptions(), context.getCatalogTables().get(0));
+    }
+
+    static class FieldRulesValidator implements ConditionExtension<List<Map<String, Object>>> {
+        @Override
+        public String description() {
+            return "each field_rules entry must contain 'field_name' and either 'rule_type' or 'rules'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            for (int i = 0; i < value.size(); i++) {
+                Map<String, Object> entry = value.get(i);
+                Object fieldName = entry.get("field_name");
+                if (fieldName == null
+                        || (fieldName instanceof String && ((String) fieldName).trim().isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "field_rules[%d]: 'field_name' must not be null or empty", i));
+                }
+                boolean hasRuleType = entry.containsKey("rule_type");
+                Object rulesObj = entry.get("rules");
+                boolean hasRules = rulesObj instanceof List && !((List<?>) rulesObj).isEmpty();
+                if (!hasRuleType && !hasRules) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "field_rules[%d]: must contain 'rule_type' or non-empty 'rules'",
+                                    i));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.validator;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class DataValidatorTransformFactoryTest {
+
+    private final OptionRule rule = new DataValidatorTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "age");
+        fieldRule.put("rule_type", "NOT_NULL");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingFieldRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("field_rules", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingFieldNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("rule_type", "NOT_NULL");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingRuleTypeAndRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "age");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testNestedRulesValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "email");
+        Map<String, Object> nestedRule = new HashMap<>();
+        nestedRule.put("rule_type", "NOT_NULL");
+        fieldRule.put("rules", Arrays.asList(nestedRule));
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyRulesListFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "email");
+        fieldRule.put("rules", Collections.emptyList());
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate DataValidator imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `DataValidatorTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="DataValidatorTransformFactoryTest" -DfailIfNoTests=false
```