### PR TITLE
[Improve][Connector-V2] Migrate jdbc validation to declarative OptionRule

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -460,7 +460,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
 
   updated-modules-integration-test-part-2:
     needs: [ changes, sanity-check ]
@@ -522,7 +522,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
 
   updated-modules-integration-test-part-4:
     needs: [ changes, sanity-check ]
@@ -583,7 +583,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
   updated-modules-integration-test-part-6:
     needs: [ changes, sanity-check ]
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
@@ -613,7 +613,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
   updated-modules-integration-test-part-7:
     needs: [ changes, sanity-check ]
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
@@ -643,7 +643,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
 
   updated-modules-integration-test-part-8:
     needs: [ changes, sanity-check ]
@@ -674,7 +674,7 @@ jobs:
             echo "sub modules is empty, skipping"
           fi
         env:
-          MAVEN_OPTS: -Xmx2048m
+          MAVEN_OPTS: -Xmx4096m
 
   engine-v2-it:
     needs: [ changes, sanity-check ]

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.dm;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.Catalog;
@@ -42,9 +39,6 @@ public class DamengCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(urlWithDatabase),
-                "Miss config <url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
         return new DamengCatalog(
                 catalogName,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
@@ -18,14 +18,11 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.highgo;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
-
-import java.util.Optional;
 
 public class HighGoCatalogFactory implements CatalogFactory {
 
@@ -33,10 +30,6 @@ public class HighGoCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new HighGoCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.iris;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.Catalog;
@@ -42,9 +39,6 @@ public class IrisCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(urlWithDatabase),
-                "Miss config <url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
         return new IrisCatalog(
                 catalogName,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalogFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.kingbase;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.Catalog;
@@ -42,9 +39,6 @@ public class KingbaseCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(urlWithDatabase),
-                "Miss config <base-url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
         return new KingbaseCatalog(
                 catalogName,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.Catalog;
@@ -42,9 +39,6 @@ public class MySqlCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(urlWithDatabase),
-                "Miss config <url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
         return new MySqlCatalog(
                 catalogName,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
@@ -17,12 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oceanbase;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -30,17 +26,10 @@ import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class OceanBaseCatalogFactory implements CatalogFactory {
-
-    private static final Logger log = LoggerFactory.getLogger(OceanBaseCatalogFactory.class);
 
     @Override
     public String factoryIdentifier() {
@@ -50,19 +39,9 @@ public class OceanBaseCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(urlWithDatabase),
-                "Miss config <url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
 
         String compatibleMode = options.get(JdbcCommonOptions.COMPATIBLE_MODE);
-        Preconditions.checkArgument(
-                StringUtils.isNoneBlank(compatibleMode),
-                "Miss config <compatible_mode>! Please check your config.");
 
         if ("oracle".equalsIgnoreCase(compatibleMode.trim())) {
             return new OceanBaseOracleCatalog(
@@ -83,7 +62,7 @@ public class OceanBaseCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE
+        return JdbcCommonOptions.baseCatalogRule()
                 .required(JdbcCommonOptions.COMPATIBLE_MODE)
                 .build();
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.opengauss;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -28,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class OpenGaussCatalogFactory implements CatalogFactory {
@@ -43,10 +40,6 @@ public class OpenGaussCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new OpenGaussCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -28,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class OracleCatalogFactory implements CatalogFactory {
@@ -43,10 +40,6 @@ public class OracleCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = OracleURLParser.parse(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new OracleCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.psql;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -28,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class PostgresCatalogFactory implements CatalogFactory {
@@ -43,10 +40,6 @@ public class PostgresCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new PostgresCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
@@ -17,12 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.redshift;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -31,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class RedshiftCatalogFactory implements CatalogFactory {
@@ -45,14 +39,7 @@ public class RedshiftCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        Preconditions.checkArgument(
-                StringUtils.isNotBlank(urlWithDatabase),
-                "Miss config <url>! Please check your config.");
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new RedshiftCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.saphana;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -28,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class SapHanaCatalogFactory implements CatalogFactory {
@@ -43,10 +40,6 @@ public class SapHanaCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = SapHanaURLParser.parse(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new SapHanaCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.tidb;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -28,8 +27,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class TiDBCatalogFactory implements CatalogFactory {
@@ -43,10 +40,6 @@ public class TiDBCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new TiDBCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.xugu;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -29,8 +28,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
 import com.google.auto.service.AutoService;
-
-import java.util.Optional;
 
 @AutoService(Factory.class)
 public class XuguCatalogFactory implements CatalogFactory {
@@ -44,10 +41,6 @@ public class XuguCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
         JdbcUrlUtil.UrlInfo urlInfo = OracleURLParser.parse(urlWithDatabase);
-        Optional<String> defaultDatabase = urlInfo.getDefaultDatabase();
-        if (!defaultDatabase.isPresent()) {
-            throw new OptionValidationException(JdbcCommonOptions.URL);
-        }
         return new XuguCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -19,7 +19,12 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.config;
 
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 
 import java.util.Map;
 
@@ -158,9 +163,34 @@ public class JdbcCommonOptions {
     public static final Option<String> REGION =
             Options.key("region").stringType().noDefaultValue().withDescription("region");
 
-    public static final OptionRule.Builder BASE_CATALOG_RULE =
-            OptionRule.builder()
-                    .required(URL)
-                    .required(USERNAME, PASSWORD)
-                    .optional(SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
+    /** @deprecated Use {@link #baseCatalogRule()} instead to avoid shared mutable state. */
+    @Deprecated public static final OptionRule.Builder BASE_CATALOG_RULE = baseCatalogRule();
+
+    public static OptionRule.Builder baseCatalogRule() {
+        return OptionRule.builder()
+                .required(URL, Conditions.extension(URL, new UrlContainsDatabaseValidator()))
+                .required(USERNAME, PASSWORD)
+                .optional(SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
+    }
+
+    public static class UrlContainsDatabaseValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "JDBC URL must contain a database name";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String url)
+                throws OptionValidationException {
+            if (url == null || url.trim().isEmpty()) {
+                throw new OptionValidationException("JDBC URL must not be blank");
+            }
+            JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(url);
+            if (!urlInfo.getDefaultDatabase().isPresent()) {
+                throw new OptionValidationException(
+                        "JDBC URL must contain a database name: " + url);
+            }
+            return true;
+        }
+    }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -23,7 +23,6 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 
 import java.util.Map;
@@ -166,6 +165,17 @@ public class JdbcCommonOptions {
     /** @deprecated Use {@link #baseCatalogRule()} instead to avoid shared mutable state. */
     @Deprecated public static final OptionRule.Builder BASE_CATALOG_RULE = baseCatalogRule();
 
+    /**
+     * Returns a fresh {@link OptionRule.Builder} with the base validation rules shared by all JDBC
+     * catalog factories (MySQL, PostgreSQL, Oracle, etc.).
+     *
+     * <p>These rules are evaluated at <b>submission time</b> via {@code
+     * ConfigValidator.validate(factory.optionRule())} in the {@code FactoryUtil} entry path. They
+     * enforce that the JDBC URL contains a database name, and that username/password are provided.
+     *
+     * <p>Individual catalog factories may append additional rules (e.g. OceanBase requires {@code
+     * compatible_mode}) before calling {@code .build()}.
+     */
     public static OptionRule.Builder baseCatalogRule() {
         return OptionRule.builder()
                 .required(URL, Conditions.extension(URL, new UrlContainsDatabaseValidator()))
@@ -173,6 +183,13 @@ public class JdbcCommonOptions {
                 .optional(SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
     }
 
+    /**
+     * Submission-time validator that ensures the JDBC URL contains a database name.
+     *
+     * <p>This validator is attached to the {@code url} option via {@link
+     * Conditions#extension(Option, ConditionExtension)} and is evaluated by {@code ConfigValidator}
+     * before the catalog/source/sink factory creates its connector instance.
+     */
     public static class UrlContainsDatabaseValidator implements ConditionExtension<String> {
         @Override
         public String description() {
@@ -180,17 +197,15 @@ public class JdbcCommonOptions {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, String url)
-                throws OptionValidationException {
+        public boolean evaluate(ReadonlyConfig config, String url) {
             if (url == null || url.trim().isEmpty()) {
-                throw new OptionValidationException("JDBC URL must not be blank");
+                return false;
             }
-            JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(url);
-            if (!urlInfo.getDefaultDatabase().isPresent()) {
-                throw new OptionValidationException(
-                        "JDBC URL must contain a database name: " + url);
+            try {
+                return JdbcUrlUtil.getUrlInfo(url).getDefaultDatabase().isPresent();
+            } catch (IllegalArgumentException e) {
+                return false;
             }
-            return true;
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceConfig.java
@@ -88,15 +88,7 @@ public class JdbcSourceConfig implements Serializable {
                 config.get(MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY));
 
         config.getOptional(JdbcSourceOptions.WHERE_CONDITION)
-                .ifPresent(
-                        whereConditionClause -> {
-                            if (!whereConditionClause.toLowerCase().startsWith("where")) {
-                                throw new IllegalArgumentException(
-                                        "The where condition clause must start with 'where'. value: "
-                                                + whereConditionClause);
-                            }
-                            builder.whereConditionClause(whereConditionClause);
-                        });
+                .ifPresent(builder::whereConditionClause);
 
         return builder.build();
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceTableConfig.java
@@ -72,11 +72,6 @@ public class JdbcSourceTableConfig implements Serializable {
     public static List<JdbcSourceTableConfig> of(ReadonlyConfig connectorConfig) {
         List<JdbcSourceTableConfig> tableList;
         if (connectorConfig.getOptional(JdbcSourceOptions.TABLE_LIST).isPresent()) {
-            if (connectorConfig.getOptional(JdbcSourceOptions.QUERY).isPresent()
-                    || connectorConfig.getOptional(JdbcSourceOptions.TABLE_PATH).isPresent()) {
-                throw new IllegalArgumentException(
-                        "Please configure either `table_list` or `table_path`/`query`, not both");
-            }
             tableList = connectorConfig.get(JdbcSourceOptions.TABLE_LIST);
         } else {
             JdbcSourceTableConfig tableProperty =

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilder.java
@@ -380,29 +380,9 @@ public class JdbcOutputFormatBuilder {
             throw new IllegalArgumentException(
                     "oracle_insert_mode=APPEND_VALUES only supports Oracle JDBC sink.");
         }
-        if (jdbcSinkConfig.isUseCopyStatement()) {
-            throw new IllegalArgumentException(
-                    "oracle_insert_mode=APPEND_VALUES does not support copy statement.");
-        }
-        if (StringUtils.isNotBlank(jdbcSinkConfig.getSimpleSql())) {
-            throw new IllegalArgumentException(
-                    "oracle_insert_mode=APPEND_VALUES does not support custom query.");
-        }
-        if (jdbcSinkConfig.isExactlyOnce()) {
-            throw new IllegalArgumentException(
-                    "oracle_insert_mode=APPEND_VALUES does not support exactly-once JDBC sink.");
-        }
-        if (!jdbcSinkConfig.getJdbcConnectionConfig().isAutoCommit()) {
-            throw new IllegalArgumentException(
-                    "oracle_insert_mode=APPEND_VALUES requires auto_commit=true.");
-        }
         if (primaryKeys != null && !primaryKeys.isEmpty()) {
             throw new IllegalArgumentException(
                     "oracle_insert_mode=APPEND_VALUES only supports insert-only writes without primary keys.");
-        }
-        if (jdbcSinkConfig.isSupportUpsertByInsertOnly()) {
-            throw new IllegalArgumentException(
-                    "oracle_insert_mode=APPEND_VALUES does not support insert-only upsert paths.");
         }
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -262,6 +262,18 @@ public class JdbcSinkFactory implements TableSinkFactory {
                 .build();
     }
 
+    /**
+     * Submission-time validator for {@code oracle_insert_mode=APPEND_VALUES}.
+     *
+     * <p>Enforces config-level incompatibilities that can be detected from the user-supplied
+     * options alone: copy statement, exactly-once, auto_commit=false, custom query, and insert-only
+     * upsert.
+     *
+     * <p><b>Note:</b> The {@code primary_keys} conflict is <em>not</em> checked here because
+     * primary keys may be derived from the upstream {@code CatalogTable} at factory time (inside
+     * {@link #createSink}), which happens after OptionRule validation. That case is guarded at
+     * runtime by {@code JdbcOutputFormatBuilder.validateOracleInsertMode}.
+     */
     static class OracleAppendValuesValidator
             implements ConditionExtension<JdbcSinkConfig.OracleInsertMode> {
         @Override
@@ -299,6 +311,12 @@ public class JdbcSinkFactory implements TableSinkFactory {
         }
     }
 
+    /**
+     * Submission-time validator for {@code is_exactly_once=true}.
+     *
+     * <p>JDBC XA sink does not support retries; {@code max_retries} must be 0 when exactly-once is
+     * enabled, otherwise duplicates may occur.
+     */
     static class ExactlyOnceMaxRetriesValidator implements ConditionExtension<Boolean> {
         @Override
         public String description() {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -20,7 +20,10 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.sink;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.sink.DataSaveMode;
@@ -214,20 +217,28 @@ public class JdbcSinkFactory implements TableSinkFactory {
                         JdbcSinkOptions.SCHEMA_SAVE_MODE,
                         JdbcSinkOptions.DATA_SAVE_MODE)
                 .optional(
+                        JdbcSinkOptions.ORACLE_INSERT_MODE,
+                        Conditions.extension(
+                                JdbcSinkOptions.ORACLE_INSERT_MODE,
+                                new OracleAppendValuesValidator()))
+                .optional(
+                        JdbcSinkOptions.IS_EXACTLY_ONCE,
+                        Conditions.extension(
+                                JdbcSinkOptions.IS_EXACTLY_ONCE,
+                                new ExactlyOnceMaxRetriesValidator()))
+                .optional(
                         JdbcSinkOptions.CREATE_INDEX,
                         JdbcSinkOptions.USERNAME,
                         JdbcSinkOptions.PASSWORD,
                         JdbcSinkOptions.CONNECTION_CHECK_TIMEOUT_SEC,
                         JdbcSinkOptions.BATCH_SIZE,
                         JdbcSinkOptions.BATCH_INTERVAL_MS,
-                        JdbcSinkOptions.IS_EXACTLY_ONCE,
                         JdbcSinkOptions.GENERATE_SINK_SQL,
                         JdbcSinkOptions.AUTO_COMMIT,
                         JdbcSinkOptions.PRIMARY_KEYS,
                         JdbcSinkOptions.IS_PRIMARY_KEY_UPDATED,
                         JdbcSinkOptions.SUPPORT_UPSERT_BY_INSERT_ONLY,
                         JdbcSinkOptions.USE_COPY_STATEMENT,
-                        JdbcSinkOptions.ORACLE_INSERT_MODE,
                         JdbcSinkOptions.COMPATIBLE_MODE,
                         JdbcSinkOptions.ENABLE_UPSERT,
                         JdbcSinkOptions.FIELD_IDE,
@@ -249,5 +260,63 @@ public class JdbcSinkFactory implements TableSinkFactory {
                         DataSaveMode.CUSTOM_PROCESSING,
                         JdbcSinkOptions.CUSTOM_SQL)
                 .build();
+    }
+
+    static class OracleAppendValuesValidator
+            implements ConditionExtension<JdbcSinkConfig.OracleInsertMode> {
+        @Override
+        public String description() {
+            return "oracle_insert_mode=APPEND_VALUES conflicts with certain options";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, JdbcSinkConfig.OracleInsertMode value)
+                throws OptionValidationException {
+            if (value != JdbcSinkConfig.OracleInsertMode.APPEND_VALUES) {
+                return true;
+            }
+            if (config.get(JdbcSinkOptions.USE_COPY_STATEMENT)) {
+                throw new OptionValidationException(
+                        "oracle_insert_mode=APPEND_VALUES does not support copy statement.");
+            }
+            if (config.get(JdbcSinkOptions.IS_EXACTLY_ONCE)) {
+                throw new OptionValidationException(
+                        "oracle_insert_mode=APPEND_VALUES does not support exactly-once.");
+            }
+            if (!config.get(JdbcSinkOptions.AUTO_COMMIT)) {
+                throw new OptionValidationException(
+                        "oracle_insert_mode=APPEND_VALUES requires auto_commit=true.");
+            }
+            if (!config.get(JdbcSinkOptions.GENERATE_SINK_SQL)) {
+                throw new OptionValidationException(
+                        "oracle_insert_mode=APPEND_VALUES does not support custom query.");
+            }
+            if (config.get(JdbcSinkOptions.SUPPORT_UPSERT_BY_INSERT_ONLY)) {
+                throw new OptionValidationException(
+                        "oracle_insert_mode=APPEND_VALUES does not support insert-only upsert.");
+            }
+            return true;
+        }
+    }
+
+    static class ExactlyOnceMaxRetriesValidator implements ConditionExtension<Boolean> {
+        @Override
+        public String description() {
+            return "is_exactly_once=true requires max_retries=0";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, Boolean value)
+                throws OptionValidationException {
+            if (Boolean.TRUE.equals(value)) {
+                int maxRetries = config.get(JdbcSinkOptions.MAX_RETRIES);
+                if (maxRetries != 0) {
+                    throw new OptionValidationException(
+                            "JDBC XA sink requires max_retries equal to 0 when is_exactly_once=true, "
+                                    + "otherwise it could cause duplicates.");
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -26,6 +30,7 @@ import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceTableConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectLoader;
 
@@ -33,6 +38,7 @@ import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Slf4j
 @AutoService(Factory.class)
@@ -64,6 +70,15 @@ public class JdbcSourceFactory implements TableSourceFactory {
         return OptionRule.builder()
                 .required(JdbcSourceOptions.URL, JdbcSourceOptions.DRIVER)
                 .optional(
+                        JdbcSourceOptions.TABLE_LIST,
+                        Conditions.extension(
+                                JdbcSourceOptions.TABLE_LIST, new TableListExclusiveValidator()))
+                .optional(
+                        JdbcSourceOptions.WHERE_CONDITION,
+                        Conditions.extension(
+                                JdbcSourceOptions.WHERE_CONDITION,
+                                new WhereConditionPrefixValidator()))
+                .optional(
                         JdbcSourceOptions.USERNAME,
                         JdbcSourceOptions.PASSWORD,
                         JdbcSourceOptions.CONNECTION_CHECK_TIMEOUT_SEC,
@@ -82,8 +97,6 @@ public class JdbcSourceFactory implements TableSourceFactory {
                         JdbcSourceOptions.SKIP_ANALYZE,
                         JdbcSourceOptions.USE_REGEX,
                         JdbcSourceOptions.TABLE_PATH,
-                        JdbcSourceOptions.WHERE_CONDITION,
-                        JdbcSourceOptions.TABLE_LIST,
                         JdbcSourceOptions.SPLIT_SIZE,
                         JdbcSourceOptions.SPLIT_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND,
                         JdbcSourceOptions.SPLIT_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND,
@@ -99,5 +112,41 @@ public class JdbcSourceFactory implements TableSourceFactory {
     @Override
     public Class<? extends SeaTunnelSource> getSourceClass() {
         return JdbcSource.class;
+    }
+
+    static class TableListExclusiveValidator
+            implements ConditionExtension<List<JdbcSourceTableConfig>> {
+        @Override
+        public String description() {
+            return "'table_list' and 'table_path'/'query' are mutually exclusive";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<JdbcSourceTableConfig> value)
+                throws OptionValidationException {
+            if (config.getOptional(JdbcSourceOptions.TABLE_PATH).isPresent()
+                    || config.getOptional(JdbcSourceOptions.QUERY).isPresent()) {
+                throw new OptionValidationException(
+                        "Please configure either 'table_list' or 'table_path'/'query', not both");
+            }
+            return true;
+        }
+    }
+
+    static class WhereConditionPrefixValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "'where_condition' must start with 'where'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String value)
+                throws OptionValidationException {
+            if (value != null && !value.toLowerCase().startsWith("where")) {
+                throw new OptionValidationException(
+                        "The where_condition must start with 'where'. value: " + value);
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactory.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -114,6 +113,11 @@ public class JdbcSourceFactory implements TableSourceFactory {
         return JdbcSource.class;
     }
 
+    /**
+     * Submission-time validator that enforces mutual exclusion between {@code table_list} and the
+     * legacy {@code table_path}/{@code query} options. Users must choose one table selection mode,
+     * not both.
+     */
     static class TableListExclusiveValidator
             implements ConditionExtension<List<JdbcSourceTableConfig>> {
         @Override
@@ -122,17 +126,16 @@ public class JdbcSourceFactory implements TableSourceFactory {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, List<JdbcSourceTableConfig> value)
-                throws OptionValidationException {
-            if (config.getOptional(JdbcSourceOptions.TABLE_PATH).isPresent()
-                    || config.getOptional(JdbcSourceOptions.QUERY).isPresent()) {
-                throw new OptionValidationException(
-                        "Please configure either 'table_list' or 'table_path'/'query', not both");
-            }
-            return true;
+        public boolean evaluate(ReadonlyConfig config, List<JdbcSourceTableConfig> value) {
+            return !config.getOptional(JdbcSourceOptions.TABLE_PATH).isPresent()
+                    && !config.getOptional(JdbcSourceOptions.QUERY).isPresent();
         }
     }
 
+    /**
+     * Submission-time validator that ensures {@code where_condition} starts with the keyword {@code
+     * "where"} to avoid malformed SQL at runtime.
+     */
     static class WhereConditionPrefixValidator implements ConditionExtension<String> {
         @Override
         public String description() {
@@ -140,13 +143,8 @@ public class JdbcSourceFactory implements TableSourceFactory {
         }
 
         @Override
-        public boolean evaluate(ReadonlyConfig config, String value)
-                throws OptionValidationException {
-            if (value != null && !value.toLowerCase().startsWith("where")) {
-                throw new OptionValidationException(
-                        "The where_condition must start with 'where'. value: " + value);
-            }
-            return true;
+        public boolean evaluate(ReadonlyConfig config, String value) {
+            return value == null || value.toLowerCase().startsWith("where");
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalogFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oceanbase.OceanBaseCatalogFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.psql.PostgresCatalogFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class JdbcCatalogFactoryTest {
+
+    private final OptionRule mysqlRule = new MySqlCatalogFactory().optionRule();
+    private final OptionRule pgRule = new PostgresCatalogFactory().optionRule();
+
+    private void validate(OptionRule rule, Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    @Test
+    void testValidCatalogConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
+        cfg.put("username", "root");
+        cfg.put("password", "secret");
+        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testMySqlCatalogValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://host:3306/mydb");
+        cfg.put("username", "root");
+        cfg.put("password", "pass");
+        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testPostgresCatalogValidConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:postgresql://host:5432/mydb");
+        cfg.put("username", "postgres");
+        cfg.put("password", "pass");
+        Assertions.assertDoesNotThrow(() -> validate(pgRule, cfg));
+    }
+
+    @Test
+    void testUrlWithoutDatabaseFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://host:3306");
+        cfg.put("username", "root");
+        cfg.put("password", "pass");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testBlankUrlFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "");
+        cfg.put("username", "root");
+        cfg.put("password", "pass");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testMissingUsernameFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://host:3306/mydb");
+        cfg.put("password", "pass");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testMissingPasswordFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://host:3306/mydb");
+        cfg.put("username", "root");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testOceanBaseWithoutCompatibleModeFails() {
+        OptionRule obRule = new OceanBaseCatalogFactory().optionRule();
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:oceanbase://host:2881/mydb");
+        cfg.put("username", "root");
+        cfg.put("password", "pass");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(obRule, cfg));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/JdbcOutputFormatBuilderTest.java
@@ -178,39 +178,6 @@ public class JdbcOutputFormatBuilderTest {
     }
 
     @Test
-    public void testOracleAppendValuesRejectsCustomQuery() {
-        JdbcSinkConfig config =
-                appendValuesConfigBuilder().simpleSql("INSERT INTO TEST_TABLE VALUES (?)").build();
-
-        IllegalArgumentException exception =
-                Assertions.assertThrows(
-                        IllegalArgumentException.class,
-                        () -> newBuilder(new OracleDialect(), config).build());
-
-        Assertions.assertEquals(
-                "oracle_insert_mode=APPEND_VALUES does not support custom query.",
-                exception.getMessage());
-    }
-
-    @Test
-    public void testOracleAppendValuesRejectsAutoCommitDisabled() {
-        JdbcSinkConfig config =
-                appendValuesConfigBuilder()
-                        .jdbcConnectionConfig(
-                                JdbcConnectionConfig.builder().autoCommit(false).build())
-                        .build();
-
-        IllegalArgumentException exception =
-                Assertions.assertThrows(
-                        IllegalArgumentException.class,
-                        () -> newBuilder(new OracleDialect(), config).build());
-
-        Assertions.assertEquals(
-                "oracle_insert_mode=APPEND_VALUES requires auto_commit=true.",
-                exception.getMessage());
-    }
-
-    @Test
     public void testOracleAppendValuesRejectsPrimaryKeys() {
         JdbcSinkConfig config =
                 appendValuesConfigBuilder().primaryKeys(Collections.singletonList("ID")).build();
@@ -222,20 +189,6 @@ public class JdbcOutputFormatBuilderTest {
 
         Assertions.assertEquals(
                 "oracle_insert_mode=APPEND_VALUES only supports insert-only writes without primary keys.",
-                exception.getMessage());
-    }
-
-    @Test
-    public void testOracleAppendValuesRejectsExactlyOnce() {
-        JdbcSinkConfig config = appendValuesConfigBuilder().isExactlyOnce(true).build();
-
-        IllegalArgumentException exception =
-                Assertions.assertThrows(
-                        IllegalArgumentException.class,
-                        () -> newBuilder(new OracleDialect(), config).build());
-
-        Assertions.assertEquals(
-                "oracle_insert_mode=APPEND_VALUES does not support exactly-once JDBC sink.",
                 exception.getMessage());
     }
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
@@ -21,16 +21,27 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 class JdbcSinkFactoryTest {
 
-    private final OptionRule rule = new JdbcSinkFactory().optionRule();
+    private final JdbcSinkFactory factory = new JdbcSinkFactory();
+    private final OptionRule rule = factory.optionRule();
 
     private void validate(Map<String, Object> config) {
         ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
@@ -45,6 +56,38 @@ class JdbcSinkFactoryTest {
         cfg.put("generate_sink_sql", true);
         cfg.put("database", "ORCL");
         return cfg;
+    }
+
+    private CatalogTable createCatalogTable(boolean withPrimaryKey) {
+        TableSchema.Builder schemaBuilder =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, "id"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "name", BasicType.STRING_TYPE, 128, false, null, "name"));
+        if (withPrimaryKey) {
+            schemaBuilder.primaryKey(PrimaryKey.of("pk_id", Collections.singletonList("id")));
+        }
+        return CatalogTable.of(
+                TableIdentifier.of("catalog", "ORCL", null, "TEST_TABLE"),
+                schemaBuilder.build(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                null,
+                "catalog");
+    }
+
+    /**
+     * Simulates the FactoryUtil.createAndPrepareSink entry path: OptionRule validation followed by
+     * factory.createSink(context). This covers the real submission-time path end-to-end.
+     */
+    private TableSink createSinkViaFactoryContext(Map<String, Object> cfg, boolean withPrimaryKey) {
+        ReadonlyConfig config = ReadonlyConfig.fromMap(cfg);
+        ConfigValidator.of(config).validate(factory.optionRule());
+        CatalogTable catalogTable = createCatalogTable(withPrimaryKey);
+        TableSinkFactoryContext context =
+                new TableSinkFactoryContext(catalogTable, config, getClass().getClassLoader());
+        return factory.createSink(context);
     }
 
     @Test
@@ -144,5 +187,59 @@ class JdbcSinkFactoryTest {
         cfg.put("schema_save_mode", "CREATE_SCHEMA_WHEN_NOT_EXIST");
         cfg.put("data_save_mode", "APPEND_DATA");
         Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    // ---- Entry-level regression tests through factory-context path ----
+
+    @Test
+    void testFactoryContextPathValidConfig() {
+        Map<String, Object> cfg = baseConfig();
+        Assertions.assertDoesNotThrow(() -> createSinkViaFactoryContext(cfg, false));
+    }
+
+    @Test
+    void testFactoryContextPathAppendValuesValidConfig() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("auto_commit", true);
+        cfg.put("is_exactly_once", false);
+        cfg.put("use_copy_statement", false);
+        cfg.put("support_upsert_by_insert_only", false);
+        Assertions.assertDoesNotThrow(() -> createSinkViaFactoryContext(cfg, false));
+    }
+
+    @Test
+    void testFactoryContextPathAppendValuesWithExactlyOnceFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("is_exactly_once", true);
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> createSinkViaFactoryContext(cfg, false));
+    }
+
+    /**
+     * Verifies the CatalogTable-derived primary keys + APPEND_VALUES scenario.
+     *
+     * <p>When the upstream CatalogTable carries a primary key but the user does not set {@code
+     * primary_keys} in config, {@link JdbcSinkFactory#createSink} auto-populates primary_keys from
+     * the catalog schema. The OptionRule validation passes because the primary_keys conflict cannot
+     * be detected at config time (it depends on the catalog schema). The runtime guard in {@code
+     * JdbcOutputFormatBuilder.validateOracleInsertMode} catches this case and rejects APPEND_VALUES
+     * with non-empty primary keys.
+     */
+    @Test
+    void testFactoryContextAppendValuesWithCatalogDerivedPrimaryKeys() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("auto_commit", true);
+        cfg.put("is_exactly_once", false);
+        cfg.put("use_copy_statement", false);
+        cfg.put("support_upsert_by_insert_only", false);
+
+        Assertions.assertDoesNotThrow(
+                () -> createSinkViaFactoryContext(cfg, true),
+                "Factory-level validation and createSink should succeed even when "
+                        + "CatalogTable has primary keys; the PK + APPEND_VALUES conflict "
+                        + "is guarded at runtime by JdbcOutputFormatBuilder.validateOracleInsertMode");
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class JdbcSinkFactoryTest {
+
+    private final OptionRule rule = new JdbcSinkFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:oracle:thin:@//localhost:1521/ORCL");
+        cfg.put("driver", "oracle.jdbc.OracleDriver");
+        cfg.put("schema_save_mode", "CREATE_SCHEMA_WHEN_NOT_EXIST");
+        cfg.put("data_save_mode", "APPEND_DATA");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("database", "ORCL");
+        return cfg;
+    }
+
+    @Test
+    void testValidSinkConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(baseConfig()));
+    }
+
+    @Test
+    void testOracleAppendValuesValidConfig() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("auto_commit", true);
+        cfg.put("is_exactly_once", false);
+        cfg.put("use_copy_statement", false);
+        cfg.put("support_upsert_by_insert_only", false);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testExactlyOnceWithMaxRetriesZero() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("is_exactly_once", true);
+        cfg.put("max_retries", 0);
+        cfg.put("xa_data_source_class_name", "oracle.jdbc.xa.OracleXADataSource");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testOracleAppendValuesWithExactlyOnceFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("is_exactly_once", true);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testOracleAppendValuesWithCopyStatementFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("use_copy_statement", true);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testOracleAppendValuesWithAutoCommitFalseFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("auto_commit", false);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testOracleAppendValuesWithCustomQueryFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", false);
+        cfg.remove("database");
+        cfg.put("query", "INSERT INTO t VALUES(?,?)");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testOracleAppendValuesWithInsertOnlyUpsertFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("oracle_insert_mode", "APPEND_VALUES");
+        cfg.put("generate_sink_sql", true);
+        cfg.put("support_upsert_by_insert_only", true);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testExactlyOnceWithMaxRetriesNonZeroFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("is_exactly_once", true);
+        cfg.put("max_retries", 3);
+        cfg.put("xa_data_source_class_name", "oracle.jdbc.xa.OracleXADataSource");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingUrlFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("driver", "oracle.jdbc.OracleDriver");
+        cfg.put("schema_save_mode", "CREATE_SCHEMA_WHEN_NOT_EXIST");
+        cfg.put("data_save_mode", "APPEND_DATA");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingDriverFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:oracle:thin:@//localhost:1521/ORCL");
+        cfg.put("schema_save_mode", "CREATE_SCHEMA_WHEN_NOT_EXIST");
+        cfg.put("data_save_mode", "APPEND_DATA");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactoryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class JdbcSourceFactoryTest {
+
+    private final OptionRule rule = new JdbcSourceFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://localhost:3306/test");
+        cfg.put("driver", "com.mysql.cj.jdbc.Driver");
+        return cfg;
+    }
+
+    @Test
+    void testValidConfigWithTablePath() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("table_path", "test.users");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidConfigWithTableList() {
+        Map<String, Object> cfg = baseConfig();
+        List<Map<String, String>> tableList = new ArrayList<>();
+        Map<String, String> entry = new HashMap<>();
+        entry.put("table_path", "test.users");
+        tableList.add(entry);
+        cfg.put("table_list", tableList);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidConfigWithQuery() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("query", "SELECT * FROM users");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidConfigWithTablePathAndQuery() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("table_path", "test.users");
+        cfg.put("query", "SELECT * FROM users WHERE active = 1");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testValidConfigWithWhereCondition() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("table_path", "test.users");
+        cfg.put("where_condition", "where id > 100");
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testTableListWithTablePathFails() {
+        Map<String, Object> cfg = baseConfig();
+        List<Map<String, String>> tableList = new ArrayList<>();
+        Map<String, String> entry = new HashMap<>();
+        entry.put("table_path", "test.users");
+        tableList.add(entry);
+        cfg.put("table_list", tableList);
+        cfg.put("table_path", "test.orders");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testTableListWithQueryFails() {
+        Map<String, Object> cfg = baseConfig();
+        List<Map<String, String>> tableList = new ArrayList<>();
+        Map<String, String> entry = new HashMap<>();
+        entry.put("table_path", "test.users");
+        tableList.add(entry);
+        cfg.put("table_list", tableList);
+        cfg.put("query", "SELECT * FROM orders");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testTableListWithBothTablePathAndQueryFails() {
+        Map<String, Object> cfg = baseConfig();
+        List<Map<String, String>> tableList = new ArrayList<>();
+        Map<String, String> entry = new HashMap<>();
+        entry.put("table_path", "test.users");
+        tableList.add(entry);
+        cfg.put("table_list", tableList);
+        cfg.put("table_path", "test.orders");
+        cfg.put("query", "SELECT * FROM orders");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testWhereConditionWithoutPrefixFails() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("table_path", "test.users");
+        cfg.put("where_condition", "id > 100");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingUrlFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("driver", "com.mysql.cj.jdbc.Driver");
+        cfg.put("table_path", "test.users");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMissingDriverFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://localhost:3306/test");
+        cfg.put("table_path", "test.users");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,8 @@ import java.util.Map;
 
 class JdbcSourceFactoryTest {
 
-    private final OptionRule rule = new JdbcSourceFactory().optionRule();
+    private final JdbcSourceFactory factory = new JdbcSourceFactory();
+    private final OptionRule rule = factory.optionRule();
 
     private void validate(Map<String, Object> config) {
         ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
@@ -145,5 +147,39 @@ class JdbcSourceFactoryTest {
         cfg.put("url", "jdbc:mysql://localhost:3306/test");
         cfg.put("table_path", "test.users");
         Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    // ---- Entry-level regression tests through factory-context path ----
+
+    /**
+     * Simulates the FactoryUtil.createAndPrepareSource entry path: OptionRule validation followed
+     * by factory.createSource(context). Verifies the real submission-time path end-to-end.
+     */
+    @Test
+    void testFactoryContextPathValidConfig() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put("table_path", "test.users");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(cfg);
+        ConfigValidator.of(config).validate(factory.optionRule());
+
+        TableSourceFactoryContext context =
+                new TableSourceFactoryContext(config, getClass().getClassLoader());
+        Assertions.assertDoesNotThrow(() -> factory.createSource(context));
+    }
+
+    @Test
+    void testFactoryContextPathTableListExclusionFails() {
+        Map<String, Object> cfg = baseConfig();
+        List<Map<String, String>> tableList = new ArrayList<>();
+        Map<String, String> entry = new HashMap<>();
+        entry.put("table_path", "test.users");
+        tableList.add(entry);
+        cfg.put("table_list", tableList);
+        cfg.put("table_path", "test.orders");
+
+        ReadonlyConfig config = ReadonlyConfig.fromMap(cfg);
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(config).validate(factory.optionRule()));
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Related: https://github.com/apache/seatunnel/issues/11007

Migrate JDBC connector validation from imperative `if/throw` checks to declarative `OptionRule` + `Conditions.extension()`, covering Source, Sink, and all 15 Catalog factories.

**Changes**:
- `JdbcSourceFactory` — add declarative rules: `required(URL, DRIVER)`, `TableListExclusiveValidator` (rejects `table_list` coexisting with `table_path`/`query`), `WhereConditionPrefixValidator` (requires `where` prefix)

- `JdbcSinkFactory` — add declarative rules: `required(URL, DRIVER, SCHEMA_SAVE_MODE, DATA_SAVE_MODE)`, `OracleAppendValuesValidator` (rejects conflicts with exactly-once, copy statement, auto_commit=false, custom query, insert-only upsert), `ExactlyOnceMaxRetriesValidator` (requires `max_retries=0`), conditional groups for exactly-once, generate_sink_sql, custom save mode

- `JdbcCommonOptions` — add `baseCatalogRule()` with `UrlContainsDatabaseValidator` to replace per-catalog `Preconditions.checkArgument` / `OptionValidationException` checks; deprecate shared mutable `BASE_CATALOG_RULE` field

- 13 Catalog factories (MySQL, Postgres, Oracle, SqlServer, Dameng, Iris, Kingbase, HighGo, OpenGauss, SapHana, TiDB, Xugu, Redshift) — remove imperative URL/database validation from `createCatalog()`

- `OceanBaseCatalogFactory` — extend `baseCatalogRule()` with additional `.required(COMPATIBLE_MODE)`

- `JdbcSourceConfig` — remove imperative `where_condition` prefix check (now in factory OptionRule)

- `JdbcSourceTableConfig` — remove redundant `table_list` exclusive check (now in factory OptionRule)

- `JdbcOutputFormatBuilder` — remove Oracle APPEND_VALUES runtime checks for custom query, auto_commit, exactly-once, copy statement (moved to factory OptionRule); keep runtime-only checks for dialect name and primary keys

- `JdbcOutputFormatBuilderTest` — remove 3 obsolete runtime tests now covered by `JdbcSinkFactoryTest`

- Add `JdbcSourceFactoryTest` (11 cases), `JdbcSinkFactoryTest` (11 cases), `JdbcCatalogFactoryTest` (8 cases) for declarative validation coverage

### Does this PR introduce _any_ user-facing change?


**1. Validation errors behavior by factory:**
| Error behavior | Factories |
|---|---|
| Aggregated (all errors collected and returned together) | JdbcSource, all 15 Catalog factories |
| Fail-fast (stops on first error with specific conflict detail) | JdbcSink (`OracleAppendValuesValidator`, `ExactlyOnceMaxRetriesValidator`) |

**2. Tightened validation** (configs that previously passed may now be rejected at submission time):
- `JdbcSource`: `table_list` and `table_path`/`query` coexistence now rejected; `where_condition` must start with `where`
- `JdbcSink`: `oracle_insert_mode=APPEND_VALUES` conflicts with `use_copy_statement`, `is_exactly_once`, `auto_commit=false`, custom query, `support_upsert_by_insert_only` now rejected; `is_exactly_once=true` requires `max_retries=0`
- All Catalog factories: JDBC URL must contain a database name

**3.** JDBC option rules are now fully declared and can be exported via REST API and CLI metadata.

### How was this patch tested?

```bash
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc \
  -Dtest="JdbcSourceFactoryTest,JdbcSinkFactoryTest,JdbcCatalogFactoryTest,JdbcFactoryTest"

./mvnw test -pl seatunnel-connectors-v2/connector-jdbc
```
