### PR TITLE
[Fix][Docs] Remove duplicate connector FAQ sidebar entry

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -142,7 +142,6 @@ const sidebars = {
                 "connectors/connector-isolated-dependency",
                 "connectors/connector-faq",
                 "connectors/cdc-production-cookbook",
-                "connectors/connector-faq",
                 {
                     "type": "category",
                     "label": "Source",


### PR DESCRIPTION
### Purpose
Remove the duplicated `connectors/connector-faq` entry from the docs sidebar so the Connectors menu does not show the FAQ twice.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- `./mvnw spotless:apply`
- Not run: `./mvnw -q -DskipTests verify` (skipped per requester instruction)