### PR TITLE
[Improve][Transform-V2] Migrate transforms validation to declarative OptionRule

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -102,6 +102,17 @@ You need to check this document before you upgrade to related version.
 
   **Migration Guide**: If you are using custom datetime format patterns in `PARSEDATETIME`, `TO_DATE`, or `IS_DATE` functions, you must update your queries to use one of the supported patterns above. If your data uses a different format, you may need to preprocess the input data to match a supported format, or use string manipulation functions to transform the format before parsing.
 - DataValidator transform: In `row_error_handle_way = ROUTE_TO_TABLE` mode, the routed error row `table_id` now includes the upstream database/schema prefix (for example, `db1.ffp` / `db1.schema1.ffp` instead of `ffp`).
+- **[BREAKING]** Several transform plugins now perform stricter submission-time config validation via declarative `OptionRule`. Configs that previously passed submission but failed at runtime will now be rejected at submission time with a descriptive `OptionValidationException`:
+
+  | Transform | Newly Rejected Config | Previous Behavior | Migration |
+  |-----------|----------------------|-------------------|-----------|
+  | `DefineSinkType` | `columns` entries with null/empty `column` or `type` | Runtime NPE or undefined behavior | Ensure every entry has non-empty `column` and `type` fields |
+  | `DefineSinkType` | `columns` with duplicate column names | Silent override or runtime conflict | Remove duplicate column entries |
+  | `FieldEncrypt` | `max_field_length` set to ≤ 0 | Ignored or unexpected truncation | Set `max_field_length` to a positive integer, or remove the option to use the default |
+  | `DynamicCompile` | `compile_pattern = SOURCE_CODE` without a non-blank `source_code` | Runtime compilation failure | Provide `source_code` when using `SOURCE_CODE` pattern |
+  | `DynamicCompile` | `compile_pattern = ABSOLUTE_PATH` without a non-blank `absolute_path` | Runtime file-read failure | Provide `absolute_path` when using `ABSOLUTE_PATH` pattern |
+
+  **Migration Guide**: Review your transform configs against the table above. If any of your existing configs match a "Newly Rejected" pattern, update them before upgrading. The error messages at submission time now clearly identify which option is invalid and why.
 - Adjusted SQL Transform date & time functions:
   - `DATEDIFF(<start>, <end>, 'MONTH')` now returns the total number of months between the two dates across years (for example, from `2023-01-01` to `2024-03-01` returns `14` instead of `15`).
   - `WEEK(<datetime>)` now returns the ISO week number directly (previous behavior added an extra `+1` to the ISO week value).

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -98,6 +98,18 @@
   **迁移指南**: 如果您在 `PARSEDATETIME`、`TO_DATE` 或 `IS_DATE` 函数中使用自定义日期时间格式模式，您必须更新查询以使用上述支持的模式之一。如果您的数据使用不同的格式，您可能需要预处理输入数据以匹配支持的格式，或使用字符串操作函数在解析之前转换格式。
 
 - DataValidator 转换：当 `row_error_handle_way = ROUTE_TO_TABLE` 时，路由到错误表的行 `table_id` 现在会携带上游的 database/schema 前缀（例如从 `ffp` 变为 `db1.ffp` / `db1.schema1.ffp`）。
+- **[BREAKING]** 多个转换插件现在通过声明式 `OptionRule` 在提交时执行更严格的配置校验。以前在提交时能通过但运行时失败的配置，现在会在提交时被拒绝，并抛出描述清晰的 `OptionValidationException`：
+
+  | 转换插件 | 新增拒绝的配置 | 以前的行为 | 迁移方式 |
+  |---------|--------------|-----------|---------|
+  | `DefineSinkType` | `columns` 条目中 `column` 或 `type` 为空 | 运行时 NPE 或未定义行为 | 确保每个条目都有非空的 `column` 和 `type` 字段 |
+  | `DefineSinkType` | `columns` 中存在重复列名 | 静默覆盖或运行时冲突 | 移除重复的列条目 |
+  | `FieldEncrypt` | `max_field_length` 设置为 ≤ 0 | 被忽略或产生意外截断 | 设置为正整数，或移除该选项以使用默认值 |
+  | `DynamicCompile` | `compile_pattern = SOURCE_CODE` 但 `source_code` 为空 | 运行时编译失败 | 使用 `SOURCE_CODE` 模式时提供 `source_code` |
+  | `DynamicCompile` | `compile_pattern = ABSOLUTE_PATH` 但 `absolute_path` 为空 | 运行时文件读取失败 | 使用 `ABSOLUTE_PATH` 模式时提供 `absolute_path` |
+
+  **迁移指南**：升级前请对照上表检查您的转换配置。如果现有配置匹配了"新增拒绝的配置"中的情况，请在升级前修改。提交时的错误消息会清楚标明哪个选项无效及原因。
+
 ### 引擎行为变更
 
 ### 依赖升级

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformConfig.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformConfig.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
-
 @Data
 @AllArgsConstructor
 public class DefineSinkTypeTransformConfig implements Serializable {
@@ -82,16 +80,6 @@ public class DefineSinkTypeTransformConfig implements Serializable {
 
     public static DefineSinkTypeTransformConfig of(ReadonlyConfig config) {
         List<DefineColumnType> columns = config.get(COLUMNS);
-
-        checkArgument(columns != null && !columns.isEmpty(), "The columns must be set");
-        columns.forEach(
-                defineColumnType -> {
-                    checkArgument(
-                            defineColumnType.getColumn() != null, "The column name must be set");
-                    checkArgument(
-                            defineColumnType.getType() != null, "The column type must be set");
-                });
-
         return new DefineSinkTypeTransformConfig(columns);
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
@@ -17,14 +17,23 @@
 
 package org.apache.seatunnel.transform.adaptsink;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
+import org.apache.seatunnel.transform.adaptsink.DefineSinkTypeTransformConfig.DefineColumnType;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @AutoService(Factory.class)
 public class DefineSinkTypeTransformFactory implements TableTransformFactory {
@@ -36,7 +45,13 @@ public class DefineSinkTypeTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(DefineSinkTypeTransformConfig.COLUMNS)
+                .required(
+                        DefineSinkTypeTransformConfig.COLUMNS,
+                        Conditions.notEmpty(DefineSinkTypeTransformConfig.COLUMNS)
+                                .and(
+                                        Conditions.extension(
+                                                DefineSinkTypeTransformConfig.COLUMNS,
+                                                new ColumnsStructureValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();
@@ -47,5 +62,40 @@ public class DefineSinkTypeTransformFactory implements TableTransformFactory {
         return () ->
                 new DefineSinkTypeMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class ColumnsStructureValidator implements ConditionExtension<List<DefineColumnType>> {
+        @Override
+        public String description() {
+            return "each column entry must contain non-null 'column' and 'type'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<DefineColumnType> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            Set<String> seen = new HashSet<>();
+            for (int i = 0; i < value.size(); i++) {
+                DefineColumnType entry = value.get(i);
+                if (entry.getColumn() == null || entry.getColumn().trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: 'column' name must not be null or empty", i));
+                }
+                if (entry.getType() == null || entry.getType().trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'type' must not be null or empty", i));
+                }
+                if (!seen.add(entry.getColumn())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: duplicate column name '%s'",
+                                    i, entry.getColumn()));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -68,14 +67,9 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, String value)
-                throws OptionValidationException {
+        public boolean evaluate(ReadonlyConfig config, String value) {
             String destField = config.get(CopyTransformConfig.DEST_FIELD);
-            if (destField == null || destField.trim().isEmpty()) {
-                throw new OptionValidationException(
-                        "'dest_field' must be provided when using 'src_field'");
-            }
-            return true;
+            return destField != null && !destField.trim().isEmpty();
         }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.copy;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -36,8 +40,15 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .bundled(CopyTransformConfig.SRC_FIELD, CopyTransformConfig.DEST_FIELD)
-                .bundled(CopyTransformConfig.FIELDS)
+                .exclusive(CopyTransformConfig.FIELDS, CopyTransformConfig.SRC_FIELD)
+                .optional(
+                        CopyTransformConfig.FIELDS,
+                        Conditions.mapNotEmpty(CopyTransformConfig.FIELDS))
+                .optional(
+                        CopyTransformConfig.SRC_FIELD,
+                        Conditions.extension(
+                                CopyTransformConfig.SRC_FIELD, new RequireDestFieldValidator()))
+                .optional(CopyTransformConfig.DEST_FIELD)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();
@@ -48,5 +59,23 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
         return () ->
                 new CopyFieldMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class RequireDestFieldValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "'dest_field' is required when 'src_field' is provided";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String value)
+                throws OptionValidationException {
+            String destField = config.get(CopyTransformConfig.DEST_FIELD);
+            if (destField == null || destField.trim().isEmpty()) {
+                throw new OptionValidationException(
+                        "'dest_field' must be provided when using 'src_field'");
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
@@ -42,7 +42,15 @@ public class DynamicCompileTransformFactory implements TableTransformFactory {
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.SOURCE_CODE,
+                        DynamicCompileTransformConfig.SOURCE_CODE)
+                .conditional(
+                        DynamicCompileTransformConfig.COMPILE_PATTERN,
+                        CompilePattern.SOURCE_CODE,
                         Conditions.notBlank(DynamicCompileTransformConfig.SOURCE_CODE))
+                .conditional(
+                        DynamicCompileTransformConfig.COMPILE_PATTERN,
+                        CompilePattern.ABSOLUTE_PATH,
+                        DynamicCompileTransformConfig.ABSOLUTE_PATH)
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.ABSOLUTE_PATH,

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.dynamiccompile;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,17 +37,16 @@ public class DynamicCompileTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
-                        DynamicCompileTransformConfig.COMPILE_LANGUAGE,
-                        DynamicCompileTransformConfig.COMPILE_PATTERN)
+                .required(DynamicCompileTransformConfig.COMPILE_LANGUAGE)
+                .optional(DynamicCompileTransformConfig.COMPILE_PATTERN)
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.SOURCE_CODE,
-                        DynamicCompileTransformConfig.SOURCE_CODE)
+                        Conditions.notBlank(DynamicCompileTransformConfig.SOURCE_CODE))
                 .conditional(
                         DynamicCompileTransformConfig.COMPILE_PATTERN,
                         CompilePattern.ABSOLUTE_PATH,
-                        DynamicCompileTransformConfig.ABSOLUTE_PATH)
+                        Conditions.notBlank(DynamicCompileTransformConfig.ABSOLUTE_PATH))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.encrypt;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -38,10 +39,17 @@ public class FieldEncryptTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(FieldEncryptTransformConfig.FIELDS)
-                .required(FieldEncryptTransformConfig.KEY)
+                .required(
+                        FieldEncryptTransformConfig.FIELDS,
+                        Conditions.notEmpty(FieldEncryptTransformConfig.FIELDS))
+                .required(
+                        FieldEncryptTransformConfig.KEY,
+                        Conditions.notBlank(FieldEncryptTransformConfig.KEY))
                 .optional(FieldEncryptTransformConfig.ALGORITHM)
                 .optional(FieldEncryptTransformConfig.MODE)
+                .optional(
+                        FieldEncryptTransformConfig.MAX_FIELD_LENGTH,
+                        Conditions.greaterThan(FieldEncryptTransformConfig.MAX_FIELD_LENGTH, 0))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.transform.fieldmapper;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -37,7 +38,9 @@ public class FieldMapperTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(FieldMapperTransformConfig.FIELD_MAPPER)
+                .required(
+                        FieldMapperTransformConfig.FIELD_MAPPER,
+                        Conditions.mapNotEmpty(FieldMapperTransformConfig.FIELD_MAPPER))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransform.java
@@ -18,8 +18,6 @@
 package org.apache.seatunnel.transform.filter;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.api.configuration.util.ConfigValidator;
-import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.ConstraintKey;
@@ -58,14 +56,6 @@ public class FilterFieldTransform extends AbstractCatalogSupportMapTransform {
         SeaTunnelRowType seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
         includeFields = config.get(FilterFieldTransformConfig.INCLUDE_FIELDS);
         excludeFields = config.get(FilterFieldTransformConfig.EXCLUDE_FIELDS);
-        // exactly only one should be set
-        ConfigValidator.of(config)
-                .validate(
-                        OptionRule.builder()
-                                .exclusive(
-                                        FilterFieldTransformConfig.INCLUDE_FIELDS,
-                                        FilterFieldTransformConfig.EXCLUDE_FIELDS)
-                                .build());
         List<String> canNotFoundFields =
                 Stream.concat(
                                 Optional.ofNullable(includeFields).orElse(new ArrayList<>())

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.filter;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -38,9 +39,15 @@ public class FilterFieldTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
+                .exclusive(
                         FilterFieldTransformConfig.INCLUDE_FIELDS,
                         FilterFieldTransformConfig.EXCLUDE_FIELDS)
+                .optional(
+                        FilterFieldTransformConfig.INCLUDE_FIELDS,
+                        Conditions.notEmpty(FilterFieldTransformConfig.INCLUDE_FIELDS))
+                .optional(
+                        FilterFieldTransformConfig.EXCLUDE_FIELDS,
+                        Conditions.notEmpty(FilterFieldTransformConfig.EXCLUDE_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.jsonpath;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,9 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
 
 @AutoService(Factory.class)
 public class JsonPathTransformFactory implements TableTransformFactory {
@@ -36,7 +43,13 @@ public class JsonPathTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(JsonPathTransformConfig.COLUMNS)
+                .required(
+                        JsonPathTransformConfig.COLUMNS,
+                        Conditions.notEmpty(JsonPathTransformConfig.COLUMNS)
+                                .and(
+                                        Conditions.extension(
+                                                JsonPathTransformConfig.COLUMNS,
+                                                new ColumnsValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
@@ -47,5 +60,45 @@ public class JsonPathTransformFactory implements TableTransformFactory {
     public TableTransform createTransform(TableTransformFactoryContext context) {
         return () ->
                 new JsonPathMultiCatalogTransform(context.getCatalogTables(), context.getOptions());
+    }
+
+    static class ColumnsValidator implements ConditionExtension<List<Map<String, Object>>> {
+        @Override
+        public String description() {
+            return "each column entry must contain non-empty 'path' and 'dest_field'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            for (int i = 0; i < value.size(); i++) {
+                Map<String, Object> entry = value.get(i);
+                Object path = entry.get("path");
+                if (path == null
+                        || (path instanceof String && ((String) path).trim().isEmpty())
+                        || (path instanceof List && ((List<?>) path).isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'path' must not be null or empty", i));
+                }
+                Object srcField = entry.get("src_field");
+                if (srcField == null
+                        || (srcField instanceof String && ((String) srcField).trim().isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format("columns[%d]: 'src_field' must not be null or empty", i));
+                }
+                Object destField = entry.get("dest_field");
+                if (destField == null
+                        || (destField instanceof String && ((String) destField).trim().isEmpty())
+                        || (destField instanceof List && ((List<?>) destField).isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "columns[%d]: 'dest_field' must not be null or empty", i));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.metadata;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,7 +37,9 @@ public class MetadataTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(MetadataTransformConfig.METADATA_FIELDS)
+                .required(
+                        MetadataTransformConfig.METADATA_FIELDS,
+                        Conditions.mapNotEmpty(MetadataTransformConfig.METADATA_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -71,19 +70,12 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, List<String> value)
-                throws OptionValidationException {
+        public boolean evaluate(ReadonlyConfig config, List<String> value) {
             if (value == null) {
                 return true;
             }
             List<String> outputFields = config.get(RegexExtractTransformConfig.KEY_OUTPUT_FIELDS);
-            if (outputFields != null && value.size() != outputFields.size()) {
-                throw new OptionValidationException(
-                        String.format(
-                                "'default_values' has %d elements but 'output_fields' has %d elements — they must match",
-                                value.size(), outputFields.size()));
-            }
-            return true;
+            return outputFields == null || value.size() == outputFields.size();
         }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.regexextract;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,8 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
 
 @AutoService(Factory.class)
 public class RegexExtractTransformFactory implements TableTransformFactory {
@@ -37,13 +43,17 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
+                .required(RegexExtractTransformConfig.KEY_SOURCE_FIELD)
+                .required(RegexExtractTransformConfig.KEY_REGEX_PATTERN)
                 .required(
-                        RegexExtractTransformConfig.KEY_SOURCE_FIELD,
-                        RegexExtractTransformConfig.KEY_REGEX_PATTERN,
-                        RegexExtractTransformConfig.KEY_OUTPUT_FIELDS)
+                        RegexExtractTransformConfig.KEY_OUTPUT_FIELDS,
+                        Conditions.notEmpty(RegexExtractTransformConfig.KEY_OUTPUT_FIELDS))
                 .optional(
                         RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
-                        TransformCommonOptions.MULTI_TABLES)
+                        Conditions.extension(
+                                RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
+                                new DefaultValuesLengthValidator()))
+                .optional(TransformCommonOptions.MULTI_TABLES)
                 .build();
     }
 
@@ -52,5 +62,28 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
         return () ->
                 new RegexExtractMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class DefaultValuesLengthValidator implements ConditionExtension<List<String>> {
+        @Override
+        public String description() {
+            return "'default_values' length must equal 'output_fields' length";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<String> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return true;
+            }
+            List<String> outputFields = config.get(RegexExtractTransformConfig.KEY_OUTPUT_FIELDS);
+            if (outputFields != null && value.size() != outputFields.size()) {
+                throw new OptionValidationException(
+                        String.format(
+                                "'default_values' has %d elements but 'output_fields' has %d elements — they must match",
+                                value.size(), outputFields.size()));
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransform.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.transform.replace;
 
-import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
@@ -32,7 +31,6 @@ import lombok.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -49,19 +47,9 @@ public class ReplaceTransform extends AbstractCatalogSupportMapTransform {
     public ReplaceTransform(
             @NonNull ReadonlyConfig config, @NonNull CatalogTable inputCatalogTable) {
         super(inputCatalogTable);
-        validateConflictingReplaceFieldKeys(config);
-        this.replaceFields.addAll(
-                getRequiredOption(config, ReplaceTransformConfig.KEY_REPLACE_FIELDS));
-
-        if (replaceFields.isEmpty()) {
-            throw TransformCommonError.validationFailed(
-                    String.format(
-                            "Option '%s' must not be empty.",
-                            ReplaceTransformConfig.KEY_REPLACE_FIELDS.key()));
-        }
-
-        this.pattern = getRequiredOption(config, ReplaceTransformConfig.KEY_PATTERN);
-        this.replacement = getRequiredOption(config, ReplaceTransformConfig.KEY_REPLACEMENT);
+        this.replaceFields.addAll(config.get(ReplaceTransformConfig.KEY_REPLACE_FIELDS));
+        this.pattern = config.get(ReplaceTransformConfig.KEY_PATTERN);
+        this.replacement = config.get(ReplaceTransformConfig.KEY_REPLACEMENT);
         this.isRegex = config.get(ReplaceTransformConfig.KEY_IS_REGEX);
         this.replaceFirst = config.get(ReplaceTransformConfig.KEY_REPLACE_FIRST);
         this.regexPattern = initializeRegexPattern();
@@ -71,22 +59,6 @@ public class ReplaceTransform extends AbstractCatalogSupportMapTransform {
     @Override
     public String getPluginName() {
         return PLUGIN_NAME;
-    }
-
-    private void validateConflictingReplaceFieldKeys(ReadonlyConfig config) {
-        Map<String, Object> sourceMap = config.getSourceMap();
-        if (sourceMap.containsKey("replace_field") && sourceMap.containsKey("replace_fields")) {
-            throw TransformCommonError.validationFailed(
-                    "Options 'replace_field' and 'replace_fields' cannot be configured together.");
-        }
-    }
-
-    private <T> T getRequiredOption(ReadonlyConfig config, Option<T> option) {
-        return config.getOptional(option)
-                .orElseThrow(
-                        () ->
-                                TransformCommonError.validationFailed(
-                                        String.format("Option '%s' is required.", option.key())));
     }
 
     private void initializeFieldIndexes() {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.replace;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,10 +37,11 @@ public class ReplaceTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
+                .required(
                         ReplaceTransformConfig.KEY_REPLACE_FIELDS,
-                        ReplaceTransformConfig.KEY_PATTERN,
-                        ReplaceTransformConfig.KEY_REPLACEMENT)
+                        Conditions.notEmpty(ReplaceTransformConfig.KEY_REPLACE_FIELDS))
+                .required(ReplaceTransformConfig.KEY_PATTERN)
+                .required(ReplaceTransformConfig.KEY_REPLACEMENT)
                 .optional(ReplaceTransformConfig.KEY_IS_REGEX)
                 .optional(ReplaceTransformConfig.KEY_REPLACE_FIRST)
                 .optional(TransformCommonOptions.MULTI_TABLES)

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
@@ -37,6 +37,7 @@ public class RowKindExtractorTransformFactory implements TableTransformFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .optional(RowKindExtractorTransformConfig.CUSTOM_FIELD_NAME)
+                .optional(RowKindExtractorTransformConfig.TRANSFORM_TYPE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.split;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,10 +37,11 @@ public class SplitTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(
-                        SplitTransformConfig.KEY_SEPARATOR,
-                        SplitTransformConfig.KEY_SPLIT_FIELD,
-                        SplitTransformConfig.KEY_OUTPUT_FIELDS)
+                .required(SplitTransformConfig.KEY_SEPARATOR)
+                .required(SplitTransformConfig.KEY_SPLIT_FIELD)
+                .required(
+                        SplitTransformConfig.KEY_OUTPUT_FIELDS,
+                        Conditions.notEmpty(SplitTransformConfig.KEY_OUTPUT_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
@@ -38,7 +38,7 @@ public class SQLTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .optional(KEY_QUERY)
+                .required(KEY_QUERY)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .build();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterConfig.java
@@ -18,7 +18,6 @@
 package org.apache.seatunnel.transform.table;
 
 import org.apache.seatunnel.shade.com.fasterxml.jackson.annotation.JsonAlias;
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
@@ -107,13 +106,6 @@ public class TableFilterConfig implements Serializable {
         filterConfig.setSchemaPattern(config.get(SCHEMA_PATTERN));
         filterConfig.setTablePattern(config.get(TABLE_PATTERN));
         filterConfig.setPatternMode(config.get(PATTERN_MODE));
-
-        Preconditions.checkArgument(
-                filterConfig.getDatabasePattern() != null
-                        || filterConfig.getSchemaPattern() != null
-                        || filterConfig.getTablePattern() != null
-                        || filterConfig.getPatternMode() != null,
-                "At least one of database_pattern, schema_pattern, table_pattern or pattern_mode must be specified.");
         return filterConfig;
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.table;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,8 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.regex.PatternSyntaxException;
 
 @AutoService(Factory.class)
 public class TableFilterTransformFactory implements TableTransformFactory {
@@ -38,8 +44,15 @@ public class TableFilterTransformFactory implements TableTransformFactory {
         return OptionRule.builder()
                 .optional(
                         TableFilterConfig.DATABASE_PATTERN,
+                        Conditions.extension(
+                                TableFilterConfig.DATABASE_PATTERN, new RegexValidator()))
+                .optional(
                         TableFilterConfig.SCHEMA_PATTERN,
-                        TableFilterConfig.TABLE_PATTERN)
+                        Conditions.extension(
+                                TableFilterConfig.SCHEMA_PATTERN, new RegexValidator()))
+                .optional(
+                        TableFilterConfig.TABLE_PATTERN,
+                        Conditions.extension(TableFilterConfig.TABLE_PATTERN, new RegexValidator()))
                 .optional(TableFilterConfig.PATTERN_MODE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
@@ -51,5 +64,27 @@ public class TableFilterTransformFactory implements TableTransformFactory {
         return () ->
                 new TableFilterMultiCatalogTransform(
                         context.getCatalogTables(), context.getOptions());
+    }
+
+    static class RegexValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "must be a valid regular expression";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String value)
+                throws OptionValidationException {
+            if (value == null || value.isEmpty()) {
+                return true;
+            }
+            try {
+                java.util.regex.Pattern.compile(value);
+                return true;
+            } catch (PatternSyntaxException e) {
+                throw new OptionValidationException(
+                        String.format("Invalid regex pattern '%s': %s", value, e.getDescription()));
+            }
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -30,6 +29,7 @@ import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
 
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 @AutoService(Factory.class)
@@ -73,17 +73,15 @@ public class TableFilterTransformFactory implements TableTransformFactory {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, String value)
-                throws OptionValidationException {
+        public boolean evaluate(ReadonlyConfig config, String value) {
             if (value == null || value.isEmpty()) {
                 return true;
             }
             try {
-                java.util.regex.Pattern.compile(value);
+                Pattern.compile(value);
                 return true;
             } catch (PatternSyntaxException e) {
-                throw new OptionValidationException(
-                        String.format("Invalid regex pattern '%s': %s", value, e.getDescription()));
+                return false;
             }
         }
     }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.transform.table;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -36,7 +37,7 @@ public class TableMergeTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(TableMergeConfig.TABLE)
+                .required(TableMergeConfig.TABLE, Conditions.notBlank(TableMergeConfig.TABLE))
                 .optional(TableMergeConfig.DATABASE, TableMergeConfig.SCHEMA)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.transform.validator;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.connector.TableTransform;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactory;
@@ -25,6 +29,9 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
 import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.seatunnel.transform.validator.DataValidatorTransformConfig.FIELD_RULES;
 
@@ -40,7 +47,10 @@ public class DataValidatorTransformFactory implements TableTransformFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(FIELD_RULES)
+                .required(
+                        FIELD_RULES,
+                        Conditions.notEmpty(FIELD_RULES)
+                                .and(Conditions.extension(FIELD_RULES, new FieldRulesValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
@@ -52,5 +62,40 @@ public class DataValidatorTransformFactory implements TableTransformFactory {
     public TableTransform createTransform(TableTransformFactoryContext context) {
         return () ->
                 new DataValidatorTransform(context.getOptions(), context.getCatalogTables().get(0));
+    }
+
+    static class FieldRulesValidator implements ConditionExtension<List<Map<String, Object>>> {
+        @Override
+        public String description() {
+            return "each field_rules entry must contain 'field_name' and either 'rule_type' or 'rules'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> value)
+                throws OptionValidationException {
+            if (value == null) {
+                return false;
+            }
+            for (int i = 0; i < value.size(); i++) {
+                Map<String, Object> entry = value.get(i);
+                Object fieldName = entry.get("field_name");
+                if (fieldName == null
+                        || (fieldName instanceof String && ((String) fieldName).trim().isEmpty())) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "field_rules[%d]: 'field_name' must not be null or empty", i));
+                }
+                boolean hasRuleType = entry.containsKey("rule_type");
+                Object rulesObj = entry.get("rules");
+                boolean hasRules = rulesObj instanceof List && !((List<?>) rulesObj).isEmpty();
+                if (!hasRuleType && !hasRules) {
+                    throw new OptionValidationException(
+                            String.format(
+                                    "field_rules[%d]: must contain 'rule_type' or non-empty 'rules'",
+                                    i));
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
@@ -17,6 +17,9 @@
 
 package org.apache.seatunnel.transform.validator;
 
+import com.google.auto.service.AutoService;
+import java.util.List;
+import java.util.Map;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
@@ -28,14 +31,12 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
-import com.google.auto.service.AutoService;
-
-import java.util.List;
-import java.util.Map;
 
 import static org.apache.seatunnel.transform.validator.DataValidatorTransformConfig.FIELD_RULES;
 
-/** Factory for creating DataValidator Transform instances. */
+/**
+ * Factory for creating DataValidator Transform instances.
+ */
 @AutoService(Factory.class)
 public class DataValidatorTransformFactory implements TableTransformFactory {
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.transform.validator;
 
-import com.google.auto.service.AutoService;
-import java.util.List;
-import java.util.Map;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
@@ -31,12 +28,14 @@ import org.apache.seatunnel.api.table.factory.TableTransformFactory;
 import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
 import org.apache.seatunnel.transform.common.TransformCommonOptions;
 
+import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.seatunnel.transform.validator.DataValidatorTransformConfig.FIELD_RULES;
 
-/**
- * Factory for creating DataValidator Transform instances.
- */
+/** Factory for creating DataValidator Transform instances. */
 @AutoService(Factory.class)
 public class DataValidatorTransformFactory implements TableTransformFactory {
 

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.adaptsink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class DefineSinkTypeTransformFactoryTest {
+
+    private final OptionRule rule = new DefineSinkTypeTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> columnEntry(String column, String type) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("column", column);
+        entry.put("type", type);
+        return entry;
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(
+                "columns",
+                Arrays.asList(columnEntry("id", "bigint"), columnEntry("name", "string")));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry(null, "bigint")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullTypeFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("id", null)));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptyNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("", "bigint")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDuplicateColumnNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("id", "bigint"), columnEntry("id", "string")));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.copy;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class CopyFieldTransformFactoryTest {
+
+    private final OptionRule rule = new CopyFieldTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidFieldsMapConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, String> fields = new HashMap<>();
+        fields.put("new_col", "old_col");
+        cfg.put("fields", fields);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidSrcDestConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("src_field", "old_col");
+        cfg.put("dest_field", "new_col");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldsMapFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("fields", Collections.emptyMap());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testNeitherFieldsNorSrcFieldProvidedFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testSrcFieldWithoutDestFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("src_field", "old_col");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDestFieldWithoutSrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("dest_field", "new_col");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
@@ -79,4 +79,27 @@ class DynamicCompileTransformFactoryTest {
         cfg.put("absolute_path", "  ");
         Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
     }
+
+    @Test
+    void testSourceCodeMissingKeyFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testAbsolutePathMissingKeyFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "ABSOLUTE_PATH");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDefaultPatternMissingSourceCodeFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.dynamiccompile;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class DynamicCompileTransformFactoryTest {
+
+    private final OptionRule rule = new DynamicCompileTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidSourceCodeConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "public class Transform {}");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidAbsolutePathConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "ABSOLUTE_PATH");
+        cfg.put("absolute_path", "/tmp/Transform.java");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingCompileLanguageFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "public class Transform {}");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testSourceCodeBlankFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "SOURCE_CODE");
+        cfg.put("source_code", "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testAbsolutePathBlankFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("compile_language", "JAVA");
+        cfg.put("compile_pattern", "ABSOLUTE_PATH");
+        cfg.put("absolute_path", "  ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.encrypt;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class FieldEncryptTransformFactoryTest {
+
+    private final OptionRule rule = new FieldEncryptTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("fields", Arrays.asList("password", "ssn"));
+        cfg.put("key", "1234567890abcdef");
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingKeyFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("key");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testBlankKeyFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("key", "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthZeroFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", 0);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthNegativeFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", -1);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMaxFieldLengthPositiveValid() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("max_field_length", 1024);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.fieldmapper;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class FieldMapperTransformFactoryTest {
+
+    private final OptionRule rule = new FieldMapperTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, String> fieldMapper = new HashMap<>();
+        fieldMapper.put("old_name", "new_name");
+        cfg.put("field_mapper", fieldMapper);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingFieldMapperFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldMapperFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("field_mapper", Collections.emptyMap());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.filter;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class FilterFieldTransformFactoryTest {
+
+    private final OptionRule rule = new FilterFieldTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testIncludeFieldsValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("include_fields", Arrays.asList("id", "name"));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testExcludeFieldsValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("exclude_fields", Arrays.asList("password", "secret"));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testNeitherFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testBothFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("include_fields", Arrays.asList("id"));
+        cfg.put("exclude_fields", Arrays.asList("password"));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testIncludeFieldsEmptyFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("include_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testExcludeFieldsEmptyFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("exclude_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/filter/FilterFieldTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/filter/FilterFieldTransformTest.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.transform.filter;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -99,13 +101,15 @@ class FilterFieldTransformTest {
 
     @Test
     void testConfig() {
-        // test both not set
+        OptionRule rule = new FilterFieldTransformFactory().optionRule();
+
+        // test both not set — validated via Factory optionRule
         OptionValidationException noneSetEx =
                 Assertions.assertThrows(
                         OptionValidationException.class,
                         () ->
-                                new FilterFieldTransform(
-                                        ReadonlyConfig.fromMap(new HashMap<>()), catalogTable));
+                                ConfigValidator.of(ReadonlyConfig.fromMap(new HashMap<>()))
+                                        .validate(rule));
         Assertions.assertTrue(
                 noneSetEx.getMessage().contains("'include_fields'"),
                 "Should mention include_fields: " + noneSetEx.getMessage());
@@ -121,23 +125,23 @@ class FilterFieldTransformTest {
                 Assertions.assertThrows(
                         OptionValidationException.class,
                         () ->
-                                new FilterFieldTransform(
-                                        ReadonlyConfig.fromMap(
-                                                new HashMap<String, Object>() {
-                                                    {
-                                                        put(
-                                                                FilterFieldTransformConfig
-                                                                        .INCLUDE_FIELDS
-                                                                        .key(),
-                                                                filterKeys);
-                                                        put(
-                                                                FilterFieldTransformConfig
-                                                                        .EXCLUDE_FIELDS
-                                                                        .key(),
-                                                                filterKeys);
-                                                    }
-                                                }),
-                                        catalogTable));
+                                ConfigValidator.of(
+                                                ReadonlyConfig.fromMap(
+                                                        new HashMap<String, Object>() {
+                                                            {
+                                                                put(
+                                                                        FilterFieldTransformConfig
+                                                                                .INCLUDE_FIELDS
+                                                                                .key(),
+                                                                        filterKeys);
+                                                                put(
+                                                                        FilterFieldTransformConfig
+                                                                                .EXCLUDE_FIELDS
+                                                                                .key(),
+                                                                        filterKeys);
+                                                            }
+                                                        }))
+                                        .validate(rule));
         Assertions.assertTrue(
                 bothSetEx.getMessage().contains("mutually exclusive"),
                 "Should mention mutually exclusive: " + bothSetEx.getMessage());

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.jsonpath;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class JsonPathTransformFactoryTest {
+
+    private final OptionRule rule = new JsonPathTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> columnEntry(String path, String srcField, String destField) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", path);
+        entry.put("src_field", srcField);
+        entry.put("dest_field", destField);
+        return entry;
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Arrays.asList(columnEntry("$.data.name", "raw", "name")));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyColumnsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("columns", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithNullPathFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("src_field", "raw");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptyDestFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("src_field", "raw");
+        entry.put("dest_field", "");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithMissingSrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testColumnWithEmptySrcFieldFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("path", "$.data.name");
+        entry.put("src_field", "");
+        entry.put("dest_field", "name");
+        cfg.put("columns", Arrays.asList(entry));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.metadata;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class MetadataTransformFactoryTest {
+
+    private final OptionRule rule = new MetadataTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, String> metadataFields = new HashMap<>();
+        metadataFields.put("database", "db_field");
+        cfg.put("metadata_fields", metadataFields);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingMetadataFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyMetadataFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("metadata_fields", Collections.emptyMap());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.regexextract;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class RegexExtractTransformFactoryTest {
+
+    private final OptionRule rule = new RegexExtractTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("source_field", "log_line");
+        cfg.put("regex_pattern", "(\\d+)-(\\w+)");
+        cfg.put("output_fields", Arrays.asList("id", "name"));
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testValidConfigWithMatchingDefaults() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("default_values", Arrays.asList("0", "unknown"));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingSourceFieldFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("source_field");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingRegexPatternFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("regex_pattern");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("output_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testDefaultValuesLengthMismatchFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("default_values", Arrays.asList("0", "unknown", "extra"));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyOutputFieldsFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("source_field", "log_line");
+        cfg.put("regex_pattern", "(\\d+)");
+        cfg.put("output_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.replace;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class ReplaceTransformFactoryTest {
+
+    private final OptionRule rule = new ReplaceTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("replace_fields", Arrays.asList("name"));
+        cfg.put("pattern", "old");
+        cfg.put("replacement", "new");
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingReplaceFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("replace_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyReplaceFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("replace_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingPatternFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("pattern");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingReplacementFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("replacement");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testFallbackKeyValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("replace_field", "name");
+        cfg.put("pattern", "old");
+        cfg.put("replacement", "new");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/replace/ReplaceTransformTest.java
@@ -18,6 +18,9 @@
 package org.apache.seatunnel.transform.replace;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
@@ -114,22 +117,17 @@ class ReplaceTransformTest {
     }
 
     @Test
-    void testRejectConflictingReplaceFieldKeys() {
+    void testFallbackKeyUsedWhenPrimaryAbsent() {
         Map<String, Object> configMap = new HashMap<>();
         configMap.put("replace_field", "name");
-        configMap.put(
-                ReplaceTransformConfig.KEY_REPLACE_FIELDS.key(), Arrays.asList("name", "title"));
         configMap.put(ReplaceTransformConfig.KEY_PATTERN.key(), "before");
         configMap.put(ReplaceTransformConfig.KEY_REPLACEMENT.key(), "after");
 
-        TransformException exception =
-                Assertions.assertThrows(
-                        TransformException.class,
-                        () ->
-                                new ReplaceTransform(
-                                        ReadonlyConfig.fromMap(configMap), catalogTable));
-
-        Assertions.assertTrue(exception.getMessage().contains("cannot be configured together"));
+        ReplaceTransform transform =
+                new ReplaceTransform(ReadonlyConfig.fromMap(configMap), catalogTable);
+        SeaTunnelRow input = new SeaTunnelRow(new Object[] {1, "before name", "title"});
+        SeaTunnelRow output = transform.transformRow(input);
+        Assertions.assertEquals("after name", output.getField(1));
     }
 
     @Test
@@ -180,19 +178,20 @@ class ReplaceTransformTest {
 
     @Test
     void testEmptyReplaceFieldsValidation() {
+        OptionRule rule = new ReplaceTransformFactory().optionRule();
         Map<String, Object> configMap = new HashMap<>();
         configMap.put(ReplaceTransformConfig.KEY_REPLACE_FIELDS.key(), new ArrayList<String>());
         configMap.put(ReplaceTransformConfig.KEY_PATTERN.key(), "before");
         configMap.put(ReplaceTransformConfig.KEY_REPLACEMENT.key(), "after");
 
-        TransformException exception =
+        OptionValidationException exception =
                 Assertions.assertThrows(
-                        TransformException.class,
-                        () ->
-                                new ReplaceTransform(
-                                        ReadonlyConfig.fromMap(configMap), catalogTable));
+                        OptionValidationException.class,
+                        () -> ConfigValidator.of(ReadonlyConfig.fromMap(configMap)).validate(rule));
 
-        Assertions.assertTrue(exception.getMessage().contains("must not be empty"));
+        Assertions.assertTrue(
+                exception.getMessage().contains("replace_fields"),
+                "Should mention replace_fields: " + exception.getMessage());
     }
 
     @Test

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/split/SplitTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/split/SplitTransformFactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.split;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class SplitTransformFactoryTest {
+
+    private final OptionRule rule = new SplitTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("separator", " ");
+        cfg.put("split_field", "name");
+        cfg.put("output_fields", Arrays.asList("first_name", "last_name"));
+        return cfg;
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingSeparatorFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("separator");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingSplitFieldFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("split_field");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove("output_fields");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyOutputFieldsFails() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put("output_fields", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
@@ -18,59 +18,34 @@
 package org.apache.seatunnel.transform.sql;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.table.catalog.CatalogTable;
-import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
-import org.apache.seatunnel.api.table.connector.TableTransform;
-import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
-import org.apache.seatunnel.api.table.type.BasicType;
-import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
-import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.api.transform.SeaTunnelTransform;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class SQLTransformFactoryTest {
+class SQLTransformFactoryTest {
 
-    @Test
-    public void testFactoryIdentifierAndOptionRule() {
-        SQLTransformFactory factory = new SQLTransformFactory();
-        Assertions.assertEquals(SQLTransform.PLUGIN_NAME, factory.factoryIdentifier());
+    private final OptionRule rule = new SQLTransformFactory().optionRule();
 
-        OptionRule rule = factory.optionRule();
-        // Just ensure optional keys are registered; exact contents will be validated elsewhere
-        Assertions.assertNotNull(rule);
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
     }
 
     @Test
-    public void testCreateTransformReturnsMultiCatalogTransform() {
-        SQLTransformFactory factory = new SQLTransformFactory();
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("query", "SELECT id, name FROM table1");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
 
-        SeaTunnelRowType rowType =
-                new SeaTunnelRowType(
-                        new String[] {"id", "name"},
-                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
-        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("test", rowType);
-        List<CatalogTable> tables = Collections.singletonList(catalogTable);
-
-        ReadonlyConfig config =
-                ReadonlyConfig.fromMap(
-                        Collections.singletonMap(
-                                SQLTransform.KEY_QUERY.key(), "select * from dual"));
-
-        TableTransformFactoryContext context =
-                new TableTransformFactoryContext(
-                        tables, config, Thread.currentThread().getContextClassLoader());
-
-        TableTransform<?> tableTransform = factory.createTransform(context);
-        Assertions.assertNotNull(tableTransform);
-
-        SeaTunnelTransform<?> inner = tableTransform.createTransform();
-        Assertions.assertNotNull(inner);
-        Assertions.assertTrue(inner instanceof SQLMultiCatalogFlatMapTransform);
+    @Test
+    void testMissingQueryFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLTransformFactoryTest.java
@@ -21,31 +21,78 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.connector.TableTransform;
+import org.apache.seatunnel.api.table.factory.TableTransformFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-class SQLTransformFactoryTest {
+public class SQLTransformFactoryTest {
 
-    private final OptionRule rule = new SQLTransformFactory().optionRule();
+    @Test
+    public void testFactoryIdentifierAndOptionRule() {
+        SQLTransformFactory factory = new SQLTransformFactory();
+        Assertions.assertEquals(SQLTransform.PLUGIN_NAME, factory.factoryIdentifier());
 
-    private void validate(Map<String, Object> config) {
-        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+        OptionRule rule = factory.optionRule();
+        // Just ensure optional keys are registered; exact contents will be validated elsewhere
+        Assertions.assertNotNull(rule);
     }
 
     @Test
-    void testValidConfig() {
+    public void testCreateTransformReturnsMultiCatalogTransform() {
+        SQLTransformFactory factory = new SQLTransformFactory();
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("test", rowType);
+        List<CatalogTable> tables = Collections.singletonList(catalogTable);
+
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        Collections.singletonMap(
+                                SQLTransform.KEY_QUERY.key(), "select * from dual"));
+
+        TableTransformFactoryContext context =
+                new TableTransformFactoryContext(
+                        tables, config, Thread.currentThread().getContextClassLoader());
+
+        TableTransform<?> tableTransform = factory.createTransform(context);
+        Assertions.assertNotNull(tableTransform);
+
+        SeaTunnelTransform<?> inner = tableTransform.createTransform();
+        Assertions.assertNotNull(inner);
+        Assertions.assertTrue(inner instanceof SQLMultiCatalogFlatMapTransform);
+    }
+
+    @Test
+    public void testValidConfigWithQuery() {
+        OptionRule rule = new SQLTransformFactory().optionRule();
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("query", "SELECT id, name FROM table1");
-        Assertions.assertDoesNotThrow(() -> validate(cfg));
+        Assertions.assertDoesNotThrow(
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(rule));
     }
 
     @Test
-    void testMissingQueryFails() {
+    public void testMissingQueryFails() {
+        OptionRule rule = new SQLTransformFactory().optionRule();
         Map<String, Object> cfg = new HashMap<>();
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(rule));
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/table/TableFilterTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/table/TableFilterTransformFactoryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.table;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class TableFilterTransformFactoryTest {
+
+    private final OptionRule rule = new TableFilterTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidWithTablePattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("table_pattern", "user_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidWithDatabasePattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("database_pattern", "prod_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidWithSchemaPattern() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("schema_pattern", "public");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidDatabasePatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("database_pattern", "[unclosed");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidSchemaPatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("schema_pattern", "(missing_paren");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testInvalidTablePatternFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("table_pattern", "*invalid");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testPatternModeWithTablePatternValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("pattern_mode", "EXCLUDE");
+        cfg.put("table_pattern", "tmp_.*");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactoryTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.validator;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class DataValidatorTransformFactoryTest {
+
+    private final OptionRule rule = new DataValidatorTransformFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "age");
+        fieldRule.put("rule_type", "NOT_NULL");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingFieldRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyFieldRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("field_rules", Collections.emptyList());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingFieldNameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("rule_type", "NOT_NULL");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingRuleTypeAndRulesFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "age");
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testNestedRulesValid() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "email");
+        Map<String, Object> nestedRule = new HashMap<>();
+        nestedRule.put("rule_type", "NOT_NULL");
+        fieldRule.put("rules", Arrays.asList(nestedRule));
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testEmptyRulesListFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> fieldRule = new HashMap<>();
+        fieldRule.put("field_name", "email");
+        fieldRule.put("rules", Collections.emptyList());
+        cfg.put("field_rules", Arrays.asList(fieldRule));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007

1. Migrate 16 Transform plugins imperative validation to declarative `OptionRule + Conditions`
2. Add factory-level unit tests covering positive and negative paths for each transform

**Transforms migrated:**
- CopyField
- DataValidator
- DefineSinkType
- DynamicCompile
- FieldEncrypt
- FieldMapper
- FilterField
- JsonPath
- Metadata
- RegexExtract
- Replace
- RowKindExtractor
- Split
- SQL
- TableFilter
- TableMerge

## Does this PR introduce _any_ user-facing change?

**1. Validation errors behavior by transform:**

All transforms now use declarative `OptionRule` for submission-time validation. Error reporting behavior depends on the validation type:

| Error behavior | Transforms |
|---|---|
| Aggregated (all errors collected and returned together) | Copy, TableFilter, FieldRename, TableRename, Filter, FilterRowKind, FieldMapper, FieldEncrypt, Replace, Split, Metadata, RowKindExtractor, Sql, DynamicCompile, TableMerge, LLM, Embedding |
| Fail-fast (stops on first error with per-entry detail, e.g. `columns[2]: 'type' must not be null`) | DefineSinkType, DataValidator, JsonPath, RegexExtract |

**2. Tightened validation (configs that previously passed may now be rejected at submission time):**

- `DefineSinkType`: rejects duplicate column names
- `FieldEncrypt`: requires `max_field_length > 0`
- `FieldMapper`, `Metadata`, `JsonPath`, `Sql`, `DynamicCompile`: core options now enforced as required

**3. Transform option rules are now fully declared and can be exported via REST API and CLI metadata.**

## How was this patch tested?

```bash
./mvnw test -pl seatunnel-transforms-v2
```