### PR TITLE
[Test][E2E] Stabilize Db2 container readiness for JDBC IT

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDb2IT.java
@@ -27,7 +27,7 @@ import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerLoggerFactory;
 
 import java.math.BigDecimal;
@@ -56,8 +56,11 @@ public class JdbcDb2IT extends AbstractJdbcIT {
     private static final List<String> CONFIG_FILE =
             Lists.newArrayList("/jdbc_db2_source_and_sink.conf");
 
-    /** <a href="https://hub.docker.com/r/ibmcom/db2">db2 in dockerhub</a> */
-    private static final String DB2_IMAGE = "ibmcom/db2";
+    /**
+     * Keep the tag aligned with Testcontainers' validated default instead of relying on {@code
+     * latest}, whose startup behavior is not stable enough for CI.
+     */
+    private static final String DB2_IMAGE = "ibmcom/db2:11.5.0.0a";
 
     private static final int PORT = 50000;
     private static final int LOCAL_PORT = 50000;
@@ -181,6 +184,8 @@ public class JdbcDb2IT extends AbstractJdbcIT {
 
     @Override
     protected GenericContainer<?> initContainer() {
+        // The DB2 port becomes reachable before the instance can accept JDBC logins, and the
+        // first-time initialization regularly exceeds the default 10 minute wait on slow runners.
         GenericContainer<?> container =
                 new Db2Container(DB2_IMAGE)
                         .withExposedPorts(PORT)
@@ -190,7 +195,9 @@ public class JdbcDb2IT extends AbstractJdbcIT {
                         .withUsername(DB2_USER)
                         .withPassword(DB2_PASSWORD)
                         .waitingFor(
-                                Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(5)))
+                                new LogMessageWaitStrategy()
+                                        .withRegEx(".*Setup has completed\\..*")
+                                        .withStartupTimeout(Duration.ofMinutes(20)))
                         .withLogConsumer(
                                 new Slf4jLogConsumer(DockerLoggerFactory.getLogger(DB2_IMAGE)))
                         .acceptLicense();


### PR DESCRIPTION
## What does this PR do?

This fixes an unrelated JDBC Db2 E2E startup failure that surfaced while validating PR #11137.

The Db2 test was using `ibmcom/db2:latest` and a short startup readiness configuration. On slow runners, the container can spend several minutes in instance initialization before the database is actually usable, which makes the E2E fail for infrastructure timing reasons instead of test logic reasons.

## Changes

- pin the Db2 image to `ibmcom/db2:11.5.0.0a`, which matches the Testcontainers validated default instead of relying on `latest`
- wait for the official `Setup has completed.` readiness log and extend the startup timeout to 20 minutes for the Db2 test container
- keep the change scoped to `JdbcDb2IT`

## Validation

- `./mvnw -nsu -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1 spotless:apply`
- `./mvnw -nsu -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1 -DfailIfNoTests=false -Dtest=JdbcDb2UpsertIT test`

Local runtime note:

- this machine's Docker Desktop is limited to about 1975 MB RAM, so the Db2 container still did not fully reach the final ready log locally
- however, after this change the container progressed well past the previous failure point: it completed instance configuration, ran `DB2START`, and reached `Creating database E2E`, which is materially further than the original startup timeout behavior
- `seatunnel-engine-ui` was not changed and was not included in this validation scope
