### PR TITLE
[Feature][Connector-V2] PR1: Pass sink table-options into auto-created MySQL target tables

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -60,7 +60,7 @@ support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
 | data_save_mode                            | Enum    | No       | APPEND_DATA                  |
 | custom_sql                                | String  | No       | -                            |
 | enable_upsert                             | Boolean | No       | true                         |
-| table-options                             | Map     | No       | -                            |
+| table_options                             | Map     | No       | -                            |
 | use_copy_statement                        | Boolean | No       | false                        |
 | oracle_insert_mode                        | Enum    | No       | CONVENTIONAL                 |
 | create_index                              | Boolean | No       | true                         |
@@ -231,7 +231,7 @@ When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL
 
 Note: in sink `query` mode, `custom_sql` is not executed. This behavior is a current limitation of JDBC sink.
 
-### table-options [Map]
+### table_options [Map]
 
 Sink-specific table options applied when SaveMode creates the target table (DDL phase). They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** affect INSERT/UPSERT at runtime and do **not** run `ALTER TABLE` on existing tables.
 
@@ -240,7 +240,7 @@ Current support:
 | Dialect | Supported | Allowed keys |
 |---------|-----------|--------------|
 | MySQL / TiDB | Yes | `engine`, `charset`, `collate` |
-| Other JDBC dialects | No | Non-empty `table-options` fails validation at job submission |
+| Other JDBC dialects | No | Non-empty `table_options` fails validation at job submission |
 
 Example (MySQL auto-create with engine and charset):
 
@@ -256,7 +256,7 @@ sink {
     generate_sink_sql = true
     schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
     primary_keys = ["id"]
-    table-options = {
+    table_options = {
       "engine" = "InnoDB"
       "charset" = "utf8mb4"
       "collate" = "utf8mb4_general_ci"

--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -60,6 +60,7 @@ support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
 | data_save_mode                            | Enum    | No       | APPEND_DATA                  |
 | custom_sql                                | String  | No       | -                            |
 | enable_upsert                             | Boolean | No       | true                         |
+| table-options                             | Map     | No       | -                            |
 | use_copy_statement                        | Boolean | No       | false                        |
 | oracle_insert_mode                        | Enum    | No       | CONVENTIONAL                 |
 | create_index                              | Boolean | No       | true                         |
@@ -229,6 +230,42 @@ Option introduction：
 When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL parameter. This parameter usually fills in a SQL that can be executed. SQL will be executed before synchronization tasks.
 
 Note: in sink `query` mode, `custom_sql` is not executed. This behavior is a current limitation of JDBC sink.
+
+### table-options [Map]
+
+Sink-specific table options applied when SaveMode creates the target table (DDL phase). They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** affect INSERT/UPSERT at runtime and do **not** run `ALTER TABLE` on existing tables.
+
+Current support:
+
+| Dialect | Supported | Allowed keys |
+|---------|-----------|--------------|
+| MySQL / TiDB | Yes | `engine`, `charset`, `collate` |
+| Other JDBC dialects | No | Non-empty `table-options` fails validation at job submission |
+
+Example (MySQL auto-create with engine and charset):
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:mysql://localhost:3307/mydb"
+    driver = "com.mysql.cj.jdbc.Driver"
+    username = "root"
+    password = "password"
+    database = "mydb"
+    table = "orders"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table-options = {
+      "engine" = "InnoDB"
+      "charset" = "utf8mb4"
+      "collate" = "utf8mb4_general_ci"
+    }
+  }
+}
+```
+
+The generated `CREATE TABLE` statement appends `ENGINE`, `DEFAULT CHARSET`, and `COLLATE` clauses. Keys outside the dialect whitelist (for example `bucket_num`) fail during job submission.
 
 ### enable_upsert [boolean]
 

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -58,7 +58,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | data_save_mode                            | Enum    | 否    | APPEND_DATA                  |
 | custom_sql                                | String  | 否    | -                            |
 | enable_upsert                             | Boolean | 否    | true                         |
-| table-options                             | Map     | 否    | -                            |
+| table_options                             | Map     | 否    | -                            |
 | use_copy_statement                        | Boolean | 否    | false                        |
 | oracle_insert_mode                        | Enum    | 否    | CONVENTIONAL                 |
 | access_key_id                             | String  | 否       |                              |
@@ -219,7 +219,7 @@ Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-com
 `CUSTOM_PROCESSING`：允许用户自定义数据处理方式<br/>
 `ERROR_WHEN_DATA_EXISTS`：当有数据时抛出错误<br/>
 
-### table-options [Map]
+### table_options [Map]
 
 Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_save_mode` 触发建表时生效，例如 `CREATE_SCHEMA_WHEN_NOT_EXIST`、`RECREATE_SCHEMA`；**不影响**数据写入阶段的 INSERT/UPSERT，也**不会**对已存在表执行 `ALTER TABLE`。
 
@@ -228,7 +228,7 @@ Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_
 | 方言 | 是否支持 | 可用 key |
 |------|----------|----------|
 | MySQL / TiDB | 是 | `engine`、`charset`、`collate` |
-| 其他 JDBC 方言 | 否 | 配置非空 `table-options` 时任务启动即校验失败 |
+| 其他 JDBC 方言 | 否 | 配置非空 `table_options` 时任务启动即校验失败 |
 
 示例（MySQL 自动建表时指定存储引擎与字符集）：
 
@@ -244,7 +244,7 @@ sink {
     generate_sink_sql = true
     schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
     primary_keys = ["id"]
-    table-options = {
+    table_options = {
       "engine" = "InnoDB"
       "charset" = "utf8mb4"
       "collate" = "utf8mb4_general_ci"

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -58,6 +58,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | data_save_mode                            | Enum    | 否    | APPEND_DATA                  |
 | custom_sql                                | String  | 否    | -                            |
 | enable_upsert                             | Boolean | 否    | true                         |
+| table-options                             | Map     | 否    | -                            |
 | use_copy_statement                        | Boolean | 否    | false                        |
 | oracle_insert_mode                        | Enum    | 否    | CONVENTIONAL                 |
 | access_key_id                             | String  | 否       |                              |
@@ -217,6 +218,42 @@ Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-com
 `APPEND_DATA`：保留数据库结构，保留数据<br/>
 `CUSTOM_PROCESSING`：允许用户自定义数据处理方式<br/>
 `ERROR_WHEN_DATA_EXISTS`：当有数据时抛出错误<br/>
+
+### table-options [Map]
+
+Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_save_mode` 触发建表时生效，例如 `CREATE_SCHEMA_WHEN_NOT_EXIST`、`RECREATE_SCHEMA`；**不影响**数据写入阶段的 INSERT/UPSERT，也**不会**对已存在表执行 `ALTER TABLE`。
+
+当前支持情况：
+
+| 方言 | 是否支持 | 可用 key |
+|------|----------|----------|
+| MySQL / TiDB | 是 | `engine`、`charset`、`collate` |
+| 其他 JDBC 方言 | 否 | 配置非空 `table-options` 时任务启动即校验失败 |
+
+示例（MySQL 自动建表时指定存储引擎与字符集）：
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:mysql://localhost:3307/mydb"
+    driver = "com.mysql.cj.jdbc.Driver"
+    username = "root"
+    password = "password"
+    database = "mydb"
+    table = "orders"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table-options = {
+      "engine" = "InnoDB"
+      "charset" = "utf8mb4"
+      "collate" = "utf8mb4_general_ci"
+    }
+  }
+}
+```
+
+生成的 DDL 会追加 `ENGINE`、`DEFAULT CHARSET`、`COLLATE` 子句。未在白名单内的 key（如 `bucket_num`）会在作业提交阶段报错。
 
 ### custom_sql [String]
 

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/SinkConnectorCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/SinkConnectorCommonOptions.java
@@ -21,6 +21,9 @@ import org.apache.seatunnel.api.annotation.Experimental;
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class SinkConnectorCommonOptions extends ConnectorCommonOptions {
 
     @Experimental
@@ -29,4 +32,12 @@ public class SinkConnectorCommonOptions extends ConnectorCommonOptions {
                     .intType()
                     .defaultValue(1)
                     .withDescription("The replica number of multi table sink writer");
+
+    @Experimental
+    public static Option<Map<String, String>> TABLE_OPTIONS =
+            Options.key("table-options")
+                    .mapType()
+                    .defaultValue(new HashMap<>())
+                    .withDescription(
+                            "Sink-specific table options applied when auto-creating target tables.");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/SinkConnectorCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/SinkConnectorCommonOptions.java
@@ -35,7 +35,7 @@ public class SinkConnectorCommonOptions extends ConnectorCommonOptions {
 
     @Experimental
     public static Option<Map<String, String>> TABLE_OPTIONS =
-            Options.key("table-options")
+            Options.key("table_options")
                     .mapType()
                     .defaultValue(new HashMap<>())
                     .withDescription(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialect.java
@@ -920,7 +920,7 @@ public interface JdbcDialect extends Serializable {
         throw new JdbcConnectorException(
                 SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                 String.format(
-                        "JDBC table-options are not supported for dialect '%s' yet.",
+                        "JDBC table_options are not supported for dialect '%s' yet.",
                         dialectName()));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/JdbcDialect.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect;
 
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
@@ -32,6 +33,7 @@ import org.apache.seatunnel.api.table.schema.event.AlterTableModifyColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.connection.JdbcConnectionProvider;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.connection.SimpleJdbcConnectionProvider;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
@@ -903,5 +905,22 @@ public interface JdbcDialect extends Serializable {
 
     default String dualTable() {
         return "";
+    }
+
+    /**
+     * Validate sink table options for auto-create mode.
+     *
+     * <p>Default behavior is fail-fast for any non-empty table options. Dialects should override
+     * this when they support sink-specific table options.
+     */
+    default void validateTableOptions(Map<String, String> tableOptions) {
+        if (tableOptions == null || tableOptions.isEmpty()) {
+            return;
+        }
+        throw new JdbcConnectorException(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                String.format(
+                        "JDBC table-options are not supported for dialect '%s' yet.",
+                        dialectName()));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialect.java
@@ -410,7 +410,7 @@ public class MysqlDialect implements JdbcDialect {
             throw new JdbcConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                     String.format(
-                            "Unsupported JDBC table-options for dialect '%s': %s. Supported keys: %s",
+                            "Unsupported JDBC table_options for dialect '%s': %s. Supported keys: %s",
                             dialectName(),
                             String.join(", ", unsupportedOptions),
                             String.join(", ", SUPPORTED_TABLE_OPTIONS)));

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialect.java
@@ -19,9 +19,11 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql;
 
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
 import org.apache.seatunnel.api.table.converter.TypeConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
@@ -41,11 +43,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -53,6 +58,9 @@ public class MysqlDialect implements JdbcDialect {
 
     private static final List NOT_SUPPORTED_DEFAULT_VALUES =
             Arrays.asList(MysqlType.BLOB, MysqlType.TEXT, MysqlType.JSON, MysqlType.GEOMETRY);
+    private static final Set<String> SUPPORTED_TABLE_OPTIONS =
+            Collections.unmodifiableSet(
+                    new LinkedHashSet<>(Arrays.asList("engine", "charset", "collate")));
 
     public String fieldIde = FieldIdeEnum.ORIGINAL.getValue();
 
@@ -387,6 +395,25 @@ public class MysqlDialect implements JdbcDialect {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    @Override
+    public void validateTableOptions(Map<String, String> tableOptions) {
+        if (tableOptions == null || tableOptions.isEmpty()) {
+            return;
+        }
+
+        Set<String> unsupportedOptions = new LinkedHashSet<>(tableOptions.keySet());
+        unsupportedOptions.removeAll(SUPPORTED_TABLE_OPTIONS);
+        if (!unsupportedOptions.isEmpty()) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Unsupported JDBC table-options for dialect '%s': %s. Supported keys: %s",
+                            dialectName(),
+                            String.join(", ", unsupportedOptions),
+                            String.join(", ", SUPPORTED_TABLE_OPTIONS)));
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -70,6 +70,7 @@ public class JdbcSinkFactory implements TableSinkFactory {
     @Override
     public TableSink createSink(TableSinkFactoryContext context) {
         ReadonlyConfig config = context.getOptions();
+        Map<String, String> sinkTableOptions = config.get(SinkConnectorCommonOptions.TABLE_OPTIONS);
         CatalogTable catalogTable = context.getCatalogTable();
         ReadonlyConfig catalogOptions = getCatalogOptions(context);
         Optional<String> optionalTable = config.getOptional(JdbcSinkOptions.TABLE);
@@ -179,6 +180,7 @@ public class JdbcSinkFactory implements TableSinkFactory {
         final ReadonlyConfig options = config;
         JdbcSinkConfig sinkConfig = JdbcSinkConfig.of(config);
         FieldIdeEnum fieldIdeEnum = config.get(JdbcSinkOptions.FIELD_IDE);
+        catalogTable.getOptions().putAll(sinkTableOptions);
         catalogTable
                 .getOptions()
                 .put("fieldIde", fieldIdeEnum == null ? null : fieldIdeEnum.getValue());
@@ -188,6 +190,7 @@ public class JdbcSinkFactory implements TableSinkFactory {
                         sinkConfig.getJdbcConnectionConfig().getCompatibleMode(),
                         sinkConfig.getJdbcConnectionConfig().getDialect(),
                         fieldIdeEnum == null ? null : fieldIdeEnum.getValue());
+        dialect.validateTableOptions(sinkTableOptions);
         dialect.connectionUrlParse(
                 sinkConfig.getJdbcConnectionConfig().getUrl(),
                 sinkConfig.getJdbcConnectionConfig().getProperties(),
@@ -234,6 +237,7 @@ public class JdbcSinkFactory implements TableSinkFactory {
                         JdbcSinkOptions.TABLE_PREFIX,
                         JdbcSinkOptions.TABLE_SUFFIX,
                         SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA,
+                        SinkConnectorCommonOptions.TABLE_OPTIONS,
                         JdbcSinkOptions.DIALECT)
                 .conditional(
                         JdbcSinkOptions.IS_EXACTLY_ONCE,

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
@@ -40,7 +40,9 @@ import org.junit.jupiter.api.Test;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -148,6 +150,36 @@ public class MysqlCreateTableSqlBuilderTest {
                         + ") COMMENT = 'User table';";
         CONSOLE.println(expectSkipIndex);
         Assertions.assertEquals(expectSkipIndex, createTableSqlSkipIndex);
+    }
+
+    @Test
+    public void testBuildCreateTableSqlWithTableOptions() {
+        TablePath tablePath = TablePath.of("test_db", "test_table");
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 0, false, null, "id"))
+                        .primaryKey(PrimaryKey.of("id", Lists.newArrayList("id")))
+                        .build();
+        Map<String, String> options = new HashMap<>();
+        options.put(MySqlCatalog.TABLE_OPTION_ENGINE, "InnoDB");
+        options.put(MySqlCatalog.TABLE_OPTION_CHARSET, "utf8mb4");
+        options.put(MySqlCatalog.TABLE_OPTION_COLLATE, "utf8mb4_unicode_ci");
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("test_catalog", "test_db", "test_table"),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with options");
+
+        String createTableSql =
+                MysqlCreateTableSqlBuilder.builder(
+                                tablePath, catalogTable, MySqlTypeConverter.DEFAULT_INSTANCE, true)
+                        .build(DatabaseIdentifier.MYSQL);
+
+        Assertions.assertTrue(createTableSql.contains("ENGINE = InnoDB"));
+        Assertions.assertTrue(createTableSql.contains("DEFAULT CHARSET = utf8mb4"));
+        Assertions.assertTrue(createTableSql.contains("COLLATE = utf8mb4_unicode_ci"));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialectTest.java
@@ -18,6 +18,11 @@
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql;
 
 import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectTypeMapper;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.source.JdbcSourceTable;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.source.StringRangeSplitDecision;
 
@@ -33,14 +38,78 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.zip.CRC32;
 
 @Slf4j
 public class MysqlDialectTest {
+
+    @Test
+    public void testValidateTableOptionsForMysql() {
+        MysqlDialect dialect = new MysqlDialect();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("engine", "InnoDB");
+        tableOptions.put("charset", "utf8mb4");
+        tableOptions.put("collate", "utf8mb4_unicode_ci");
+
+        Assertions.assertDoesNotThrow(() -> dialect.validateTableOptions(tableOptions));
+    }
+
+    @Test
+    public void testValidateTableOptionsForMysqlWithUnknownOption() {
+        MysqlDialect dialect = new MysqlDialect();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("bucket_num", "3");
+
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () -> dialect.validateTableOptions(tableOptions));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table-options"));
+    }
+
+    @Test
+    public void testValidateTableOptionsForUnsupportedDialect() {
+        JdbcDialect unsupportedDialect =
+                new JdbcDialect() {
+                    @Override
+                    public String dialectName() {
+                        return DatabaseIdentifier.POSTGRESQL;
+                    }
+
+                    @Override
+                    public JdbcRowConverter getRowConverter() {
+                        return null;
+                    }
+
+                    @Override
+                    public JdbcDialectTypeMapper getJdbcDialectTypeMapper() {
+                        return null;
+                    }
+
+                    @Override
+                    public Optional<String> getUpsertStatement(
+                            String database,
+                            String tableName,
+                            String[] fieldNames,
+                            String[] pkNames) {
+                        return Optional.empty();
+                    }
+                };
+
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                unsupportedDialect.validateTableOptions(
+                                        Collections.singletonMap("engine", "InnoDB")));
+        Assertions.assertTrue(exception.getMessage().contains("not supported"));
+    }
 
     @Test
     public void testValidateStringRangeSplitAcceptsPrintableAsciiPunctuation() throws Exception {

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlDialectTest.java
@@ -70,7 +70,7 @@ public class MysqlDialectTest {
                 Assertions.assertThrows(
                         JdbcConnectorException.class,
                         () -> dialect.validateTableOptions(tableOptions));
-        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table-options"));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
     }
 
     @Test

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlTableOptionsIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlTableOptionsIT.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc;
+
+import org.apache.seatunnel.shade.com.google.common.collect.Lists;
+import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.utils.JdbcUrlUtil;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalog;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JdbcMysqlTableOptionsIT extends AbstractJdbcIT {
+
+    private static final String MYSQL_IMAGE = "mysql:8.0.43";
+    private static final String MYSQL_CONTAINER_HOST = "mysql-e2e-table-options";
+    private static final String MYSQL_DATABASE = "seatunnel";
+    private static final String MYSQL_SOURCE = "source";
+    private static final String MYSQL_SINK = "sink_table_options";
+
+    private static final String MYSQL_USERNAME = "root";
+    private static final String MYSQL_PASSWORD = "Abc!@#135_seatunnel";
+    private static final int MYSQL_PORT = 33064;
+    private static final String MYSQL_URL = "jdbc:mysql://" + HOST + ":%s/%s?useSSL=false";
+
+    private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+
+    private static final List<String> CONFIG_FILE =
+            Lists.newArrayList("/jdbc_mysql_sink_with_table_options.conf");
+
+    private static final String CREATE_SQL =
+            "CREATE TABLE IF NOT EXISTS %s (\n"
+                    + "    `id`   BIGINT       NOT NULL,\n"
+                    + "    `name` VARCHAR(255) DEFAULT NULL,\n"
+                    + "    PRIMARY KEY (`id`)\n"
+                    + ");";
+
+    @Override
+    JdbcCase getJdbcCase() {
+        Map<String, String> containerEnv = new HashMap<>();
+        String jdbcUrl = String.format(MYSQL_URL, MYSQL_PORT, MYSQL_DATABASE);
+        Pair<String[], List<SeaTunnelRow>> testDataSet = initTestData();
+        String[] fieldNames = testDataSet.getKey();
+        String insertSql = insertTable(MYSQL_DATABASE, MYSQL_SOURCE, fieldNames);
+
+        return JdbcCase.builder()
+                .dockerImage(MYSQL_IMAGE)
+                .networkAliases(MYSQL_CONTAINER_HOST)
+                .containerEnv(containerEnv)
+                .driverClass(DRIVER_CLASS)
+                .host(HOST)
+                .port(MYSQL_PORT)
+                .localPort(MYSQL_PORT)
+                .jdbcTemplate(MYSQL_URL)
+                .jdbcUrl(jdbcUrl)
+                .userName(MYSQL_USERNAME)
+                .password(MYSQL_PASSWORD)
+                .database(MYSQL_DATABASE)
+                .sourceTable(MYSQL_SOURCE)
+                .sinkTable(MYSQL_SINK)
+                .createSql(CREATE_SQL)
+                .configFile(CONFIG_FILE)
+                .insertSql(insertSql)
+                .testData(testDataSet)
+                .useSaveModeCreateTable(true)
+                .build();
+    }
+
+    @Override
+    void checkResult(String executeKey, TestContainer container, Container.ExecResult execResult) {
+        try (Statement statement = connection.createStatement()) {
+            ResultSet createTableResult =
+                    statement.executeQuery(
+                            String.format(
+                                    "SHOW CREATE TABLE `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
+            Assertions.assertTrue(createTableResult.next());
+            String createTableSql = createTableResult.getString(2).toLowerCase();
+            Assertions.assertTrue(createTableSql.contains("engine=innodb"), createTableSql);
+            Assertions.assertTrue(createTableSql.contains("charset=utf8mb4"), createTableSql);
+            Assertions.assertTrue(
+                    createTableSql.contains("collate=utf8mb4_unicode_ci"), createTableSql);
+
+            ResultSet countResult =
+                    statement.executeQuery(
+                            String.format(
+                                    "SELECT COUNT(*) FROM `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
+            Assertions.assertTrue(countResult.next());
+            Assertions.assertEquals(3, countResult.getInt(1));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    String driverUrl() {
+        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
+    }
+
+    @Override
+    Pair<String[], List<SeaTunnelRow>> initTestData() {
+        String[] fieldNames = new String[] {"id", "name"};
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            rows.add(new SeaTunnelRow(new Object[] {(long) i, "name_" + i}));
+        }
+        return Pair.of(fieldNames, rows);
+    }
+
+    @Override
+    protected GenericContainer<?> initContainer() {
+        DockerImageName imageName = DockerImageName.parse(MYSQL_IMAGE);
+
+        GenericContainer<?> container =
+                new MySQLContainer<>(imageName)
+                        .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(7)))
+                        .withUsername(MYSQL_USERNAME)
+                        .withPassword(MYSQL_PASSWORD)
+                        .withDatabaseName(MYSQL_DATABASE)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(MYSQL_CONTAINER_HOST)
+                        .withExposedPorts(MYSQL_PORT)
+                        .waitingFor(Wait.forHealthcheck())
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(DockerLoggerFactory.getLogger(MYSQL_IMAGE)));
+
+        container.setPortBindings(Lists.newArrayList(String.format("%s:%s", MYSQL_PORT, 3306)));
+
+        return container;
+    }
+
+    @Override
+    protected void initCatalog() {
+        catalog =
+                new MySqlCatalog(
+                        "mysql",
+                        jdbcCase.getUserName(),
+                        jdbcCase.getPassword(),
+                        JdbcUrlUtil.getUrlInfo(
+                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
+                        null);
+        catalog.open();
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlTableOptionsIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcMysqlTableOptionsIT.java
@@ -17,34 +17,42 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc;
 
-import org.apache.seatunnel.shade.com.google.common.collect.Lists;
-import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
-
-import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalog;
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
+import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
 import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
+import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.stream.Stream;
 
-public class JdbcMysqlTableOptionsIT extends AbstractJdbcIT {
+@Slf4j
+public class JdbcMysqlTableOptionsIT extends TestSuiteBase implements TestResource {
+
+    private static final String MYSQL_DRIVER_JAR =
+            "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
 
     private static final String MYSQL_IMAGE = "mysql:8.0.43";
     private static final String MYSQL_CONTAINER_HOST = "mysql-e2e-table-options";
@@ -54,97 +62,44 @@ public class JdbcMysqlTableOptionsIT extends AbstractJdbcIT {
 
     private static final String MYSQL_USERNAME = "root";
     private static final String MYSQL_PASSWORD = "Abc!@#135_seatunnel";
-    private static final int MYSQL_PORT = 33064;
-    private static final String MYSQL_URL = "jdbc:mysql://" + HOST + ":%s/%s?useSSL=false";
 
-    private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+    private static final String CONFIG_FILE = "/jdbc_mysql_sink_with_table_options.conf";
 
-    private static final List<String> CONFIG_FILE =
-            Lists.newArrayList("/jdbc_mysql_sink_with_table_options.conf");
-
-    private static final String CREATE_SQL =
-            "CREATE TABLE IF NOT EXISTS %s (\n"
+    private static final String CREATE_SOURCE_TABLE_SQL =
+            "CREATE TABLE IF NOT EXISTS `"
+                    + MYSQL_SOURCE
+                    + "` (\n"
                     + "    `id`   BIGINT       NOT NULL,\n"
                     + "    `name` VARCHAR(255) DEFAULT NULL,\n"
                     + "    PRIMARY KEY (`id`)\n"
                     + ");";
 
-    @Override
-    JdbcCase getJdbcCase() {
-        Map<String, String> containerEnv = new HashMap<>();
-        String jdbcUrl = String.format(MYSQL_URL, MYSQL_PORT, MYSQL_DATABASE);
-        Pair<String[], List<SeaTunnelRow>> testDataSet = initTestData();
-        String[] fieldNames = testDataSet.getKey();
-        String insertSql = insertTable(MYSQL_DATABASE, MYSQL_SOURCE, fieldNames);
+    private static final String INSERT_SOURCE_SQL =
+            "INSERT INTO `"
+                    + MYSQL_SOURCE
+                    + "` (`id`, `name`) VALUES (1, 'name_1'), (2, 'name_2'), (3, 'name_3');";
 
-        return JdbcCase.builder()
-                .dockerImage(MYSQL_IMAGE)
-                .networkAliases(MYSQL_CONTAINER_HOST)
-                .containerEnv(containerEnv)
-                .driverClass(DRIVER_CLASS)
-                .host(HOST)
-                .port(MYSQL_PORT)
-                .localPort(MYSQL_PORT)
-                .jdbcTemplate(MYSQL_URL)
-                .jdbcUrl(jdbcUrl)
-                .userName(MYSQL_USERNAME)
-                .password(MYSQL_PASSWORD)
-                .database(MYSQL_DATABASE)
-                .sourceTable(MYSQL_SOURCE)
-                .sinkTable(MYSQL_SINK)
-                .createSql(CREATE_SQL)
-                .configFile(CONFIG_FILE)
-                .insertSql(insertSql)
-                .testData(testDataSet)
-                .useSaveModeCreateTable(true)
-                .build();
-    }
+    // MySQL 8.0.43 cold start may exceed the default 120s JDBC wait in Testcontainers.
+    private static final int MYSQL_STARTUP_TIMEOUT_SECONDS =
+            (int) Duration.ofMinutes(10).getSeconds();
 
-    @Override
-    void checkResult(String executeKey, TestContainer container, Container.ExecResult execResult) {
-        try (Statement statement = connection.createStatement()) {
-            ResultSet createTableResult =
-                    statement.executeQuery(
-                            String.format(
-                                    "SHOW CREATE TABLE `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
-            Assertions.assertTrue(createTableResult.next());
-            String createTableSql = createTableResult.getString(2).toLowerCase();
-            Assertions.assertTrue(createTableSql.contains("engine=innodb"), createTableSql);
-            Assertions.assertTrue(createTableSql.contains("charset=utf8mb4"), createTableSql);
-            Assertions.assertTrue(
-                    createTableSql.contains("collate=utf8mb4_unicode_ci"), createTableSql);
+    private MySQLContainer<?> mysqlContainer;
 
-            ResultSet countResult =
-                    statement.executeQuery(
-                            String.format(
-                                    "SELECT COUNT(*) FROM `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
-            Assertions.assertTrue(countResult.next());
-            Assertions.assertEquals(3, countResult.getInt(1));
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    @TestContainerExtension
+    protected final ContainerExtendedFactory extendedFactory =
+            container -> {
+                Container.ExecResult extraCommands =
+                        container.execInContainer(
+                                "bash",
+                                "-c",
+                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
+                                        + MYSQL_DRIVER_JAR);
+                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+            };
 
-    @Override
-    String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
-    }
-
-    @Override
-    Pair<String[], List<SeaTunnelRow>> initTestData() {
-        String[] fieldNames = new String[] {"id", "name"};
-        List<SeaTunnelRow> rows = new ArrayList<>();
-        for (int i = 1; i <= 3; i++) {
-            rows.add(new SeaTunnelRow(new Object[] {(long) i, "name_" + i}));
-        }
-        return Pair.of(fieldNames, rows);
-    }
-
-    @Override
-    protected GenericContainer<?> initContainer() {
+    void initContainer() {
         DockerImageName imageName = DockerImageName.parse(MYSQL_IMAGE);
-
-        GenericContainer<?> container =
+        mysqlContainer =
                 new MySQLContainer<>(imageName)
                         .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(7)))
                         .withUsername(MYSQL_USERNAME)
@@ -152,26 +107,97 @@ public class JdbcMysqlTableOptionsIT extends AbstractJdbcIT {
                         .withDatabaseName(MYSQL_DATABASE)
                         .withNetwork(NETWORK)
                         .withNetworkAliases(MYSQL_CONTAINER_HOST)
-                        .withExposedPorts(MYSQL_PORT)
+                        .withStartupTimeoutSeconds(MYSQL_STARTUP_TIMEOUT_SECONDS)
                         .waitingFor(Wait.forHealthcheck())
                         .withLogConsumer(
                                 new Slf4jLogConsumer(DockerLoggerFactory.getLogger(MYSQL_IMAGE)));
 
-        container.setPortBindings(Lists.newArrayList(String.format("%s:%s", MYSQL_PORT, 3306)));
-
-        return container;
+        Startables.deepStart(Stream.of(mysqlContainer)).join();
     }
 
     @Override
-    protected void initCatalog() {
-        catalog =
-                new MySqlCatalog(
-                        "mysql",
-                        jdbcCase.getUserName(),
-                        jdbcCase.getPassword(),
-                        JdbcUrlUtil.getUrlInfo(
-                                jdbcCase.getJdbcUrl().replace(HOST, dbServer.getHost())),
-                        null);
-        catalog.open();
+    @BeforeAll
+    public void startUp() throws Exception {
+        initContainer();
+        initializeJdbcTable();
+    }
+
+    @Override
+    @AfterAll
+    public void tearDown() {
+        if (mysqlContainer != null) {
+            mysqlContainer.close();
+        }
+    }
+
+    @TestTemplate
+    public void testTableOptionsSink(TestContainer container)
+            throws IOException, InterruptedException, SQLException {
+        try {
+            Container.ExecResult execResult = container.executeJob(CONFIG_FILE);
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+            assertSinkTableOptions();
+        } finally {
+            clearSinkTable();
+        }
+    }
+
+    private void assertSinkTableOptions() throws SQLException {
+        try (Connection connection = getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            ResultSet createTableResult =
+                    statement.executeQuery(
+                            String.format(
+                                    "SHOW CREATE TABLE `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
+            Assertions.assertTrue(createTableResult.next());
+            String createTableSql = createTableResult.getString(2).toLowerCase();
+            Assertions.assertTrue(
+                    createTableSql.contains(
+                            MySqlCatalog.TABLE_OPTION_ENGINE.toLowerCase() + "=innodb"),
+                    createTableSql);
+            Assertions.assertTrue(
+                    createTableSql.contains(
+                            MySqlCatalog.TABLE_OPTION_CHARSET.toLowerCase() + "=utf8mb4"),
+                    createTableSql);
+            Assertions.assertTrue(
+                    createTableSql.contains(
+                            MySqlCatalog.TABLE_OPTION_COLLATE.toLowerCase()
+                                    + "=utf8mb4_unicode_ci"),
+                    createTableSql);
+
+            ResultSet countResult =
+                    statement.executeQuery(
+                            String.format(
+                                    "SELECT COUNT(*) FROM `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
+            Assertions.assertTrue(countResult.next());
+            Assertions.assertEquals(3, countResult.getInt(1));
+        }
+    }
+
+    private Connection getJdbcConnection() throws SQLException {
+        return DriverManager.getConnection(
+                mysqlContainer.getJdbcUrl(),
+                mysqlContainer.getUsername(),
+                mysqlContainer.getPassword());
+    }
+
+    private void initializeJdbcTable() {
+        try (Connection connection = getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute(CREATE_SOURCE_TABLE_SQL);
+            statement.execute(INSERT_SOURCE_SQL);
+        } catch (SQLException e) {
+            throw new RuntimeException("Initializing MySQL table failed!", e);
+        }
+    }
+
+    private void clearSinkTable() {
+        try (Connection connection = getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute(
+                    String.format("DROP TABLE IF EXISTS `%s`.`%s`", MYSQL_DATABASE, MYSQL_SINK));
+        } catch (SQLException e) {
+            throw new RuntimeException("Clearing sink table failed!", e);
+        }
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
@@ -25,7 +25,7 @@ source {
     url = "jdbc:mysql://mysql-e2e-table-options:3306/seatunnel?useSSL=false"
     driver = "com.mysql.cj.jdbc.Driver"
     connection_check_timeout_sec = 100
-    user = "root"
+    username = "root"
     password = "Abc!@#135_seatunnel"
     query = "select * from source;"
   }
@@ -35,7 +35,7 @@ sink {
   jdbc {
     url = "jdbc:mysql://mysql-e2e-table-options:3306/seatunnel?useSSL=false"
     driver = "com.mysql.cj.jdbc.Driver"
-    user = "root"
+    username = "root"
     password = "Abc!@#135_seatunnel"
 
     generate_sink_sql = true

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
@@ -45,7 +45,7 @@ sink {
 
     schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
     data_save_mode = "APPEND_DATA"
-    table-options = {
+    table_options = {
       "engine" = "InnoDB"
       "charset" = "utf8mb4"
       "collate" = "utf8mb4_unicode_ci"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_mysql_sink_with_table_options.conf
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  jdbc {
+    url = "jdbc:mysql://mysql-e2e-table-options:3306/seatunnel?useSSL=false"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    user = "root"
+    password = "Abc!@#135_seatunnel"
+    query = "select * from source;"
+  }
+}
+
+sink {
+  jdbc {
+    url = "jdbc:mysql://mysql-e2e-table-options:3306/seatunnel?useSSL=false"
+    driver = "com.mysql.cj.jdbc.Driver"
+    user = "root"
+    password = "Abc!@#135_seatunnel"
+
+    generate_sink_sql = true
+    database = "seatunnel"
+    table = "sink_table_options"
+    primary_keys = ["id"]
+
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
+    table-options = {
+      "engine" = "InnoDB"
+      "charset" = "utf8mb4"
+      "collate" = "utf8mb4_unicode_ci"
+    }
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request

Add `table-options` for JDBC sink auto-create flow (MySQL first delivery for #11047).

- Introduce shared `table-options` config in `SinkConnectorCommonOptions`
- Propagate options into `CatalogTable` in `JdbcSinkFactory`
- Validate per dialect; MySQL/TiDB allow `engine`, `charset`, `collate`
- Fail fast for unsupported JDBC dialects or unknown keys

**Status** — MySQL JDBC only; StarRocks/Paimon out of scope for this draft.

### Does this PR introduce _any_ user-facing change?

Yes. New optional sink config `table-options` (map). Applied only when `schema_save_mode` triggers DDL (e.g. `CREATE_SCHEMA_WHEN_NOT_EXIST`). Does not alter existing tables or runtime INSERT/UPSERT.

### How was this patch tested?

- Unit: `MysqlDialectTest`, `MysqlCreateTableSqlBuilderTest`
- E2E: `JdbcMysqlTableOptionsIT`

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)


