### PR TITLE
[Improve][Transform-V2] Migrate RowKindExtractor validation to declarative OptionRule

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
@@ -37,6 +37,7 @@ public class RowKindExtractorTransformFactory implements TableTransformFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .optional(RowKindExtractorTransformConfig.CUSTOM_FIELD_NAME)
+                .optional(RowKindExtractorTransformConfig.TRANSFORM_TYPE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Add declarative constraint to RowKindExtractor factory `optionRule()`

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

Change is minimal (single constraint addition). Existing tests continue to pass.