### PR TITLE
[Improve][Transform-V2] Migrate RegexExtract validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.regexextract;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,8 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
 
 @AutoService(Factory.class)
 public class RegexExtractTransformFactory implements TableTransformFactory {
@@ -37,13 +43,17 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
+                .required(RegexExtractTransformConfig.KEY_SOURCE_FIELD)
+                .required(RegexExtractTransformConfig.KEY_REGEX_PATTERN)
                 .required(
-                        RegexExtractTransformConfig.KEY_SOURCE_FIELD,
-                        RegexExtractTransformConfig.KEY_REGEX_PATTERN,
-                        RegexExtractTransformConfig.KEY_OUTPUT_FIELDS)
+                        RegexExtractTransformConfig.KEY_OUTPUT_FIELDS,
+                        Conditions.notEmpty(RegexExtractTransformConfig.KEY_OUTPUT_FIELDS))
                 .optional(
                         RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
-                        TransformCommonOptions.MULTI_TABLES)
+                        Conditions.extension(
+                                RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
+                                new DefaultValuesLengthValidator()))
+                .optional(TransformCommonOptions.MULTI_TABLES)
                 .build();
     }
 
@@ -52,5 +62,28 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
         return () ->
                 new RegexExtractMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class DefaultValuesLengthValidator implements ConditionExtension<List<String>> {
+        @Override
+        public String description() {
+            return "'default_values' length must equal 'output_fields' length";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<String> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return true;
+            }
+            List<String> outputFields = config.get(RegexExtractTransformConfig.KEY_OUTPUT_FIELDS);
+            if (outputFields != null && value.size() != outputFields.size()) {
+                throw new OptionValidationException(
+                        String.format(
+                                "'default_values' has %d elements but 'output_fields' has %d elements — they must match",
+                                value.size(), outputFields.size()));
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.regexextract;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class RegexExtractTransformFactoryTest {
+
+    private final OptionRule rule = new RegexExtractTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("source_field", "log_line");
+        cfg.put("regex_pattern", "(\\d+)-(\\w+)");
+        cfg.put("output_fields", Arrays.asList("id", "name"));
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testValidConfigWithMatchingDefaults() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("default_values", Arrays.asList("0", "unknown"));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingSourceFieldFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("source_field");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingRegexPatternFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("regex_pattern");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("output_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDefaultValuesLengthMismatchFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("default_values", Arrays.asList("0", "unknown", "extra"));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyOutputFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("source_field", "log_line");
+        cfg.put("regex_pattern", "(\\d+)");
+        cfg.put("output_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate RegexExtract imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit test covering positive and negative paths

## Does this PR introduce _any_ user-facing change?

No. Validation behavior is preserved; only the mechanism changes from imperative to declarative.

## How was this patch tested?

Unit tests in `RegexExtractTransformFactoryTest`:

- Positive: valid config passes
- Negative: missing/invalid fields rejected with `OptionValidationException`

```bash
./mvnw test -pl seatunnel-transforms-v2 -Dtest="RegexExtractTransformFactoryTest" -DfailIfNoTests=false
```