### PR TITLE
[Feature][Transform-V2] Add multi-table rule match mode

### DIFF
--- a/docs/en/transforms/transform-multi-table.md
+++ b/docs/en/transforms/transform-multi-table.md
@@ -19,7 +19,7 @@ Multi-table Transform has no limitations on Transform capabilities; any Transfor
 | table_match_regex          | String | No       | .*      | A regular expression to match the tables that require transformation. By default, it matches all tables. Note that this table name refers to the actual upstream table name, not `plugin_output`.                                                               |
 | table_transform            | List   | No       | -       | You can use a list in `table_transform` to specify rules for individual tables. If a transformation rule is configured for a specific table in `table_transform`, the outer rules will not apply to that table. The rules in `table_transform` take precedence. |
 | table_transform.table_path | String | No       | -       | When configuring a transformation rule for a table in `table_transform`, you need to specify the table path using the `table_path` field. The table path should include `databaseName[.schemaName].tableName` and is matched exactly.                         |
-| rule_match_mode            | String | No       | FIRST_MATCH | Controls how multiple `table_transform` entries with the same exact `table_path` are evaluated. Supported values are `FIRST_MATCH` and `ALL_MATCH`.                                                                                                         |
+| rule_match_mode            | String | No       | -       | Controls how multiple `table_transform` entries with the same exact `table_path` are evaluated. Supported values are `FIRST_MATCH` and `ALL_MATCH`.                                                                                                         |
 
 ## Matching Logic
 
@@ -69,7 +69,8 @@ For each table, the priority of configuration is: `table_transform` > `table_mat
 
 `table_transform.table_path` uses exact table path matching. `rule_match_mode` only controls the case where multiple `table_transform` entries use the same exact `table_path`:
 
-- `FIRST_MATCH`: apply the first matching `table_transform` entry in declaration order. This is the default behavior.
+- If `rule_match_mode` is not configured, duplicate exact `table_path` entries are rejected during config resolution.
+- `FIRST_MATCH`: apply the first matching `table_transform` entry in declaration order.
 - `ALL_MATCH`: apply all matching `table_transform` entries in declaration order. The output of an earlier matching rule becomes the input of the next matching rule for the same table.
 
 For example, when `rule_match_mode` is `ALL_MATCH`, the following configuration first copies `name` to `name2` for `test.xyz`, and then copies `name2` to `name3` for the same table:

--- a/docs/en/transforms/transform-multi-table.md
+++ b/docs/en/transforms/transform-multi-table.md
@@ -18,7 +18,8 @@ Multi-table Transform has no limitations on Transform capabilities; any Transfor
 |----------------------------|--------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | table_match_regex          | String | No       | .*      | A regular expression to match the tables that require transformation. By default, it matches all tables. Note that this table name refers to the actual upstream table name, not `plugin_output`.                                                               |
 | table_transform            | List   | No       | -       | You can use a list in `table_transform` to specify rules for individual tables. If a transformation rule is configured for a specific table in `table_transform`, the outer rules will not apply to that table. The rules in `table_transform` take precedence. |
-| table_transform.table_path | String | No       | -       | When configuring a transformation rule for a table in `table_transform`, you need to specify the table path using the `table_path` field. The table path should include `databaseName[.schemaName].tableName`.                                                  |
+| table_transform.table_path | String | No       | -       | When configuring a transformation rule for a table in `table_transform`, you need to specify the table path using the `table_path` field. The table path should include `databaseName[.schemaName].tableName` and is matched exactly.                         |
+| rule_match_mode            | String | No       | FIRST_MATCH | Controls how multiple `table_transform` entries with the same exact `table_path` are evaluated. Supported values are `FIRST_MATCH` and `ALL_MATCH`.                                                                                                         |
 
 ## Matching Logic
 
@@ -65,6 +66,35 @@ transform {
 This allows us to handle transformations for multiple tables within a single transform configuration.
 
 For each table, the priority of configuration is: `table_transform` > `table_match_regex`. If no rules match a table, no transformation will be applied.
+
+`table_transform.table_path` uses exact table path matching. `rule_match_mode` only controls the case where multiple `table_transform` entries use the same exact `table_path`:
+
+- `FIRST_MATCH`: apply the first matching `table_transform` entry in declaration order. This is the default behavior.
+- `ALL_MATCH`: apply all matching `table_transform` entries in declaration order. The output of an earlier matching rule becomes the input of the next matching rule for the same table.
+
+For example, when `rule_match_mode` is `ALL_MATCH`, the following configuration first copies `name` to `name2` for `test.xyz`, and then copies `name2` to `name3` for the same table:
+
+```hocon
+transform {
+  Copy {
+    rule_match_mode = "ALL_MATCH"
+
+    table_transform = [{
+      table_path = "test.xyz"
+      src_field = "name"
+      dest_field = "name2"
+    }, {
+      table_path = "test.xyz"
+      src_field = "name2"
+      dest_field = "name3"
+    }]
+  }
+}
+```
+
+Output structure:
+
+| id | name | age | name2 | name3 |
 
 Below are the transform configurations for each table:
 

--- a/docs/zh/transforms/transform-multi-table.md
+++ b/docs/zh/transforms/transform-multi-table.md
@@ -20,7 +20,8 @@ SeaTunnel 的 Multi-Table Transform 支持在上游插件输出多个表时，�
 |----------------------------|--------|----------|---------|--------------------------------------------------------------------------------------------------|
 | table_match_regex          | String | No       | .*      | 表名的正则表达式，通过正则表达式来匹配需要进行转换的表，默认匹配所有的表。注意这个表名是上游的真正表名，不是`plugin_output`。                           |
 | table_transform            | List   | No       | -       | 可以通过table_transform列表来指定部分表的规则，当在table_transform中配置某个表的转换规则后，外层针对当前表的规则不会生效，以table_transform中的为准 |
-| table_transform.table_path | String | No       | -       | 当在table_transform中配置某个表的转换规则后，需要使用table_path字段指定表名，表名需要包含`databaseName[.schemaName].tableName`。  |
+| table_transform.table_path | String | No       | -       | 当在table_transform中配置某个表的转换规则后，需要使用table_path字段指定表名，表名需要包含`databaseName[.schemaName].tableName`，并且按完整表路径精确匹配。  |
+| rule_match_mode            | String | No       | FIRST_MATCH | 控制多个 `table_transform` 配置使用相同精确 `table_path` 时的执行方式，支持 `FIRST_MATCH` 和 `ALL_MATCH`。 |
 
 ## 匹配逻辑
 
@@ -61,6 +62,35 @@ transform {
 这样我们就可以通过一个transform完成对多个表的转换操作。
 
 对于每个表来说，配置的优先级是：`table_transform` > `table_match_regex`。如果所有的规则都没有匹配到，那么该表将不会进行任何转换操作。
+
+`table_transform.table_path` 使用精确表路径匹配。`rule_match_mode` 只控制多个 `table_transform` 配置使用相同精确 `table_path` 的场景：
+
+- `FIRST_MATCH`：按声明顺序使用第一个匹配的 `table_transform` 配置。这是默认行为。
+- `ALL_MATCH`：按声明顺序执行所有匹配的 `table_transform` 配置。前一个规则的输出会作为同一张表上后一个规则的输入。
+
+例如，当 `rule_match_mode` 为 `ALL_MATCH` 时，下面的配置会先为 `test.xyz` 将 `name` 复制为 `name2`，然后继续将 `name2` 复制为 `name3`：
+
+```hocon
+transform {
+  Copy {
+    rule_match_mode = "ALL_MATCH"
+
+    table_transform = [{
+      table_path = "test.xyz"
+      src_field = "name"
+      dest_field = "name2"
+    }, {
+      table_path = "test.xyz"
+      src_field = "name2"
+      dest_field = "name3"
+    }]
+  }
+}
+```
+
+输出表结构：
+
+| id | name | age | name2 | name3 |
 
 针对每个表来说，他们的Transform配置是：
 

--- a/docs/zh/transforms/transform-multi-table.md
+++ b/docs/zh/transforms/transform-multi-table.md
@@ -21,7 +21,7 @@ SeaTunnel 的 Multi-Table Transform 支持在上游插件输出多个表时，�
 | table_match_regex          | String | No       | .*      | 表名的正则表达式，通过正则表达式来匹配需要进行转换的表，默认匹配所有的表。注意这个表名是上游的真正表名，不是`plugin_output`。                           |
 | table_transform            | List   | No       | -       | 可以通过table_transform列表来指定部分表的规则，当在table_transform中配置某个表的转换规则后，外层针对当前表的规则不会生效，以table_transform中的为准 |
 | table_transform.table_path | String | No       | -       | 当在table_transform中配置某个表的转换规则后，需要使用table_path字段指定表名，表名需要包含`databaseName[.schemaName].tableName`，并且按完整表路径精确匹配。  |
-| rule_match_mode            | String | No       | FIRST_MATCH | 控制多个 `table_transform` 配置使用相同精确 `table_path` 时的执行方式，支持 `FIRST_MATCH` 和 `ALL_MATCH`。 |
+| rule_match_mode            | String | No       | -       | 控制多个 `table_transform` 配置使用相同精确 `table_path` 时的执行方式，支持 `FIRST_MATCH` 和 `ALL_MATCH`。 |
 
 ## 匹配逻辑
 
@@ -65,7 +65,8 @@ transform {
 
 `table_transform.table_path` 使用精确表路径匹配。`rule_match_mode` 只控制多个 `table_transform` 配置使用相同精确 `table_path` 的场景：
 
-- `FIRST_MATCH`：按声明顺序使用第一个匹配的 `table_transform` 配置。这是默认行为。
+- 如果没有配置 `rule_match_mode`，重复的精确 `table_path` 配置会在配置解析阶段失败。
+- `FIRST_MATCH`：按声明顺序使用第一个匹配的 `table_transform` 配置。
 - `ALL_MATCH`：按声明顺序执行所有匹配的 `table_transform` 配置。前一个规则的输出会作为同一张表上后一个规则的输入。
 
 例如，当 `rule_match_mode` 为 `ALL_MATCH` 时，下面的配置会先为 `test.xyz` 将 `name` 复制为 `name2`，然后继续将 `name2` 复制为 `name3`：

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/adaptsink/DefineSinkTypeTransformFactory.java
@@ -54,6 +54,7 @@ public class DefineSinkTypeTransformFactory implements TableTransformFactory {
                                                 new ColumnsStructureValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogFlatMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogFlatMapTransform.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.SeaTunnelFlatMapTransform;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 
 import java.util.List;
 
@@ -31,6 +32,15 @@ public abstract class AbstractMultiCatalogFlatMapTransform extends AbstractMulti
     public AbstractMultiCatalogFlatMapTransform(
             List<CatalogTable> inputCatalogTables, ReadonlyConfig config) {
         super(inputCatalogTables, config);
+    }
+
+    @Override
+    protected SeaTunnelTransform<SeaTunnelRow> composeTransforms(
+            List<SeaTunnelTransform<SeaTunnelRow>> transforms) {
+        if (transforms.size() == 1) {
+            return transforms.get(0);
+        }
+        return new ChainedFlatMapTransform(transforms);
     }
 
     @Override

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogMapTransform.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.SeaTunnelMapTransform;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 
 import java.util.List;
 
@@ -31,6 +32,15 @@ public abstract class AbstractMultiCatalogMapTransform extends AbstractMultiCata
     public AbstractMultiCatalogMapTransform(
             List<CatalogTable> inputCatalogTables, ReadonlyConfig config) {
         super(inputCatalogTables, config);
+    }
+
+    @Override
+    protected SeaTunnelTransform<SeaTunnelRow> composeTransforms(
+            List<SeaTunnelTransform<SeaTunnelRow>> transforms) {
+        if (transforms.size() == 1) {
+            return transforms.get(0);
+        }
+        return new ChainedMapTransform(transforms);
     }
 
     @Override

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransform.java
@@ -25,10 +25,11 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.SeaTunnelTransform;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -50,28 +51,37 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
         this.transformMap = new HashMap<>();
         Pattern tableMatchRegex =
                 Pattern.compile(config.get(TransformCommonOptions.TABLE_MATCH_REGEX));
-        Map<String, ReadonlyConfig> singleTableConfig =
+        TransformCommonOptions.RuleMatchMode ruleMatchMode =
+                config.get(TransformCommonOptions.RULE_MATCH_MODE);
+        List<ReadonlyConfig> singleTableConfigs =
                 config.get(TransformCommonOptions.MULTI_TABLES).stream()
                         .map(ReadonlyConfig::fromMap)
                         .filter(c -> c.get(TransformCommonOptions.TABLE_PATH) != null)
-                        .collect(
-                                Collectors.toMap(
-                                        c -> c.get(TransformCommonOptions.TABLE_PATH),
-                                        Function.identity()));
+                        .collect(Collectors.toList());
 
         inputCatalogTables.forEach(
                 inputCatalogTable -> {
                     String tableId = inputCatalogTable.getTableId().toTablePath().toString();
-                    ReadonlyConfig tableConfig;
-                    if (singleTableConfig.containsKey(tableId)) {
-                        tableConfig = singleTableConfig.get(tableId);
+                    List<ReadonlyConfig> tableConfigs =
+                            singleTableConfigs.stream()
+                                    .filter(
+                                            c ->
+                                                    tableId.equals(
+                                                            c.get(
+                                                                    TransformCommonOptions
+                                                                            .TABLE_PATH)))
+                                    .collect(Collectors.toList());
+                    if (!tableConfigs.isEmpty()) {
+                        transformMap.put(
+                                tableId,
+                                buildTransform(
+                                        inputCatalogTable,
+                                        selectTableConfigs(tableConfigs, ruleMatchMode)));
                     } else if (tableMatchRegex.matcher(tableId).matches()) {
-                        tableConfig = config;
-                    } else {
-                        tableConfig = null;
-                    }
-                    if (tableConfig != null) {
-                        transformMap.put(tableId, buildTransform(inputCatalogTable, tableConfig));
+                        transformMap.put(
+                                tableId,
+                                buildTransform(
+                                        inputCatalogTable, Collections.singletonList(config)));
                     } else {
                         transformMap.put(tableId, createIdentityTransform(inputCatalogTable));
                     }
@@ -90,6 +100,36 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
 
     protected abstract SeaTunnelTransform<SeaTunnelRow> buildTransform(
             CatalogTable inputCatalogTable, ReadonlyConfig config);
+
+    private List<ReadonlyConfig> selectTableConfigs(
+            List<ReadonlyConfig> tableConfigs, TransformCommonOptions.RuleMatchMode ruleMatchMode) {
+        if (ruleMatchMode == TransformCommonOptions.RuleMatchMode.FIRST_MATCH) {
+            return Collections.singletonList(tableConfigs.get(0));
+        }
+        return tableConfigs;
+    }
+
+    private SeaTunnelTransform<SeaTunnelRow> buildTransform(
+            CatalogTable inputCatalogTable, List<ReadonlyConfig> configs) {
+        List<SeaTunnelTransform<SeaTunnelRow>> transforms = new ArrayList<>();
+        CatalogTable currentCatalogTable = inputCatalogTable;
+        for (ReadonlyConfig config : configs) {
+            SeaTunnelTransform<SeaTunnelRow> transform =
+                    buildTransform(currentCatalogTable, config);
+            transforms.add(transform);
+            currentCatalogTable = transform.getProducedCatalogTable();
+        }
+        return composeTransforms(transforms);
+    }
+
+    protected SeaTunnelTransform<SeaTunnelRow> composeTransforms(
+            List<SeaTunnelTransform<SeaTunnelRow>> transforms) {
+        if (transforms.size() == 1) {
+            return transforms.get(0);
+        }
+        throw new UnsupportedOperationException(
+                String.format("%s does not support chained transforms", getPluginName()));
+    }
 
     protected abstract SeaTunnelTransform<SeaTunnelRow> createIdentityTransform(
             CatalogTable catalogTable);
@@ -151,6 +191,8 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
             SeaTunnelTransform<SeaTunnelRow> inner = transformMap.get(tableId);
             if (inner instanceof AbstractSeaTunnelTransform) {
                 ((AbstractSeaTunnelTransform<?, ?>) inner).setInputCatalogTable(newInput);
+            } else if (inner != null) {
+                inner.setInputCatalogTables(Collections.singletonList(newInput));
             }
         }
         refreshOutputCatalogTables();

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransform.java
@@ -51,6 +51,8 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
         this.transformMap = new HashMap<>();
         Pattern tableMatchRegex =
                 Pattern.compile(config.get(TransformCommonOptions.TABLE_MATCH_REGEX));
+        boolean ruleMatchModeConfigured =
+                config.getOptional(TransformCommonOptions.RULE_MATCH_MODE).isPresent();
         TransformCommonOptions.RuleMatchMode ruleMatchMode =
                 config.get(TransformCommonOptions.RULE_MATCH_MODE);
         List<ReadonlyConfig> singleTableConfigs =
@@ -58,6 +60,9 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
                         .map(ReadonlyConfig::fromMap)
                         .filter(c -> c.get(TransformCommonOptions.TABLE_PATH) != null)
                         .collect(Collectors.toList());
+        if (!ruleMatchModeConfigured) {
+            rejectDuplicateTablePaths(singleTableConfigs);
+        }
 
         inputCatalogTables.forEach(
                 inputCatalogTable -> {
@@ -100,6 +105,19 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
 
     protected abstract SeaTunnelTransform<SeaTunnelRow> buildTransform(
             CatalogTable inputCatalogTable, ReadonlyConfig config);
+
+    private void rejectDuplicateTablePaths(List<ReadonlyConfig> tableConfigs) {
+        Map<String, Boolean> tablePaths = new HashMap<>();
+        for (ReadonlyConfig tableConfig : tableConfigs) {
+            String tablePath = tableConfig.get(TransformCommonOptions.TABLE_PATH);
+            if (tablePaths.put(tablePath, true) != null) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Duplicate table_transform rules are configured for table_path [%s]",
+                                tablePath));
+            }
+        }
+    }
 
     private List<ReadonlyConfig> selectTableConfigs(
             List<ReadonlyConfig> tableConfigs, TransformCommonOptions.RuleMatchMode ruleMatchMode) {
@@ -158,18 +176,24 @@ public abstract class AbstractMultiCatalogTransform implements SeaTunnelTransfor
         String targetTableId = event.tablePath().toString();
         SeaTunnelTransform<SeaTunnelRow> targetTransform = transformMap.get(targetTableId);
         if (targetTransform != null) {
-            targetTransform.mapSchemaChangeEvent(event);
+            SchemaChangeEvent mappedEvent = targetTransform.mapSchemaChangeEvent(event);
+            if (mappedEvent == null) {
+                return null;
+            }
             refreshOutputCatalogTables();
             // Propagate this transform's actual produced catalog through the chain via the event's
             // changeAfter field (existing API designed for exactly this). Downstream transforms
             // and the sink read changeAfter to adopt upstream's actual row layout instead of
             // re-applying ALTER locally — which would diverge from the actual row order.
-            if (event instanceof AlterTableEvent) {
+            if (mappedEvent instanceof AlterTableEvent) {
                 outputCatalogTables.stream()
                         .filter(t -> t.getTableId().toTablePath().toString().equals(targetTableId))
                         .findFirst()
-                        .ifPresent(produced -> ((AlterTableEvent) event).setChangeAfter(produced));
+                        .ifPresent(
+                                produced ->
+                                        ((AlterTableEvent) mappedEvent).setChangeAfter(produced));
             }
+            return mappedEvent;
         }
         return event;
     }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedFlatMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedFlatMapTransform.java
@@ -78,6 +78,9 @@ class ChainedFlatMapTransform implements SeaTunnelFlatMapTransform<SeaTunnelRow>
         for (int i = 0; i < transforms.size(); i++) {
             SeaTunnelTransform<SeaTunnelRow> transform = transforms.get(i);
             currentEvent = transform.mapSchemaChangeEvent(currentEvent);
+            if (currentEvent == null) {
+                return null;
+            }
             if (i + 1 < transforms.size()) {
                 setTransformInput(transforms.get(i + 1), transform.getProducedCatalogTable());
             }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedFlatMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedFlatMapTransform.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.common;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.transform.SeaTunnelFlatMapTransform;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class ChainedFlatMapTransform implements SeaTunnelFlatMapTransform<SeaTunnelRow> {
+
+    private final List<SeaTunnelTransform<SeaTunnelRow>> transforms;
+
+    ChainedFlatMapTransform(List<SeaTunnelTransform<SeaTunnelRow>> transforms) {
+        this.transforms = transforms;
+    }
+
+    @Override
+    public String getPluginName() {
+        return transforms.get(0).getPluginName();
+    }
+
+    @Override
+    public void open() {
+        transforms.forEach(SeaTunnelTransform::open);
+    }
+
+    @Override
+    public List<SeaTunnelRow> flatMap(SeaTunnelRow row) {
+        List<SeaTunnelRow> currentRows = Collections.singletonList(row);
+        for (SeaTunnelTransform<SeaTunnelRow> transform : transforms) {
+            List<SeaTunnelRow> nextRows = new ArrayList<>();
+            for (SeaTunnelRow currentRow : currentRows) {
+                List<SeaTunnelRow> rows =
+                        ((SeaTunnelFlatMapTransform<SeaTunnelRow>) transform).flatMap(currentRow);
+                if (rows != null) {
+                    nextRows.addAll(rows);
+                }
+            }
+            currentRows = nextRows;
+        }
+        return currentRows;
+    }
+
+    @Override
+    public CatalogTable getProducedCatalogTable() {
+        return transforms.get(transforms.size() - 1).getProducedCatalogTable();
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(getProducedCatalogTable());
+    }
+
+    @Override
+    public SchemaChangeEvent mapSchemaChangeEvent(SchemaChangeEvent schemaChangeEvent) {
+        SchemaChangeEvent currentEvent = schemaChangeEvent;
+        for (int i = 0; i < transforms.size(); i++) {
+            SeaTunnelTransform<SeaTunnelRow> transform = transforms.get(i);
+            currentEvent = transform.mapSchemaChangeEvent(currentEvent);
+            if (i + 1 < transforms.size()) {
+                setTransformInput(transforms.get(i + 1), transform.getProducedCatalogTable());
+            }
+        }
+        return currentEvent;
+    }
+
+    @Override
+    public void setInputCatalogTables(List<CatalogTable> inputCatalogTables) {
+        if (inputCatalogTables == null || inputCatalogTables.isEmpty()) {
+            return;
+        }
+        CatalogTable currentCatalogTable = inputCatalogTables.get(0);
+        for (SeaTunnelTransform<SeaTunnelRow> transform : transforms) {
+            setTransformInput(transform, currentCatalogTable);
+            currentCatalogTable = transform.getProducedCatalogTable();
+        }
+    }
+
+    @Override
+    public void close() {
+        transforms.forEach(SeaTunnelTransform::close);
+    }
+
+    private void setTransformInput(
+            SeaTunnelTransform<SeaTunnelRow> transform, CatalogTable catalogTable) {
+        if (transform instanceof AbstractSeaTunnelTransform) {
+            ((AbstractSeaTunnelTransform<?, ?>) transform).setInputCatalogTable(catalogTable);
+        } else {
+            transform.setInputCatalogTables(Collections.singletonList(catalogTable));
+        }
+    }
+}

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedMapTransform.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.common;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.transform.SeaTunnelMapTransform;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
+
+import java.util.Collections;
+import java.util.List;
+
+class ChainedMapTransform implements SeaTunnelMapTransform<SeaTunnelRow> {
+
+    private final List<SeaTunnelTransform<SeaTunnelRow>> transforms;
+
+    ChainedMapTransform(List<SeaTunnelTransform<SeaTunnelRow>> transforms) {
+        this.transforms = transforms;
+    }
+
+    @Override
+    public String getPluginName() {
+        return transforms.get(0).getPluginName();
+    }
+
+    @Override
+    public void open() {
+        transforms.forEach(SeaTunnelTransform::open);
+    }
+
+    @Override
+    public SeaTunnelRow map(SeaTunnelRow row) {
+        SeaTunnelRow currentRow = row;
+        for (SeaTunnelTransform<SeaTunnelRow> transform : transforms) {
+            if (currentRow == null) {
+                return null;
+            }
+            currentRow = ((SeaTunnelMapTransform<SeaTunnelRow>) transform).map(currentRow);
+        }
+        return currentRow;
+    }
+
+    @Override
+    public CatalogTable getProducedCatalogTable() {
+        return transforms.get(transforms.size() - 1).getProducedCatalogTable();
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(getProducedCatalogTable());
+    }
+
+    @Override
+    public SchemaChangeEvent mapSchemaChangeEvent(SchemaChangeEvent schemaChangeEvent) {
+        SchemaChangeEvent currentEvent = schemaChangeEvent;
+        for (int i = 0; i < transforms.size(); i++) {
+            SeaTunnelTransform<SeaTunnelRow> transform = transforms.get(i);
+            currentEvent = transform.mapSchemaChangeEvent(currentEvent);
+            if (i + 1 < transforms.size()) {
+                setTransformInput(transforms.get(i + 1), transform.getProducedCatalogTable());
+            }
+        }
+        return currentEvent;
+    }
+
+    @Override
+    public void setInputCatalogTables(List<CatalogTable> inputCatalogTables) {
+        if (inputCatalogTables == null || inputCatalogTables.isEmpty()) {
+            return;
+        }
+        CatalogTable currentCatalogTable = inputCatalogTables.get(0);
+        for (SeaTunnelTransform<SeaTunnelRow> transform : transforms) {
+            setTransformInput(transform, currentCatalogTable);
+            currentCatalogTable = transform.getProducedCatalogTable();
+        }
+    }
+
+    @Override
+    public void close() {
+        transforms.forEach(SeaTunnelTransform::close);
+    }
+
+    private void setTransformInput(
+            SeaTunnelTransform<SeaTunnelRow> transform, CatalogTable catalogTable) {
+        if (transform instanceof AbstractSeaTunnelTransform) {
+            ((AbstractSeaTunnelTransform<?, ?>) transform).setInputCatalogTable(catalogTable);
+        } else {
+            transform.setInputCatalogTables(Collections.singletonList(catalogTable));
+        }
+    }
+}

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedMapTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/ChainedMapTransform.java
@@ -72,6 +72,9 @@ class ChainedMapTransform implements SeaTunnelMapTransform<SeaTunnelRow> {
         for (int i = 0; i < transforms.size(); i++) {
             SeaTunnelTransform<SeaTunnelRow> transform = transforms.get(i);
             currentEvent = transform.mapSchemaChangeEvent(currentEvent);
+            if (currentEvent == null) {
+                return null;
+            }
             if (i + 1 < transforms.size()) {
                 setTransformInput(transforms.get(i + 1), transform.getProducedCatalogTable());
             }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/TransformCommonOptions.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/common/TransformCommonOptions.java
@@ -47,6 +47,12 @@ public class TransformCommonOptions {
                     .defaultValue(".*")
                     .withDescription("The regex to match the table path");
 
+    public static final Option<RuleMatchMode> RULE_MATCH_MODE =
+            Options.key("rule_match_mode")
+                    .enumType(RuleMatchMode.class)
+                    .defaultValue(RuleMatchMode.FIRST_MATCH)
+                    .withDescription("The rule match mode for table transform config");
+
     public static final Option<ErrorHandleWay> ROW_ERROR_HANDLE_WAY_OPTION =
             Options.key("row_error_handle_way")
                     .singleChoice(
@@ -76,4 +82,9 @@ public class TransformCommonOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Target table name for routing invalid data when error_handle_way is ROUTE_TO_TABLE");
+
+    public enum RuleMatchMode {
+        FIRST_MATCH,
+        ALL_MATCH
+    }
 }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/copy/CopyFieldTransformFactory.java
@@ -50,6 +50,7 @@ public class CopyFieldTransformFactory implements TableTransformFactory {
                 .optional(CopyTransformConfig.DEST_FIELD)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/DynamicCompileTransformFactory.java
@@ -57,6 +57,7 @@ public class DynamicCompileTransformFactory implements TableTransformFactory {
                         Conditions.notBlank(DynamicCompileTransformConfig.ABSOLUTE_PATH))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/encrypt/FieldEncryptTransformFactory.java
@@ -52,6 +52,7 @@ public class FieldEncryptTransformFactory implements TableTransformFactory {
                         Conditions.greaterThan(FieldEncryptTransformConfig.MAX_FIELD_LENGTH, 0))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/fieldmapper/FieldMapperTransformFactory.java
@@ -43,6 +43,7 @@ public class FieldMapperTransformFactory implements TableTransformFactory {
                         Conditions.mapNotEmpty(FieldMapperTransformConfig.FIELD_MAPPER))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filter/FilterFieldTransformFactory.java
@@ -50,6 +50,7 @@ public class FilterFieldTransformFactory implements TableTransformFactory {
                         Conditions.notEmpty(FilterFieldTransformConfig.EXCLUDE_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filterrowkind/FilterRowKindTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/filterrowkind/FilterRowKindTransformFactory.java
@@ -41,6 +41,7 @@ public class FilterRowKindTransformFactory implements TableTransformFactory {
                         FilterRowKinkTransformConfig.INCLUDE_KINDS)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/jsonpath/JsonPathTransformFactory.java
@@ -52,6 +52,7 @@ public class JsonPathTransformFactory implements TableTransformFactory {
                                                 new ColumnsValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
                 .build();
     }

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/metadata/MetadataTransformFactory.java
@@ -42,6 +42,7 @@ public class MetadataTransformFactory implements TableTransformFactory {
                         Conditions.mapNotEmpty(MetadataTransformConfig.METADATA_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/embedding/EmbeddingTransformFactory.java
@@ -81,6 +81,7 @@ public class EmbeddingTransformFactory implements TableTransformFactory {
                         EmbeddingTransformConfig.DIMENSION)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/LLMTransformFactory.java
@@ -66,6 +66,7 @@ public class LLMTransformFactory implements TableTransformFactory {
                         LLMTransformConfig.CustomRequestConfig.CUSTOM_CONFIG)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -52,7 +52,7 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
                         Conditions.extension(
                                 RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
                                 new DefaultValuesLengthValidator()))
-                .optional(TransformCommonOptions.MULTI_TABLES)
+                .optional(TransformCommonOptions.MULTI_TABLES, TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -53,8 +53,7 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
                                 RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
                                 new DefaultValuesLengthValidator()))
                 .optional(
-                        TransformCommonOptions.MULTI_TABLES,
-                        TransformCommonOptions.RULE_MATCH_MODE)
+                        TransformCommonOptions.MULTI_TABLES, TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/regexextract/RegexExtractTransformFactory.java
@@ -52,7 +52,9 @@ public class RegexExtractTransformFactory implements TableTransformFactory {
                         Conditions.extension(
                                 RegexExtractTransformConfig.KEY_DEFAULT_VALUES,
                                 new DefaultValuesLengthValidator()))
-                .optional(TransformCommonOptions.MULTI_TABLES, TransformCommonOptions.RULE_MATCH_MODE)
+                .optional(
+                        TransformCommonOptions.MULTI_TABLES,
+                        TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/FieldRenameTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/FieldRenameTransformFactory.java
@@ -46,6 +46,7 @@ public class FieldRenameTransformFactory implements TableTransformFactory {
                 .optional(CONVERT_CASE, PREFIX, SUFFIX, REPLACEMENTS_WITH_REGEX, SPECIFIC)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/TableRenameTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/TableRenameTransformFactory.java
@@ -44,6 +44,7 @@ public class TableRenameTransformFactory implements TableTransformFactory {
                 .optional(CONVERT_CASE, PREFIX, SUFFIX, REPLACEMENTS_WITH_REGEX)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/replace/ReplaceTransformFactory.java
@@ -46,6 +46,7 @@ public class ReplaceTransformFactory implements TableTransformFactory {
                 .optional(ReplaceTransformConfig.KEY_REPLACE_FIRST)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rowkind/RowKindExtractorTransformFactory.java
@@ -40,6 +40,7 @@ public class RowKindExtractorTransformFactory implements TableTransformFactory {
                 .optional(RowKindExtractorTransformConfig.TRANSFORM_TYPE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/split/SplitTransformFactory.java
@@ -44,6 +44,7 @@ public class SplitTransformFactory implements TableTransformFactory {
                         Conditions.notEmpty(SplitTransformConfig.KEY_OUTPUT_FIELDS))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/SQLTransformFactory.java
@@ -41,6 +41,7 @@ public class SQLTransformFactory implements TableTransformFactory {
                 .required(KEY_QUERY)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableFilterTransformFactory.java
@@ -56,6 +56,7 @@ public class TableFilterTransformFactory implements TableTransformFactory {
                 .optional(TableFilterConfig.PATTERN_MODE)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/table/TableMergeTransformFactory.java
@@ -41,6 +41,7 @@ public class TableMergeTransformFactory implements TableTransformFactory {
                 .optional(TableMergeConfig.DATABASE, TableMergeConfig.SCHEMA)
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .build();
     }
 

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/DataValidatorTransformFactory.java
@@ -53,6 +53,7 @@ public class DataValidatorTransformFactory implements TableTransformFactory {
                                 .and(Conditions.extension(FIELD_RULES, new FieldRulesValidator())))
                 .optional(TransformCommonOptions.MULTI_TABLES)
                 .optional(TransformCommonOptions.TABLE_MATCH_REGEX)
+                .optional(TransformCommonOptions.RULE_MATCH_MODE)
                 .optional(TransformCommonOptions.ROW_ERROR_HANDLE_WAY_OPTION)
                 .optional(TransformCommonOptions.ERROR_TABLE_OPTION)
                 .build();

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransformTest.java
@@ -26,6 +26,8 @@ import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -57,20 +59,52 @@ class AbstractMultiCatalogTransformTest {
                     .noDefaultValue()
                     .withDescription("Field that must exist before this rule is built");
 
+    private static final Option<Boolean> FILTER_SCHEMA_CHANGE_EVENT =
+            Options.key("filter_schema_change_event")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Return null for schema-change events");
+
+    private static final Option<Boolean> FAIL_ON_SCHEMA_CHANGE_EVENT =
+            Options.key("fail_on_schema_change_event")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Fail if a schema-change event reaches this rule");
+
     @Test
-    void defaultModeUsesFirstExactTablePathRule() {
+    void defaultModeRejectsDuplicateExactTablePathRules() {
         CatalogTable table = catalogTable();
         String tablePath = tablePath(table);
         ReadonlyConfig config =
                 config(tableRule(tablePath, "first"), tableRule(tablePath, "second"));
-        TestMapMultiCatalogTransform transform =
-                new TestMapMultiCatalogTransform(Collections.singletonList(table), config);
 
-        SeaTunnelRow output = transform.map(row(tablePath));
+        IllegalStateException exception =
+                Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                new TestMapMultiCatalogTransform(
+                                        Collections.singletonList(table), config));
 
-        Assertions.assertEquals(Arrays.asList("id", "first"), fieldNames(transform));
-        Assertions.assertEquals(2, output.getArity());
-        Assertions.assertEquals("first", output.getField(1));
+        Assertions.assertTrue(exception.getMessage().contains(tablePath));
+    }
+
+    @Test
+    void defaultModeRejectsDuplicateExactTablePathRulesBeforeTableMatching() {
+        CatalogTable table = catalogTable();
+        String duplicateTablePath = "database.schema.customers";
+        ReadonlyConfig config =
+                config(
+                        tableRule(duplicateTablePath, "first"),
+                        tableRule(duplicateTablePath, "second"));
+
+        IllegalStateException exception =
+                Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                new TestMapMultiCatalogTransform(
+                                        Collections.singletonList(table), config));
+
+        Assertions.assertTrue(exception.getMessage().contains(duplicateTablePath));
     }
 
     @Test
@@ -132,6 +166,42 @@ class AbstractMultiCatalogTransformTest {
         Assertions.assertEquals(1, outputRows.size());
         Assertions.assertEquals("first", outputRows.get(0).getField(1));
         Assertions.assertEquals("second", outputRows.get(0).getField(2));
+    }
+
+    @Test
+    void chainedMapTransformStopsSchemaChangeAfterFilteredEvent() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        Map<String, Object> firstRule = tableRule(tablePath, "first");
+        firstRule.put(FILTER_SCHEMA_CHANGE_EVENT.key(), true);
+        Map<String, Object> secondRule = tableRule(tablePath, "second");
+        secondRule.put(FAIL_ON_SCHEMA_CHANGE_EVENT.key(), true);
+        ReadonlyConfig config =
+                config(TransformCommonOptions.RuleMatchMode.ALL_MATCH, firstRule, secondRule);
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        SchemaChangeEvent event = transform.mapSchemaChangeEvent(addColumnEvent(table));
+
+        Assertions.assertNull(event);
+    }
+
+    @Test
+    void chainedFlatMapTransformStopsSchemaChangeAfterFilteredEvent() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        Map<String, Object> firstRule = tableRule(tablePath, "first");
+        firstRule.put(FILTER_SCHEMA_CHANGE_EVENT.key(), true);
+        Map<String, Object> secondRule = tableRule(tablePath, "second");
+        secondRule.put(FAIL_ON_SCHEMA_CHANGE_EVENT.key(), true);
+        ReadonlyConfig config =
+                config(TransformCommonOptions.RuleMatchMode.ALL_MATCH, firstRule, secondRule);
+        TestFlatMapMultiCatalogTransform transform =
+                new TestFlatMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        SchemaChangeEvent event = transform.mapSchemaChangeEvent(addColumnEvent(table));
+
+        Assertions.assertNull(event);
     }
 
     @Test
@@ -207,6 +277,12 @@ class AbstractMultiCatalogTransformTest {
         SeaTunnelRow row = new SeaTunnelRow(new Object[] {1});
         row.setTableId(tablePath);
         return row;
+    }
+
+    private static SchemaChangeEvent addColumnEvent(CatalogTable table) {
+        return AlterTableAddColumnEvent.add(
+                table.getTableId(),
+                PhysicalColumn.of("created_at", BasicType.STRING_TYPE, 0L, true, null, null));
     }
 
     private static List<String> fieldNames(SeaTunnelTransform<SeaTunnelRow> transform) {
@@ -305,10 +381,16 @@ class AbstractMultiCatalogTransformTest {
 
         private final String fieldName;
 
+        private final boolean filterSchemaChangeEvent;
+
+        private final boolean failOnSchemaChangeEvent;
+
         private AppendFieldMapTransform(CatalogTable inputCatalogTable, ReadonlyConfig config) {
             super(inputCatalogTable);
             assertRequiredField(inputCatalogTable, config);
             this.fieldName = config.get(FIELD_NAME);
+            this.filterSchemaChangeEvent = config.get(FILTER_SCHEMA_CHANGE_EVENT);
+            this.failOnSchemaChangeEvent = config.get(FAIL_ON_SCHEMA_CHANGE_EVENT);
         }
 
         @Override
@@ -319,6 +401,17 @@ class AbstractMultiCatalogTransformTest {
         @Override
         protected SeaTunnelRow transformRow(SeaTunnelRow inputRow) {
             return appendField(inputRow, fieldName);
+        }
+
+        @Override
+        public SchemaChangeEvent mapSchemaChangeEvent(SchemaChangeEvent event) {
+            if (failOnSchemaChangeEvent) {
+                throw new AssertionError("Schema-change event should not reach this rule");
+            }
+            if (filterSchemaChangeEvent) {
+                return null;
+            }
+            return super.mapSchemaChangeEvent(event);
         }
 
         @Override
@@ -337,10 +430,16 @@ class AbstractMultiCatalogTransformTest {
 
         private final String fieldName;
 
+        private final boolean filterSchemaChangeEvent;
+
+        private final boolean failOnSchemaChangeEvent;
+
         private AppendFieldFlatMapTransform(CatalogTable inputCatalogTable, ReadonlyConfig config) {
             super(inputCatalogTable);
             assertRequiredField(inputCatalogTable, config);
             this.fieldName = config.get(FIELD_NAME);
+            this.filterSchemaChangeEvent = config.get(FILTER_SCHEMA_CHANGE_EVENT);
+            this.failOnSchemaChangeEvent = config.get(FAIL_ON_SCHEMA_CHANGE_EVENT);
         }
 
         @Override
@@ -351,6 +450,17 @@ class AbstractMultiCatalogTransformTest {
         @Override
         protected List<SeaTunnelRow> transformRow(SeaTunnelRow inputRow) {
             return Collections.singletonList(appendField(inputRow, fieldName));
+        }
+
+        @Override
+        public SchemaChangeEvent mapSchemaChangeEvent(SchemaChangeEvent event) {
+            if (failOnSchemaChangeEvent) {
+                throw new AssertionError("Schema-change event should not reach this rule");
+            }
+            if (filterSchemaChangeEvent) {
+                return null;
+            }
+            return event;
         }
 
         @Override

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/common/AbstractMultiCatalogTransformTest.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.common;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.transform.SeaTunnelTransform;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class AbstractMultiCatalogTransformTest {
+
+    private static final Option<String> FIELD_NAME =
+            Options.key("field_name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Field name to append");
+
+    private static final Option<String> REQUIRED_FIELD =
+            Options.key("required_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Field that must exist before this rule is built");
+
+    @Test
+    void defaultModeUsesFirstExactTablePathRule() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        ReadonlyConfig config =
+                config(tableRule(tablePath, "first"), tableRule(tablePath, "second"));
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        SeaTunnelRow output = transform.map(row(tablePath));
+
+        Assertions.assertEquals(Arrays.asList("id", "first"), fieldNames(transform));
+        Assertions.assertEquals(2, output.getArity());
+        Assertions.assertEquals("first", output.getField(1));
+    }
+
+    @Test
+    void firstMatchModeUsesOnlyFirstExactTablePathRule() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        ReadonlyConfig config =
+                config(
+                        TransformCommonOptions.RuleMatchMode.FIRST_MATCH,
+                        tableRule(tablePath, "first"),
+                        tableRule(tablePath, "second"));
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        SeaTunnelRow output = transform.map(row(tablePath));
+
+        Assertions.assertEquals(Arrays.asList("id", "first"), fieldNames(transform));
+        Assertions.assertEquals(2, output.getArity());
+        Assertions.assertEquals("first", output.getField(1));
+    }
+
+    @Test
+    void allMatchModeAppliesExactTablePathRulesInDeclarationOrder() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        Map<String, Object> secondRule = tableRule(tablePath, "second");
+        secondRule.put(REQUIRED_FIELD.key(), "first");
+        ReadonlyConfig config =
+                config(
+                        TransformCommonOptions.RuleMatchMode.ALL_MATCH,
+                        tableRule(tablePath, "first"),
+                        secondRule);
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        SeaTunnelRow output = transform.map(row(tablePath));
+
+        Assertions.assertEquals(Arrays.asList("id", "first", "second"), fieldNames(transform));
+        Assertions.assertEquals(3, output.getArity());
+        Assertions.assertEquals("first", output.getField(1));
+        Assertions.assertEquals("second", output.getField(2));
+    }
+
+    @Test
+    void allMatchModeWorksForFlatMapTransforms() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        ReadonlyConfig config =
+                config(
+                        TransformCommonOptions.RuleMatchMode.ALL_MATCH,
+                        tableRule(tablePath, "first"),
+                        tableRule(tablePath, "second"));
+        TestFlatMapMultiCatalogTransform transform =
+                new TestFlatMapMultiCatalogTransform(Collections.singletonList(table), config);
+
+        List<SeaTunnelRow> outputRows = transform.flatMap(row(tablePath));
+
+        Assertions.assertEquals(Arrays.asList("id", "first", "second"), fieldNames(transform));
+        Assertions.assertEquals(1, outputRows.size());
+        Assertions.assertEquals("first", outputRows.get(0).getField(1));
+        Assertions.assertEquals("second", outputRows.get(0).getField(2));
+    }
+
+    @Test
+    void tableMatchRegexIsFallbackWhenExactTablePathRuleDoesNotMatch() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(TransformCommonOptions.TABLE_MATCH_REGEX.key(), ".*orders");
+        configMap.put(FIELD_NAME.key(), "fallback");
+        configMap.put(
+                TransformCommonOptions.MULTI_TABLES.key(),
+                Collections.singletonList(tableRule("database.schema.customers", "specific")));
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(
+                        Collections.singletonList(table), ReadonlyConfig.fromMap(configMap));
+
+        SeaTunnelRow output = transform.map(row(tablePath));
+
+        Assertions.assertEquals(Arrays.asList("id", "fallback"), fieldNames(transform));
+        Assertions.assertEquals("fallback", output.getField(1));
+    }
+
+    @Test
+    void identityTransformIsUsedWhenNoRuleMatches() {
+        CatalogTable table = catalogTable();
+        String tablePath = tablePath(table);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(TransformCommonOptions.TABLE_MATCH_REGEX.key(), "does-not-match");
+        TestMapMultiCatalogTransform transform =
+                new TestMapMultiCatalogTransform(
+                        Collections.singletonList(table), ReadonlyConfig.fromMap(configMap));
+        SeaTunnelRow input = row(tablePath);
+
+        SeaTunnelRow output = transform.map(input);
+
+        Assertions.assertSame(input, output);
+        Assertions.assertEquals(Collections.singletonList("id"), fieldNames(transform));
+    }
+
+    private static ReadonlyConfig config(Map<String, Object>... tableRules) {
+        return config(null, tableRules);
+    }
+
+    private static ReadonlyConfig config(
+            TransformCommonOptions.RuleMatchMode ruleMatchMode, Map<String, Object>... tableRules) {
+        Map<String, Object> configMap = new HashMap<>();
+        if (ruleMatchMode != null) {
+            configMap.put(TransformCommonOptions.RULE_MATCH_MODE.key(), ruleMatchMode);
+        }
+        configMap.put(TransformCommonOptions.MULTI_TABLES.key(), Arrays.asList(tableRules));
+        return ReadonlyConfig.fromMap(configMap);
+    }
+
+    private static Map<String, Object> tableRule(String tablePath, String fieldName) {
+        Map<String, Object> rule = new HashMap<>();
+        rule.put(TransformCommonOptions.TABLE_PATH.key(), tablePath);
+        rule.put(FIELD_NAME.key(), fieldName);
+        return rule;
+    }
+
+    private static CatalogTable catalogTable() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"id"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        return CatalogTableUtil.getCatalogTable("catalog", "database", "schema", "orders", rowType);
+    }
+
+    private static String tablePath(CatalogTable table) {
+        return table.getTableId().toTablePath().toString();
+    }
+
+    private static SeaTunnelRow row(String tablePath) {
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1});
+        row.setTableId(tablePath);
+        return row;
+    }
+
+    private static List<String> fieldNames(SeaTunnelTransform<SeaTunnelRow> transform) {
+        return transform.getProducedCatalogTable().getTableSchema().getColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
+    }
+
+    private static SeaTunnelRow appendField(SeaTunnelRow inputRow, String fieldName) {
+        Object[] fields = Arrays.copyOf(inputRow.getFields(), inputRow.getArity() + 1);
+        fields[fields.length - 1] = fieldName;
+        SeaTunnelRow outputRow = new SeaTunnelRow(fields);
+        outputRow.setTableId(inputRow.getTableId());
+        outputRow.setRowKind(inputRow.getRowKind());
+        if (inputRow.getOptionsOrNull() != null) {
+            outputRow.setOptions(inputRow.getOptionsOrNull());
+        }
+        return outputRow;
+    }
+
+    private static TableSchema appendField(CatalogTable inputCatalogTable, String fieldName) {
+        List<Column> columns =
+                inputCatalogTable.getTableSchema().getColumns().stream()
+                        .map(Column::copy)
+                        .collect(Collectors.toCollection(ArrayList::new));
+        columns.add(PhysicalColumn.of(fieldName, BasicType.STRING_TYPE, 0L, true, null, null));
+        return TableSchema.builder()
+                .columns(columns)
+                .primaryKey(inputCatalogTable.getTableSchema().getPrimaryKey())
+                .constraintKey(inputCatalogTable.getTableSchema().getConstraintKeys())
+                .build();
+    }
+
+    private static void assertRequiredField(CatalogTable inputCatalogTable, ReadonlyConfig config) {
+        config.getOptional(REQUIRED_FIELD)
+                .ifPresent(
+                        field ->
+                                inputCatalogTable
+                                        .getTableSchema()
+                                        .toPhysicalRowDataType()
+                                        .indexOf(field));
+    }
+
+    private static class TestMapMultiCatalogTransform extends AbstractMultiCatalogMapTransform {
+
+        private TestMapMultiCatalogTransform(
+                List<CatalogTable> inputCatalogTables, ReadonlyConfig config) {
+            super(inputCatalogTables, config);
+        }
+
+        @Override
+        public String getPluginName() {
+            return "TestMap";
+        }
+
+        @Override
+        protected SeaTunnelTransform<SeaTunnelRow> buildTransform(
+                CatalogTable inputCatalogTable, ReadonlyConfig config) {
+            return new AppendFieldMapTransform(inputCatalogTable, config);
+        }
+
+        @Override
+        protected SeaTunnelTransform<SeaTunnelRow> createIdentityTransform(
+                CatalogTable catalogTable) {
+            return new IdentityMapTransform(catalogTable);
+        }
+    }
+
+    private static class TestFlatMapMultiCatalogTransform
+            extends AbstractMultiCatalogFlatMapTransform {
+
+        private TestFlatMapMultiCatalogTransform(
+                List<CatalogTable> inputCatalogTables, ReadonlyConfig config) {
+            super(inputCatalogTables, config);
+        }
+
+        @Override
+        public String getPluginName() {
+            return "TestFlatMap";
+        }
+
+        @Override
+        protected SeaTunnelTransform<SeaTunnelRow> buildTransform(
+                CatalogTable inputCatalogTable, ReadonlyConfig config) {
+            return new AppendFieldFlatMapTransform(inputCatalogTable, config);
+        }
+
+        @Override
+        protected SeaTunnelTransform<SeaTunnelRow> createIdentityTransform(
+                CatalogTable catalogTable) {
+            return new IdentityFlatMapTransform(catalogTable);
+        }
+    }
+
+    private static class AppendFieldMapTransform extends AbstractCatalogSupportMapTransform {
+
+        private final String fieldName;
+
+        private AppendFieldMapTransform(CatalogTable inputCatalogTable, ReadonlyConfig config) {
+            super(inputCatalogTable);
+            assertRequiredField(inputCatalogTable, config);
+            this.fieldName = config.get(FIELD_NAME);
+        }
+
+        @Override
+        public String getPluginName() {
+            return "AppendFieldMap";
+        }
+
+        @Override
+        protected SeaTunnelRow transformRow(SeaTunnelRow inputRow) {
+            return appendField(inputRow, fieldName);
+        }
+
+        @Override
+        protected TableSchema transformTableSchema() {
+            return appendField(inputCatalogTable, fieldName);
+        }
+
+        @Override
+        protected TableIdentifier transformTableIdentifier() {
+            return inputCatalogTable.getTableId().copy();
+        }
+    }
+
+    private static class AppendFieldFlatMapTransform
+            extends AbstractCatalogSupportFlatMapTransform {
+
+        private final String fieldName;
+
+        private AppendFieldFlatMapTransform(CatalogTable inputCatalogTable, ReadonlyConfig config) {
+            super(inputCatalogTable);
+            assertRequiredField(inputCatalogTable, config);
+            this.fieldName = config.get(FIELD_NAME);
+        }
+
+        @Override
+        public String getPluginName() {
+            return "AppendFieldFlatMap";
+        }
+
+        @Override
+        protected List<SeaTunnelRow> transformRow(SeaTunnelRow inputRow) {
+            return Collections.singletonList(appendField(inputRow, fieldName));
+        }
+
+        @Override
+        protected TableSchema transformTableSchema() {
+            return appendField(inputCatalogTable, fieldName);
+        }
+
+        @Override
+        protected TableIdentifier transformTableIdentifier() {
+            return inputCatalogTable.getTableId().copy();
+        }
+    }
+}

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldMultiCatalogTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/copy/CopyFieldMultiCatalogTransformTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.transform.copy;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.transform.common.TransformCommonOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class CopyFieldMultiCatalogTransformTest {
+
+    @Test
+    void allMatchModeAppliesCopyRulesInDeclarationOrder() {
+        CatalogTable table = catalogTable();
+        String tablePath = table.getTableId().toTablePath().toString();
+        CopyFieldMultiCatalogTransform transform =
+                new CopyFieldMultiCatalogTransform(
+                        Collections.singletonList(table), allMatchConfig(tablePath));
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "name-value"});
+        row.setTableId(tablePath);
+
+        SeaTunnelRow output = transform.map(row);
+
+        Assertions.assertEquals(
+                Arrays.asList("id", "name", "name2", "name3"), fieldNames(transform));
+        Assertions.assertEquals(4, output.getArity());
+        Assertions.assertEquals("name-value", output.getField(2));
+        Assertions.assertEquals("name-value", output.getField(3));
+    }
+
+    private static ReadonlyConfig allMatchConfig(String tablePath) {
+        Map<String, Object> firstRule = copyRule(tablePath, "name", "name2");
+        Map<String, Object> secondRule = copyRule(tablePath, "name2", "name3");
+        Map<String, Object> config = new HashMap<>();
+        config.put(
+                TransformCommonOptions.RULE_MATCH_MODE.key(),
+                TransformCommonOptions.RuleMatchMode.ALL_MATCH);
+        config.put(TransformCommonOptions.MULTI_TABLES.key(), Arrays.asList(firstRule, secondRule));
+        return ReadonlyConfig.fromMap(config);
+    }
+
+    private static Map<String, Object> copyRule(
+            String tablePath, String srcField, String destField) {
+        Map<String, Object> rule = new HashMap<>();
+        rule.put(TransformCommonOptions.TABLE_PATH.key(), tablePath);
+        rule.put(CopyTransformConfig.SRC_FIELD.key(), srcField);
+        rule.put(CopyTransformConfig.DEST_FIELD.key(), destField);
+        return rule;
+    }
+
+    private static CatalogTable catalogTable() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "name"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+        return CatalogTableUtil.getCatalogTable("catalog", "database", "schema", "orders", rowType);
+    }
+
+    private static List<String> fieldNames(CopyFieldMultiCatalogTransform transform) {
+        return transform.getProducedCatalogTable().getTableSchema().getColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION

### Purpose of this pull request

Enhances #11045.

This PR adds `rule_match_mode` for multi-table transform matching.

Changes:

- adds `FIRST_MATCH` and `ALL_MATCH` modes for repeated `table_transform` entries with the same exact `table_path`
- keeps the legacy behavior when `rule_match_mode` is not configured, so duplicate exact `table_path` rules still fail fast
- keeps `table_match_regex` as the fallback when no exact `table_transform` rule matches
- applies `ALL_MATCH` rules in declaration order, so later rules consume the schema and row produced by earlier rules
- preserves schema-change filtering when a chained transform returns `null`
- wires the new option into transform factories that support multi-table transform
- updates English and Chinese docs with an `ALL_MATCH` example
- adds focused common resolver tests and a real `CopyFieldMultiCatalogTransform` regression test

### Does this PR introduce _any_ user-facing change?

Yes.

Users can now configure `rule_match_mode = "FIRST_MATCH"` or `rule_match_mode = "ALL_MATCH"` when multiple `table_transform` entries target the same exact `table_path`.

If `rule_match_mode` is not configured, duplicate exact `table_path` entries still fail during config resolution. Existing valid configs keep the same behavior.

### How was this patch tested?

Added unit coverage for:

- legacy duplicate exact `table_path` fail-fast behavior when `rule_match_mode` is not configured
- explicit `FIRST_MATCH`
- `ALL_MATCH` sequential rule application
- deterministic declaration order
- fallback to outer `table_match_regex`
- no-match identity behavior
- chained schema-change null short-circuit behavior for map and flatMap transforms
- real Copy transform chaining where the second rule reads a field produced by the first rule

Verified with:

```shell
JAVA_HOME=$(/usr/libexec/java_home -v 11) PATH="$JAVA_HOME/bin:$PATH" ./mvnw -pl seatunnel-transforms-v2 -Dtest=org.apache.seatunnel.transform.common.AbstractMultiCatalogTransformTest,org.apache.seatunnel.transform.copy.CopyFieldMultiCatalogTransformTest test
JAVA_HOME=$(/usr/libexec/java_home -v 11) PATH="$JAVA_HOME/bin:$PATH" ./mvnw -pl seatunnel-transforms-v2 -DskipIT package
```

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)