### PR TITLE
[Docs] Fix IMap persistence grammar

### DIFF
--- a/docs/en/engines/zeta/separated-cluster-deployment.md
+++ b/docs/en/engines/zeta/separated-cluster-deployment.md
@@ -232,7 +232,7 @@ The following describes how to use the MapStore persistence configuration. For d
 
 **type**
 
-The type of IMap persistence, currently only supports `hdfs`.
+The type of IMap persistence. Currently, only `hdfs` is supported.
 
 **namespace**
 


### PR DESCRIPTION
## Summary

- Fix a grammar issue in the Zeta separated cluster deployment documentation.
- Change the IMap persistence `type` description so it clearly states that only `hdfs` is currently supported.

## Why

The previous sentence used `type` as the subject for `supports`, which made the user-facing documentation grammatically incorrect.

## Validation

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

The Chinese document already uses correct wording, so no zh doc change was needed.