### PR TITLE
[Fix][E2E] Stabilize connector-file-local CI by retrying job and disabling JUnit parallel execution

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1470,8 +1470,19 @@ jobs:
       - name: free disk space
         run: tools/github/free_disk_space.sh
       - name: run file local connector integration test
-        run: |
-          ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :connector-file-local-e2e -am -Pci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 7200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            ./mvnw -B -T 1 verify \
+            -DskipUT=true -DskipIT=false \
+            -D"license.skipAddThirdParty"=true -D"skip.ui"=true \
+            -Djunit.jupiter.execution.parallel.enabled=false \
+            -Djunit.jupiter.execution.parallel.mode.default=same_thread \
+            -Djunit.jupiter.execution.parallel.mode.classes.default=same_thread \
+            --no-snapshot-updates -pl :connector-file-local-e2e -am -Pci
         env:
           MAVEN_OPTS: -Xmx4096m
 


### PR DESCRIPTION
## Purpose of this pull request

Stabilize `connector-file-local-e2e` in CI when it flakes due to **Docker host port conflicts** (e.g. `Bind for 0.0.0.0:<port> failed: port is already allocated`). When a container fails to start, it can cascade into widespread test failures (e.g. `ParameterResolutionException`) and timeouts.

This PR avoids changing test/container implementation code and focuses on a **CI-only mitigation** for the affected job.

Key changes:

- Update `.github/workflows/backend.yml` (job: `connector-file-local-it`)
  - Add `nick-fields/retry@v3` (up to 3 attempts)
  - Disable JUnit 5 parallel execution via system properties:
    - `junit.jupiter.execution.parallel.enabled=false`
    - `junit.jupiter.execution.parallel.mode.default=same_thread`
    - `junit.jupiter.execution.parallel.mode.classes.default=same_thread`

## Does this PR introduce any user-facing change?

No. CI-only change.

## How was this patch tested?

- CI validation:
  - `connector-file-local-it` should no longer fail intermittently with port allocation errors
