### PR TITLE
[Docs] Fix Pulsar source fetching typo

### DIFF
--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -117,7 +117,7 @@ The maximum time (in ms) to wait when fetching records. A longer time increases 
 
 ### poll.interval [Long]
 
-The interval time(in ms) when fetcing records. A shorter time increases throughput, but also increases CPU load.
+The interval time (in ms) when fetching records. A shorter time increases throughput, but also increases CPU load.
 
 ### poll.batch.size [Integer]
 


### PR DESCRIPTION
## Summary

- Fix a typo in the Pulsar source `poll.interval` option description.
- Add the missing space before `(in ms)` in the same sentence.

## Why

The user-facing Pulsar source documentation had `fetcing` instead of `fetching`, which makes the option description look unpolished.

## Validation

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

The Chinese Pulsar source document already uses correct wording, so no zh doc change was needed.