### PR TITLE
[Fix][Connector-V2] Fix Oracle CDC schema cache matching

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/utils/OracleSchema.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/utils/OracleSchema.java
@@ -74,14 +74,15 @@ public class OracleSchema {
                     null,
                     false);
             for (TableId id : tables.tableIds()) {
-                if (tableMap.containsKey(id)) {
+                TableId tableMapId = resolveTableId(id, tableId, tableMap);
+                if (tableMap.containsKey(tableMapId)) {
                     Table table =
                             CatalogTableUtils.mergeCatalogTableConfig(
-                                    tables.forTable(id), tableMap.get(id));
+                                    tables.forTable(id), tableMap.get(tableMapId));
                     TableChanges.TableChange tableChange =
                             new TableChanges.TableChange(
                                     TableChanges.TableChangeType.CREATE, table);
-                    schemasByTableId.put(id, tableChange);
+                    schemasByTableId.put(tableMapId, tableChange);
                 }
             }
         } catch (SQLException e) {
@@ -95,5 +96,20 @@ public class OracleSchema {
         }
 
         return schemasByTableId.get(tableId);
+    }
+
+    static TableId resolveTableId(
+            TableId readTableId, TableId requestedTableId, Map<TableId, ?> tableMap) {
+        if (tableMap.containsKey(readTableId)) {
+            return readTableId;
+        }
+
+        TableId readTableIdWithRequestedCatalog =
+                new TableId(requestedTableId.catalog(), readTableId.schema(), readTableId.table());
+        if (tableMap.containsKey(readTableIdWithRequestedCatalog)) {
+            return readTableIdWithRequestedCatalog;
+        }
+
+        return readTableId;
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/utils/OracleUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/utils/OracleUtilsTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import io.debezium.relational.TableId;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class OracleUtilsTest {
     @Test
     public void testSplitScanQuery() {
@@ -69,5 +72,16 @@ public class OracleUtilsTest {
                         true);
         Assertions.assertEquals(
                 "SELECT * FROM \"schema1\".\"table1\" WHERE \"id\" >= ?", splitScanSQL);
+    }
+
+    @Test
+    public void testResolveTableIdWithRequestedCatalog() {
+        TableId requestedTableId = TableId.parse("ORCLPDB.LIB_B.T_B1");
+        TableId readTableIdWithoutCatalog = new TableId(null, "LIB_B", "T_B1");
+        Map<TableId, ?> tableMap = Collections.singletonMap(requestedTableId, null);
+
+        Assertions.assertEquals(
+                requestedTableId,
+                OracleSchema.resolveTableId(readTableIdWithoutCatalog, requestedTableId, tableMap));
     }
 }


### PR DESCRIPTION
### Purpose

Fixes #11034.

Oracle CDC can fail to obtain a schema in multi-schema CDB/PDB jobs when Debezium reads a table identifier without the catalog/database part while SeaTunnel keeps catalog-qualified table identifiers in its catalog table map. That makes the schema cache miss a valid table and can raise `Can't obtain schema for table ...`.

### Changes

- Resolve Oracle `readSchema` table ids against the requested table catalog before checking the SeaTunnel catalog table map.
- Store the loaded schema under the catalog-qualified table id used by SeaTunnel.
- Add a regression test for catalog-qualified Oracle CDC table id matching.

### Tests

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-oracle -Dtest=OracleUtilsTest test`