### PR TITLE
[Feature][Connector-V2] Maxcompute Source Round-Robin Split Assignment

### DIFF
--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
@@ -109,35 +109,51 @@ public class MaxcomputeSourceSplitEnumerator
     @Override
     public void handleSplitRequest(int subtaskId) {}
 
-    private void discoverySplits() throws TunnelException {
-        int numReaders = enumeratorContext.currentParallelism();
+    // visible for testing
+    static Set<MaxcomputeSourceSplit> computeSplits(
+            int numReaders,
+            Collection<SourceTableInfo> sourceTableInfos,
+            Map<TablePath, Long> tableRecordCounts) {
         Set<MaxcomputeSourceSplit> allSplit = new LinkedHashSet<>();
         int chunkIndex = 0;
-        for (SourceTableInfo sourceTableInfo : sourceTableInfos.values()) {
-            Set<MaxcomputeSourceSplit> splits = new LinkedHashSet<>();
-            TableTunnel.DownloadSession session =
-                    MaxcomputeUtil.getDownloadSession(
-                            readonlyConfig,
-                            sourceTableInfo.getCatalogTable().getTablePath(),
-                            sourceTableInfo.getPartitionSpec());
-            long recordCount = session.getRecordCount();
+        for (SourceTableInfo sourceTableInfo : sourceTableInfos) {
+            TablePath tablePath = sourceTableInfo.getCatalogTable().getTablePath();
+            long recordCount = tableRecordCounts.get(tablePath);
             int splitRow = MaxcomputeSourceOptions.SPLIT_ROW.defaultValue();
             if (sourceTableInfo.getSplitRow() != null && sourceTableInfo.getSplitRow() > 0) {
                 splitRow = sourceTableInfo.getSplitRow();
             }
             for (long num = 0; num < recordCount; num += splitRow) {
                 int ownerReader = chunkIndex % numReaders;
-                splits.add(
+                allSplit.add(
                         new MaxcomputeSourceSplit(
                                 num,
                                 Math.min((long) splitRow, recordCount - num),
-                                sourceTableInfo.getCatalogTable().getTablePath(),
+                                tablePath,
                                 ownerReader));
                 chunkIndex++;
             }
-            assignedSplits.forEach(splits::remove);
-            allSplit.addAll(splits);
         }
+        return allSplit;
+    }
+
+    private void discoverySplits() throws TunnelException {
+        int numReaders = enumeratorContext.currentParallelism();
+        Map<TablePath, Long> tableRecordCounts = new HashMap<>();
+        for (SourceTableInfo sourceTableInfo : sourceTableInfos.values()) {
+            TableTunnel.DownloadSession session =
+                    MaxcomputeUtil.getDownloadSession(
+                            readonlyConfig,
+                            sourceTableInfo.getCatalogTable().getTablePath(),
+                            sourceTableInfo.getPartitionSpec());
+            tableRecordCounts.put(
+                    sourceTableInfo.getCatalogTable().getTablePath(), session.getRecordCount());
+        }
+
+        Set<MaxcomputeSourceSplit> allSplit =
+                computeSplits(numReaders, sourceTableInfos.values(), tableRecordCounts);
+        assignedSplits.forEach(allSplit::remove);
+
         addSplitChangeToPendingAssignments(allSplit);
         log.debug("Assigned {} to {} readers.", allSplit, numReaders);
         log.info("Calculated splits successfully, the size of splits is {}.", allSplit.size());

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,31 +111,29 @@ public class MaxcomputeSourceSplitEnumerator
 
     private void discoverySplits() throws TunnelException {
         int numReaders = enumeratorContext.currentParallelism();
-        Set<MaxcomputeSourceSplit> allSplit = new HashSet<>();
+        Set<MaxcomputeSourceSplit> allSplit = new LinkedHashSet<>();
+        int chunkIndex = 0;
         for (SourceTableInfo sourceTableInfo : sourceTableInfos.values()) {
-            Set<MaxcomputeSourceSplit> splits = new HashSet<>();
+            Set<MaxcomputeSourceSplit> splits = new LinkedHashSet<>();
             TableTunnel.DownloadSession session =
                     MaxcomputeUtil.getDownloadSession(
                             readonlyConfig,
                             sourceTableInfo.getCatalogTable().getTablePath(),
                             sourceTableInfo.getPartitionSpec());
             long recordCount = session.getRecordCount();
-            int splitRowNum = (int) Math.ceil((double) recordCount / numReaders);
             int splitRow = MaxcomputeSourceOptions.SPLIT_ROW.defaultValue();
             if (sourceTableInfo.getSplitRow() != null && sourceTableInfo.getSplitRow() > 0) {
                 splitRow = sourceTableInfo.getSplitRow();
             }
-            for (int i = 0; i < numReaders; i++) {
-                int readerStart = i * splitRowNum;
-                int readerEnd = (int) Math.min((i + 1) * splitRowNum, recordCount);
-                for (int num = readerStart; num < readerEnd; num += splitRow) {
-                    splits.add(
-                            new MaxcomputeSourceSplit(
-                                    num,
-                                    Math.min(splitRow, readerEnd - num),
-                                    sourceTableInfo.getCatalogTable().getTablePath(),
-                                    i));
-                }
+            for (long num = 0; num < recordCount; num += splitRow) {
+                int ownerReader = chunkIndex % numReaders;
+                splits.add(
+                        new MaxcomputeSourceSplit(
+                                num,
+                                Math.min((long) splitRow, recordCount - num),
+                                sourceTableInfo.getCatalogTable().getTablePath(),
+                                ownerReader));
+                chunkIndex++;
             }
             assignedSplits.forEach(splits::remove);
             allSplit.addAll(splits);
@@ -147,7 +146,7 @@ public class MaxcomputeSourceSplitEnumerator
     private void addSplitChangeToPendingAssignments(Collection<MaxcomputeSourceSplit> newSplits) {
         for (MaxcomputeSourceSplit split : newSplits) {
             int ownerReader = split.getIndex() % enumeratorContext.currentParallelism();
-            pendingSplits.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
+            pendingSplits.computeIfAbsent(ownerReader, r -> new LinkedHashSet<>()).add(split);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
@@ -17,13 +17,21 @@
 
 package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
 
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MaxcomputeSourceSplitTest {
 
@@ -34,34 +42,31 @@ public class MaxcomputeSourceSplitTest {
         int splitRow = 10000;
 
         TablePath tablePath = TablePath.of("test_db", "test_schema", "test_table");
+
+        Map<TablePath, Long> tableRecordCounts = new HashMap<>();
+        tableRecordCounts.put(tablePath, recordCount);
+
+        CatalogTable catalogTable = mock(CatalogTable.class);
+        when(catalogTable.getTablePath()).thenReturn(tablePath);
+
+        SourceTableInfo tableInfo = new SourceTableInfo(catalogTable, null, splitRow);
+        List<SourceTableInfo> tableInfos = new ArrayList<>();
+        tableInfos.add(tableInfo);
+
+        Set<MaxcomputeSourceSplit> splits =
+                MaxcomputeSourceSplitEnumerator.computeSplits(
+                        numReaders, tableInfos, tableRecordCounts);
+
         Set<String> splitIds = new HashSet<>();
         int[] indexCounts = new int[numReaders];
-        int totalSplits = 0;
-        int chunkIndex = 0;
-        // Simulate the inner logic of MaxcomputeSourceSplitEnumerator.discoverySplits
-        for (long num = 0; num < recordCount; num += splitRow) {
-            int ownerReader = chunkIndex % numReaders;
-            MaxcomputeSourceSplit split =
-                    new MaxcomputeSourceSplit(
-                            num,
-                            Math.min((long) splitRow, recordCount - num),
-                            tablePath,
-                            ownerReader);
 
-            // Verify splitId uniqueness
+        for (MaxcomputeSourceSplit split : splits) {
             Assertions.assertTrue(
                     splitIds.add(split.splitId()), "Duplicate splitId found: " + split.splitId());
-
-            // Verify index assigned to the split matches the reader index
-            Assertions.assertEquals(ownerReader, split.getIndex());
-
-            indexCounts[ownerReader]++;
-            totalSplits++;
-            chunkIndex++;
+            indexCounts[split.getIndex()]++;
         }
 
-        // 105000 / 10000 = 10 full splits + 1 remainder split = 11 splits total!
-        Assertions.assertEquals(11, totalSplits);
+        Assertions.assertEquals(11, splits.size());
 
         // Verify index distribution (round-robin):
         // 11 splits / 5 readers = 2 splits each, plus 1 remainder for reader 0.
@@ -79,35 +84,88 @@ public class MaxcomputeSourceSplitTest {
         long recordCountPerTable = 15000;
         int splitRow = 10000;
 
-        int[] indexCounts = new int[numReaders];
-        int chunkIndex = 0;
-        int totalSplits = 0;
+        Map<TablePath, Long> tableRecordCounts = new HashMap<>();
+        List<SourceTableInfo> tableInfos = new ArrayList<>();
 
-        // Simulate multiple tables with 15k rows each (2 splits per table: 10k + 5k)
         for (int t = 0; t < numTables; t++) {
             TablePath tablePath = TablePath.of("test_db", "test_schema", "test_table_" + t);
-            for (long num = 0; num < recordCountPerTable; num += splitRow) {
-                int ownerReader = chunkIndex % numReaders;
-                MaxcomputeSourceSplit split =
-                        new MaxcomputeSourceSplit(
-                                num,
-                                Math.min((long) splitRow, recordCountPerTable - num),
-                                tablePath,
-                                ownerReader);
+            tableRecordCounts.put(tablePath, recordCountPerTable);
 
-                Assertions.assertEquals(ownerReader, split.getIndex());
-                indexCounts[ownerReader]++;
-                totalSplits++;
-                chunkIndex++;
-            }
+            CatalogTable catalogTable = mock(CatalogTable.class);
+            when(catalogTable.getTablePath()).thenReturn(tablePath);
+
+            SourceTableInfo tableInfo = new SourceTableInfo(catalogTable, null, splitRow);
+            tableInfos.add(tableInfo);
         }
 
-        // 5 tables * 2 splits = 10 total splits
-        Assertions.assertEquals(10, totalSplits);
+        Set<MaxcomputeSourceSplit> splits =
+                MaxcomputeSourceSplitEnumerator.computeSplits(
+                        numReaders, tableInfos, tableRecordCounts);
+
+        int[] indexCounts = new int[numReaders];
+
+        for (MaxcomputeSourceSplit split : splits) {
+            indexCounts[split.getIndex()]++;
+        }
+
+        Assertions.assertEquals(10, splits.size());
 
         // 10 splits / 3 readers = 3 splits each, plus 1 remainder for reader 0.
         Assertions.assertEquals(4, indexCounts[0], "Reader 0 split count mismatch!");
         Assertions.assertEquals(3, indexCounts[1], "Reader 1 split count mismatch!");
         Assertions.assertEquals(3, indexCounts[2], "Reader 2 split count mismatch!");
+    }
+
+    @Test
+    public void testComputeSplitsAscendingRowStartOrder() {
+        int numReaders = 3;
+        int numTables = 2;
+        Map<TablePath, Long> tableRecordCounts = new HashMap<>();
+        List<SourceTableInfo> tableInfos = new ArrayList<>();
+
+        for (int i = 0; i < numTables; i++) {
+            TablePath path = TablePath.of("db", "schema", "table" + i);
+            // 105,000 rows / 10,000 splitRow = 11 splits per table.
+            // With 3 readers, each reader gets 3-4 splits PER TABLE.
+            tableRecordCounts.put(path, 105000L);
+
+            CatalogTable catalogTable = mock(CatalogTable.class);
+            when(catalogTable.getTablePath()).thenReturn(path);
+
+            SourceTableInfo tableInfo = new SourceTableInfo(catalogTable, null, 10000);
+            tableInfos.add(tableInfo);
+        }
+
+        // Drive the actual production logic
+        Set<MaxcomputeSourceSplit> splits =
+                MaxcomputeSourceSplitEnumerator.computeSplits(
+                        numReaders, tableInfos, tableRecordCounts);
+
+        // Guard against HashSet regression: splits iterated from the Set MUST be in insertion
+        // order,
+        // which means for any given reader and table, the rowStart must be strictly ascending.
+        Map<Integer, Map<TablePath, Long>> lastRowStarts = new HashMap<>();
+
+        for (MaxcomputeSourceSplit split : splits) {
+            int reader = split.getIndex();
+            TablePath path = split.getTablePath();
+            long rowStart = split.getRowStart();
+
+            lastRowStarts.computeIfAbsent(reader, r -> new HashMap<>());
+            Long lastStart = lastRowStarts.get(reader).get(path);
+
+            if (lastStart != null) {
+                Assertions.assertTrue(
+                        rowStart > lastStart,
+                        "HashSet Regression! Splits for reader "
+                                + reader
+                                + " and table "
+                                + path
+                                + " are not in ascending order!");
+            }
+            lastRowStarts.get(reader).put(path, rowStart);
+        }
+
+        Assertions.assertEquals(22, splits.size(), "Should have exactly 22 splits total");
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitTest.java
@@ -33,42 +33,81 @@ public class MaxcomputeSourceSplitTest {
         long recordCount = 105000;
         int splitRow = 10000;
 
-        int splitRowNum = (int) Math.ceil((double) recordCount / numReaders); // 21000
         TablePath tablePath = TablePath.of("test_db", "test_schema", "test_table");
-
         Set<String> splitIds = new HashSet<>();
         int[] indexCounts = new int[numReaders];
         int totalSplits = 0;
-
+        int chunkIndex = 0;
         // Simulate the inner logic of MaxcomputeSourceSplitEnumerator.discoverySplits
-        for (int i = 0; i < numReaders; i++) {
-            int readerStart = i * splitRowNum;
-            int readerEnd = (int) Math.min((i + 1) * splitRowNum, recordCount);
-            for (int num = readerStart; num < readerEnd; num += splitRow) {
+        for (long num = 0; num < recordCount; num += splitRow) {
+            int ownerReader = chunkIndex % numReaders;
+            MaxcomputeSourceSplit split =
+                    new MaxcomputeSourceSplit(
+                            num,
+                            Math.min((long) splitRow, recordCount - num),
+                            tablePath,
+                            ownerReader);
+
+            // Verify splitId uniqueness
+            Assertions.assertTrue(
+                    splitIds.add(split.splitId()), "Duplicate splitId found: " + split.splitId());
+
+            // Verify index assigned to the split matches the reader index
+            Assertions.assertEquals(ownerReader, split.getIndex());
+
+            indexCounts[ownerReader]++;
+            totalSplits++;
+            chunkIndex++;
+        }
+
+        // 105000 / 10000 = 10 full splits + 1 remainder split = 11 splits total!
+        Assertions.assertEquals(11, totalSplits);
+
+        // Verify index distribution (round-robin):
+        // 11 splits / 5 readers = 2 splits each, plus 1 remainder for reader 0.
+        Assertions.assertEquals(3, indexCounts[0], "Reader 0 split count mismatch!");
+        Assertions.assertEquals(2, indexCounts[1], "Reader 1 split count mismatch!");
+        Assertions.assertEquals(2, indexCounts[2], "Reader 2 split count mismatch!");
+        Assertions.assertEquals(2, indexCounts[3], "Reader 3 split count mismatch!");
+        Assertions.assertEquals(2, indexCounts[4], "Reader 4 split count mismatch!");
+    }
+
+    @Test
+    public void testMultiTableRoundRobinDistribution() {
+        int numReaders = 3;
+        int numTables = 5;
+        long recordCountPerTable = 15000;
+        int splitRow = 10000;
+
+        int[] indexCounts = new int[numReaders];
+        int chunkIndex = 0;
+        int totalSplits = 0;
+
+        // Simulate multiple tables with 15k rows each (2 splits per table: 10k + 5k)
+        for (int t = 0; t < numTables; t++) {
+            TablePath tablePath = TablePath.of("test_db", "test_schema", "test_table_" + t);
+            for (long num = 0; num < recordCountPerTable; num += splitRow) {
+                int ownerReader = chunkIndex % numReaders;
                 MaxcomputeSourceSplit split =
                         new MaxcomputeSourceSplit(
-                                num, Math.min(splitRow, readerEnd - num), tablePath, i);
+                                num,
+                                Math.min((long) splitRow, recordCountPerTable - num),
+                                tablePath,
+                                ownerReader);
 
-                // Verify splitId uniqueness
-                Assertions.assertTrue(
-                        splitIds.add(split.splitId()),
-                        "Duplicate splitId found: " + split.splitId());
-
-                // Verify index assigned to the split matches the reader index
-                Assertions.assertEquals(i, split.getIndex());
-
-                indexCounts[i]++;
+                Assertions.assertEquals(ownerReader, split.getIndex());
+                indexCounts[ownerReader]++;
                 totalSplits++;
+                chunkIndex++;
             }
         }
 
-        Assertions.assertTrue(totalSplits == 15);
+        // 5 tables * 2 splits = 10 total splits
+        Assertions.assertEquals(10, totalSplits);
 
-        // Verify index distribution:
-        // Record count 105000 / 5 readers = 21000 splits per reader.
-        // Split row is 10000. Loop steps: 0, 10000, 20000. So 3 splits per reader.
-        for (int i = 0; i < numReaders; i++) {
-            Assertions.assertEquals(3, indexCounts[i], "Reader " + i + " split count mismatch!");
-        }
+        // 10 splits / 3 readers = 3 splits each, plus 1 remainder for reader 0.
+        Assertions.assertEquals(4, indexCounts[0], "Reader 0 split count mismatch!");
+        Assertions.assertEquals(3, indexCounts[1], "Reader 1 split count mismatch!");
+        Assertions.assertEquals(3, indexCounts[2], "Reader 2 split count mismatch!");
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
Currently, the MaxcomputeSource divides the total record count into massive contiguous blocks sequentially (e.g., Reader 0 gets the first 25% of the table, Reader 1 gets the next 25%). Furthermore, it stores these splits internally using a HashSet, which completely scrambles the split assignment order before they are processed by the readers.

Because of this, if a user uses ORDER BY or RANGE CLUSTERED BY in their MaxCompute table to prioritize data, running SeaTunnel with parallelism > 1 destroys this ordering entirely.

This PR introduces a Round-Robin Split Assignment logic:

Replaces the massive contiguous block chunking with striped/round-robin chunking (e.g. Reader 0 gets chunk 1, Reader 1 gets chunk 2). This allows all parallel readers to pull from the "top" of the table simultaneously, preserving a high-level priority order across multiple threads.
Replaces HashSet with LinkedHashSet in MaxcomputeSourceSplitEnumerator to guarantee that the chronological insertion order of splits is strictly preserved when assigning them to the readers.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->
No. This PR only modifies the internal split enumeration and distribution logic for the MaxCompute Source. It introduces no new configuration options and does not break any existing contracts. It purely optimizes the reading order to be more evenly distributed across parallel readers.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->
Ran mvn clean install -pl seatunnel-connectors-v2/connector-maxcompute -am -DskipTests to verify compilation and dependency integrity.
Manually tested the execution graph locally to verify that splits are correctly striped and assigned in round-robin order without hash scrambling.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
