### PR TITLE
[Docs] Fix RocketMQ transform links

### DIFF
--- a/docs/en/connectors/sink/RocketMQ.md
+++ b/docs/en/connectors/sink/RocketMQ.md
@@ -95,7 +95,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -194,7 +194,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 sink {
   Rocketmq {

--- a/docs/en/connectors/source/RocketMQ.md
+++ b/docs/en/connectors/source/RocketMQ.md
@@ -108,7 +108,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -160,7 +160,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 sink {
   Console {
@@ -215,7 +215,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -274,7 +274,7 @@ source {
 
 transform {
   # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/category/transform
+  # please go to https://seatunnel.apache.org/docs/transforms
 }
 
 sink {

--- a/docs/zh/connectors/sink/RocketMQ.md
+++ b/docs/zh/connectors/sink/RocketMQ.md
@@ -93,7 +93,7 @@ source {
 
 transform {
 	#如果你想了解更多关于如何配置seatunnel的信息，并查看转换插件的完整列表，
-	#请前往https://seatunnel.apache.org/docs/category/transform
+	#请前往https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -192,7 +192,7 @@ source {
 
 transform {
 	#如果你想了解更多关于如何配置seatunnel的信息，并查看转换插件的完整列表，
-	#请前往https://seatunnel.apache.org/docs/category/transform
+	#请前往https://seatunnel.apache.org/docs/transforms
 }
 sink {
   Rocketmq {

--- a/docs/zh/connectors/source/RocketMQ.md
+++ b/docs/zh/connectors/source/RocketMQ.md
@@ -108,7 +108,7 @@ source {
 
 transform {
   # 如果您想了解有关如何配置 seatunnel 的更多信息并查看完整的转换插件列表，
-  # 请访问 https://seatunnel.apache.org/docs/category/transform
+  # 请访问 https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -159,7 +159,7 @@ source {
 
 transform {
   # 如果您想了解有关如何配置 seatunnel 的更多信息并查看完整的转换插件列表，
-  # 请访问 https://seatunnel.apache.org/docs/category/transform
+  # 请访问 https://seatunnel.apache.org/docs/transforms
 }
 
 sink {
@@ -217,4 +217,3 @@ sink {
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
### Purpose of this pull request

This PR fixes stale Transform documentation links in the RocketMQ connector docs.

The RocketMQ source and sink examples pointed readers to `https://seatunnel.apache.org/docs/category/transform`, which currently returns 404. The links now point to `https://seatunnel.apache.org/docs/transforms`, the valid Transform documentation entry.

### Does this PR introduce any user-facing change?

Yes. Users reading the English and Chinese RocketMQ source/sink docs can now open the Transform documentation link from the examples without hitting a 404 page.

### How was this patch tested?

- Verified the old URL returns 404 and the new URL returns 200 with `curl -L`.
- Verified the stale RocketMQ link no longer appears with `rg -n "docs/category/transform"` on the changed RocketMQ docs.
- Ran `./mvnw spotless:apply`.
- Ran `./mvnw -q -DskipTests verify`.
