### PR TITLE
[Docs] Polish Pulsar sink routing mode docs

### DIFF
--- a/docs/en/connectors/sink/Pulsar.md
+++ b/docs/en/connectors/sink/Pulsar.md
@@ -108,11 +108,11 @@ covering all the producer parameters specified in the official Pulsar document.
 
 ### message.routing.mode [Enum]
 
-Default routing mode for messages to partition.
-Available options are SinglePartition,RoundRobinPartition.
-If you choose SinglePartition, If no key is provided, The partitioned producer will randomly pick one single partition and publish all the messages into that partition, If a key is provided on the message, the partitioned producer will hash the key and assign message to a particular partition.
-If you choose RoundRobinPartition, If no key is provided, the producer will publish messages across all partitions in round-robin fashion to achieve maximum throughput.
-Please note that round-robin is not done per individual message but rather it's set to the same boundary of batching delay, to ensure batching is effective.
+Default routing mode for partitioned messages.
+Available options are `SinglePartition` and `RoundRobinPartition`.
+When `SinglePartition` is selected and no key is provided, the partitioned producer randomly selects one partition and publishes all messages to that partition. When a key is provided, the producer hashes the key and sends the message to the selected partition.
+When `RoundRobinPartition` is selected and no key is provided, the producer publishes messages across all partitions in round-robin order to achieve maximum throughput.
+Round-robin routing is applied at the batching delay boundary rather than per individual message, so batching remains effective.
 
 ### partition_key_fields [String]
 

--- a/docs/zh/connectors/sink/Pulsar.md
+++ b/docs/zh/connectors/sink/Pulsar.md
@@ -92,9 +92,9 @@ Pulsar 服务的 Service URL 提供程序。要使用客户端库连接到 Pulsa
 
 ### message.routing.mode [Enum]
 
-要分区的消息的默认路由模式。可用选项包括 SinglePartition、RoundRobinPartition。
-如果选择 SinglePartition，如果未提供密钥，分区生产者将随机选择一个分区并将所有消息发布到该分区中，如果消息上提供了密钥，则分区生产者将对密钥进行哈希处理并将消息分配给特定分区。
-如果选择 RoundRobinPartition，则如果未提供密钥，则生产者将以循环方式跨所有分区发布消息，以实现最大吞吐量。请注意，轮询不是按单个消息完成的，而是设置为相同的批处理延迟边界，以确保批处理有效。
+分区消息的默认路由模式。可用选项包括 `SinglePartition` 和 `RoundRobinPartition`。
+选择 `SinglePartition` 且未提供 key 时，分区生产者会随机选择一个分区，并将所有消息发布到该分区。提供 key 时，生产者会对 key 做哈希，并将消息发送到对应分区。
+选择 `RoundRobinPartition` 且未提供 key 时，生产者会以轮询方式将消息发布到所有分区，以获得最大吞吐量。请注意，轮询不是逐条消息执行，而是在批处理延迟边界上执行，以确保批处理仍然有效。
 
 ### partition_key_fields [String]
 


### PR DESCRIPTION
## Summary

- Polish the Pulsar sink `message.routing.mode` description in English and Chinese docs.
- Split the long routing-mode explanation into clearer sentences.
- Format `SinglePartition` and `RoundRobinPartition` as option values.

## Why

The previous text mixed multiple conditions into one sentence and used inconsistent capitalization and punctuation, which made the routing behavior harder to read.

## Validation

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`