### PR TITLE
[Docs] Fix default engine grammar

### DIFF
--- a/docs/en/introduction/about.md
+++ b/docs/en/introduction/about.md
@@ -62,7 +62,7 @@ The Source Connector is responsible for parallel reading and sending the data to
 
 SeaTunnel is an EtL(T) data integration tool. Therefore, in SeaTunnel, transform can only be used to perform some simple transformations on data, such as converting the data of a column to uppercase or lowercase, changing the column name, or splitting a column into multiple columns.
 
-The default engine use by SeaTunnel is [SeaTunnel Engine](../engines/zeta/about.md). If you choose to use the Flink or Spark engine, SeaTunnel will package the Connector into a Flink or Spark program and submit it to Flink or Spark to run.
+The default engine used by SeaTunnel is [SeaTunnel Engine](../engines/zeta/about.md). If you choose to use the Flink or Spark engine, SeaTunnel will package the Connector into a Flink or Spark program and submit it to Flink or Spark to run.
 
 ## Connector
 


### PR DESCRIPTION
## Summary

- Fix a grammar issue in the English introduction page.
- Change `The default engine use by SeaTunnel` to `The default engine used by SeaTunnel`.

## Why

The previous sentence was grammatically incorrect in user-facing documentation.

## Validation

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

The Chinese introduction page already uses correct wording, so no zh doc change was needed.