### PR TITLE
[Fix][API] Add missing OptionRule validation for CatalogFactory creation path

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/factory/FactoryUtil.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/factory/FactoryUtil.java
@@ -286,13 +286,17 @@ public final class FactoryUtil {
 
     public static Optional<Catalog> createOptionalCatalog(
             String catalogName,
-            ReadonlyConfig options,
+            ReadonlyConfig readonlyConfig,
             ClassLoader classLoader,
             String factoryIdentifier) {
         Optional<CatalogFactory> optionalFactory =
                 discoverOptionalFactory(classLoader, CatalogFactory.class, factoryIdentifier);
+
         return optionalFactory.map(
-                catalogFactory -> catalogFactory.createCatalog(catalogName, options));
+                catalogFactory -> {
+                    ConfigValidator.of(readonlyConfig).validate(catalogFactory.optionRule());
+                    return catalogFactory.createCatalog(catalogName, readonlyConfig);
+                });
     }
 
     public static <T extends Factory> URL getFactoryUrl(T factory) {

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtilTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/catalog/CatalogTableUtilTest.java
@@ -22,7 +22,9 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigValueFactory;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.table.factory.FactoryUtil;
 import org.apache.seatunnel.api.table.type.ArrayType;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.DecimalType;
@@ -43,7 +45,10 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.seatunnel.common.constants.CollectionConstants.PLUGIN_NAME;
 
@@ -207,5 +212,66 @@ public class CatalogTableUtilTest {
             throw new FileNotFoundException("Can't find config file: " + configFile);
         }
         return Paths.get(resource.toURI()).toString();
+    }
+
+    @Test
+    void createOptionalCatalogWithValidConfig() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("username", "admin");
+        configMap.put("password", "secret");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Optional<Catalog> catalog =
+                FactoryUtil.createOptionalCatalog(
+                        "test", config, Thread.currentThread().getContextClassLoader(), "InMemory");
+
+        Assertions.assertTrue(catalog.isPresent());
+    }
+
+    @Test
+    void createOptionalCatalogWithMissingRequiredOptionsThrows() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("host", "localhost");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        FactoryUtil.createOptionalCatalog(
+                                "test",
+                                config,
+                                Thread.currentThread().getContextClassLoader(),
+                                "InMemory"));
+    }
+
+    @Test
+    void createOptionalCatalogWithPartialRequiredOptionsThrows() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("username", "admin");
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        FactoryUtil.createOptionalCatalog(
+                                "test",
+                                config,
+                                Thread.currentThread().getContextClassLoader(),
+                                "InMemory"));
+    }
+
+    @Test
+    void createOptionalCatalogWithUnknownFactoryReturnsEmpty() {
+        Map<String, Object> configMap = new HashMap<>();
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+
+        Optional<Catalog> catalog =
+                FactoryUtil.createOptionalCatalog(
+                        "test",
+                        config,
+                        Thread.currentThread().getContextClassLoader(),
+                        "NonExistentFactory");
+
+        Assertions.assertFalse(catalog.isPresent());
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/duckdb/DuckDBCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/duckdb/DuckDBCatalogFactory.java
@@ -28,6 +28,13 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseI
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.DECIMAL_TYPE_NARROWING;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.HANDLE_BLOB_AS_STRING;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.PASSWORD;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.SCHEMA;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.URL;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.USERNAME;
+
 /** Factory for {@link DuckDBCatalog} */
 @AutoService(Factory.class)
 public class DuckDBCatalogFactory implements CatalogFactory {
@@ -50,6 +57,9 @@ public class DuckDBCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return OptionRule.builder()
+                .required(URL)
+                .optional(USERNAME, PASSWORD, SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING)
+                .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/catalog/LanceCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/catalog/LanceCatalogFactory.java
@@ -35,6 +35,6 @@ public class LanceCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return null;
+        return OptionRule.builder().build();
     }
 }


### PR DESCRIPTION
### Purpose

All factory creation paths in SeaTunnel validate user config against `optionRule()` before instantiation — except Catalog:

| Factory Type | Validates `optionRule()` | Entry Point |
|---|---|---|
| Source | ✅ | `FactoryUtil.createSource()` |
| Sink | ✅ | `FactoryUtil.createSink()` |
| Transform | ✅ | `FactoryUtil.createTransform()` |
| **Catalog** | ❌ | `FactoryUtil.createOptionalCatalog()` |

This is a framework-level bug: **all 37 CatalogFactory implementations** silently skip config validation. When users provide invalid configs (e.g. missing required `username`/`password` for JDBC catalogs, or missing `hosts` for Elasticsearch), the error is not caught upfront — it surfaces later as a cryptic `NullPointerException` or connection failure deep in the catalog implementation.

This PR fixes the gap by adding `ConfigValidator.validate(optionRule())` to `createOptionalCatalog()`.

### Changes

- Add `ConfigValidator.of(readonlyConfig).validate(catalogFactory.optionRule())` in `FactoryUtil.createOptionalCatalog()` before calling `createCatalog()`.
- Fix `LanceCatalogFactory.optionRule()` returning `null` → return empty `OptionRule.builder().build()` to prevent NPE.
- Add 4 unit tests in `CatalogTableUtilTest` covering valid config, missing/partial required options, and unknown factory identifier.

### How was this patch tested?

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-api -Dtest=CatalogTableUtilTest test`
- `./mvnw -q -DskipTests verify`
