### PR TITLE
[Fix][Transform-V2] Align Scala compiler with Spark Scala version

### DIFF
--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ScalaCompilerVersionCheckTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ScalaCompilerVersionCheckTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.File;
+
+public class ScalaCompilerVersionCheckTest {
+
+    @Test
+    public void testScalaCompilerModuleUsesRootScalaVersion() throws Exception {
+        File scalaCompilerPom = new File("../seatunnel-shade/seatunnel-scala-compiler/pom.xml");
+        Document pom = parsePom(scalaCompilerPom);
+
+        Assertions.assertFalse(
+                hasDirectProperty(pom, "scala.version"),
+                "seatunnel-scala-compiler must inherit scala.version from root pom.xml");
+        Assertions.assertFalse(
+                hasDirectProperty(pom, "scala.binary.version"),
+                "seatunnel-scala-compiler must inherit scala.binary.version from root pom.xml");
+        Assertions.assertEquals(
+                "${scala.version}",
+                findDependencyVersion(pom, "org.scala-lang", "scala-compiler"),
+                "scala-compiler dependency must track the root scala.version property");
+    }
+
+    private Document parsePom(File pomFile) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setNamespaceAware(false);
+        return factory.newDocumentBuilder().parse(pomFile);
+    }
+
+    private boolean hasDirectProperty(Document pom, String propertyName) {
+        NodeList properties = pom.getDocumentElement().getChildNodes();
+        for (int i = 0; i < properties.getLength(); i++) {
+            Node node = properties.item(i);
+            if ("properties".equals(node.getNodeName())) {
+                NodeList children = node.getChildNodes();
+                for (int j = 0; j < children.getLength(); j++) {
+                    if (propertyName.equals(children.item(j).getNodeName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private String findDependencyVersion(Document pom, String groupId, String artifactId) {
+        NodeList dependencies = pom.getElementsByTagName("dependency");
+        for (int i = 0; i < dependencies.getLength(); i++) {
+            Node dependency = dependencies.item(i);
+            if (groupId.equals(childText(dependency, "groupId"))
+                    && artifactId.equals(childText(dependency, "artifactId"))) {
+                return childText(dependency, "version");
+            }
+        }
+        Assertions.fail("Dependency not found: " + groupId + ":" + artifactId);
+        return null;
+    }
+
+    private String childText(Node node, String childName) {
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (childName.equals(child.getNodeName())) {
+                return child.getTextContent().trim();
+            }
+        }
+        return null;
+    }
+}

--- a/seatunnel-shade/seatunnel-scala-compiler/pom.xml
+++ b/seatunnel-shade/seatunnel-scala-compiler/pom.xml
@@ -26,11 +26,6 @@
     <artifactId>seatunnel-scala-compiler</artifactId>
     <name>SeaTunnel : Shade : Scala</name>
 
-    <properties>
-        <scala.version>2.13.11</scala.version>
-        <scala.binary.version>2.13</scala.binary.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/parse/ScalaClassParser.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/dynamiccompile/parse/ScalaClassParser.java
@@ -18,7 +18,6 @@ package org.apache.seatunnel.transform.dynamiccompile.parse;
 
 import org.apache.seatunnel.shade.scala.tools.nsc.Settings;
 import org.apache.seatunnel.shade.scala.tools.nsc.interpreter.IMain;
-import org.apache.seatunnel.shade.scala.tools.nsc.interpreter.shell.ReplReporterImpl;
 
 import org.apache.seatunnel.transform.exception.TransformException;
 
@@ -38,7 +37,7 @@ public class ScalaClassParser extends AbstractParser {
         try {
             Settings settings = new Settings();
             settings.usejavacp().v_$eq(true);
-            scalaInterpreter = new IMain(settings, new ReplReporterImpl(settings));
+            scalaInterpreter = new IMain(settings);
         } catch (Exception e) {
             throw new TransformException(COMPILE_TRANSFORM_ERROR_CODE, e.getMessage());
         }

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -27,8 +27,9 @@ protostuff-collectionschema-1.8.0.jar
 protostuff-core-1.8.0.jar
 protostuff-runtime-1.8.0.jar
 scala-library-2.12.15.jar
-scala-compiler-2.13.11.jar
-scala-reflect-2.13.11.jar
+scala-compiler-2.12.15.jar
+scala-reflect-2.12.15.jar
+scala-xml_2.12-1.0.6.jar
 seatunnel-scala-compiler-3.0.0-SNAPSHOT-optional.jar
 seatunnel-jackson-3.0.0-SNAPSHOT-optional.jar
 seatunnel-guava-3.0.0-SNAPSHOT-optional.jar
@@ -75,7 +76,6 @@ jetty-util-9.4.56.v20240826.jar
 jetty-util-ajax-9.4.56.v20240826.jar
 javax.servlet-api-3.1.0.jar
 seatunnel-jetty9-9.4.56-3.0.0-SNAPSHOT-optional.jar
-jna-5.13.0.jar
 jna-5.15.0.jar
 jna-platform-5.15.0.jar
 oshi-core-6.6.5.jar
@@ -127,5 +127,3 @@ netty-common-4.1.118.Final.jar
 netty-handler-4.1.118.Final.jar
 netty-resolver-4.1.118.Final.jar
 eventstream-1.0.1.jar
-java-diff-utils-4.12.jar
-jline-3.22.0.jar


### PR DESCRIPTION
### Purpose

Fixes #11115.

`seatunnel-scala-compiler` was pinned to Scala 2.13 while the root build and Spark translation modules use Scala 2.12. That lets Scala 2.13 compiler/reflect classes enter the transform package and can break Spark 2.12 runtime reflection with Scala signature version mismatch errors.

### Changes

- Remove the local Scala 2.13 override from `seatunnel-scala-compiler` so it inherits the root Scala 2.12 version.
- Update `ScalaClassParser` to use the Scala 2.12-compatible `IMain(Settings)` constructor instead of the Scala 2.13-only reporter implementation package.
- Add a CI test to prevent `seatunnel-scala-compiler` from overriding the root Scala version again.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-ci-tools -Dtest=ScalaCompilerVersionCheckTest -DforkCount=0 test`
- `./mvnw -pl seatunnel-transforms-v2 -am -DskipTests verify`
- `./mvnw -q -DskipTests verify`
