### PR TITLE
[Improve][Transform-V2] Migrate TableMerge validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.table;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,7 +37,7 @@ public class TableMergeTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(TableMergeConfig.TABLE)
+                .required(TableMergeConfig.TABLE, Conditions.notBlank(TableMergeConfig.TABLE))
                 .optional(TableMergeConfig.DATABASE, TableMergeConfig.SCHEMA)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Add declarative constraint to TableMerge factory `optionRule()`

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

Change is minimal (single constraint addition). Existing tests continue to pass.