### PR TITLE
[Test][E2E] Wait for SFTP continuous job exit after cancel

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
@@ -343,14 +343,7 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
 
             Container.ExecResult cancelResult = container.cancelJob(jobId);
             Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());
-
-            Container.ExecResult execResult;
-            try {
-                execResult = jobFuture.get(120, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                throw new RuntimeException("Wait continuous job exit failed.", e);
-            }
-            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+            waitContinuousJobExit(container, jobId, jobFuture);
         } finally {
             deleteFileFromContainer(SFTP_CONTAINER_HOME + "/tmp/seatunnel/continuous");
         }
@@ -402,14 +395,7 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
 
             Container.ExecResult cancelResult = container.cancelJob(jobId);
             Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());
-
-            Container.ExecResult execResult;
-            try {
-                execResult = jobFuture.get(120, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                throw new RuntimeException("Wait continuous job exit failed.", e);
-            }
-            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+            waitContinuousJobExit(container, jobId, jobFuture);
         } finally {
             deleteFileFromContainer(SFTP_CONTAINER_HOME + "/tmp/seatunnel/continuous");
         }
@@ -581,6 +567,31 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
         Container.ExecResult result =
                 sftpContainer.execInContainer("sh", "-c", "test -f '" + containerPath + "'");
         return result.getExitCode() == 0;
+    }
+
+    /**
+     * Wait for the continuous discovery job to enter the terminal canceled state and for the
+     * asynchronous execute call to finish its post-job thread cleanup.
+     */
+    private void waitContinuousJobExit(
+            TestContainer container,
+            String jobId,
+            CompletableFuture<Container.ExecResult> jobFuture) {
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> Assertions.assertEquals("CANCELED", container.getJobStatus(jobId)));
+        Awaitility.await()
+                .atMost(180, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .until(jobFuture::isDone);
+        try {
+            Container.ExecResult execResult = jobFuture.get(30, TimeUnit.SECONDS);
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+        } catch (Exception e) {
+            throw new RuntimeException("Wait continuous job exit failed.", e);
+        }
     }
 
     private void waitUntilContainerTimeAfter(long epochSeconds) {


### PR DESCRIPTION
## What does this PR do?

This follow-up stabilizes the SFTP continuous discovery E2E flow by waiting for the job to reach the terminal `CANCELED` state before asserting the asynchronous execute future exits cleanly.

It addresses the unrelated `connector-file-sftp-it` failure exposed while checking PR #11139.

## Validation

- `./mvnw -B -T 1 spotless:apply -Dskip.ui=true --no-snapshot-updates -pl :connector-file-sftp-e2e -am`
- `./mvnw -B -T 1 verify -DfailIfNoTests=false -DskipUT=true -DskipIT=false -Dlicense.skipAddThirdParty=true -Dskip.ui=true --no-snapshot-updates -pl :connector-file-sftp-e2e -am -Pci -Dit.test='SftpFileIT#testSftpBinaryUpdateModeContinuousDiscoveryDistcp+testSftpBinaryUpdateModeContinuousDiscoveryWithNonRecursiveScan'`

Docker-backed E2E validation passed in this run.

## Scope and reuse

- Revalidated scope: `seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e`.
- Reused artifacts: none intentionally reused from a prior run; this validation was rerun in the current worktree with Docker available.
- Not revalidated in this run: unrelated `jdbc-connectors-it-ddl`, engine cancel-state jobs, and other CI suites outside the SFTP E2E module.
- UI note: no `seatunnel-engine-ui` source files changed. The module still appeared in the Maven reactor even with `-Dskip.ui=true`, but it was outside the functional change scope.
