### PR TITLE
[Docs] Update CNCF landscape license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Refer to this [Setup](https://seatunnel.apache.org/docs/developer/setup) for com
 - Twitter: [ASFSeaTunnel on Twitter](https://twitter.com/ASFSeaTunnel)
 
 ## Landscapes
-SeaTunnel enriches the [CNCF CLOUD NATIVE Landscape](https://landscape.cncf.io/?landscape=observability-and-analysis&license=apache-license-2-0).
+SeaTunnel enriches the [CNCF CLOUD NATIVE Landscape](https://landscape.cncf.io/?landscape=observability-and-analysis&license=Apache+License+2.0).
 
 ## License
 [Apache 2.0 License](LICENSE)
@@ -93,4 +93,3 @@ More information, please refer to [FAQ](https://seatunnel.apache.org/docs/faq).
 
 ### 4. How can I contribute to SeaTunnel?
 We welcome contributions! Please refer to our [Contribution Guidelines](https://seatunnel.apache.org/docs/developer/coding-guide) for details.
-


### PR DESCRIPTION
## Summary
- Update the CNCF Landscape license filter link in README to use `Apache+License+2.0`. The previous link has expired.

## Tests
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`