### PR TITLE
[Fix][Connector-V2]  fix fluss-connector‘s sink writer issues

### DIFF
--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriter.java
@@ -97,7 +97,10 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                 writer = table.newAppend().createWriter();
             }
         } catch (Throwable t) {
-            closeQuietly();
+            Exception closeError = closeResources();
+            if (closeError != null && closeError != t) {
+                t.addSuppressed(closeError);
+            }
             throw t;
         }
     }
@@ -159,6 +162,18 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
 
     @Override
     public void close() {
+        Exception closeError = closeResources();
+        if (closeError != null) {
+            throw CommonError.closeFailed(FlussSinkOptions.CONNECTOR_IDENTITY, closeError);
+        }
+    }
+
+    /**
+     * Closes every initialized Fluss resource and preserves all failures in close order.
+     *
+     * @return the first close failure with later failures attached as suppressed exceptions
+     */
+    private Exception closeResources() {
         Exception firstError = null;
         log.info("Close Fluss table.");
         try {
@@ -182,24 +197,7 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
             }
         }
 
-        if (firstError != null) {
-            throw CommonError.closeFailed(FlussSinkOptions.CONNECTOR_IDENTITY, firstError);
-        }
-    }
-
-    private void closeQuietly() {
-        try {
-            if (table != null) {
-                table.close();
-            }
-        } catch (Exception ignored) {
-        }
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (Exception ignored) {
-        }
+        return firstError;
     }
 
     protected Object convert(SeaTunnelDataType dataType, String fieldName, Object val) {

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriter.java
@@ -69,39 +69,36 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     public FlussSinkWriter(
             SinkWriter.Context context, CatalogTable catalogTable, ReadonlyConfig pluginConfig) {
         seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
+        String bootstrapServers = pluginConfig.get(FlussSinkOptions.BOOTSTRAP_SERVERS);
         Configuration flussConfig = new Configuration();
-        flussConfig.setString(
-                FlussSinkOptions.BOOTSTRAP_SERVERS.key(),
-                pluginConfig.get(FlussSinkOptions.BOOTSTRAP_SERVERS));
+        flussConfig.setString(FlussSinkOptions.BOOTSTRAP_SERVERS.key(), bootstrapServers);
         Optional<Map<String, String>> clientConfig =
                 pluginConfig.getOptional(FlussSinkOptions.CLIENT_CONFIG);
-        if (clientConfig.isPresent()) {
-            clientConfig
-                    .get()
-                    .forEach(
-                            (k, v) -> {
-                                flussConfig.setString(k, v);
-                            });
-        }
-        log.info("Connect to Fluss with config: {}", flussConfig);
-        connection = ConnectionFactory.createConnection(flussConfig);
-        log.info("Connect to Fluss success");
-        dbName =
-                pluginConfig
-                        .getOptional(FlussSinkOptions.DATABASE)
-                        .orElseGet(() -> catalogTable.getTableId().getDatabaseName());
-        tableName =
-                pluginConfig
-                        .getOptional(FlussSinkOptions.TABLE)
-                        .orElseGet(() -> catalogTable.getTableId().getTableName());
-        TablePath tablePath = TablePath.of(dbName, tableName);
-        table = connection.getTable(tablePath);
-        if (table.getTableInfo().hasPrimaryKey()) {
-            log.info("Table {} has primary key, use upsert writer", tableName);
-            writer = table.newUpsert().createWriter();
-        } else {
-            log.info("Table {} has no primary key, use append writer", tableName);
-            writer = table.newAppend().createWriter();
+        clientConfig.ifPresent(cfg -> cfg.forEach(flussConfig::setString));
+        log.info("Connect to Fluss with bootstrap.servers: {}", bootstrapServers);
+        try {
+            connection = ConnectionFactory.createConnection(flussConfig);
+            log.info("Connect to Fluss success");
+            dbName =
+                    pluginConfig
+                            .getOptional(FlussSinkOptions.DATABASE)
+                            .orElseGet(() -> catalogTable.getTableId().getDatabaseName());
+            tableName =
+                    pluginConfig
+                            .getOptional(FlussSinkOptions.TABLE)
+                            .orElseGet(() -> catalogTable.getTableId().getTableName());
+            TablePath tablePath = TablePath.of(dbName, tableName);
+            table = connection.getTable(tablePath);
+            if (table.getTableInfo().hasPrimaryKey()) {
+                log.info("Table {} has primary key, use upsert writer", tableName);
+                writer = table.newUpsert().createWriter();
+            } else {
+                log.info("Table {} has no primary key, use append writer", tableName);
+                writer = table.newAppend().createWriter();
+            }
+        } catch (Throwable t) {
+            closeQuietly();
+            throw t;
         }
     }
 
@@ -162,13 +159,14 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
 
     @Override
     public void close() {
+        Exception firstError = null;
         log.info("Close Fluss table.");
         try {
             if (table != null) {
                 table.close();
             }
         } catch (Exception e) {
-            throw CommonError.closeFailed("Close Fluss table failed.", e);
+            firstError = e;
         }
 
         log.info("Close Fluss connection.");
@@ -177,7 +175,30 @@ public class FlussSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                 connection.close();
             }
         } catch (Exception e) {
-            throw CommonError.closeFailed("Close Fluss connection failed.", e);
+            if (firstError == null) {
+                firstError = e;
+            } else {
+                firstError.addSuppressed(e);
+            }
+        }
+
+        if (firstError != null) {
+            throw CommonError.closeFailed(FlussSinkOptions.CONNECTOR_IDENTITY, firstError);
+        }
+    }
+
+    private void closeQuietly() {
+        try {
+            if (table != null) {
+                table.close();
+            }
+        } catch (Exception ignored) {
+        }
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (Exception ignored) {
         }
     }
 

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriterTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.fluss.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussSinkOptions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.table.Table;
+import com.alibaba.fluss.client.table.writer.Append;
+import com.alibaba.fluss.client.table.writer.AppendWriter;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TableInfo;
+import com.alibaba.fluss.metadata.TablePath;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the Fluss sink releases all partially or fully initialized client resources.
+ *
+ * <p>The tests preserve the primary failure while checking every later cleanup failure.
+ */
+public class FlussSinkWriterTest {
+
+    private SinkWriter.Context context;
+    private CatalogTable catalogTable;
+    private ReadonlyConfig pluginConfig;
+    private Connection connection;
+    private Table table;
+
+    /**
+     * Creates the common writer dependencies with an append-only Fluss table.
+     *
+     * <p>Individual tests override only the lifecycle stage that they need to fail.
+     */
+    @BeforeEach
+    void setUp() {
+        context = mock(SinkWriter.Context.class);
+        catalogTable = mock(CatalogTable.class);
+        pluginConfig = mock(ReadonlyConfig.class);
+        connection = mock(Connection.class);
+        table = mock(Table.class);
+
+        TableSchema tableSchema = mock(TableSchema.class);
+        SeaTunnelRowType rowType = new SeaTunnelRowType(new String[0], new SeaTunnelDataType<?>[0]);
+        when(catalogTable.getTableSchema()).thenReturn(tableSchema);
+        when(tableSchema.toPhysicalRowDataType()).thenReturn(rowType);
+
+        when(pluginConfig.get(FlussSinkOptions.BOOTSTRAP_SERVERS)).thenReturn("localhost:9123");
+        when(pluginConfig.getOptional(FlussSinkOptions.CLIENT_CONFIG)).thenReturn(Optional.empty());
+        when(pluginConfig.getOptional(FlussSinkOptions.DATABASE))
+                .thenReturn(Optional.of("database"));
+        when(pluginConfig.getOptional(FlussSinkOptions.TABLE)).thenReturn(Optional.of("table"));
+
+        TableInfo tableInfo = mock(TableInfo.class);
+        Append append = mock(Append.class);
+        AppendWriter appendWriter = mock(AppendWriter.class);
+        when(connection.getTable(any(TablePath.class))).thenReturn(table);
+        when(table.getTableInfo()).thenReturn(tableInfo);
+        when(tableInfo.hasPrimaryKey()).thenReturn(false);
+        when(table.newAppend()).thenReturn(append);
+        when(append.createWriter()).thenReturn(appendWriter);
+    }
+
+    /**
+     * Verifies that constructor cleanup keeps the initialization failure as the primary cause.
+     *
+     * @throws Exception if the mocked connection cannot be configured for the close failure
+     */
+    @Test
+    void shouldCloseConnectionWhenTableCreationFails() throws Exception {
+        RuntimeException initializationFailure = new RuntimeException("table creation failed");
+        Exception connectionCloseFailure = new Exception("connection close failed");
+        when(connection.getTable(any(TablePath.class))).thenThrow(initializationFailure);
+        doThrow(connectionCloseFailure).when(connection).close();
+
+        try (MockedStatic<ConnectionFactory> connectionFactory =
+                mockStatic(ConnectionFactory.class)) {
+            connectionFactory
+                    .when(() -> ConnectionFactory.createConnection(any(Configuration.class)))
+                    .thenReturn(connection);
+
+            RuntimeException thrown =
+                    assertThrows(
+                            RuntimeException.class,
+                            () -> new FlussSinkWriter(context, catalogTable, pluginConfig));
+
+            assertSame(initializationFailure, thrown);
+            assertEquals(1, thrown.getSuppressed().length);
+            assertSame(connectionCloseFailure, thrown.getSuppressed()[0]);
+            verify(connection).close();
+        }
+    }
+
+    /**
+     * Verifies that normal shutdown closes every initialized resource without an error.
+     *
+     * <p>This is the primary successful lifecycle path for the shared close helper.
+     */
+    @Test
+    void shouldCloseAllResourcesWithoutFailure() {
+        FlussSinkWriter sinkWriter = createSinkWriter();
+
+        sinkWriter.close();
+
+        verify(table).close();
+        verify(connection).close();
+    }
+
+    /**
+     * Verifies that normal shutdown closes both resources and retains both close failures.
+     *
+     * @throws Exception if the mocked resources cannot be configured for close failures
+     */
+    @Test
+    void shouldCloseAllResourcesAndAggregateFailures() throws Exception {
+        FlussSinkWriter sinkWriter = createSinkWriter();
+
+        Exception tableCloseFailure = new Exception("table close failed");
+        Exception connectionCloseFailure = new Exception("connection close failed");
+        doThrow(tableCloseFailure).when(table).close();
+        doThrow(connectionCloseFailure).when(connection).close();
+
+        SeaTunnelRuntimeException thrown =
+                assertThrows(SeaTunnelRuntimeException.class, sinkWriter::close);
+
+        assertSame(tableCloseFailure, thrown.getCause());
+        assertEquals(1, thrown.getCause().getSuppressed().length);
+        assertSame(connectionCloseFailure, thrown.getCause().getSuppressed()[0]);
+        assertTrue(thrown.getMessage().contains(FlussSinkOptions.CONNECTOR_IDENTITY));
+        verify(table).close();
+        verify(connection).close();
+    }
+
+    /**
+     * Creates a fully initialized writer while keeping the static factory mock scoped locally.
+     *
+     * @return the initialized Fluss sink writer
+     */
+    private FlussSinkWriter createSinkWriter() {
+        try (MockedStatic<ConnectionFactory> connectionFactory =
+                mockStatic(ConnectionFactory.class)) {
+            connectionFactory
+                    .when(() -> ConnectionFactory.createConnection(any(Configuration.class)))
+                    .thenReturn(connection);
+            return new FlussSinkWriter(context, catalogTable, pluginConfig);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/sink/FlussSinkWriterTest.java
@@ -133,9 +133,11 @@ public class FlussSinkWriterTest {
      * Verifies that normal shutdown closes every initialized resource without an error.
      *
      * <p>This is the primary successful lifecycle path for the shared close helper.
+     *
+     * @throws Exception if the mocked resources cannot be verified for close invocation
      */
     @Test
-    void shouldCloseAllResourcesWithoutFailure() {
+    void shouldCloseAllResourcesWithoutFailure() throws Exception {
         FlussSinkWriter sinkWriter = createSinkWriter();
 
         sinkWriter.close();


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

1. Wrong identifier passed to CommonError.closeFailed (close path)

  The close() method was passing a free-text message ("Close Fluss table failed.") as the identifier parameter, which is supposed to be the connector name. This produced misleading
  error messages such as Failed to close 'Close Fluss table failed.'. Now both error paths correctly pass FlussSinkOptions.CONNECTOR_IDENTITY ("Fluss"). Additionally, if both the
  table and connection fail to close, the second exception is no longer silently lost — it is attached via addSuppressed.
  
2. Resource leak in the writer constructor

  If connection.getTable(...), table.getTableInfo(), or createWriter() threw an exception after the Fluss Connection had been established, the already-allocated connection/table
  were never closed (the SinkWriter framework only calls close() on fully-constructed instances). The constructor now wraps the post-connect logic in a try { ... } catch (Throwable 
  t) { closeQuietly(); throw t; } block, and a new private closeQuietly() helper releases any partially-initialized resources before the exception propagates.
  
3. Sensitive client config logged at INFO level

  The previous code logged the entire Fluss Configuration object, which could include user-supplied authentication settings from client.config (SASL credentials, TLS material,
  etc.). This violates the project rule "NEVER log sensitive information". The log line now only emits the bootstrap.servers value.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
