### PR TITLE
[Fix][E2E] Use dynamic port allocation to avoid port conflict in test containers

### DIFF
--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.e2e.common.container.flink;
 
-import org.apache.seatunnel.shade.com.google.common.collect.Lists;
-
 import org.apache.seatunnel.common.utils.FileUtils;
 import org.apache.seatunnel.e2e.common.container.AbstractTestContainer;
 import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
@@ -84,7 +82,7 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
                         .withCommand("jobmanager")
                         .withNetwork(NETWORK)
                         .withNetworkAliases("jobmanager")
-                        .withExposedPorts()
+                        .withExposedPorts(8081)
                         .withEnv("FLINK_PROPERTIES", properties)
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
@@ -99,7 +97,6 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
                                 BindMode.READ_WRITE);
         copySeaTunnelStarterToContainer(jobManager);
         copySeaTunnelStarterLoggingToContainer(jobManager);
-        jobManager.setPortBindings(Lists.newArrayList(String.format("%s:%s", 8081, 8081)));
 
         taskManager =
                 new GenericContainer<>(dockerImage)

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/Flink20Container.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/Flink20Container.java
@@ -136,7 +136,7 @@ public class Flink20Container extends AbstractTestFlinkContainer {
                         .withCommand("sh", "-c", createJobManagerStartupCommand())
                         .withNetwork(NETWORK)
                         .withNetworkAliases("jobmanager")
-                        .withExposedPorts()
+                        .withExposedPorts(8081)
                         .withEnv("FLINK_PROPERTIES", properties)
                         .withLogConsumer(
                                 new org.testcontainers.containers.output.Slf4jLogConsumer(
@@ -154,8 +154,6 @@ public class Flink20Container extends AbstractTestFlinkContainer {
 
         copySeaTunnelStarterToContainer(jobManager);
         copySeaTunnelStarterLoggingToContainer(jobManager);
-
-        jobManager.setPortBindings(java.util.Arrays.asList(String.format("%s:%s", 8081, 8081)));
 
         taskManager =
                 new org.testcontainers.containers.GenericContainer<>(dockerImage)

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -110,7 +110,7 @@ public class SeaTunnelContainer extends AbstractTestContainer {
                         .withEnv("TZ", "UTC")
                         .withCommand(buildStartCommand())
                         .withNetworkAliases("server")
-                        .withExposedPorts()
+                        .withExposedPorts(5801, 8080)
                         .withFileSystemBind("/tmp", "/opt/hive")
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
@@ -122,7 +122,6 @@ public class SeaTunnelContainer extends AbstractTestContainer {
                                 BindMode.READ_WRITE)
                         .waitingFor(Wait.forLogMessage(".*received new worker register:.*", 1));
         copySeaTunnelStarterToContainer(server);
-        server.setPortBindings(Arrays.asList("5801:5801", "8080:8080"));
         server.withCopyFileToContainer(
                 MountableFile.forHostPath(
                         PROJECT_ROOT_PATH
@@ -158,15 +157,13 @@ public class SeaTunnelContainer extends AbstractTestContainer {
                                 ContainerUtil.adaptPathForWin(
                                         Paths.get(SEATUNNEL_HOME, "bin", SERVER_SHELL).toString()))
                         .withNetworkAliases("server")
-                        .withExposedPorts()
+                        .withExposedPorts(5801, 8080)
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
                                         DockerLoggerFactory.getLogger(
                                                 "seatunnel-engine:" + JDK_DOCKER_IMAGE)))
                         .waitingFor(Wait.forLogMessage(".*received new worker register:.*", 1));
         copySeaTunnelStarterToContainer(server);
-        server.setPortBindings(Arrays.asList("5801:5801", "8080:8080"));
-        server.setExposedPorts(Arrays.asList(5801, 8080));
 
         server.withCopyFileToContainer(
                 MountableFile.forHostPath(


### PR DESCRIPTION
## Purpose  of this pull request

Fix flaky E2E tests caused by fixed Docker port bindings in Flink and SeaTunnel engine test containers.

## Problem

The E2E test framework containers (`AbstractTestFlinkContainer`, `Flink20Container`, `SeaTunnelContainer`) used **fixed host port bindings** (e.g., `8081:8081`, `5801:5801`, `8080:8080`) via `setPortBindings()`.

This caused **"port is already allocated"** errors leading to cascading test failures:

```
com.github.dockerjava.api.exception.InternalServerErrorException: Status 500:
  {"message":"Bind for 0.0.0.0:8081 failed: port is already allocated"}
```

### Root Cause

When a test container fails (e.g., due to timeout or resource exhaustion) and doesn't release the fixed port properly, **all subsequent tests** attempting to bind the same port will fail immediately. This is a primary cause of flaky tests in CI that pass on re-run.

### Failure Scenario

1. Test A starts a Flink container bound to host port `8081`
2. Test A fails/hangs, the container doesn't cleanly release port `8081`
3. Tests B, C, D... all try to start Flink containers on the same fixed port `8081`
4. All fail with `port is already allocated` — cascading failures

## Solution

Replace fixed port bindings (`setPortBindings`) with dynamic port allocation (`withExposedPorts(port)`). Docker automatically assigns a random available host port for each container, eliminating port conflicts.

The test code already uses `getMappedPort(port)` to access containers from the host, so this change is fully backward-compatible.

## Changes

| File | Before | After |
|------|--------|-------|
| `AbstractTestFlinkContainer.java` | `.withExposedPorts()` + `setPortBindings("8081:8081")` | `.withExposedPorts(8081)` |
| `Flink20Container.java` | `.withExposedPorts()` + `setPortBindings("8081:8081")` | `.withExposedPorts(8081)` |
| `SeaTunnelContainer.java` (2 places) | `.withExposedPorts()` + `setPortBindings("5801:5801", "8080:8080")` | `.withExposedPorts(5801, 8080)` |

## Impact

- Flink E2E tests (all versions: 1.4, 1.8, 2.0) will no longer conflict on port 8081
- SeaTunnel engine E2E tests will no longer conflict on ports 5801/8080
- Multiple test containers can coexist on the same CI runner without port collisions
- Significantly reduces flaky test rate in CI