### PR TITLE
[Docs] Fix Typesense sink common options link

### DIFF
--- a/docs/en/connectors/sink/Typesense.md
+++ b/docs/en/connectors/sink/Typesense.md
@@ -56,7 +56,7 @@ The maximum size of document batches.
 
 ### common options
 
-Common parameters for Sink plugins. Refer to [Common Sink Options](../common-options/source-common-options.md) for more details.
+Common parameters for Sink plugins. Refer to [Common Sink Options](../common-options/sink-common-options.md) for more details.
 
 ### schema_save_mode
 

--- a/docs/zh/connectors/sink/Typesense.md
+++ b/docs/zh/connectors/sink/Typesense.md
@@ -56,7 +56,7 @@ typesense 安全认证的 api_key。
 
 ### common options
 
-Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-common-options.md) 了解详情
+Sink 插件常用参数，请参考 [Sink 常用选项](../common-options/sink-common-options.md) 了解详情。
 
 ### schema_save_mode
 


### PR DESCRIPTION
## Summary
- fix the incorrect common options link in the English Typesense sink documentation
- align the corresponding Chinese sentence formatting in the same section

## Verification
- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify