### PR TITLE
[Test][E2E] Stabilize schema evolution add-column assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>seatunnel-plugin-discovery</module>
         <module>seatunnel-formats</module>
         <module>seatunnel-engine</module>
+        <module>seatunnel-trace</module>
         <module>seatunnel-examples</module>
         <module>seatunnel-e2e</module>
         <module>seatunnel-shade</module>

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/event/EventType.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/event/EventType.java
@@ -32,4 +32,5 @@ public enum EventType {
     READER_MESSAGE_DELAYED,
     JOB_STATUS,
     SCHEMA_CHANGE_FLUSH,
+    STAIN_TRACE,
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/event/StainTraceEvent.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/event/StainTraceEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class StainTraceEvent implements Event {
+    private long createdTime;
+    private String jobId;
+    private EventType eventType = EventType.STAIN_TRACE;
+
+    private long traceId;
+    private byte[] payload;
+    private long sinkTaskId;
+    private String tableId;
+
+    public StainTraceEvent(long traceId, byte[] payload, long sinkTaskId, String tableId) {
+        this.createdTime = System.currentTimeMillis();
+        this.traceId = traceId;
+        this.payload = payload;
+        this.sinkTaskId = sinkTaskId;
+        this.tableId = tableId;
+    }
+}

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/type/SeaTunnelRow.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 /** SeaTunnel row type. */
 public final class SeaTunnelRow implements Serializable {
     private static final long serialVersionUID = -1L;
+    private static final String TRACE_PAYLOAD_OPTION_KEY = "__st_trace_payload";
     /** Table identifier. */
     private String tableId = "";
     /** The kind of change that a row describes in a changelog. */
@@ -78,6 +79,10 @@ public final class SeaTunnelRow implements Serializable {
         if (options == null) {
             options = new HashMap<>();
         }
+        return options;
+    }
+
+    public Map<String, Object> getOptionsOrNull() {
         return options;
     }
 
@@ -379,25 +384,39 @@ public final class SeaTunnelRow implements Serializable {
         SeaTunnelRow that = (SeaTunnelRow) o;
         return Objects.equals(tableId, that.tableId)
                 && rowKind == that.rowKind
-                && Arrays.deepEquals(fields, that.fields);
+                && Arrays.deepEquals(fields, that.fields)
+                && Arrays.equals(
+                        getTracePayloadOrNull(options), getTracePayloadOrNull(that.options));
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(tableId, rowKind);
         result = 31 * result + Arrays.deepHashCode(fields);
+        result = 31 * result + Arrays.hashCode(getTracePayloadOrNull(options));
         return result;
     }
 
     @Override
     public String toString() {
-        return "SeaTunnelRow{"
-                + "tableId="
-                + tableId
-                + ", kind="
-                + rowKind.shortString()
-                + ", fields="
-                + Arrays.toString(fields)
-                + '}';
+        boolean tracePayloadPresent =
+                options != null && options.get(TRACE_PAYLOAD_OPTION_KEY) instanceof byte[];
+        StringBuilder sb = new StringBuilder("SeaTunnelRow{");
+        sb.append("tableId=").append(tableId);
+        sb.append(", kind=").append(rowKind.shortString());
+        sb.append(", fields=").append(Arrays.toString(fields));
+        if (tracePayloadPresent) {
+            sb.append(", tracePayloadPresent=true");
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static byte[] getTracePayloadOrNull(Map<String, Object> options) {
+        if (options == null || options.isEmpty()) {
+            return null;
+        }
+        Object payload = options.get(TRACE_PAYLOAD_OPTION_KEY);
+        return payload instanceof byte[] ? (byte[]) payload : null;
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/SeaTunnelRowTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/type/SeaTunnelRowTest.java
@@ -31,6 +31,64 @@ import java.util.Map;
 public class SeaTunnelRowTest {
 
     @Test
+    void testGetOptionsOrNull() {
+        SeaTunnelRow row = new SeaTunnelRow(1);
+        Assertions.assertNull(row.getOptionsOrNull());
+        row.getOptions().put("k", "v");
+        Assertions.assertNotNull(row.getOptionsOrNull());
+        Assertions.assertEquals("v", row.getOptionsOrNull().get("k"));
+    }
+
+    @Test
+    void testToStringShowsOptionsAndTraceFlag() {
+        SeaTunnelRow row = new SeaTunnelRow(1);
+        String s1 = row.toString();
+        Assertions.assertFalse(s1.contains("tracePayloadPresent=true"));
+
+        row.getOptions().put("__st_trace_payload", new byte[] {1});
+        String s2 = row.toString();
+        Assertions.assertTrue(s2.contains("tracePayloadPresent=true"));
+    }
+
+    @Test
+    void testEqualsAndHashCodeConsiderOptions() {
+        SeaTunnelRow row1 = new SeaTunnelRow(new Object[] {1, "a"});
+        row1.setTableId("t");
+
+        SeaTunnelRow row2 = new SeaTunnelRow(new Object[] {1, "a"});
+        row2.setTableId("t");
+
+        Assertions.assertEquals(row1, row2);
+        Assertions.assertEquals(row1.hashCode(), row2.hashCode());
+
+        row2.setOptions(new HashMap<>());
+        Assertions.assertEquals(row1, row2);
+        Assertions.assertEquals(row1.hashCode(), row2.hashCode());
+
+        row2.getOptions().put("k", "v");
+        Assertions.assertEquals(row1, row2);
+        Assertions.assertEquals(row1.hashCode(), row2.hashCode());
+    }
+
+    @Test
+    void testEqualsAndHashCodeWithTracePayloadByteArray() {
+        SeaTunnelRow row1 = new SeaTunnelRow(new Object[] {1, "a"});
+        row1.setTableId("t");
+        row1.getOptions().put("__st_trace_payload", new byte[] {1, 2, 3});
+
+        SeaTunnelRow row2 = new SeaTunnelRow(new Object[] {1, "a"});
+        row2.setTableId("t");
+        row2.getOptions().put("__st_trace_payload", new byte[] {1, 2, 3});
+
+        Assertions.assertEquals(row1, row2);
+        Assertions.assertEquals(row1.hashCode(), row2.hashCode());
+
+        SeaTunnelRow row3 = new SeaTunnelRow(new Object[] {1, "a"});
+        row3.setTableId("t");
+        Assertions.assertNotEquals(row1, row3);
+    }
+
+    @Test
     void testForRowSize() {
         Map<String, Object> map = new HashMap<>();
         map.put(

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/ClientExecuteCommand.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/ClientExecuteCommand.java
@@ -243,8 +243,10 @@ public class ClientExecuteCommand implements Command<ClientCommandArgs> {
                                 "Total Write Count",
                                 jobMetricsSummary.getSinkWriteCount(),
                                 "Total Failed Count",
-                                jobMetricsSummary.getSourceReadCount()
-                                        - jobMetricsSummary.getSinkWriteCount()));
+                                Math.max(
+                                        0,
+                                        jobMetricsSummary.getSourceReadCount()
+                                                - jobMetricsSummary.getSinkWriteCount())));
             }
             closeClient();
         }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
@@ -321,34 +321,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
                                                         schemaChangeCase.getSinkQueryColumns(),
                                                         schemaChangeCase.getSchemaName(),
                                                         sinkTable))));
-        await().atMost(60000, TimeUnit.MILLISECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertIterableEquals(
-                                    querySource(
-                                            String.format(QUERY, SOURCE_DATABASE, sourceTable)
-                                                    + " where id >= 128"),
-                                    querySink(
-                                            String.format(
-                                                            QUERY,
-                                                            schemaChangeCase.getSchemaName(),
-                                                            sinkTable)
-                                                    + " where id >= 128"
-                                                    + ORDER_BY));
-
-                            Assertions.assertIterableEquals(
-                                    querySource(
-                                            String.format(
-                                                    PROJECTION_QUERY,
-                                                    SOURCE_DATABASE,
-                                                    sourceTable)),
-                                    querySink(
-                                            String.format(
-                                                            PROJECTION_QUERY,
-                                                            schemaChangeCase.getSchemaName(),
-                                                            sinkTable)
-                                                    + ORDER_BY));
-                        });
+        assertAddColumnsDataSynced(sourceTable, sinkTable);
 
         // case2 drop columns with cdc data at same time
         assertCaseByDdlName("drop_columns");
@@ -381,20 +354,36 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
 
         // case1 add columns with cdc data at same time
         sourceDatabase.setTemplateName("add_columns").createAndInitialize();
-        given().pollDelay(Duration.ofSeconds(5))
-                .await()
-                .atMost(120000, TimeUnit.MILLISECONDS)
+        waitForSinkColumnsCatchUp(sourceTable, sinkTable);
+        assertAddColumnsDataSynced(sourceTable, sinkTable);
+    }
+
+    /**
+     * Schema-change sinks can publish the new rows before the sink table metadata is fully updated.
+     * Waiting for the column list first avoids racing the add-columns data assertions.
+     */
+    private void waitForSinkColumnsCatchUp(String sourceTable, String sinkTable) {
+        await().atMost(60000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
                                         querySource(
-                                                String.format(QUERY, SOURCE_DATABASE, sourceTable)),
+                                                String.format(
+                                                        SOURCE_QUERY_COLUMNS,
+                                                        SOURCE_DATABASE,
+                                                        sourceTable)),
                                         querySink(
                                                 String.format(
-                                                                QUERY,
-                                                                schemaChangeCase.getSchemaName(),
-                                                                sinkTable)
-                                                        + ORDER_BY)));
+                                                        schemaChangeCase.getSinkQueryColumns(),
+                                                        schemaChangeCase.getSchemaName(),
+                                                        sinkTable))));
+    }
+
+    /**
+     * Validates both the new add-columns rows and the projected full-table view once schema
+     * evolution has settled on the sink side.
+     */
+    private void assertAddColumnsDataSynced(String sourceTable, String sinkTable) {
         await().atMost(60000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
@@ -99,6 +99,15 @@ public class EngineConfig {
     private HttpConfig httpConfig =
             ServerConfigOptions.MasterServerConfigOptions.HTTP.defaultValue();
 
+    private boolean stainTraceEnabled = ServerConfigOptions.STAIN_TRACE_ENABLED.defaultValue();
+    private int stainTraceSampleRate = ServerConfigOptions.STAIN_TRACE_SAMPLE_RATE.defaultValue();
+    private int stainTraceMaxTracesPerSecondPerWorker =
+            ServerConfigOptions.STAIN_TRACE_MAX_TRACES_PER_SECOND_PER_WORKER.defaultValue();
+    private int stainTraceMaxEntriesPerTrace =
+            ServerConfigOptions.STAIN_TRACE_MAX_ENTRIES_PER_TRACE.defaultValue();
+    private boolean stainTracePropagateToAllSplits =
+            ServerConfigOptions.STAIN_TRACE_PROPAGATE_TO_ALL_SPLITS.defaultValue();
+
     public void setBackupCount(int newBackupCount) {
         checkBackupCount(newBackupCount, 0);
         this.backupCount = newBackupCount;
@@ -173,5 +182,32 @@ public class EngineConfig {
     public EngineConfig setEventReportHttpHeaders(Map<String, String> eventReportHttpHeaders) {
         this.eventReportHttpHeaders = eventReportHttpHeaders;
         return this;
+    }
+
+    public void setStainTraceSampleRate(int stainTraceSampleRate) {
+        checkPositive(
+                stainTraceSampleRate, ServerConfigOptions.STAIN_TRACE_SAMPLE_RATE + " must be > 0");
+        this.stainTraceSampleRate = stainTraceSampleRate;
+    }
+
+    public void setStainTraceMaxTracesPerSecondPerWorker(
+            int stainTraceMaxTracesPerSecondPerWorker) {
+        if (stainTraceMaxTracesPerSecondPerWorker < 0) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.STAIN_TRACE_MAX_TRACES_PER_SECOND_PER_WORKER
+                            + " must be >= 0");
+        }
+        this.stainTraceMaxTracesPerSecondPerWorker = stainTraceMaxTracesPerSecondPerWorker;
+    }
+
+    public void setStainTraceMaxEntriesPerTrace(int stainTraceMaxEntriesPerTrace) {
+        checkPositive(
+                stainTraceMaxEntriesPerTrace,
+                ServerConfigOptions.STAIN_TRACE_MAX_ENTRIES_PER_TRACE + " must be > 0");
+        this.stainTraceMaxEntriesPerTrace = stainTraceMaxEntriesPerTrace;
+    }
+
+    public void setStainTracePropagateToAllSplits(boolean stainTracePropagateToAllSplits) {
+        this.stainTracePropagateToAllSplits = stainTracePropagateToAllSplits;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -223,6 +223,29 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                 engineConfig.setConnectorJarStorageConfig(parseConnectorJarStorageConfig(node));
             } else if (ServerConfigOptions.CLASSLOADER_CACHE_MODE.key().equals(name)) {
                 engineConfig.setClassloaderCacheMode(getBooleanValue(getTextContent(node)));
+            } else if (ServerConfigOptions.STAIN_TRACE_ENABLED.key().equals(name)) {
+                engineConfig.setStainTraceEnabled(getBooleanValue(getTextContent(node)));
+            } else if (ServerConfigOptions.STAIN_TRACE_SAMPLE_RATE.key().equals(name)) {
+                engineConfig.setStainTraceSampleRate(
+                        getIntegerValue(
+                                ServerConfigOptions.STAIN_TRACE_SAMPLE_RATE.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.STAIN_TRACE_MAX_TRACES_PER_SECOND_PER_WORKER
+                    .key()
+                    .equals(name)) {
+                engineConfig.setStainTraceMaxTracesPerSecondPerWorker(
+                        getIntegerValue(
+                                ServerConfigOptions.STAIN_TRACE_MAX_TRACES_PER_SECOND_PER_WORKER
+                                        .key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.STAIN_TRACE_MAX_ENTRIES_PER_TRACE.key().equals(name)) {
+                engineConfig.setStainTraceMaxEntriesPerTrace(
+                        getIntegerValue(
+                                ServerConfigOptions.STAIN_TRACE_MAX_ENTRIES_PER_TRACE.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.STAIN_TRACE_PROPAGATE_TO_ALL_SPLITS.key().equals(name)) {
+                engineConfig.setStainTracePropagateToAllSplits(
+                        getBooleanValue(getTextContent(node)));
             } else if (ServerConfigOptions.MasterServerConfigOptions.EVENT_REPORT_HTTP
                     .equalsIgnoreCase(name)) {
                 NamedNodeMap attributes = node.getAttributes();

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -33,6 +33,40 @@ public class ServerConfigOptions {
                     .withDescription(
                             "Whether to use classloader cache mode. With cache mode, all jobs share the same classloader if the jars are the same");
 
+    public static final Option<Boolean> STAIN_TRACE_ENABLED =
+            Options.key("stain-trace-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable stain trace. When enabled, the engine will sample a small number of records and report end-to-end latency breakdown as events.");
+
+    public static final Option<Integer> STAIN_TRACE_SAMPLE_RATE =
+            Options.key("stain-trace-sample-rate")
+                    .intType()
+                    .defaultValue(100000)
+                    .withDescription("Sample 1 record per N records for stain trace.");
+
+    public static final Option<Integer> STAIN_TRACE_MAX_TRACES_PER_SECOND_PER_WORKER =
+            Options.key("stain-trace-max-traces-per-second-per-worker")
+                    .intType()
+                    .defaultValue(50)
+                    .withDescription(
+                            "Maximum number of stain traces generated per second per worker. 0 means disable trace generation.");
+
+    public static final Option<Integer> STAIN_TRACE_MAX_ENTRIES_PER_TRACE =
+            Options.key("stain-trace-max-entries-per-trace")
+                    .intType()
+                    .defaultValue(32)
+                    .withDescription("Maximum stage entries recorded per stain trace payload.");
+
+    public static final Option<Boolean> STAIN_TRACE_PROPAGATE_TO_ALL_SPLITS =
+            Options.key("stain-trace-propagate-to-all-splits")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to propagate stain trace payload to all split outputs in transform (e.g. flatMap). "
+                                    + "When enabled, all derived output rows will inherit payload and append TRANSFORM_OUT stage.");
+
     /////////////////////////////////////////////////
     // The options for metrics start
     public static final Option<Boolean> TELEMETRY_METRIC_ENABLED =

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -581,9 +581,15 @@ public class CoordinatorService {
         runningJobMasterMap.clear();
 
         try {
-            executorService.awaitTermination(20, TimeUnit.SECONDS);
+            boolean terminated = executorService.awaitTermination(20, TimeUnit.SECONDS);
+            if (!terminated) {
+                logger.warning(
+                        "Coordinator service executorService did not terminate within 20 seconds.");
+            }
         } catch (InterruptedException e) {
-            throw new SeaTunnelEngineException("wait clean executor service error", e);
+            Thread.currentThread().interrupt();
+            logger.info(
+                    "Coordinator service shutdown interrupted while waiting executorService termination, continue cleanup.");
         }
 
         if (resourceManager != null) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/event/JobEventHttpReportHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/event/JobEventHttpReportHandler.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.shade.com.google.common.util.concurrent.ThreadFactor
 import org.apache.seatunnel.api.event.Event;
 import org.apache.seatunnel.api.event.EventHandler;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -38,7 +39,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
@@ -49,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 public class JobEventHttpReportHandler implements EventHandler {
     public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     public static final Duration REPORT_INTERVAL = Duration.ofSeconds(10);
+    private static final int LOCAL_EVENT_BUFFER_CAPACITY = 2000;
 
     private final String httpEndpoint;
     private final Map<String, String> httpHeaders;
@@ -57,6 +63,8 @@ public class JobEventHttpReportHandler implements EventHandler {
     private final Ringbuffer ringbuffer;
     private volatile long committedEventIndex;
     private final ScheduledExecutorService scheduledExecutorService;
+    private final Object localBufferLock = new Object();
+    private final Deque<Event> localBuffer = new ArrayDeque<>();
 
     public JobEventHttpReportHandler(String httpEndpoint, Ringbuffer ringbuffer) {
         this(httpEndpoint, REPORT_INTERVAL, ringbuffer);
@@ -102,12 +110,22 @@ public class JobEventHttpReportHandler implements EventHandler {
 
     @Override
     public void handle(Event event) {
-        CompletionStage completionStage = ringbuffer.addAsync(event, OverflowPolicy.OVERWRITE);
-        completionStage.toCompletableFuture().join();
+        addToLocalBuffer(event);
+        try {
+            CompletionStage completionStage = ringbuffer.addAsync(event, OverflowPolicy.OVERWRITE);
+            completionStage.toCompletableFuture().join();
+        } catch (HazelcastInstanceNotActiveException e) {
+            // Hazelcast is shutting down, keep event in local buffer for best-effort flush.
+            log.info("Skip writing event to ringbuffer because Hazelcast instance is not active");
+        }
     }
 
     @VisibleForTesting
     synchronized void report() throws IOException {
+        reportFromRingbuffer();
+    }
+
+    private boolean reportFromRingbuffer() throws IOException {
         long headSequence = ringbuffer.headSequence();
         if (headSequence > committedEventIndex) {
             log.warn(
@@ -121,10 +139,35 @@ public class JobEventHttpReportHandler implements EventHandler {
                         committedEventIndex, 0, RingbufferProxy.MAX_BATCH_SIZE, null);
         ReadResultSet<Event> resultSet = completionStage.toCompletableFuture().join();
         if (resultSet.size() <= 0) {
-            return;
+            return false;
         }
 
         String events = JSON_MAPPER.writeValueAsString(resultSet.iterator());
+        if (postEvents(events)) {
+            committedEventIndex += resultSet.readCount();
+            drainLocalBuffer(resultSet.readCount());
+            return true;
+        }
+        return false;
+    }
+
+    private void reportFromLocalBuffer() throws IOException {
+        List<Event> snapshot;
+        synchronized (localBufferLock) {
+            if (localBuffer.isEmpty()) {
+                return;
+            }
+            snapshot = new ArrayList<>(localBuffer);
+        }
+        String events = JSON_MAPPER.writeValueAsString(snapshot);
+        if (postEvents(events)) {
+            synchronized (localBufferLock) {
+                localBuffer.clear();
+            }
+        }
+    }
+
+    private boolean postEvents(String events) throws IOException {
         Request.Builder requestBuilder =
                 new Request.Builder()
                         .url(httpEndpoint)
@@ -133,10 +176,10 @@ public class JobEventHttpReportHandler implements EventHandler {
         Response response = httpClient.newCall(requestBuilder.build()).execute();
         try (ResponseBody closeable = response.body()) {
             if (response.isSuccessful()) {
-                committedEventIndex += resultSet.readCount();
-            } else {
-                log.error("Failed to request http server: {}", response);
+                return true;
             }
+            log.error("Failed to request http server: {}", response);
+            return false;
         }
     }
 
@@ -144,6 +187,19 @@ public class JobEventHttpReportHandler implements EventHandler {
     public void close() {
         log.info("Close http report handler");
         scheduledExecutorService.shutdown();
+        try {
+            // Flush all remaining events before closing
+            reportFromRingbuffer();
+        } catch (HazelcastInstanceNotActiveException e) {
+            // Hazelcast is shutting down, ringbuffer is not available. Flush from local buffer.
+        } catch (IOException e) {
+            log.error("Failed to flush events on close", e);
+        }
+        try {
+            reportFromLocalBuffer();
+        } catch (IOException e) {
+            log.error("Failed to flush events on close", e);
+        }
     }
 
     private OkHttpClient createHttpClient() {
@@ -151,5 +207,27 @@ public class JobEventHttpReportHandler implements EventHandler {
         client.setConnectTimeout(30, TimeUnit.SECONDS);
         client.setWriteTimeout(10, TimeUnit.SECONDS);
         return client;
+    }
+
+    private void addToLocalBuffer(Event event) {
+        synchronized (localBufferLock) {
+            while (localBuffer.size() >= LOCAL_EVENT_BUFFER_CAPACITY) {
+                localBuffer.pollFirst();
+            }
+            localBuffer.addLast(event);
+        }
+    }
+
+    private void drainLocalBuffer(int count) {
+        if (count <= 0) {
+            return;
+        }
+        synchronized (localBufferLock) {
+            int remaining = count;
+            while (remaining > 0 && !localBuffer.isEmpty()) {
+                localBuffer.pollFirst();
+                remaining--;
+            }
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetJobTaskMappingOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetJobTaskMappingOperation.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.operation;
+
+import org.apache.seatunnel.common.utils.JsonUtils;
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.serializable.ClientToServerOperationDataSerializerHook;
+import org.apache.seatunnel.engine.server.trace.TaskMappingBuilder;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+
+public class GetJobTaskMappingOperation extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
+
+    private long jobId;
+    private String response;
+
+    public GetJobTaskMappingOperation() {}
+
+    public GetJobTaskMappingOperation(long jobId) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClientToServerOperationDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ClientToServerOperationDataSerializerHook.GET_JOB_TASK_MAPPING_OPERATION;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeLong(jobId);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        jobId = in.readLong();
+    }
+
+    @Override
+    public void run() {
+        SeaTunnelServer service = getService();
+        response = JsonUtils.toJsonString(TaskMappingBuilder.build(service, jobId));
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
@@ -98,6 +98,7 @@ public class RestConstant {
     public static final String REST_URL_GET_ALL_LOG_NAME = "/get-all-log-name";
     public static final String REST_URL_METRICS = "/metrics";
     public static final String REST_URL_OPEN_METRICS = "/openmetrics";
+    public static final String REST_URL_TRACE_TASK_MAPPING = "/trace/task-mapping";
     // api path end
 
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestHttpGetCommandProcessor.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.engine.server.rest.service.OverviewService;
 import org.apache.seatunnel.engine.server.rest.service.RunningThreadService;
 import org.apache.seatunnel.engine.server.rest.service.SystemMonitoringService;
 import org.apache.seatunnel.engine.server.rest.service.ThreadDumpService;
+import org.apache.seatunnel.engine.server.rest.service.TraceTaskMappingService;
 
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
@@ -67,6 +68,7 @@ import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_RUNN
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_RUNNING_THREADS;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_SYSTEM_MONITORING_INFORMATION;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_THREAD_DUMP;
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_TRACE_TASK_MAPPING;
 
 @Slf4j
 public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand> {
@@ -79,6 +81,7 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
     private ThreadDumpService threadDumpService;
     private RunningThreadService runningThreadService;
     private LogService logService;
+    private TraceTaskMappingService traceTaskMappingService;
 
     public RestHttpGetCommandProcessor(TextCommandService textCommandService) {
 
@@ -90,6 +93,7 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
         this.threadDumpService = new ThreadDumpService(nodeEngine);
         this.runningThreadService = new RunningThreadService(nodeEngine);
         this.logService = new LogService(nodeEngine);
+        this.traceTaskMappingService = new TraceTaskMappingService(nodeEngine);
     }
 
     public RestHttpGetCommandProcessor(
@@ -106,6 +110,7 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
         this.threadDumpService = new ThreadDumpService(nodeEngine);
         this.runningThreadService = new RunningThreadService(nodeEngine);
         this.logService = new LogService(nodeEngine);
+        this.traceTaskMappingService = new TraceTaskMappingService(nodeEngine);
     }
 
     @Override
@@ -138,6 +143,8 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
                 getAllNodeLog(httpGetCommand, uri);
             } else if (uri.startsWith(CONTEXT_PATH + REST_URL_LOG)) {
                 getCurrentNodeLog(httpGetCommand, uri);
+            } else if (uri.startsWith(CONTEXT_PATH + REST_URL_TRACE_TASK_MAPPING)) {
+                handleTraceTaskMapping(httpGetCommand, uri);
             } else {
                 original.handle(httpGetCommand);
             }
@@ -218,6 +225,18 @@ public class RestHttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCom
 
     private void getRunningThread(HttpGetCommand command) {
         this.prepareResponse(command, runningThreadService.getRunningThread());
+    }
+
+    private void handleTraceTaskMapping(HttpGetCommand command, String uri) {
+        uri = StringUtil.stripTrailingSlash(uri);
+        String prefix = CONTEXT_PATH + REST_URL_TRACE_TASK_MAPPING + "/";
+        if (!uri.startsWith(prefix)) {
+            command.send400();
+            return;
+        }
+        String jobIdStr = uri.substring(prefix.length());
+        long jobId = Long.parseLong(jobIdStr);
+        this.prepareResponse(command, traceTaskMappingService.getJobTaskMappingJson(jobId));
     }
 
     private void handleMetrics(HttpGetCommand httpGetCommand, String contentType) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/TraceTaskMappingService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/TraceTaskMappingService.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.common.utils.JsonUtils;
+import org.apache.seatunnel.engine.server.operation.GetJobTaskMappingOperation;
+import org.apache.seatunnel.engine.server.trace.TaskMappingBuilder;
+import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.util.Map;
+
+public class TraceTaskMappingService extends BaseService {
+
+    public TraceTaskMappingService(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+    }
+
+    public String getJobTaskMappingJson(long jobId) {
+        if (getSeaTunnelServer(true) == null) {
+            return (String)
+                    NodeEngineUtil.sendOperationToMasterNode(
+                                    nodeEngine, new GetJobTaskMappingOperation(jobId))
+                            .join();
+        }
+        Map<String, Object> mapping = TaskMappingBuilder.build(getSeaTunnelServer(false), jobId);
+        return JsonUtils.toJsonString(mapping);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.engine.server.operation.GetJobDetailStatusOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobInfoOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobMetricsOperation;
 import org.apache.seatunnel.engine.server.operation.GetJobStatusOperation;
+import org.apache.seatunnel.engine.server.operation.GetJobTaskMappingOperation;
 import org.apache.seatunnel.engine.server.operation.GetRunningJobMetricsOperation;
 import org.apache.seatunnel.engine.server.operation.PrintMessageOperation;
 import org.apache.seatunnel.engine.server.operation.SavePointJobOperation;
@@ -67,6 +68,7 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
 
     public static final int UPLOAD_CONNECTOR_JAR_OPERATION = 11;
     public static final int GET_JOB_CHECKPOINT_OPERATION = 12;
+    public static final int GET_JOB_TASK_MAPPING_OPERATION = 13;
 
     public static final int FACTORY_ID =
             FactoryIdHelper.getFactoryId(
@@ -113,6 +115,8 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
                     return new UploadConnectorJarOperation();
                 case GET_JOB_CHECKPOINT_OPERATION:
                     return new GetJobCheckpointOperation();
+                case GET_JOB_TASK_MAPPING_OPERATION:
+                    return new GetJobTaskMappingOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/RecordSerializer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/RecordSerializer.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.table.type.RowKind;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 import org.apache.seatunnel.engine.server.checkpoint.CheckpointBarrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -31,17 +32,25 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class RecordSerializer implements StreamSerializer<Record> {
-    enum RecordDataType {
-        CHECKPOINT_BARRIER,
-        SEATUNNEL_ROW;
-    }
+    private static final byte TYPE_CHECKPOINT_BARRIER = 0;
+    /**
+     * Legacy SeaTunnelRow record type.
+     *
+     * <p>Keep this value for backward compatibility (new version must be able to read old data).
+     */
+    private static final byte TYPE_SEATUNNEL_ROW_V1 = 1;
+
+    /** SeaTunnelRow with optional stain trace payload extension. */
+    private static final byte TYPE_SEATUNNEL_ROW_V2 = 2;
+
+    private static final int MAX_TRACE_PAYLOAD_LENGTH = 8 * 1024;
 
     @Override
     public void write(ObjectDataOutput out, Record record) throws IOException {
         Object data = record.getData();
         if (data instanceof CheckpointBarrier) {
             CheckpointBarrier checkpointBarrier = (CheckpointBarrier) data;
-            out.writeByte(RecordDataType.CHECKPOINT_BARRIER.ordinal());
+            out.writeByte(TYPE_CHECKPOINT_BARRIER);
             out.writeLong(checkpointBarrier.getId());
             out.writeLong(checkpointBarrier.getTimestamp());
             out.writeString(checkpointBarrier.getCheckpointType().getName());
@@ -49,12 +58,30 @@ public class RecordSerializer implements StreamSerializer<Record> {
             out.writeObject(checkpointBarrier.getClosedTasks());
         } else if (data instanceof SeaTunnelRow) {
             SeaTunnelRow row = (SeaTunnelRow) data;
-            out.writeByte(RecordDataType.SEATUNNEL_ROW.ordinal());
+            Object payloadObj =
+                    row.getOptionsOrNull() == null
+                            ? null
+                            : row.getOptionsOrNull()
+                                    .get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+            byte[] payload = payloadObj instanceof byte[] ? (byte[]) payloadObj : null;
+            if (payload != null
+                    && (payload.length <= 0 || payload.length > MAX_TRACE_PAYLOAD_LENGTH)) {
+                payload = null;
+            }
+            if (payload == null) {
+                out.writeByte(TYPE_SEATUNNEL_ROW_V1);
+            } else {
+                out.writeByte(TYPE_SEATUNNEL_ROW_V2);
+            }
             out.writeString(row.getTableId());
             out.writeByte(row.getRowKind().toByteValue());
             out.writeByte(row.getArity());
             for (Object field : row.getFields()) {
                 out.writeObject(field);
+            }
+            if (payload != null) {
+                out.writeInt(payload.length);
+                out.write(payload);
             }
         } else {
             throw new UnsupportedEncodingException(
@@ -66,7 +93,7 @@ public class RecordSerializer implements StreamSerializer<Record> {
     public Record read(ObjectDataInput in) throws IOException {
         Object data;
         byte dataType = in.readByte();
-        if (dataType == RecordDataType.CHECKPOINT_BARRIER.ordinal()) {
+        if (dataType == TYPE_CHECKPOINT_BARRIER) {
             data =
                     new CheckpointBarrier(
                             in.readLong(),
@@ -74,7 +101,7 @@ public class RecordSerializer implements StreamSerializer<Record> {
                             CheckpointType.fromName(in.readString()),
                             in.readObject(),
                             in.readObject());
-        } else if (dataType == RecordDataType.SEATUNNEL_ROW.ordinal()) {
+        } else if (dataType == TYPE_SEATUNNEL_ROW_V1 || dataType == TYPE_SEATUNNEL_ROW_V2) {
             String tableId = in.readString();
             byte rowKind = in.readByte();
             byte arity = in.readByte();
@@ -83,6 +110,18 @@ public class RecordSerializer implements StreamSerializer<Record> {
             row.setRowKind(RowKind.fromByteValue(rowKind));
             for (int i = 0; i < arity; i++) {
                 row.setField(i, in.readObject());
+            }
+            if (dataType == TYPE_SEATUNNEL_ROW_V2) {
+                int payloadLength = in.readInt();
+                if (payloadLength < 0) {
+                    throw new IOException("Negative stain trace payload length: " + payloadLength);
+                } else if (payloadLength > MAX_TRACE_PAYLOAD_LENGTH) {
+                    in.skipBytes(payloadLength);
+                } else if (payloadLength > 0) {
+                    byte[] payload = new byte[payloadLength];
+                    in.readFully(payload);
+                    row.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, payload);
+                }
             }
             data = row;
         } else {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelSourceCollector.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelSourceCollector.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.task;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.table.catalog.TablePath;
@@ -31,9 +32,15 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.core.starter.flowcontrol.FlowControlGate;
 import org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.server.metrics.ConnectorMetricsCalcContext;
 import org.apache.seatunnel.engine.server.task.flow.OneInputFlowLifeCycle;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTracePayload;
+import org.apache.seatunnel.engine.server.trace.StainTraceSampler;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -44,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
 
 @Slf4j
 public class SeaTunnelSourceCollector<T> implements Collector<T> {
@@ -65,16 +73,52 @@ public class SeaTunnelSourceCollector<T> implements Collector<T> {
     private SeaTunnelDataType rowType;
     private FlowControlGate flowControlGate;
 
+    private final long sourceTaskId;
+    private final int stainTraceMaxEntriesPerTrace;
+    private final Counter stainTraceBudgetThrottledTotal;
+    private final Counter stainTraceSamplesGeneratedTotal;
+    private final Counter stainTraceEntriesTruncatedTotal;
+    private final StainTraceSampler stainTraceSampler;
+    private final LongSupplier currentTimeMillisSupplier;
+
     public SeaTunnelSourceCollector(
             Object checkpointLock,
             List<OneInputFlowLifeCycle<Record<?>>> outputs,
             MetricsContext metricsContext,
             FlowControlStrategy flowControlStrategy,
             SeaTunnelDataType rowType,
-            List<TablePath> tablePaths) {
+            List<TablePath> tablePaths,
+            SeaTunnelTask runningTask,
+            EngineConfig engineConfig) {
+        this(
+                checkpointLock,
+                outputs,
+                metricsContext,
+                flowControlStrategy,
+                rowType,
+                tablePaths,
+                runningTask,
+                engineConfig,
+                System::currentTimeMillis);
+    }
+
+    public SeaTunnelSourceCollector(
+            Object checkpointLock,
+            List<OneInputFlowLifeCycle<Record<?>>> outputs,
+            MetricsContext metricsContext,
+            FlowControlStrategy flowControlStrategy,
+            SeaTunnelDataType rowType,
+            List<TablePath> tablePaths,
+            SeaTunnelTask runningTask,
+            EngineConfig engineConfig,
+            LongSupplier currentTimeMillisSupplier) {
         this.checkpointLock = checkpointLock;
         this.outputs = outputs;
         this.rowType = rowType;
+        this.currentTimeMillisSupplier =
+                currentTimeMillisSupplier != null
+                        ? currentTimeMillisSupplier
+                        : System::currentTimeMillis;
         if (rowType instanceof MultipleRowType) {
             ((MultipleRowType) rowType)
                     .iterator()
@@ -87,6 +131,27 @@ public class SeaTunnelSourceCollector<T> implements Collector<T> {
                         CollectionUtils.isNotEmpty(tablePaths),
                         tablePaths);
         flowControlGate = FlowControlGate.create(flowControlStrategy);
+
+        this.sourceTaskId = runningTask.getTaskLocation().getTaskID();
+        this.stainTraceBudgetThrottledTotal =
+                metricsContext.counter(StainTraceConstants.METRIC_BUDGET_THROTTLED_TOTAL);
+        this.stainTraceSamplesGeneratedTotal =
+                metricsContext.counter(StainTraceConstants.METRIC_SAMPLES_GENERATED_TOTAL);
+        this.stainTraceEntriesTruncatedTotal =
+                metricsContext.counter(StainTraceConstants.METRIC_ENTRIES_TRUNCATED_TOTAL);
+        this.stainTraceMaxEntriesPerTrace = engineConfig.getStainTraceMaxEntriesPerTrace();
+        if (engineConfig.isStainTraceEnabled()) {
+            this.stainTraceSampler =
+                    new StainTraceSampler(
+                            true,
+                            engineConfig.getStainTraceSampleRate(),
+                            engineConfig.getStainTraceMaxTracesPerSecondPerWorker(),
+                            engineConfig.getStainTraceMaxEntriesPerTrace(),
+                            stainTraceSamplesGeneratedTotal,
+                            stainTraceBudgetThrottledTotal);
+        } else {
+            this.stainTraceSampler = null;
+        }
     }
 
     @Override
@@ -107,6 +172,7 @@ public class SeaTunnelSourceCollector<T> implements Collector<T> {
                 }
                 flowControlGate.audit((SeaTunnelRow) row);
                 connectorMetricsCalcContext.updateMetrics(row, tableId);
+                tryStainTrace((SeaTunnelRow) row);
             }
             sendRecordToNext(new Record<>(row));
             emptyThisPollNext = false;
@@ -194,5 +260,34 @@ public class SeaTunnelSourceCollector<T> implements Collector<T> {
                 output.received(record);
             }
         }
+    }
+
+    private void tryStainTrace(SeaTunnelRow row) {
+        if (stainTraceSampler == null) {
+            return;
+        }
+        if (StainTraceUtils.hasPayload(row)) {
+            return;
+        }
+        long nowMs = currentTimeMillisSupplier.getAsLong();
+        long traceId = stainTraceSampler.tryGenerateTraceId(sourceTaskId, nowMs);
+        if (traceId == StainTraceConstants.NO_TRACE_ID) {
+            return;
+        }
+        byte[] payload = StainTracePayload.init(traceId, nowMs);
+        StainTracePayload.AppendResult result =
+                StainTracePayload.append(
+                        payload,
+                        StainTraceStage.SOURCE_EMIT,
+                        sourceTaskId,
+                        nowMs,
+                        stainTraceMaxEntriesPerTrace);
+        if (result.getStatus() == StainTracePayload.AppendStatus.TRUNCATED) {
+            stainTraceEntriesTruncatedTotal.inc();
+        }
+        if (result.getStatus() == StainTracePayload.AppendStatus.APPENDED) {
+            payload = result.getPayload();
+        }
+        StainTraceUtils.setPayload(row, payload);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.dag.actions.SourceAction;
 import org.apache.seatunnel.engine.server.dag.physical.config.SourceConfig;
@@ -94,6 +95,11 @@ public class SourceSeaTunnelTask<T, SplitT extends SourceSplit> extends SeaTunne
                 // TODO remove it when all connector use `getProducedCatalogTables`
                 sourceProducedType = sourceFlow.getAction().getSource().getProducedType();
             }
+            EngineConfig engineConfig =
+                    getExecutionContext()
+                            .getTaskExecutionService()
+                            .getSeaTunnelConfig()
+                            .getEngineConfig();
             this.collector =
                     new SeaTunnelSourceCollector<>(
                             checkpointLock,
@@ -101,7 +107,9 @@ public class SourceSeaTunnelTask<T, SplitT extends SourceSplit> extends SeaTunne
                             this.getMetricsContext(),
                             FlowControlStrategy.fromMap(envOption),
                             sourceProducedType,
-                            tablePaths);
+                            tablePaths,
+                            this,
+                            engineConfig);
             ((SourceFlowLifeCycle<T, SplitT>) startFlowLifeCycle).setCollector(collector);
         }
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/IntermediateQueueFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/IntermediateQueueFlowLifeCycle.java
@@ -17,11 +17,13 @@
 
 package org.apache.seatunnel.engine.server.task.flow;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.table.type.Record;
 import org.apache.seatunnel.api.transform.Collector;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
 import org.apache.seatunnel.engine.server.task.group.queue.AbstractIntermediateQueue;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
 
 import java.io.IOException;
 
@@ -30,6 +32,9 @@ public class IntermediateQueueFlowLifeCycle<T extends AbstractIntermediateQueue<
         implements OneInputFlowLifeCycle<Record<?>>, OneOutputFlowLifeCycle<Record<?>> {
 
     private final AbstractIntermediateQueue<?> queue;
+
+    private volatile Counter stainTraceEntriesTruncatedTotal;
+    private volatile int stainTraceMaxEntriesPerTrace = -1;
 
     public IntermediateQueueFlowLifeCycle(
             SeaTunnelTask runningTask,
@@ -55,5 +60,36 @@ public class IntermediateQueueFlowLifeCycle<T extends AbstractIntermediateQueue<
     public void close() throws IOException {
         queue.close();
         super.close();
+    }
+
+    public Counter getStainTraceEntriesTruncatedTotal() {
+        if (stainTraceEntriesTruncatedTotal == null) {
+            synchronized (this) {
+                if (stainTraceEntriesTruncatedTotal == null) {
+                    stainTraceEntriesTruncatedTotal =
+                            runningTask
+                                    .getMetricsContext()
+                                    .counter(StainTraceConstants.METRIC_ENTRIES_TRUNCATED_TOTAL);
+                }
+            }
+        }
+        return stainTraceEntriesTruncatedTotal;
+    }
+
+    public int getStainTraceMaxEntriesPerTrace() {
+        if (stainTraceMaxEntriesPerTrace < 0) {
+            synchronized (this) {
+                if (stainTraceMaxEntriesPerTrace < 0) {
+                    stainTraceMaxEntriesPerTrace =
+                            runningTask
+                                    .getExecutionContext()
+                                    .getTaskExecutionService()
+                                    .getSeaTunnelConfig()
+                                    .getEngineConfig()
+                                    .getStainTraceMaxEntriesPerTrace();
+                }
+            }
+        }
+        return stainTraceMaxEntriesPerTrace;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -17,8 +17,10 @@
 
 package org.apache.seatunnel.engine.server.task.flow;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.event.StainTraceEvent;
 import org.apache.seatunnel.api.serialization.Serializer;
 import org.apache.seatunnel.api.sink.SinkCommitter;
 import org.apache.seatunnel.api.sink.SinkWriter;
@@ -47,6 +49,10 @@ import org.apache.seatunnel.engine.server.task.operation.checkpoint.BarrierFlowO
 import org.apache.seatunnel.engine.server.task.operation.sink.SinkPrepareCommitOperation;
 import org.apache.seatunnel.engine.server.task.operation.sink.SinkRegisterOperation;
 import org.apache.seatunnel.engine.server.task.record.Barrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTracePayload;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import com.hazelcast.cluster.Address;
 import lombok.extern.slf4j.Slf4j;
@@ -102,6 +108,11 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
     /** Mapping relationship between upstream TablePath and downstream TablePath. */
     private final Map<TablePath, TablePath> tablesMaps = new HashMap<>();
 
+    private final Counter stainTraceEventsReportedTotal;
+    private final Counter stainTraceInvalidPayloadTotal;
+    private volatile Counter stainTraceEntriesTruncatedTotal;
+    private volatile int stainTraceMaxEntriesPerTrace = -1;
+
     public SinkFlowLifeCycle(
             SinkAction<T, StateT, CommitInfoT, AggregatedCommitInfoT> sinkAction,
             TaskLocation taskLocation,
@@ -119,6 +130,8 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         this.containAggCommitter = containAggCommitter;
         this.metricsContext = metricsContext;
         this.eventListener = new JobEventListener(taskLocation, runningTask.getExecutionContext());
+        this.stainTraceEventsReportedTotal =
+                metricsContext.counter(StainTraceConstants.METRIC_EVENTS_REPORTED_TOTAL);
         List<TablePath> sinkTables = new ArrayList<>();
         boolean isMulti = sinkAction.getSink() instanceof MultiTableSink;
         if (isMulti) {
@@ -142,6 +155,8 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         this.connectorMetricsCalcContext =
                 new ConnectorMetricsCalcContext(
                         metricsContext, PluginType.SINK, isMulti, sinkTables);
+        this.stainTraceInvalidPayloadTotal =
+                metricsContext.counter(StainTraceConstants.METRIC_INVALID_PAYLOAD_TOTAL);
     }
 
     @Override
@@ -269,17 +284,13 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
                 String tableId;
                 writer.write((T) record.getData());
                 if (record.getData() instanceof SeaTunnelRow) {
+                    SeaTunnelRow row = (SeaTunnelRow) record.getData();
                     if (this.sinkAction.getSink() instanceof MultiTableSink) {
-                        if (((SeaTunnelRow) record.getData()).getTableId() == null
-                                || ((SeaTunnelRow) record.getData()).getTableId().isEmpty()) {
-                            tableId = ((SeaTunnelRow) record.getData()).getTableId();
+                        if (row.getTableId() == null || row.getTableId().isEmpty()) {
+                            tableId = row.getTableId();
                         } else {
 
-                            TablePath tablePath =
-                                    tablesMaps.get(
-                                            TablePath.of(
-                                                    ((SeaTunnelRow) record.getData())
-                                                            .getTableId()));
+                            TablePath tablePath = tablesMaps.get(TablePath.of(row.getTableId()));
                             tableId =
                                     tablePath != null
                                             ? tablePath.getFullName()
@@ -298,6 +309,32 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
                     }
 
                     connectorMetricsCalcContext.updateMetrics(record.getData(), tableId);
+
+                    if (StainTraceUtils.hasPayload(row)) {
+                        long nowMs = System.currentTimeMillis();
+                        StainTraceUtils.appendIfPresent(
+                                row,
+                                StainTraceStage.SINK_WRITE_DONE,
+                                runningTask.getTaskID(),
+                                nowMs,
+                                getStainTraceMaxEntriesPerTrace(),
+                                getStainTraceEntriesTruncatedTotal());
+                        byte[] payload = StainTraceUtils.getPayloadOrNull(row);
+                        if (payload != null) {
+                            try {
+                                long traceId = StainTracePayload.readTraceId(payload);
+                                eventListener.onEvent(
+                                        new StainTraceEvent(
+                                                traceId,
+                                                payload,
+                                                taskLocation.getTaskID(),
+                                                tableId));
+                                stainTraceEventsReportedTotal.inc();
+                            } catch (Exception ignore) {
+                                stainTraceInvalidPayloadTotal.inc();
+                            }
+                        }
+                    }
                 }
             }
         } catch (Exception e) {
@@ -347,5 +384,36 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         } else {
             this.writer = sinkAction.getSink().restoreWriter(writerContext, states);
         }
+    }
+
+    private Counter getStainTraceEntriesTruncatedTotal() {
+        if (stainTraceEntriesTruncatedTotal == null) {
+            synchronized (this) {
+                if (stainTraceEntriesTruncatedTotal == null) {
+                    stainTraceEntriesTruncatedTotal =
+                            runningTask
+                                    .getMetricsContext()
+                                    .counter(StainTraceConstants.METRIC_ENTRIES_TRUNCATED_TOTAL);
+                }
+            }
+        }
+        return stainTraceEntriesTruncatedTotal;
+    }
+
+    private int getStainTraceMaxEntriesPerTrace() {
+        if (stainTraceMaxEntriesPerTrace < 0) {
+            synchronized (this) {
+                if (stainTraceMaxEntriesPerTrace < 0) {
+                    stainTraceMaxEntriesPerTrace =
+                            runningTask
+                                    .getExecutionContext()
+                                    .getTaskExecutionService()
+                                    .getSeaTunnelConfig()
+                                    .getEngineConfig()
+                                    .getStainTraceMaxEntriesPerTrace();
+                }
+            }
+        }
+        return stainTraceMaxEntriesPerTrace;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycle.java
@@ -17,8 +17,10 @@
 
 package org.apache.seatunnel.engine.server.task.flow;
 
+import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.Collector;
 import org.apache.seatunnel.api.transform.SeaTunnelFlatMapTransform;
 import org.apache.seatunnel.api.transform.SeaTunnelMapTransform;
@@ -30,6 +32,9 @@ import org.apache.seatunnel.engine.server.checkpoint.ActionSubtaskState;
 import org.apache.seatunnel.engine.server.checkpoint.CheckpointBarrier;
 import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
 import org.apache.seatunnel.engine.server.task.record.Barrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -49,6 +54,10 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
     private final List<SeaTunnelTransform<T>> transform;
 
     private final Collector<Record<?>> collector;
+
+    private volatile int stainTraceMaxEntriesPerTrace = -1;
+    private volatile Counter stainTraceEntriesTruncatedTotal;
+    private volatile Boolean stainTracePropagateToAllSplits;
 
     public TransformFlowLifeCycle(
             TransformChainAction<T> action,
@@ -119,10 +128,60 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
                 return;
             }
             T inputData = (T) record.getData();
+            boolean hasTracePayload =
+                    inputData instanceof SeaTunnelRow
+                            && StainTraceUtils.hasPayload((SeaTunnelRow) inputData);
+            if (hasTracePayload) {
+                SeaTunnelRow inputRow = (SeaTunnelRow) inputData;
+                StainTraceUtils.appendIfPresent(
+                        inputRow,
+                        StainTraceStage.TRANSFORM_IN,
+                        runningTask.getTaskID(),
+                        System.currentTimeMillis(),
+                        getStainTraceMaxEntriesPerTrace(),
+                        getStainTraceEntriesTruncatedTotal());
+            }
             List<T> outputDataList = transform(inputData);
             if (!outputDataList.isEmpty()) {
                 // todo log metrics
+                byte[] inheritedPayload = null;
+                if (hasTracePayload) {
+                    inheritedPayload = StainTraceUtils.getPayloadOrNull((SeaTunnelRow) inputData);
+                }
+                boolean propagateToAllSplits =
+                        hasTracePayload
+                                && inheritedPayload != null
+                                && outputDataList.size() > 1
+                                && isStainTracePropagateToAllSplits();
+                boolean payloadInherited = false;
                 for (T outputData : outputDataList) {
+                    if (hasTracePayload && outputData instanceof SeaTunnelRow) {
+                        SeaTunnelRow outputRow = (SeaTunnelRow) outputData;
+                        if (inheritedPayload == null) {
+                            StainTraceUtils.removePayload(outputRow);
+                        } else if (propagateToAllSplits) {
+                            StainTraceUtils.setPayload(outputRow, inheritedPayload);
+                            StainTraceUtils.appendIfPresent(
+                                    outputRow,
+                                    StainTraceStage.TRANSFORM_OUT,
+                                    runningTask.getTaskID(),
+                                    System.currentTimeMillis(),
+                                    getStainTraceMaxEntriesPerTrace(),
+                                    getStainTraceEntriesTruncatedTotal());
+                        } else if (!payloadInherited) {
+                            StainTraceUtils.setPayload(outputRow, inheritedPayload);
+                            StainTraceUtils.appendIfPresent(
+                                    outputRow,
+                                    StainTraceStage.TRANSFORM_OUT,
+                                    runningTask.getTaskID(),
+                                    System.currentTimeMillis(),
+                                    getStainTraceMaxEntriesPerTrace(),
+                                    getStainTraceEntriesTruncatedTotal());
+                            payloadInherited = true;
+                        } else {
+                            StainTraceUtils.removePayload(outputRow);
+                        }
+                    }
                     collector.collect(new Record<>(outputData));
                 }
             }
@@ -196,5 +255,53 @@ public class TransformFlowLifeCycle<T> extends ActionFlowLifeCycle
             }
         }
         super.close();
+    }
+
+    private Counter getStainTraceEntriesTruncatedTotal() {
+        if (stainTraceEntriesTruncatedTotal == null) {
+            synchronized (this) {
+                if (stainTraceEntriesTruncatedTotal == null) {
+                    stainTraceEntriesTruncatedTotal =
+                            runningTask
+                                    .getMetricsContext()
+                                    .counter(StainTraceConstants.METRIC_ENTRIES_TRUNCATED_TOTAL);
+                }
+            }
+        }
+        return stainTraceEntriesTruncatedTotal;
+    }
+
+    private int getStainTraceMaxEntriesPerTrace() {
+        if (stainTraceMaxEntriesPerTrace < 0) {
+            synchronized (this) {
+                if (stainTraceMaxEntriesPerTrace < 0) {
+                    stainTraceMaxEntriesPerTrace =
+                            runningTask
+                                    .getExecutionContext()
+                                    .getTaskExecutionService()
+                                    .getSeaTunnelConfig()
+                                    .getEngineConfig()
+                                    .getStainTraceMaxEntriesPerTrace();
+                }
+            }
+        }
+        return stainTraceMaxEntriesPerTrace;
+    }
+
+    private boolean isStainTracePropagateToAllSplits() {
+        if (stainTracePropagateToAllSplits == null) {
+            synchronized (this) {
+                if (stainTracePropagateToAllSplits == null) {
+                    stainTracePropagateToAllSplits =
+                            runningTask
+                                    .getExecutionContext()
+                                    .getTaskExecutionService()
+                                    .getSeaTunnelConfig()
+                                    .getEngineConfig()
+                                    .isStainTracePropagateToAllSplits();
+                }
+            }
+        }
+        return stainTracePropagateToAllSplits;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueue.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueue.java
@@ -19,10 +19,14 @@ package org.apache.seatunnel.engine.server.task.group.queue;
 
 import org.apache.seatunnel.api.common.metrics.Counter;
 import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.Collector;
 import org.apache.seatunnel.common.utils.function.ConsumerWithException;
 import org.apache.seatunnel.engine.server.checkpoint.CheckpointBarrier;
 import org.apache.seatunnel.engine.server.task.record.Barrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
@@ -31,6 +35,8 @@ import java.util.concurrent.TimeUnit;
 public class IntermediateBlockingQueue extends AbstractIntermediateQueue<BlockingQueue<Record<?>>> {
 
     private final Counter intermediateQueueSize;
+    private volatile Counter stainTraceEntriesTruncatedTotal;
+    private volatile int stainTraceMaxEntriesPerTrace = -1;
 
     public IntermediateBlockingQueue(
             BlockingQueue<Record<?>> queue, Counter intermediateQueueSize) {
@@ -41,7 +47,7 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
     @Override
     public void received(Record<?> record) {
         try {
-            handleRecord(record, getIntermediateQueue()::put);
+            handleRecord(record, getIntermediateQueue()::put, StainTraceStage.QUEUE_IN);
             intermediateQueueSize.inc();
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -53,7 +59,7 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
         while (true) {
             Record<?> record = getIntermediateQueue().poll(100, TimeUnit.MILLISECONDS);
             if (record != null) {
-                handleRecord(record, collector::collect);
+                handleRecord(record, collector::collect, StainTraceStage.QUEUE_OUT);
                 intermediateQueueSize.dec();
             } else {
                 break;
@@ -68,6 +74,12 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
 
     private void handleRecord(Record<?> record, ConsumerWithException<Record<?>> consumer)
             throws Exception {
+        handleRecord(record, consumer, null);
+    }
+
+    private void handleRecord(
+            Record<?> record, ConsumerWithException<Record<?>> consumer, StainTraceStage stage)
+            throws Exception {
         if (record.getData() instanceof Barrier) {
             CheckpointBarrier barrier = (CheckpointBarrier) record.getData();
             getRunningTask().ack(barrier);
@@ -79,7 +91,47 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
             if (getIntermediateQueueFlowLifeCycle().getPrepareClose()) {
                 return;
             }
+            if (stage != null && record.getData() instanceof SeaTunnelRow) {
+                StainTraceUtils.appendIfPresent(
+                        (SeaTunnelRow) record.getData(),
+                        stage,
+                        getRunningTask().getTaskID(),
+                        System.currentTimeMillis(),
+                        getStainTraceMaxEntriesPerTrace(),
+                        getStainTraceEntriesTruncatedTotal());
+            }
             consumer.accept(record);
         }
+    }
+
+    private Counter getStainTraceEntriesTruncatedTotal() {
+        if (stainTraceEntriesTruncatedTotal == null) {
+            synchronized (this) {
+                if (stainTraceEntriesTruncatedTotal == null) {
+                    stainTraceEntriesTruncatedTotal =
+                            getRunningTask()
+                                    .getMetricsContext()
+                                    .counter(StainTraceConstants.METRIC_ENTRIES_TRUNCATED_TOTAL);
+                }
+            }
+        }
+        return stainTraceEntriesTruncatedTotal;
+    }
+
+    private int getStainTraceMaxEntriesPerTrace() {
+        if (stainTraceMaxEntriesPerTrace < 0) {
+            synchronized (this) {
+                if (stainTraceMaxEntriesPerTrace < 0) {
+                    stainTraceMaxEntriesPerTrace =
+                            getRunningTask()
+                                    .getExecutionContext()
+                                    .getTaskExecutionService()
+                                    .getSeaTunnelConfig()
+                                    .getEngineConfig()
+                                    .getStainTraceMaxEntriesPerTrace();
+                }
+            }
+        }
+        return stainTraceMaxEntriesPerTrace;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/disruptor/RecordEventHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/disruptor/RecordEventHandler.java
@@ -18,11 +18,14 @@
 package org.apache.seatunnel.engine.server.task.group.queue.disruptor;
 
 import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.transform.Collector;
 import org.apache.seatunnel.engine.server.checkpoint.CheckpointBarrier;
 import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
 import org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle;
 import org.apache.seatunnel.engine.server.task.record.Barrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import com.lmax.disruptor.EventHandler;
 
@@ -60,6 +63,18 @@ public class RecordEventHandler implements EventHandler<RecordEvent> {
             } else {
                 if (this.intermediateQueueFlowLifeCycle.getPrepareClose()) {
                     return;
+                }
+            }
+            if (record.getData() instanceof SeaTunnelRow) {
+                SeaTunnelRow row = (SeaTunnelRow) record.getData();
+                if (StainTraceUtils.hasPayload(row)) {
+                    StainTraceUtils.appendIfPresent(
+                            row,
+                            StainTraceStage.QUEUE_OUT,
+                            runningTask.getTaskID(),
+                            System.currentTimeMillis(),
+                            intermediateQueueFlowLifeCycle.getStainTraceMaxEntriesPerTrace(),
+                            intermediateQueueFlowLifeCycle.getStainTraceEntriesTruncatedTotal());
                 }
             }
             collector.collect(record);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/disruptor/RecordEventProducer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/disruptor/RecordEventProducer.java
@@ -18,9 +18,12 @@
 package org.apache.seatunnel.engine.server.task.group.queue.disruptor;
 
 import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.engine.server.checkpoint.CheckpointBarrier;
 import org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle;
 import org.apache.seatunnel.engine.server.task.record.Barrier;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+import org.apache.seatunnel.engine.server.trace.StainTraceUtils;
 
 import com.lmax.disruptor.RingBuffer;
 
@@ -48,6 +51,18 @@ public class RecordEventProducer {
         try {
             RecordEvent recordEvent = ringBuffer.get(sequence);
             recordEvent.setRecord(record);
+            if (record.getData() instanceof SeaTunnelRow) {
+                SeaTunnelRow row = (SeaTunnelRow) record.getData();
+                if (StainTraceUtils.hasPayload(row)) {
+                    StainTraceUtils.appendIfPresent(
+                            row,
+                            StainTraceStage.QUEUE_IN,
+                            intermediateQueueFlowLifeCycle.getRunningTask().getTaskID(),
+                            System.currentTimeMillis(),
+                            intermediateQueueFlowLifeCycle.getStainTraceMaxEntriesPerTrace(),
+                            intermediateQueueFlowLifeCycle.getStainTraceEntriesTruncatedTotal());
+                }
+            }
         } finally {
             ringBuffer.publish(sequence);
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/log/TaskLogManagerService.java
@@ -36,6 +36,11 @@ public class TaskLogManagerService {
     public void initClean() {
         try {
             path = LogUtil.getLogPath();
+        } catch (IllegalArgumentException e) {
+            // log4j appender 未配置时（例如本地示例/自定义日志配置），避免打印堆栈污染日志
+            log.debug(
+                    "The corresponding log file path is not properly configured, please check the log configuration file. {}",
+                    e.getMessage());
         } catch (Exception e) {
             log.debug(
                     "The corresponding log file path is not properly configured, please check the log configuration file.",

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceBudget.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceBudget.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class StainTraceBudget {
+    private final AtomicLong second = new AtomicLong(-1L);
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    public boolean tryAcquire(int maxPerSecond, long nowMs) {
+        if (maxPerSecond <= 0) {
+            return false;
+        }
+        long nowSecond = nowMs / 1000L;
+        long prev = second.get();
+        if (prev != nowSecond && second.compareAndSet(prev, nowSecond)) {
+            count.set(0);
+        }
+        while (true) {
+            int cur = count.get();
+            if (cur >= maxPerSecond) {
+                return false;
+            }
+            if (count.compareAndSet(cur, cur + 1)) {
+                return true;
+            }
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceConstants.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+public final class StainTraceConstants {
+    private StainTraceConstants() {}
+
+    public static final long NO_TRACE_ID = -1L;
+
+    public static final String TRACE_PAYLOAD_OPTION_KEY = "__st_trace_payload";
+
+    public static final String METRIC_SAMPLES_GENERATED_TOTAL =
+            "stain_trace_samples_generated_total";
+    public static final String METRIC_EVENTS_REPORTED_TOTAL = "stain_trace_events_reported_total";
+    public static final String METRIC_BUDGET_THROTTLED_TOTAL = "stain_trace_budget_throttled_total";
+    public static final String METRIC_ENTRIES_TRUNCATED_TOTAL =
+            "stain_trace_entries_truncated_total";
+    public static final String METRIC_INVALID_PAYLOAD_TOTAL = "stain_trace_invalid_payload_total";
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTracePayload.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTracePayload.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+public final class StainTracePayload {
+    private StainTracePayload() {}
+
+    public static final int MAGIC = 0x53545452; // 'STTR'
+    public static final short VERSION = 1;
+    public static final int HEADER_LENGTH = 4 + 2 + 8 + 8 + 2;
+    public static final int ENTRY_LENGTH = 1 + 8 + 8;
+
+    private static final int TRACE_ID_OFFSET = 4 + 2;
+    private static final int START_TS_OFFSET = TRACE_ID_OFFSET + 8;
+    private static final int COUNT_OFFSET = START_TS_OFFSET + 8;
+
+    public static byte[] init(long traceId, long startTsMs) {
+        ByteBuffer buffer = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
+        buffer.putInt(MAGIC);
+        buffer.putShort(VERSION);
+        buffer.putLong(traceId);
+        buffer.putLong(startTsMs);
+        buffer.putShort((short) 0);
+        return buffer.array();
+    }
+
+    public static long readTraceId(byte[] payload) {
+        if (!isValid(payload)) {
+            throw new IllegalArgumentException("Invalid stain trace payload");
+        }
+        return ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN).getLong(TRACE_ID_OFFSET);
+    }
+
+    public static boolean isValid(byte[] payload) {
+        if (payload == null || payload.length < HEADER_LENGTH) {
+            return false;
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN);
+        int magic = buffer.getInt(0);
+        if (magic != MAGIC) {
+            return false;
+        }
+        short ver = buffer.getShort(4);
+        if (ver != VERSION) {
+            return false;
+        }
+        int count = readUnsignedShort(payload, COUNT_OFFSET);
+        long expected = (long) HEADER_LENGTH + (long) count * ENTRY_LENGTH;
+        return expected == payload.length;
+    }
+
+    public static AppendResult append(
+            byte[] payload, StainTraceStage stage, long taskId, long tsMs, int maxEntries) {
+        if (!isValid(payload)) {
+            return AppendResult.invalid(payload);
+        }
+        int count = readUnsignedShort(payload, COUNT_OFFSET);
+        if (count >= maxEntries) {
+            return AppendResult.truncated(payload);
+        }
+        byte[] newPayload = Arrays.copyOf(payload, payload.length + ENTRY_LENGTH);
+        ByteBuffer buffer = ByteBuffer.wrap(newPayload).order(ByteOrder.BIG_ENDIAN);
+        buffer.position(payload.length);
+        buffer.put(stage.getCode());
+        buffer.putLong(taskId);
+        buffer.putLong(tsMs);
+        writeUnsignedShort(newPayload, COUNT_OFFSET, count + 1);
+        return AppendResult.appended(newPayload);
+    }
+
+    private static int readUnsignedShort(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF);
+    }
+
+    private static void writeUnsignedShort(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) ((value >>> 8) & 0xFF);
+        bytes[offset + 1] = (byte) (value & 0xFF);
+    }
+
+    public enum AppendStatus {
+        APPENDED,
+        TRUNCATED,
+        INVALID
+    }
+
+    public static final class AppendResult {
+        private final byte[] payload;
+        private final AppendStatus status;
+
+        private AppendResult(byte[] payload, AppendStatus status) {
+            this.payload = payload;
+            this.status = status;
+        }
+
+        public static AppendResult appended(byte[] payload) {
+            return new AppendResult(payload, AppendStatus.APPENDED);
+        }
+
+        public static AppendResult truncated(byte[] payload) {
+            return new AppendResult(payload, AppendStatus.TRUNCATED);
+        }
+
+        public static AppendResult invalid(byte[] payload) {
+            return new AppendResult(payload, AppendStatus.INVALID);
+        }
+
+        public byte[] getPayload() {
+            return payload;
+        }
+
+        public AppendStatus getStatus() {
+            return status;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceSampler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceSampler.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.api.common.metrics.Counter;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class StainTraceSampler {
+    private static final StainTraceBudget WORKER_BUDGET = new StainTraceBudget();
+
+    private final boolean enabled;
+    private final int sampleRate;
+    private final int maxTracesPerSecondPerWorker;
+    private final int maxEntriesPerTrace;
+
+    private final AtomicLong sequence = new AtomicLong(0);
+
+    private final Counter samplesGeneratedTotal;
+    private final Counter budgetThrottledTotal;
+
+    public StainTraceSampler(
+            boolean enabled,
+            int sampleRate,
+            int maxTracesPerSecondPerWorker,
+            int maxEntriesPerTrace,
+            Counter samplesGeneratedTotal,
+            Counter budgetThrottledTotal) {
+        this.enabled = enabled;
+        this.sampleRate = sampleRate;
+        this.maxTracesPerSecondPerWorker = maxTracesPerSecondPerWorker;
+        this.maxEntriesPerTrace = maxEntriesPerTrace;
+        this.samplesGeneratedTotal = samplesGeneratedTotal;
+        this.budgetThrottledTotal = budgetThrottledTotal;
+    }
+
+    public int getMaxEntriesPerTrace() {
+        return maxEntriesPerTrace;
+    }
+
+    public long tryGenerateTraceId(long taskId, long nowMs) {
+        if (!enabled) {
+            return StainTraceConstants.NO_TRACE_ID;
+        }
+        if (sampleRate <= 0) {
+            return StainTraceConstants.NO_TRACE_ID;
+        }
+        long seq = sequence.incrementAndGet();
+        if (seq % sampleRate != 0) {
+            return StainTraceConstants.NO_TRACE_ID;
+        }
+        if (!WORKER_BUDGET.tryAcquire(maxTracesPerSecondPerWorker, nowMs)) {
+            if (budgetThrottledTotal != null) {
+                budgetThrottledTotal.inc();
+            }
+            return StainTraceConstants.NO_TRACE_ID;
+        }
+        if (samplesGeneratedTotal != null) {
+            samplesGeneratedTotal.inc();
+        }
+        return mixTraceId(taskId, seq, nowMs);
+    }
+
+    private long mixTraceId(long taskId, long seq, long nowMs) {
+        long x = taskId * 0x9E3779B97F4A7C15L;
+        x ^= seq * 0xC2B2AE3D27D4EB4FL;
+        x ^= nowMs;
+        x ^= (x >>> 33);
+        x *= 0xFF51AFD7ED558CCDL;
+        x ^= (x >>> 33);
+        return x & Long.MAX_VALUE;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceStage.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceStage.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+public enum StainTraceStage {
+    SOURCE_EMIT((byte) 1),
+    QUEUE_IN((byte) 2),
+    QUEUE_OUT((byte) 3),
+    TRANSFORM_IN((byte) 4),
+    TRANSFORM_OUT((byte) 5),
+    SINK_WRITE_DONE((byte) 6);
+
+    private final byte code;
+
+    StainTraceStage(byte code) {
+        this.code = code;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceUtils.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/StainTraceUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.api.common.metrics.Counter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class StainTraceUtils {
+    private StainTraceUtils() {}
+
+    public static byte[] getPayloadOrNull(SeaTunnelRow row) {
+        if (row == null) {
+            return null;
+        }
+        Map<String, Object> options = row.getOptionsOrNull();
+        if (options == null) {
+            return null;
+        }
+        Object payload = options.get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+        return payload instanceof byte[] ? (byte[]) payload : null;
+    }
+
+    public static boolean hasPayload(SeaTunnelRow row) {
+        return getPayloadOrNull(row) != null;
+    }
+
+    public static void setPayload(SeaTunnelRow row, byte[] payload) {
+        ensureMutableOptions(row).put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, payload);
+    }
+
+    public static void removePayload(SeaTunnelRow row) {
+        Map<String, Object> options = row.getOptionsOrNull();
+        if (options == null) {
+            return;
+        }
+        if (!options.containsKey(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY)) {
+            return;
+        }
+        ensureMutableOptions(row).remove(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+    }
+
+    public static void appendIfPresent(
+            SeaTunnelRow row,
+            StainTraceStage stage,
+            long taskId,
+            long tsMs,
+            int maxEntries,
+            Counter entriesTruncatedTotal) {
+        Map<String, Object> options = row.getOptionsOrNull();
+        if (options == null) {
+            return;
+        }
+        Object payloadObj = options.get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+        if (!(payloadObj instanceof byte[])) {
+            return;
+        }
+        byte[] payload = (byte[]) payloadObj;
+        StainTracePayload.AppendResult result =
+                StainTracePayload.append(payload, stage, taskId, tsMs, maxEntries);
+        if (result.getStatus() == StainTracePayload.AppendStatus.TRUNCATED) {
+            if (entriesTruncatedTotal != null) {
+                entriesTruncatedTotal.inc();
+            }
+            return;
+        }
+        if (result.getStatus() == StainTracePayload.AppendStatus.INVALID) {
+            return;
+        }
+        if (result.getPayload() != payload) {
+            ensureMutableOptions(row)
+                    .put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, result.getPayload());
+        }
+    }
+
+    private static Map<String, Object> ensureMutableOptions(SeaTunnelRow row) {
+        Map<String, Object> options = row.getOptionsOrNull();
+        if (options == null) {
+            return row.getOptions();
+        }
+        if (options instanceof HashMap) {
+            return options;
+        }
+        Map<String, Object> copied = new HashMap<>(options);
+        row.setOptions(copied);
+        return copied;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/TaskMappingBuilder.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/trace/TaskMappingBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex;
+import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
+import org.apache.seatunnel.engine.server.execution.Task;
+import org.apache.seatunnel.engine.server.execution.TaskGroup;
+import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.master.JobMaster;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+
+import com.hazelcast.map.IMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class TaskMappingBuilder {
+    private TaskMappingBuilder() {}
+
+    public static Map<String, Object> build(SeaTunnelServer server, long jobId) {
+        Map<String, Object> root = new HashMap<>();
+        root.put("jobId", String.valueOf(jobId));
+        root.put("generatedAt", System.currentTimeMillis());
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        root.put("items", items);
+
+        JobMaster jobMaster = server.getCoordinatorService().getJobMaster(jobId);
+        if (jobMaster == null) {
+            return root;
+        }
+
+        PhysicalPlan plan = jobMaster.getPhysicalPlan();
+        if (plan == null) {
+            return root;
+        }
+
+        IMap ownedSlotProfilesIMap =
+                server.getNodeEngine()
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_OWNED_SLOT_PROFILES);
+
+        for (SubPlan subPlan : plan.getPipelineList()) {
+            appendVertices(items, ownedSlotProfilesIMap, subPlan.getPhysicalVertexList());
+            appendVertices(items, ownedSlotProfilesIMap, subPlan.getCoordinatorVertexList());
+        }
+        return root;
+    }
+
+    private static void appendVertices(
+            List<Map<String, Object>> items,
+            IMap ownedSlotProfilesIMap,
+            List<PhysicalVertex> vertices) {
+        for (PhysicalVertex v : vertices) {
+            TaskGroup taskGroup = v.getTaskGroup();
+            TaskGroupLocation location = taskGroup.getTaskGroupLocation();
+            SlotProfile slotProfile = getSlotProfile(ownedSlotProfilesIMap, location);
+            String worker = slotProfile == null ? null : slotProfile.getWorker().toString();
+            String taskGroupName = null;
+            try {
+                taskGroupName =
+                        (String)
+                                taskGroup
+                                        .getClass()
+                                        .getMethod("getTaskGroupName")
+                                        .invoke(taskGroup);
+            } catch (Exception ignored) {
+                // keep null for non-default task group implementations
+            }
+
+            for (Task task : taskGroup.getTasks()) {
+                Map<String, Object> item = new HashMap<>();
+                item.put("taskId", String.valueOf(task.getTaskID()));
+                item.put("pipelineId", location.getPipelineId());
+                item.put("taskGroupId", String.valueOf(location.getTaskGroupId()));
+                item.put("taskGroupName", taskGroupName);
+                item.put("worker", worker);
+                item.put("taskClass", task.getClass().getName());
+                items.add(item);
+            }
+        }
+    }
+
+    private static SlotProfile getSlotProfile(
+            IMap ownedSlotProfilesIMap, TaskGroupLocation location) {
+        Object map = ownedSlotProfilesIMap.get(location.getPipelineLocation());
+        if (!(map instanceof Map)) {
+            return null;
+        }
+        Map owned = (Map) map;
+        Object slot = owned.get(location);
+        if (slot instanceof SlotProfile) {
+            return (SlotProfile) slot;
+        }
+        return null;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobEventHttpReportHandlerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobEventHttpReportHandlerTest.java
@@ -125,6 +125,39 @@ public class JobEventHttpReportHandlerTest {
         }
     }
 
+    @Test
+    public void testCloseWhenHazelcastNotActive() {
+        String closeTestRingBufferName = "close-test";
+        Config config = new Config();
+        config.setRingbufferConfigs(
+                Collections.singletonMap(
+                        closeTestRingBufferName,
+                        new RingbufferConfig(closeTestRingBufferName)
+                                .setCapacity(capacity)
+                                .setBackupCount(0)
+                                .setAsyncBackupCount(1)
+                                .setTimeToLiveSeconds(0)
+                                .setRingbufferStoreConfig(
+                                        new RingbufferStoreConfig().setEnabled(false))));
+
+        HazelcastInstance localHazelcast = Hazelcast.newHazelcastInstance(config);
+        JobEventHttpReportHandler handler = null;
+        try {
+            Ringbuffer ringbuffer = localHazelcast.getRingbuffer(closeTestRingBufferName);
+            handler =
+                    new JobEventHttpReportHandler(
+                            mockWebServer.url("/api").toString(),
+                            Duration.ofSeconds(1),
+                            ringbuffer);
+        } finally {
+            localHazelcast.shutdown();
+        }
+
+        Assertions.assertNotNull(handler);
+        JobEventHttpReportHandler finalHandler = handler;
+        Assertions.assertDoesNotThrow(finalHandler::close);
+    }
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/RecordSerializerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/RecordSerializerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.serializable;
+
+import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTracePayload;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.nio.BufferObjectDataOutput;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+
+import java.io.IOException;
+
+public class RecordSerializerTest {
+
+    @Test
+    void testSerializeDeserializeRowWithTracePayload() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "a"});
+        row.setTableId("t");
+        row.setRowKind(RowKind.INSERT);
+        byte[] payload = StainTracePayload.init(1L, 2L);
+        payload =
+                StainTracePayload.append(payload, StainTraceStage.SOURCE_EMIT, 3L, 4L, 32)
+                        .getPayload();
+        row.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, payload);
+
+        serializer.write(out, new Record<>(row));
+
+        BufferObjectDataInput in = service.createObjectDataInput(out.toByteArray());
+        Record<?> deserialized = serializer.read(in);
+        SeaTunnelRow readRow = (SeaTunnelRow) deserialized.getData();
+        Assertions.assertEquals("t", readRow.getTableId());
+        Assertions.assertEquals(RowKind.INSERT, readRow.getRowKind());
+        Assertions.assertNotNull(readRow.getOptionsOrNull());
+        Assertions.assertArrayEquals(
+                payload,
+                (byte[])
+                        readRow.getOptionsOrNull()
+                                .get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY));
+    }
+
+    @Test
+    void testSerializeDeserializeRowWithoutTracePayloadUsesLegacyType() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "a"});
+        row.setTableId("t");
+        row.setRowKind(RowKind.INSERT);
+        serializer.write(out, new Record<>(row));
+
+        byte[] bytes = out.toByteArray();
+        Assertions.assertEquals(1, bytes[0]);
+
+        BufferObjectDataInput in = service.createObjectDataInput(bytes);
+        Record<?> deserialized = serializer.read(in);
+        SeaTunnelRow readRow = (SeaTunnelRow) deserialized.getData();
+        Assertions.assertEquals("t", readRow.getTableId());
+        Assertions.assertEquals(RowKind.INSERT, readRow.getRowKind());
+        Assertions.assertNull(readRow.getOptionsOrNull());
+    }
+
+    @Test
+    void testSerializeDeserializeRowWithEmptyTracePayloadUsesLegacyType() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "a"});
+        row.setTableId("t");
+        row.setRowKind(RowKind.INSERT);
+        row.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, new byte[0]);
+
+        serializer.write(out, new Record<>(row));
+
+        byte[] bytes = out.toByteArray();
+        Assertions.assertEquals(1, bytes[0]);
+
+        BufferObjectDataInput in = service.createObjectDataInput(bytes);
+        Record<?> deserialized = serializer.read(in);
+        SeaTunnelRow readRow = (SeaTunnelRow) deserialized.getData();
+        Assertions.assertNull(readRow.getOptionsOrNull());
+    }
+
+    @Test
+    void testSerializeDeserializeRowWithOversizeTracePayloadUsesLegacyType() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "a"});
+        row.setTableId("t");
+        row.setRowKind(RowKind.INSERT);
+        row.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, new byte[9 * 1024]);
+
+        serializer.write(out, new Record<>(row));
+
+        byte[] bytes = out.toByteArray();
+        Assertions.assertEquals(1, bytes[0]);
+
+        BufferObjectDataInput in = service.createObjectDataInput(bytes);
+        Record<?> deserialized = serializer.read(in);
+        SeaTunnelRow readRow = (SeaTunnelRow) deserialized.getData();
+        Assertions.assertNull(readRow.getOptionsOrNull());
+    }
+
+    @Test
+    void testReadNegativePayloadLengthFailsFast() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        out.writeByte(2);
+        out.writeString("t");
+        out.writeByte(RowKind.INSERT.toByteValue());
+        out.writeByte((byte) 2);
+        out.writeObject(1);
+        out.writeObject("a");
+        out.writeInt(-1);
+
+        BufferObjectDataInput in = service.createObjectDataInput(out.toByteArray());
+        Assertions.assertThrows(IOException.class, () -> serializer.read(in));
+    }
+
+    @Test
+    void testBackwardCompatibilityReadLegacyBytes() throws IOException {
+        RecordSerializer serializer = new RecordSerializer();
+        InternalSerializationService service = new DefaultSerializationServiceBuilder().build();
+        BufferObjectDataOutput out = service.createObjectDataOutput();
+
+        out.writeByte(1);
+        out.writeString("t");
+        out.writeByte(RowKind.INSERT.toByteValue());
+        out.writeByte((byte) 2);
+        out.writeObject(1);
+        out.writeObject("a");
+
+        BufferObjectDataInput in = service.createObjectDataInput(out.toByteArray());
+        Record<?> deserialized = serializer.read(in);
+        SeaTunnelRow readRow = (SeaTunnelRow) deserialized.getData();
+        Assertions.assertEquals("t", readRow.getTableId());
+        Assertions.assertEquals(RowKind.INSERT, readRow.getRowKind());
+        Assertions.assertNull(readRow.getOptionsOrNull());
+        Assertions.assertEquals(1, readRow.getField(0));
+        Assertions.assertEquals("a", readRow.getField(1));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycleStainTraceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/flow/TransformFlowLifeCycleStainTraceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.task.flow;
+
+import org.apache.seatunnel.api.common.metrics.ThreadSafeCounter;
+import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.transform.Collector;
+import org.apache.seatunnel.api.transform.SeaTunnelFlatMapTransform;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.core.dag.actions.TransformChainAction;
+import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
+import org.apache.seatunnel.engine.server.trace.StainTraceConstants;
+import org.apache.seatunnel.engine.server.trace.StainTracePayload;
+import org.apache.seatunnel.engine.server.trace.StainTraceStage;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class TransformFlowLifeCycleStainTraceTest {
+
+    @Test
+    void testFlatMapOnlyFirstOutputInheritsTracePayload() throws Exception {
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {1});
+        byte[] payload = StainTracePayload.init(11L, 22L);
+        payload =
+                StainTracePayload.append(payload, StainTraceStage.SOURCE_EMIT, 1L, 2L, 32)
+                        .getPayload();
+        inputRow.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, payload);
+
+        SeaTunnelRow out1 = new SeaTunnelRow(new Object[] {1});
+        SeaTunnelRow out2 = new SeaTunnelRow(new Object[] {2});
+
+        SeaTunnelFlatMapTransform<SeaTunnelRow> flatMapTransform =
+                Mockito.mock(SeaTunnelFlatMapTransform.class);
+        Mockito.when(flatMapTransform.flatMap(Mockito.any())).thenReturn(Arrays.asList(out1, out2));
+
+        TransformChainAction<SeaTunnelRow> action =
+                new TransformChainAction<>(
+                        1L,
+                        "t",
+                        Collections.emptySet(),
+                        Collections.emptySet(),
+                        Collections.singletonList(flatMapTransform));
+
+        List<Record<?>> outputs = new ArrayList<>();
+        Collector<Record<?>> collector =
+                new Collector<Record<?>>() {
+                    @Override
+                    public void collect(Record<?> record) {
+                        outputs.add(record);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        SeaTunnelTask runningTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(runningTask.getTaskID()).thenReturn(100L);
+
+        TransformFlowLifeCycle<SeaTunnelRow> flow =
+                new TransformFlowLifeCycle<>(
+                        action, runningTask, collector, new CompletableFuture<>());
+        setField(flow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(flow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+        setField(flow, "stainTracePropagateToAllSplits", Boolean.FALSE);
+
+        flow.received(new Record<>(inputRow));
+
+        Assertions.assertEquals(2, outputs.size());
+        SeaTunnelRow r1 = (SeaTunnelRow) outputs.get(0).getData();
+        SeaTunnelRow r2 = (SeaTunnelRow) outputs.get(1).getData();
+
+        byte[] p1 =
+                (byte[]) r1.getOptionsOrNull().get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+        Assertions.assertNotNull(p1);
+        Assertions.assertTrue(StainTracePayload.isValid(p1));
+        Assertions.assertEquals(11L, StainTracePayload.readTraceId(p1));
+
+        Assertions.assertNull(r2.getOptionsOrNull());
+    }
+
+    @Test
+    void testFlatMapAllOutputsInheritTracePayloadWhenEnabled() throws Exception {
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {1});
+        byte[] payload = StainTracePayload.init(11L, 22L);
+        payload =
+                StainTracePayload.append(payload, StainTraceStage.SOURCE_EMIT, 1L, 2L, 32)
+                        .getPayload();
+        inputRow.getOptions().put(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY, payload);
+
+        SeaTunnelRow out1 = new SeaTunnelRow(new Object[] {1});
+        SeaTunnelRow out2 = new SeaTunnelRow(new Object[] {2});
+
+        SeaTunnelFlatMapTransform<SeaTunnelRow> flatMapTransform =
+                Mockito.mock(SeaTunnelFlatMapTransform.class);
+        Mockito.when(flatMapTransform.flatMap(Mockito.any())).thenReturn(Arrays.asList(out1, out2));
+
+        TransformChainAction<SeaTunnelRow> action =
+                new TransformChainAction<>(
+                        1L,
+                        "t",
+                        Collections.emptySet(),
+                        Collections.emptySet(),
+                        Collections.singletonList(flatMapTransform));
+
+        List<Record<?>> outputs = new ArrayList<>();
+        Collector<Record<?>> collector =
+                new Collector<Record<?>>() {
+                    @Override
+                    public void collect(Record<?> record) {
+                        outputs.add(record);
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        SeaTunnelTask runningTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(runningTask.getTaskID()).thenReturn(100L);
+
+        TransformFlowLifeCycle<SeaTunnelRow> flow =
+                new TransformFlowLifeCycle<>(
+                        action, runningTask, collector, new CompletableFuture<>());
+        setField(flow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(flow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+        setField(flow, "stainTracePropagateToAllSplits", Boolean.TRUE);
+
+        flow.received(new Record<>(inputRow));
+
+        Assertions.assertEquals(2, outputs.size());
+        SeaTunnelRow r1 = (SeaTunnelRow) outputs.get(0).getData();
+        SeaTunnelRow r2 = (SeaTunnelRow) outputs.get(1).getData();
+
+        byte[] p1 =
+                (byte[]) r1.getOptionsOrNull().get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+        byte[] p2 =
+                (byte[]) r2.getOptionsOrNull().get(StainTraceConstants.TRACE_PAYLOAD_OPTION_KEY);
+
+        Assertions.assertNotNull(p1);
+        Assertions.assertNotNull(p2);
+        Assertions.assertNotSame(p1, p2);
+        Assertions.assertTrue(StainTracePayload.isValid(p1));
+        Assertions.assertTrue(StainTracePayload.isValid(p2));
+        Assertions.assertEquals(11L, StainTracePayload.readTraceId(p1));
+        Assertions.assertEquals(11L, StainTracePayload.readTraceId(p2));
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceFlowIT.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceFlowIT.java
@@ -1,0 +1,502 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.api.common.metrics.Counter;
+import org.apache.seatunnel.api.common.metrics.Meter;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.common.metrics.ThreadSafeCounter;
+import org.apache.seatunnel.api.common.metrics.ThreadSafeQPSMeter;
+import org.apache.seatunnel.api.event.Event;
+import org.apache.seatunnel.api.event.StainTraceEvent;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.transform.Collector;
+import org.apache.seatunnel.api.transform.SeaTunnelMapTransform;
+import org.apache.seatunnel.engine.common.config.EngineConfig;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.core.dag.actions.SinkAction;
+import org.apache.seatunnel.engine.core.dag.actions.TransformChainAction;
+import org.apache.seatunnel.engine.server.TaskExecutionService;
+import org.apache.seatunnel.engine.server.execution.TaskExecutionContext;
+import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.execution.TaskLocation;
+import org.apache.seatunnel.engine.server.task.SeaTunnelSourceCollector;
+import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
+import org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle;
+import org.apache.seatunnel.engine.server.task.flow.SinkFlowLifeCycle;
+import org.apache.seatunnel.engine.server.task.flow.TransformFlowLifeCycle;
+import org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class StainTraceFlowIT {
+
+    @Test
+    void testEndToEndStagesAndSingleEventReport() throws Exception {
+        long nowMs = 1_700_000_001_000L;
+        TestMetricsContext metricsContext = new TestMetricsContext();
+        List<Event> reported = new ArrayList<>();
+        TaskExecutionContext taskExecutionContext = mockTaskExecutionContext(reported);
+
+        SinkFlowLifeCycle<SeaTunnelRow, String, String, String> sinkFlow =
+                createSinkFlow(metricsContext, taskExecutionContext);
+        sinkFlow.init();
+        sinkFlow.restoreState(Collections.emptyList());
+        setField(sinkFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(sinkFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        TransformFlowLifeCycle<SeaTunnelRow> transformFlow = createTransformFlow(sinkFlow);
+        setField(transformFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(transformFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        IntermediateQueueFlowLifeCycle<?> queueFlow = createQueueFlow();
+
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.setStainTraceEnabled(true);
+        engineConfig.setStainTraceSampleRate(1);
+        engineConfig.setStainTraceMaxTracesPerSecondPerWorker(1000);
+        engineConfig.setStainTraceMaxEntriesPerTrace(32);
+
+        SeaTunnelTask sourceTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(sourceTask.getTaskLocation())
+                .thenReturn(new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 1L, 0));
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"f1"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        SeaTunnelSourceCollector<SeaTunnelRow> sourceCollector =
+                new SeaTunnelSourceCollector<>(
+                        new Object(),
+                        Collections.singletonList(queueFlow),
+                        metricsContext,
+                        org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy.builder()
+                                .build(),
+                        rowType,
+                        Collections.singletonList(TablePath.DEFAULT),
+                        sourceTask,
+                        engineConfig,
+                        () -> nowMs);
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1});
+        row.setTableId(TablePath.DEFAULT.getFullName());
+        sourceCollector.collect(row);
+        queueFlow.collect(new ForwardCollector(transformFlow));
+
+        Assertions.assertEquals(1, reported.size());
+        Assertions.assertTrue(reported.get(0) instanceof StainTraceEvent);
+        StainTraceEvent event = (StainTraceEvent) reported.get(0);
+
+        Assertions.assertEquals(
+                event.getTraceId(), StainTracePayload.readTraceId(event.getPayload()));
+        Assertions.assertEquals(TablePath.DEFAULT.getFullName(), event.getTableId());
+
+        byte[] payload = event.getPayload();
+        Assertions.assertTrue(StainTracePayload.isValid(payload));
+        Assertions.assertEquals(
+                Arrays.asList(
+                        StainTraceStage.SOURCE_EMIT.getCode(),
+                        StainTraceStage.QUEUE_IN.getCode(),
+                        StainTraceStage.QUEUE_OUT.getCode(),
+                        StainTraceStage.TRANSFORM_IN.getCode(),
+                        StainTraceStage.TRANSFORM_OUT.getCode(),
+                        StainTraceStage.SINK_WRITE_DONE.getCode()),
+                readStageCodes(payload));
+    }
+
+    @Test
+    void testFilteredRowDoesNotReportEvent() throws Exception {
+        long nowMs = 1_700_000_002_000L;
+        TestMetricsContext metricsContext = new TestMetricsContext();
+        List<Event> reported = new ArrayList<>();
+        TaskExecutionContext taskExecutionContext = mockTaskExecutionContext(reported);
+
+        SinkFlowLifeCycle<SeaTunnelRow, String, String, String> sinkFlow =
+                createSinkFlow(metricsContext, taskExecutionContext);
+        sinkFlow.init();
+        sinkFlow.restoreState(Collections.emptyList());
+        setField(sinkFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(sinkFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        SeaTunnelMapTransform<SeaTunnelRow> filter = Mockito.mock(SeaTunnelMapTransform.class);
+        Mockito.when(filter.map(Mockito.any())).thenReturn(null);
+        TransformChainAction<SeaTunnelRow> action =
+                new TransformChainAction<>(
+                        1L,
+                        "t",
+                        Collections.emptySet(),
+                        Collections.emptySet(),
+                        Collections.singletonList(filter));
+        TransformFlowLifeCycle<SeaTunnelRow> transformFlow =
+                new TransformFlowLifeCycle<>(
+                        action,
+                        mockTask(300L, null),
+                        new ForwardCollector(sinkFlow),
+                        new CompletableFuture<>());
+        setField(transformFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(transformFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        IntermediateQueueFlowLifeCycle<?> queueFlow = createQueueFlow();
+
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.setStainTraceEnabled(true);
+        engineConfig.setStainTraceSampleRate(1);
+        engineConfig.setStainTraceMaxTracesPerSecondPerWorker(1000);
+        engineConfig.setStainTraceMaxEntriesPerTrace(32);
+
+        SeaTunnelTask sourceTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(sourceTask.getTaskLocation())
+                .thenReturn(new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 1L, 0));
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"f1"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        SeaTunnelSourceCollector<SeaTunnelRow> sourceCollector =
+                new SeaTunnelSourceCollector<>(
+                        new Object(),
+                        Collections.singletonList(queueFlow),
+                        metricsContext,
+                        org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy.builder()
+                                .build(),
+                        rowType,
+                        Collections.singletonList(TablePath.DEFAULT),
+                        sourceTask,
+                        engineConfig,
+                        () -> nowMs);
+
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1});
+        row.setTableId(TablePath.DEFAULT.getFullName());
+        sourceCollector.collect(row);
+        queueFlow.collect(new ForwardCollector(transformFlow));
+
+        Assertions.assertTrue(reported.isEmpty());
+        byte[] payload = StainTraceUtils.getPayloadOrNull(row);
+        Assertions.assertNotNull(payload);
+        Assertions.assertEquals(
+                Arrays.asList(
+                        StainTraceStage.SOURCE_EMIT.getCode(),
+                        StainTraceStage.QUEUE_IN.getCode(),
+                        StainTraceStage.QUEUE_OUT.getCode(),
+                        StainTraceStage.TRANSFORM_IN.getCode()),
+                readStageCodes(payload));
+    }
+
+    @Test
+    void testSamplingRateEffectiveInEndToEndFlow() throws Exception {
+        long nowMs = 1_700_000_003_000L;
+        TestMetricsContext metricsContext = new TestMetricsContext();
+        List<Event> reported = new ArrayList<>();
+        TaskExecutionContext taskExecutionContext = mockTaskExecutionContext(reported);
+
+        SinkFlowLifeCycle<SeaTunnelRow, String, String, String> sinkFlow =
+                createSinkFlow(metricsContext, taskExecutionContext);
+        sinkFlow.init();
+        sinkFlow.restoreState(Collections.emptyList());
+        setField(sinkFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(sinkFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        TransformFlowLifeCycle<SeaTunnelRow> transformFlow = createTransformFlow(sinkFlow);
+        setField(transformFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(transformFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        IntermediateQueueFlowLifeCycle<?> queueFlow = createQueueFlow();
+
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.setStainTraceEnabled(true);
+        engineConfig.setStainTraceSampleRate(2);
+        engineConfig.setStainTraceMaxTracesPerSecondPerWorker(1000);
+        engineConfig.setStainTraceMaxEntriesPerTrace(32);
+
+        SeaTunnelTask sourceTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(sourceTask.getTaskLocation())
+                .thenReturn(new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 1L, 0));
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"f1"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        SeaTunnelSourceCollector<SeaTunnelRow> sourceCollector =
+                new SeaTunnelSourceCollector<>(
+                        new Object(),
+                        Collections.singletonList(queueFlow),
+                        metricsContext,
+                        org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy.builder()
+                                .build(),
+                        rowType,
+                        Collections.singletonList(TablePath.DEFAULT),
+                        sourceTask,
+                        engineConfig,
+                        () -> nowMs);
+
+        SeaTunnelRow row1 = new SeaTunnelRow(new Object[] {1});
+        row1.setTableId(TablePath.DEFAULT.getFullName());
+        SeaTunnelRow row2 = new SeaTunnelRow(new Object[] {2});
+        row2.setTableId(TablePath.DEFAULT.getFullName());
+        sourceCollector.collect(row1);
+        sourceCollector.collect(row2);
+        queueFlow.collect(new ForwardCollector(transformFlow));
+
+        Assertions.assertEquals(1, reported.size());
+        Assertions.assertTrue(reported.get(0) instanceof StainTraceEvent);
+        assertStageOrder((StainTraceEvent) reported.get(0));
+    }
+
+    @Test
+    void testWorkerBudgetEffectiveInEndToEndFlow() throws Exception {
+        long nowMs = 1_700_000_004_000L;
+        TestMetricsContext metricsContext = new TestMetricsContext();
+        List<Event> reported = new ArrayList<>();
+        TaskExecutionContext taskExecutionContext = mockTaskExecutionContext(reported);
+
+        SinkFlowLifeCycle<SeaTunnelRow, String, String, String> sinkFlow =
+                createSinkFlow(metricsContext, taskExecutionContext);
+        sinkFlow.init();
+        sinkFlow.restoreState(Collections.emptyList());
+        setField(sinkFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(sinkFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        TransformFlowLifeCycle<SeaTunnelRow> transformFlow = createTransformFlow(sinkFlow);
+        setField(transformFlow, "stainTraceMaxEntriesPerTrace", 32);
+        setField(transformFlow, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+
+        IntermediateQueueFlowLifeCycle<?> queueFlow = createQueueFlow();
+
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.setStainTraceEnabled(true);
+        engineConfig.setStainTraceSampleRate(1);
+        engineConfig.setStainTraceMaxTracesPerSecondPerWorker(1);
+        engineConfig.setStainTraceMaxEntriesPerTrace(32);
+
+        SeaTunnelTask sourceTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(sourceTask.getTaskLocation())
+                .thenReturn(new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 1L, 0));
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"f1"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        SeaTunnelSourceCollector<SeaTunnelRow> sourceCollector =
+                new SeaTunnelSourceCollector<>(
+                        new Object(),
+                        Collections.singletonList(queueFlow),
+                        metricsContext,
+                        org.apache.seatunnel.core.starter.flowcontrol.FlowControlStrategy.builder()
+                                .build(),
+                        rowType,
+                        Collections.singletonList(TablePath.DEFAULT),
+                        sourceTask,
+                        engineConfig,
+                        () -> nowMs);
+
+        for (int i = 0; i < 10; i++) {
+            SeaTunnelRow row = new SeaTunnelRow(new Object[] {i});
+            row.setTableId(TablePath.DEFAULT.getFullName());
+            sourceCollector.collect(row);
+        }
+        queueFlow.collect(new ForwardCollector(transformFlow));
+
+        Assertions.assertEquals(1, reported.size());
+        Assertions.assertTrue(reported.get(0) instanceof StainTraceEvent);
+        assertStageOrder((StainTraceEvent) reported.get(0));
+    }
+
+    private static void assertStageOrder(StainTraceEvent event) {
+        Assertions.assertEquals(
+                Arrays.asList(
+                        StainTraceStage.SOURCE_EMIT.getCode(),
+                        StainTraceStage.QUEUE_IN.getCode(),
+                        StainTraceStage.QUEUE_OUT.getCode(),
+                        StainTraceStage.TRANSFORM_IN.getCode(),
+                        StainTraceStage.TRANSFORM_OUT.getCode(),
+                        StainTraceStage.SINK_WRITE_DONE.getCode()),
+                readStageCodes(event.getPayload()));
+    }
+
+    private static SinkFlowLifeCycle<SeaTunnelRow, String, String, String> createSinkFlow(
+            MetricsContext metricsContext, TaskExecutionContext executionContext) {
+        SeaTunnelSink<SeaTunnelRow, String, String, String> sink =
+                Mockito.mock(SeaTunnelSink.class);
+        SinkWriter<SeaTunnelRow, String, String> writer = Mockito.mock(SinkWriter.class);
+        try {
+            Mockito.when(sink.createWriter(Mockito.any())).thenReturn(writer);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Mockito.when(sink.getWriteCatalogTable()).thenReturn(Optional.empty());
+        Mockito.when(sink.getCommitInfoSerializer()).thenReturn(Optional.empty());
+        Mockito.when(sink.getWriterStateSerializer()).thenReturn(Optional.empty());
+        try {
+            Mockito.when(sink.createCommitter()).thenReturn(Optional.empty());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        SinkAction<SeaTunnelRow, String, String, String> sinkAction =
+                new SinkAction<>(1L, "s", sink, Collections.emptySet(), Collections.emptySet());
+
+        TaskLocation taskLocation = new TaskLocation(new TaskGroupLocation(1L, 1, 2L), 1L, 0);
+        SeaTunnelTask runningTask = mockTask(400L, executionContext);
+        return new SinkFlowLifeCycle<>(
+                sinkAction,
+                taskLocation,
+                0,
+                runningTask,
+                new TaskLocation(new TaskGroupLocation(1L, 1, 2L), 2L, 0),
+                false,
+                new CompletableFuture<>(),
+                metricsContext);
+    }
+
+    private static TransformFlowLifeCycle<SeaTunnelRow> createTransformFlow(
+            SinkFlowLifeCycle<SeaTunnelRow, String, String, String> sinkFlow) {
+        SeaTunnelMapTransform<SeaTunnelRow> mapTransform =
+                Mockito.mock(SeaTunnelMapTransform.class);
+        Mockito.when(mapTransform.map(Mockito.any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TransformChainAction<SeaTunnelRow> action =
+                new TransformChainAction<>(
+                        1L,
+                        "t",
+                        Collections.emptySet(),
+                        Collections.emptySet(),
+                        Collections.singletonList(mapTransform));
+
+        SeaTunnelTask runningTask = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(runningTask.getTaskID()).thenReturn(300L);
+
+        return new TransformFlowLifeCycle<>(
+                action, runningTask, new ForwardCollector(sinkFlow), new CompletableFuture<>());
+    }
+
+    private static IntermediateQueueFlowLifeCycle<?> createQueueFlow() throws Exception {
+        SeaTunnelTask queueTask = mockTask(200L, null);
+        BlockingQueue<Record<?>> queue = new LinkedBlockingQueue<>();
+        IntermediateBlockingQueue blockingQueue =
+                new IntermediateBlockingQueue(queue, new ThreadSafeCounter("qsize"));
+        setField(blockingQueue, "stainTraceMaxEntriesPerTrace", 32);
+        setField(blockingQueue, "stainTraceEntriesTruncatedTotal", new ThreadSafeCounter("c"));
+        return new IntermediateQueueFlowLifeCycle<>(
+                queueTask, new CompletableFuture<>(), blockingQueue);
+    }
+
+    private static SeaTunnelTask mockTask(long taskId, TaskExecutionContext executionContext) {
+        SeaTunnelTask task = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(task.getTaskID()).thenReturn(taskId);
+        if (executionContext != null) {
+            Mockito.when(task.getExecutionContext()).thenReturn(executionContext);
+        }
+        return task;
+    }
+
+    private static TaskExecutionContext mockTaskExecutionContext(List<Event> events) {
+        TaskExecutionService taskExecutionService = Mockito.mock(TaskExecutionService.class);
+        Mockito.doAnswer(
+                        invocation -> {
+                            events.add(invocation.getArgument(0));
+                            return null;
+                        })
+                .when(taskExecutionService)
+                .reportEvent(Mockito.any());
+        TaskExecutionContext taskExecutionContext = Mockito.mock(TaskExecutionContext.class);
+        Mockito.when(taskExecutionContext.getTaskExecutionService())
+                .thenReturn(taskExecutionService);
+        return taskExecutionContext;
+    }
+
+    private static List<Byte> readStageCodes(byte[] payload) {
+        Assertions.assertTrue(StainTracePayload.isValid(payload));
+        int countOffset = 4 + 2 + 8 + 8;
+        int entryCount = ((payload[countOffset] & 0xFF) << 8) | (payload[countOffset + 1] & 0xFF);
+        List<Byte> codes = new ArrayList<>(entryCount);
+        ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN);
+        int base = StainTracePayload.HEADER_LENGTH;
+        for (int i = 0; i < entryCount; i++) {
+            codes.add(buffer.get(base + i * StainTracePayload.ENTRY_LENGTH));
+        }
+        return codes;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static class ForwardCollector implements Collector<Record<?>> {
+        private final org.apache.seatunnel.engine.server.task.flow.OneInputFlowLifeCycle<Record<?>>
+                next;
+
+        private ForwardCollector(
+                org.apache.seatunnel.engine.server.task.flow.OneInputFlowLifeCycle<Record<?>>
+                        next) {
+            this.next = next;
+        }
+
+        @Override
+        public void collect(Record<?> record) {
+            try {
+                next.received(record);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class TestMetricsContext implements MetricsContext {
+        @Override
+        public Counter counter(String name) {
+            return new ThreadSafeCounter(name);
+        }
+
+        @Override
+        public <C extends Counter> C counter(String name, C counter) {
+            return counter;
+        }
+
+        @Override
+        public Meter meter(String name) {
+            return new ThreadSafeQPSMeter(name);
+        }
+
+        @Override
+        public <M extends Meter> M meter(String name, M meter) {
+            return meter;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTracePayloadTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTracePayloadTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StainTracePayloadTest {
+
+    @Test
+    void testInitAndReadTraceId() {
+        byte[] payload = StainTracePayload.init(123L, 456L);
+        Assertions.assertTrue(StainTracePayload.isValid(payload));
+        Assertions.assertEquals(123L, StainTracePayload.readTraceId(payload));
+    }
+
+    @Test
+    void testAppendAndTruncate() {
+        byte[] payload = StainTracePayload.init(1L, 2L);
+        for (int i = 0; i < 3; i++) {
+            StainTracePayload.AppendResult result =
+                    StainTracePayload.append(payload, StainTraceStage.QUEUE_IN, 10L, 20L, 3);
+            Assertions.assertEquals(StainTracePayload.AppendStatus.APPENDED, result.getStatus());
+            payload = result.getPayload();
+            Assertions.assertTrue(StainTracePayload.isValid(payload));
+        }
+
+        StainTracePayload.AppendResult truncated =
+                StainTracePayload.append(payload, StainTraceStage.QUEUE_OUT, 10L, 20L, 3);
+        Assertions.assertEquals(StainTracePayload.AppendStatus.TRUNCATED, truncated.getStatus());
+        Assertions.assertSame(payload, truncated.getPayload());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceSamplerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceSamplerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.api.common.metrics.ThreadSafeCounter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StainTraceSamplerTest {
+
+    @Test
+    void testDeterministicSamplingAndWorkerBudget() {
+        long nowMs = 1_700_000_000_000L;
+        long taskId = 10L;
+
+        ThreadSafeCounter generated = new ThreadSafeCounter("generated");
+        ThreadSafeCounter throttled = new ThreadSafeCounter("throttled");
+        StainTraceSampler sampler = new StainTraceSampler(true, 2, 100, 32, generated, throttled);
+
+        Assertions.assertEquals(-1L, sampler.tryGenerateTraceId(taskId, nowMs));
+        long traceId = sampler.tryGenerateTraceId(taskId, nowMs);
+        Assertions.assertNotEquals(-1L, traceId);
+        Assertions.assertEquals(1L, generated.getCount());
+        Assertions.assertEquals(0L, throttled.getCount());
+    }
+
+    @Test
+    void testBudgetThrottlesWithinSameSecondAndResetsOnSecondTick() {
+        long taskId = 10L;
+        long sec0 = 1_700_000_010_000L;
+        long sec1 = sec0 + 1_000L;
+
+        ThreadSafeCounter generated = new ThreadSafeCounter("generated");
+        ThreadSafeCounter throttled = new ThreadSafeCounter("throttled");
+        StainTraceSampler sampler = new StainTraceSampler(true, 1, 1, 32, generated, throttled);
+
+        Assertions.assertNotEquals(-1L, sampler.tryGenerateTraceId(taskId, sec0));
+        Assertions.assertEquals(-1L, sampler.tryGenerateTraceId(taskId, sec0));
+        Assertions.assertEquals(1L, generated.getCount());
+        Assertions.assertEquals(1L, throttled.getCount());
+
+        Assertions.assertNotEquals(-1L, sampler.tryGenerateTraceId(taskId, sec1));
+        Assertions.assertEquals(2L, generated.getCount());
+        Assertions.assertEquals(1L, throttled.getCount());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceUtilsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/trace/StainTraceUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.trace;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StainTraceUtilsTest {
+
+    @Test
+    void testSetPayloadDoesNotCopyHashMapOptions() {
+        SeaTunnelRow row = new SeaTunnelRow(1);
+        Map<String, Object> options = new HashMap<>();
+        row.setOptions(options);
+        StainTraceUtils.setPayload(row, new byte[] {1});
+        Assertions.assertSame(options, row.getOptionsOrNull());
+    }
+
+    @Test
+    void testSetPayloadCopiesNonHashMapOptions() {
+        SeaTunnelRow row = new SeaTunnelRow(1);
+        Map<String, Object> options = Collections.unmodifiableMap(new HashMap<>());
+        row.setOptions(options);
+        StainTraceUtils.setPayload(row, new byte[] {1});
+        Assertions.assertNotSame(options, row.getOptionsOrNull());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-ui/.env.development
+++ b/seatunnel-engine/seatunnel-engine-ui/.env.development
@@ -20,3 +20,7 @@ NODE_ENV=development
 VITE_APP_API_SERVICE='http://124.221.211.72:8081'
 # the context path of api service
 VITE_APP_API_BASE='/api'
+
+# Trace Collector (stain trace) base url
+# VITE_TRACE_COLLECTOR_BASE='http://localhost:9808'
+# VITE_TRACE_COLLECTOR_TOKEN=''

--- a/seatunnel-engine/seatunnel-engine-ui/.env.production
+++ b/seatunnel-engine/seatunnel-engine-ui/.env.production
@@ -17,3 +17,7 @@ NODE_ENV=production
 
 # the context path of api service
 VITE_APP_API_BASE=''
+
+# Trace Collector (stain trace) base url
+VITE_TRACE_COLLECTOR_BASE=''
+VITE_TRACE_COLLECTOR_TOKEN=''

--- a/seatunnel-engine/seatunnel-engine-ui/src/layouts/main/sidebar/index.tsx
+++ b/seatunnel-engine/seatunnel-engine-ui/src/layouts/main/sidebar/index.tsx
@@ -19,7 +19,13 @@ import { defineComponent, ref, type PropType, onMounted, h, type Component } fro
 import { NIcon, NLayoutSider, NMenu } from 'naive-ui'
 import { useRoute, RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { DesktopOutline, ListOutline, PeopleOutline, PersonOutline } from '@vicons/ionicons5'
+import {
+  DesktopOutline,
+  GitNetworkOutline,
+  ListOutline,
+  PeopleOutline,
+  PersonOutline
+} from '@vicons/ionicons5'
 
 const Sidebar = defineComponent({
   name: 'Sidebar',
@@ -71,6 +77,21 @@ const Sidebar = defineComponent({
           ),
         key: 'jobs',
         icon: renderIcon(ListOutline)
+      },
+      {
+        label: () =>
+          h(
+            RouterLink,
+            {
+              to: {
+                path: '/trace'
+              },
+              exact: false
+            },
+            { default: () => t('menu.trace') }
+          ),
+        key: 'trace',
+        icon: renderIcon(GitNetworkOutline)
       },
       {
         label: () =>

--- a/seatunnel-engine/seatunnel-engine-ui/src/locales/en_US/menu.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/locales/en_US/menu.ts
@@ -18,6 +18,7 @@
 export default {
   overview: 'Overview',
   jobs: 'Jobs',
+  trace: 'Trace',
   managers: {
     workers: 'Workers',
     master: 'Master'

--- a/seatunnel-engine/seatunnel-engine-ui/src/locales/zh_CN/menu.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/locales/zh_CN/menu.ts
@@ -18,6 +18,7 @@
 export default {
   overview: '概览',
   jobs: '任务',
+  trace: '链路追踪',
   managers: '管理',
   synchronization_instance: '同步任务实例',
 }

--- a/seatunnel-engine/seatunnel-engine-ui/src/router/routes.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/router/routes.ts
@@ -43,6 +43,12 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/jobs/detail')
       },
       {
+        path: 'trace',
+        name: 'trace',
+        meta: { title: 'trace', showSide: true, activeSide: 'trace' },
+        component: () => import('@/views/trace')
+      },
+      {
         path: 'managers/workers',
         name: 'managers-workers',
         meta: { title: 'workers', showSide: true, activeSide: 'workers' },

--- a/seatunnel-engine/seatunnel-engine-ui/src/service/trace/index.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/service/trace/index.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from 'axios'
+import type { AxiosInstance } from 'axios'
+import type { TraceDetail, TraceSummary } from '@/service/trace/types'
+
+export interface TraceListResponse {
+  count: number
+  items: TraceSummary[]
+}
+
+const getTraceCollectorClient = (): AxiosInstance => {
+  const baseURL = import.meta.env.VITE_TRACE_COLLECTOR_BASE || ''
+  if (!baseURL) {
+    throw new Error('Trace collector is not configured (VITE_TRACE_COLLECTOR_BASE)')
+  }
+  const token = import.meta.env.VITE_TRACE_COLLECTOR_TOKEN || ''
+  const client = axios.create({
+    timeout: 6000,
+    baseURL
+  })
+  client.interceptors.request.use((config) => {
+    if (token) {
+      config.headers = config.headers || {}
+      config.headers['X-Seatunnel-Token'] = token
+    }
+    return config
+  })
+  return client
+}
+
+export const listTraces = (params: {
+  jobId?: string
+  tableId?: string
+  fromMs?: number
+  toMs?: number
+  limit?: number
+  offset?: number
+}) => getTraceCollectorClient().get<TraceListResponse>('/api/v1/traces', { params }).then((r) => r.data)
+
+export const getTrace = (traceId: string, params?: { sinkTaskId?: string }) =>
+  getTraceCollectorClient()
+    .get<TraceDetail>(`/api/v1/traces/${traceId}`, { params })
+    .then((r) => r.data)
+
+export const TraceService = {
+  listTraces,
+  getTrace
+}
+

--- a/seatunnel-engine/seatunnel-engine-ui/src/service/trace/types.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/service/trace/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface TraceSummary {
+  traceId: number
+  sinkTaskId: number
+  jobId: string
+  tableId: string
+  createdTimeMs: number
+  receivedTimeMs: number
+  startTsMs: number
+  entryCount: number
+}
+
+export interface TraceEntry {
+  index: number
+  stage: number
+  taskId: number
+  tsMs: number
+  workerAddress?: string
+  taskGroupName?: string
+  taskClass?: string
+}
+
+export interface TraceDetail {
+  trace: TraceSummary
+  entries: TraceEntry[]
+}
+

--- a/seatunnel-engine/seatunnel-engine-ui/src/views/trace/index.tsx
+++ b/seatunnel-engine/seatunnel-engine-ui/src/views/trace/index.tsx
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineComponent, ref } from 'vue'
+import {
+  NButton,
+  NCard,
+  NDataTable,
+  NDatePicker,
+  NInput,
+  NInputNumber,
+  NLayout,
+  NLayoutContent,
+  NModal,
+  NSpace,
+  NTag,
+  type DataTableColumns
+} from 'naive-ui'
+import { TraceService } from '@/service/trace'
+import type { TraceDetail, TraceEntry, TraceSummary } from '@/service/trace/types'
+
+const formatMs = (ms?: number) => {
+  if (!ms) return '-'
+  const d = new Date(ms)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(
+    d.getMinutes()
+  )}:${pad(d.getSeconds())}`
+}
+
+const stageName = (stage: number) => {
+  switch (stage) {
+    case 1:
+      return 'SOURCE_EMIT'
+    case 2:
+      return 'QUEUE_IN'
+    case 3:
+      return 'QUEUE_OUT'
+    case 4:
+      return 'TRANSFORM_IN'
+    case 5:
+      return 'TRANSFORM_OUT'
+    case 6:
+      return 'SINK_WRITE_DONE'
+    default:
+      return String(stage)
+  }
+}
+
+export default defineComponent({
+  name: 'TraceView',
+  setup() {
+    const jobId = ref('')
+    const tableId = ref('')
+    const limit = ref(100)
+    const offset = ref(0)
+    const timeRange = ref<[number, number] | null>(null)
+
+    const loading = ref(false)
+    const error = ref('')
+    const items = ref<TraceSummary[]>([])
+
+    const detailOpen = ref(false)
+    const detailLoading = ref(false)
+    const detail = ref<TraceDetail | null>(null)
+
+    const fetchList = async () => {
+      loading.value = true
+      error.value = ''
+      try {
+        const fromMs = timeRange.value?.[0]
+        const toMs = timeRange.value?.[1]
+        const res = await TraceService.listTraces({
+          jobId: jobId.value || undefined,
+          tableId: tableId.value || undefined,
+          fromMs,
+          toMs,
+          limit: limit.value,
+          offset: offset.value
+        })
+        items.value = res.items || []
+      } catch (e: any) {
+        error.value = e?.message || 'failed'
+        items.value = []
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const openDetail = async (row: TraceSummary) => {
+      detailOpen.value = true
+      detailLoading.value = true
+      detail.value = null
+      try {
+        const res = await TraceService.getTrace(String(row.traceId), {
+          sinkTaskId: String(row.sinkTaskId)
+        })
+        detail.value = res
+      } catch (e) {
+        detail.value = null
+      } finally {
+        detailLoading.value = false
+      }
+    }
+
+    const traceColumns: DataTableColumns<TraceSummary> = [
+      { title: 'TraceId', key: 'traceId' },
+      { title: 'JobId', key: 'jobId' },
+      { title: 'TableId', key: 'tableId' },
+      { title: 'SinkTaskId', key: 'sinkTaskId' },
+      {
+        title: 'ReceivedAt',
+        key: 'receivedTimeMs',
+        render: (row) => formatMs(row.receivedTimeMs)
+      },
+      {
+        title: 'Entries',
+        key: 'entryCount',
+        render: (row) => <NTag size="small">{row.entryCount}</NTag>
+      },
+      {
+        title: 'Action',
+        key: 'action',
+        render: (row) => (
+          <NButton size="small" tertiary onClick={() => openDetail(row)}>
+            View
+          </NButton>
+        )
+      }
+    ]
+
+    const entryColumns: DataTableColumns<TraceEntry> = [
+      { title: '#', key: 'index', width: 60 },
+      {
+        title: 'Stage',
+        key: 'stage',
+        render: (row) => stageName(row.stage)
+      },
+      { title: 'TaskId', key: 'taskId' },
+      {
+        title: 'Ts',
+        key: 'tsMs',
+        render: (row) => formatMs(row.tsMs)
+      },
+      { title: 'Worker', key: 'workerAddress' },
+      { title: 'TaskGroup', key: 'taskGroupName' }
+    ]
+
+    return () => (
+      <NLayout>
+        <NLayoutContent>
+          <div class="w-full bg-white p-6 border border-gray-100 rounded-xl">
+            <h2 class="font-bold text-2xl pb-4">Trace</h2>
+            <NSpace align="center" wrap>
+              <NInput
+                value={jobId.value}
+                onUpdateValue={(v) => (jobId.value = v)}
+                placeholder="jobId"
+                style="width: 240px"
+              />
+              <NInput
+                value={tableId.value}
+                onUpdateValue={(v) => (tableId.value = v)}
+                placeholder="tableId"
+                style="width: 240px"
+              />
+              <NDatePicker
+                type="datetimerange"
+                value={timeRange.value as any}
+                onUpdateValue={(v) => (timeRange.value = v as any)}
+                clearable
+              />
+              <NInputNumber
+                value={limit.value}
+                onUpdateValue={(v) => (limit.value = v || 100)}
+                min={1}
+                max={2000}
+                style="width: 120px"
+              />
+              <NInputNumber
+                value={offset.value}
+                onUpdateValue={(v) => (offset.value = v || 0)}
+                min={0}
+                style="width: 120px"
+              />
+              <NButton type="primary" loading={loading.value} onClick={fetchList}>
+                Search
+              </NButton>
+              {error.value && <span class="text-red-500">{error.value}</span>}
+            </NSpace>
+            <div class="pt-4">
+              <NDataTable
+                columns={traceColumns}
+                data={items.value}
+                loading={loading.value}
+                bordered={false}
+              />
+            </div>
+          </div>
+
+          <NModal show={detailOpen.value} onUpdateShow={(v) => (detailOpen.value = v)}>
+            <NCard
+              style="width: 1100px"
+              title="Trace Detail"
+              bordered={false}
+              closable
+              onClose={() => (detailOpen.value = false)}
+            >
+              {detailLoading.value && <div>Loading...</div>}
+              {!detailLoading.value && detail.value?.trace && (
+                <div class="pb-4">
+                  <NSpace>
+                    <div>traceId: {detail.value.trace.traceId}</div>
+                    <div>jobId: {detail.value.trace.jobId}</div>
+                    <div>tableId: {detail.value.trace.tableId}</div>
+                    <div>sinkTaskId: {detail.value.trace.sinkTaskId}</div>
+                  </NSpace>
+                  <NSpace class="pt-2">
+                    <div>receivedAt: {formatMs(detail.value.trace.receivedTimeMs)}</div>
+                    <div>startTs: {formatMs(detail.value.trace.startTsMs)}</div>
+                  </NSpace>
+                </div>
+              )}
+              {!detailLoading.value && (
+                <NDataTable
+                  columns={entryColumns}
+                  data={detail.value?.entries || []}
+                  bordered={false}
+                />
+              )}
+            </NCard>
+          </NModal>
+        </NLayoutContent>
+      </NLayout>
+    )
+  }
+})
+

--- a/seatunnel-examples/seatunnel-engine-examples/src/main/java/org/apache/seatunnel/example/engine/SeaTunnelEngineLocalExample.java
+++ b/seatunnel-examples/seatunnel-engine-examples/src/main/java/org/apache/seatunnel/example/engine/SeaTunnelEngineLocalExample.java
@@ -36,7 +36,9 @@ public class SeaTunnelEngineLocalExample {
 
     public static void main(String[] args)
             throws FileNotFoundException, URISyntaxException, CommandException {
-        String configurePath = args.length > 0 ? args[0] : "/examples/fake_to_console.conf";
+        String configurePath =
+                args.length > 0 ? args[0] : "/examples/stain_trace_fake_sql_union_to_console.conf";
+        maybeEnableStainTraceForLocalExample(configurePath);
         String configFile = getTestConfigFile(configurePath);
         ClientCommandArgs clientCommandArgs = new ClientCommandArgs();
         clientCommandArgs.setConfigFile(configFile);
@@ -55,5 +57,22 @@ public class SeaTunnelEngineLocalExample {
             throw new FileNotFoundException("Can't find config file: " + configFile);
         }
         return Paths.get(resource.toURI()).toString();
+    }
+
+    private static void maybeEnableStainTraceForLocalExample(String jobConfigResourcePath)
+            throws FileNotFoundException, URISyntaxException {
+        if (System.getProperty("seatunnel.config") != null) {
+            return;
+        }
+        if (!"/examples/stain_trace_fake_sql_union_to_console.conf".equals(jobConfigResourcePath)) {
+            return;
+        }
+        URL resource =
+                SeaTunnelEngineLocalExample.class.getResource(
+                        "/examples/stain_trace_seatunnel.yaml");
+        if (resource == null) {
+            throw new FileNotFoundException("Can't find seatunnel.yaml for stain trace example");
+        }
+        System.setProperty("seatunnel.config", Paths.get(resource.toURI()).toString());
     }
 }

--- a/seatunnel-examples/seatunnel-engine-examples/src/main/resources/log4j2.properties
+++ b/seatunnel-examples/seatunnel-engine-examples/src/main/resources/log4j2.properties
@@ -19,7 +19,7 @@
 # The minimum amount of time, in seconds, that must elapse before the file configuration is checked for changes.
 monitorInterval = 60
 
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 
 rootLogger.appenderRef.consoleStdout.ref = consoleStdoutAppender
 rootLogger.appenderRef.consoleStderr.ref = consoleStderrAppender

--- a/seatunnel-trace/STAIN_TRACE_QUICKSTART.md
+++ b/seatunnel-trace/STAIN_TRACE_QUICKSTART.md
@@ -1,0 +1,368 @@
+# StainTrace 染色数据追踪 - 快速开始指南
+
+## 概述
+
+StainTrace（染色数据追踪）功能可以追踪数据在SeaTunnel引擎中的流转过程，记录6个关键阶段的时间戳：
+
+1. **S0** (SOURCE_EMIT): Source发出数据
+2. **Q+** (QUEUE_IN): 进入队列
+3. **Q-** (QUEUE_OUT): 离开队列
+4. **T+** (TRANSFORM_IN): Transform接收
+5. **T-** (TRANSFORM_OUT): Transform输出
+6. **W!** (SINK_WRITE_DONE): Sink写入完成
+
+6个追踪阶段：
+| 阶段 | 代码 | 说明 | 记录位置 |
+|------|------|------|---------|
+| SOURCE_EMIT | S0 | Source发出数据 | SeaTunnelSourceCollector.collect() |
+| QUEUE_IN | Q+ | 进入队列（入队前） | IntermediateQueue.received() |
+| QUEUE_OUT | Q- | 离开队列（出队后） | IntermediateQueue.collect() |
+| TRANSFORM_IN | T+ | Transform接收数据 | TransformFlowLifeCycle.received() |
+| TRANSFORM_OUT | T- | Transform输出数据 | TransformFlowLifeCycle输出前 |
+| SINK_WRITE_DONE | W! | Sink写入完成 | SinkFlowLifeCycle.writer.write()后 |
+
+追踪数据会通过HTTP上报到trace-collector，自动解析并存储到MySQL数据库。
+
+追踪数据会存储到MySQL数据库，方便后续分析端到端延迟和性能瓶颈。
+
+---
+
+## 一键配置与启动
+
+### 前提条件
+
+1. **启动MySQL服务**
+
+```bash
+# 方式1: Homebrew
+brew services start mysql
+
+# 方式2: MySQL Server
+mysql.server start
+
+# 方式3: 系统服务
+sudo /usr/local/mysql/support-files/mysql.server start
+
+# 验证MySQL运行
+mysql -uroot -p'root@123' -e "SELECT 1"
+```
+
+### 步骤1: 一键配置
+
+```bash
+cd /Users/stone/work/myworkspace/seatunnel
+./setup-stain-trace.sh
+```
+
+这个脚本会自动完成：
+- ✅ 创建MySQL数据库 `seatunnel_trace`
+- ✅ 创建3个表（st_trace_event_raw, st_trace, st_trace_entry）
+- ✅ 配置trace-collector连接MySQL
+- ✅ 配置seatunnel.yaml启用染色追踪
+- ✅ 编译trace-collector
+- ✅ 创建启动和查询脚本
+
+### 步骤2: 启动trace-collector（新终端窗口）
+
+```bash
+./start-trace-collector.sh
+```
+
+看到以下日志表示启动成功：
+```
+StainTrace collector started on port 9808
+Database initialized successfully
+```
+
+### 步骤3: 运行示例作业
+
+#### 方式A: 在IDE中运行（推荐）
+
+1. 打开 `SeaTunnelEngineLocalExample.java`
+2. 点击运行（无需传递任何参数）
+3. 观察控制台输出
+
+#### 方式B: 使用Maven命令运行
+
+```bash
+./mvnw -pl seatunnel-examples/seatunnel-engine-examples \
+  exec:java \
+  -Dexec.mainClass=org.apache.seatunnel.example.engine.SeaTunnelEngineLocalExample \
+  -nsu
+```
+
+### 步骤4: 查询追踪数据
+
+```bash
+./query-trace-data.sh
+```
+
+---
+
+## 数据库结构
+
+### 表说明
+
+#### 1. st_trace_event_raw（原始事件表）
+存储接收到的所有StainTraceEvent原始JSON数据。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | BIGINT | 自增主键 |
+| received_at | DATETIME(3) | 接收时间（毫秒精度）|
+| job_id | VARCHAR(255) | 作业ID |
+| event_type | VARCHAR(128) | 事件类型（STAIN_TRACE）|
+| body_json | JSON | 完整事件JSON |
+
+#### 2. st_trace（追踪摘要表）
+存储每条追踪记录的摘要信息。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| trace_id | BIGINT | 追踪ID（主键）|
+| sink_task_id | BIGINT | Sink任务ID（主键）|
+| job_id | VARCHAR(255) | 作业ID |
+| table_id | VARCHAR(255) | 表标识 |
+| created_time_ms | BIGINT | 创建时间戳（毫秒）|
+| received_at | DATETIME(3) | 接收时间 |
+| payload | LONGBLOB | 二进制payload（含所有阶段）|
+| start_ts_ms | BIGINT | 起始时间戳 |
+| entry_count | INT | 阶段条目数 |
+
+#### 3. st_trace_entry（追踪条目表）
+存储6个阶段的详细信息。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| trace_id | BIGINT | 追踪ID |
+| sink_task_id | BIGINT | Sink任务ID |
+| entry_index | INT | 条目索引 |
+| stage | SMALLINT | 阶段代码（1-6）|
+| task_id | BIGINT | 任务ID |
+| ts_ms | BIGINT | 时间戳（毫秒）|
+| worker_address | VARCHAR(255) | Worker地址 |
+| task_group_name | VARCHAR(255) | 任务组名称 |
+| task_class | VARCHAR(255) | 任务类名 |
+
+---
+
+## 常用SQL查询
+
+### 查询最近10条追踪记录
+
+```sql
+SELECT
+    trace_id,
+    job_id,
+    table_id,
+    received_at,
+    entry_count
+FROM st_trace
+ORDER BY received_at DESC
+LIMIT 10;
+```
+
+### 查看某条追踪的6个阶段详情
+
+```sql
+SELECT
+    entry_index,
+    CASE stage
+        WHEN 1 THEN 'SOURCE_EMIT (S0)'
+        WHEN 2 THEN 'QUEUE_IN (Q+)'
+        WHEN 3 THEN 'QUEUE_OUT (Q-)'
+        WHEN 4 THEN 'TRANSFORM_IN (T+)'
+        WHEN 5 THEN 'TRANSFORM_OUT (T-)'
+        WHEN 6 THEN 'SINK_WRITE_DONE (W!)'
+    END AS stage_name,
+    task_id,
+    FROM_UNIXTIME(ts_ms / 1000.0) AS timestamp,
+    ts_ms
+FROM st_trace_entry
+WHERE trace_id = <your_trace_id>
+  AND sink_task_id = <your_sink_task_id>
+ORDER BY entry_index;
+```
+
+### 端到端延迟分析
+
+```sql
+SELECT
+    trace_id,
+    job_id,
+    -- 端到端延迟
+    MAX(CASE WHEN stage = 6 THEN ts_ms END) -
+    MAX(CASE WHEN stage = 1 THEN ts_ms END) AS e2e_latency_ms,
+    -- Queue等待时间
+    MAX(CASE WHEN stage = 3 THEN ts_ms END) -
+    MAX(CASE WHEN stage = 2 THEN ts_ms END) AS queue_wait_ms,
+    -- Transform处理时间
+    MAX(CASE WHEN stage = 5 THEN ts_ms END) -
+    MAX(CASE WHEN stage = 4 THEN ts_ms END) AS transform_ms
+FROM st_trace t
+JOIN st_trace_entry e ON t.trace_id = e.trace_id AND t.sink_task_id = e.sink_task_id
+GROUP BY t.trace_id, t.job_id
+ORDER BY e2e_latency_ms DESC
+LIMIT 10;
+```
+
+---
+
+## 配置说明
+
+### seatunnel.yaml配置
+
+```yaml
+seatunnel:
+  engine:
+    # 启用染色追踪
+    stain-trace-enabled: true
+
+    # 采样率：每N条记录采样1条
+    stain-trace-sample-rate: 5
+
+    # 每Worker每秒最多产生多少条追踪Event
+    stain-trace-max-traces-per-second-per-worker: 100
+
+    # 每条追踪最多记录多少个阶段条目
+    stain-trace-max-entries-per-trace: 32
+
+    # Event上报配置
+    event-report-http:
+      url: "http://localhost:9808/ingest"
+```
+
+### trace-collector配置
+
+```properties
+# 服务端口
+server.port=9808
+
+# MySQL配置
+db.type=mysql
+db.jdbcUrl=jdbc:mysql://localhost:3306/seatunnel_trace
+db.username=root
+db.password=root@123
+
+# 启用payload解析
+trace.parsePayload=true
+```
+
+---
+
+## 验证效果
+
+运行作业后，检查以下内容：
+
+### 1. trace-collector日志
+
+```
+Received 2 events
+Ingested 2 traces with 12 entries
+```
+
+### 2. MySQL数据
+
+```bash
+./query-trace-data.sh
+```
+
+应该看到：
+- ✅ st_trace表有数据
+- ✅ st_trace_entry表有6个阶段的记录
+- ✅ 时间戳递增（S0 < Q+ < Q- < T+ < T- < W!）
+
+### 3. 示例作业特点
+
+默认示例作业 `stain_trace_fake_sql_union_to_console.conf`：
+- **FakeSource**: 生成10条数据
+- **Sql Transform**: 使用LATERAL VIEW EXPLODE，1条输入→2条输出
+- **Console Sink**: 输出20条数据
+- **采样率**: sample-rate=1（全采样）
+- **预期追踪数**: 10条（只有第一条split继承payload）
+
+---
+
+## 故障排查
+
+### 问题1: trace-collector启动失败
+
+**错误**: `Can't connect to MySQL`
+
+**解决**:
+```bash
+# 检查MySQL是否运行
+ps aux | grep mysqld
+
+# 启动MySQL
+brew services start mysql
+```
+
+### 问题2: 没有追踪数据
+
+**检查步骤**:
+
+1. 确认trace-collector正在运行
+```bash
+curl http://localhost:9808/health
+```
+
+2. 检查seatunnel.yaml配置是否正确
+```bash
+grep -A5 "event-report-http" seatunnel-examples/seatunnel-engine-examples/src/main/resources/examples/stain_trace_seatunnel.yaml
+```
+
+3. 查看trace-collector日志
+```bash
+# 应该看到接收Event的日志
+```
+
+### 问题3: 只有部分阶段数据
+
+**原因**: Transform的1-to-N场景，只有第一条输出继承payload
+
+**验证**: 检查`stain-trace-propagate-to-all-splits`配置
+```yaml
+stain-trace-propagate-to-all-splits: false  # 只第一条继承（默认）
+stain-trace-propagate-to-all-splits: true   # 所有split都继承
+```
+
+---
+
+## 进阶用法
+
+### 自定义作业配置
+
+创建自己的作业配置文件，参考：
+```bash
+seatunnel-examples/seatunnel-engine-examples/src/main/resources/examples/stain_trace_fake_sql_union_to_console.conf
+```
+
+运行时指定：
+```java
+public static void main(String[] args) {
+    String configurePath = "/path/to/your/job.conf";
+    // ... 其余代码
+}
+```
+
+### 性能调优
+
+生产环境建议配置：
+```yaml
+stain-trace-sample-rate: 100000  # 每10万条采样1条
+stain-trace-max-traces-per-second-per-worker: 50  # 限流
+```
+
+---
+
+## 相关文档
+
+- 设计文档: [me/design/stain.md](me/design/stain.md)
+- Review报告: [me/reviews/stain-review-final.md](me/reviews/stain-review-final.md)
+- 实现代码: 搜索 `StainTrace` 相关类
+
+---
+
+**创建时间**: 2026-01-18
+**作者**: AI Assistant

--- a/seatunnel-trace/pom.xml
+++ b/seatunnel-trace/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-trace</artifactId>
+    <packaging>pom</packaging>
+    <name>SeaTunnel : Trace</name>
+
+    <modules>
+        <module>seatunnel-trace-collector</module>
+    </modules>
+
+    <properties>
+        <!-- keep aligned with connector-clickhouse -->
+        <clickhouse.version>0.3.2-patch11</clickhouse.version>
+        <!-- keep aligned with connector-jdbc -->
+        <postgresql.version>42.4.3</postgresql.version>
+        <!-- keep aligned with seatunnel-dist -->
+        <mysql.version>8.0.27</mysql.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+</project>

--- a/seatunnel-trace/seatunnel-trace-collector/pom.xml
+++ b/seatunnel-trace/seatunnel-trace-collector/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-trace</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-trace-collector</artifactId>
+    <name>SeaTunnel : Trace : Collector</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <version>${clickhouse.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/TraceCollectorMain.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/TraceCollectorMain.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.db.clickhouse.ClickHouseTraceRepository;
+import org.apache.seatunnel.trace.collector.db.mysql.MySqlTraceRepository;
+import org.apache.seatunnel.trace.collector.db.postgres.PostgresTraceRepository;
+import org.apache.seatunnel.trace.collector.http.TraceHttpServer;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+
+import io.prometheus.client.hotspot.DefaultExports;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class TraceCollectorMain {
+
+    public static void main(String[] args) throws Exception {
+        TraceCollectorConfig config = TraceCollectorConfig.load();
+        log.info(
+                "Starting trace collector with dbType={}, port={}",
+                config.getDbType(),
+                config.getServerPort());
+
+        DefaultExports.initialize();
+        TraceCollectorMetrics metrics = new TraceCollectorMetrics();
+
+        TraceRepository repository;
+        if ("clickhouse".equalsIgnoreCase(config.getDbType())) {
+            repository = new ClickHouseTraceRepository(config, metrics);
+        } else if ("mysql".equalsIgnoreCase(config.getDbType())) {
+            repository = new MySqlTraceRepository(config, metrics);
+        } else {
+            repository = new PostgresTraceRepository(config, metrics);
+        }
+        repository.init();
+
+        TraceHttpServer server = new TraceHttpServer(config, repository, metrics);
+        server.start();
+
+        Runtime.getRuntime()
+                .addShutdownHook(
+                        new Thread(
+                                () -> {
+                                    try {
+                                        server.close();
+                                        repository.close();
+                                    } catch (IOException e) {
+                                        log.warn("Failed to shutdown trace collector cleanly", e);
+                                    }
+                                },
+                                "trace-collector-shutdown"));
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/config/TraceCollectorConfig.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/config/TraceCollectorConfig.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.config;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+@Getter
+@ToString
+public class TraceCollectorConfig {
+    private final int serverPort;
+    private final int maxRequestBytes;
+    private final String authToken;
+
+    private final String dbType;
+    private final String jdbcUrl;
+    private final String jdbcUsername;
+    private final String jdbcPassword;
+    private final String dbSchema;
+
+    private final boolean parsePayloadEnabled;
+    private final String engineTaskMappingUrlTemplate;
+    private final String engineTaskMappingToken;
+    private final long engineTaskMappingCacheTtlMs;
+
+    private TraceCollectorConfig(Properties p) {
+        this.serverPort = intOrDefault(p, "server.port", 9808);
+        this.maxRequestBytes = intOrDefault(p, "server.maxRequestBytes", 10 * 1024 * 1024);
+        this.authToken = trimToNull(p.getProperty("auth.token"));
+
+        this.dbType = trimToNull(p.getProperty("db.type", "postgres"));
+        this.jdbcUrl = required(p, "db.jdbcUrl");
+        this.jdbcUsername = p.getProperty("db.username", "");
+        this.jdbcPassword = p.getProperty("db.password", "");
+        String schema = trimToNull(p.getProperty("db.schema"));
+        if (schema == null) {
+            schema = "postgres".equalsIgnoreCase(dbType) ? "public" : "";
+        }
+        this.dbSchema = schema;
+
+        this.parsePayloadEnabled = boolOrDefault(p, "trace.parsePayload", true);
+        this.engineTaskMappingUrlTemplate =
+                trimToNull(p.getProperty("engine.taskMappingUrlTemplate"));
+        this.engineTaskMappingToken = trimToNull(p.getProperty("engine.taskMappingToken"));
+        this.engineTaskMappingCacheTtlMs =
+                longOrDefault(p, "engine.taskMappingCacheTtlMs", 30_000L);
+    }
+
+    public static TraceCollectorConfig load() throws IOException {
+        String path = System.getProperty("trace.collector.config");
+        if (path == null || path.trim().isEmpty()) {
+            path = System.getenv("TRACE_COLLECTOR_CONFIG");
+        }
+
+        Properties p = new Properties();
+        if (path == null || path.trim().isEmpty()) {
+            try (InputStream in =
+                    TraceCollectorConfig.class
+                            .getClassLoader()
+                            .getResourceAsStream("trace-collector.properties")) {
+                if (in != null) {
+                    p.load(in);
+                }
+            }
+        } else {
+            try (InputStream in = new FileInputStream(path)) {
+                p.load(in);
+            }
+        }
+        return new TraceCollectorConfig(p);
+    }
+
+    private static int intOrDefault(Properties p, String key, int defaultValue) {
+        String v = p.getProperty(key);
+        if (v == null || v.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return Integer.parseInt(v.trim());
+    }
+
+    private static boolean boolOrDefault(Properties p, String key, boolean defaultValue) {
+        String v = p.getProperty(key);
+        if (v == null || v.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(v.trim());
+    }
+
+    private static long longOrDefault(Properties p, String key, long defaultValue) {
+        String v = p.getProperty(key);
+        if (v == null || v.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return Long.parseLong(v.trim());
+    }
+
+    private static String required(Properties p, String key) {
+        String v = trimToNull(p.getProperty(key));
+        if (v == null) {
+            throw new IllegalArgumentException("Missing required config: " + key);
+        }
+        return v;
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/IngestedEvent.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/IngestedEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db;
+
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class IngestedEvent {
+    long receivedTimeMs;
+    String jobId;
+    String eventType;
+    String rawJson;
+
+    // for STAIN_TRACE only
+    Long createdTimeMs;
+    Long traceId;
+    Long sinkTaskId;
+    String tableId;
+    byte[] payloadBytes;
+    Long startTsMs;
+    Integer entryCount;
+    List<TraceEntry> entries;
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/TraceQuery.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/TraceQuery.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class TraceQuery {
+    String jobId;
+    String tableId;
+    Long fromMs;
+    Long toMs;
+    int limit;
+    int offset;
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/TraceRepository.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/TraceRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db;
+
+import org.apache.seatunnel.trace.collector.model.TraceDetail;
+import org.apache.seatunnel.trace.collector.model.TraceSummary;
+
+import java.io.Closeable;
+import java.util.List;
+
+public interface TraceRepository extends Closeable {
+
+    void init();
+
+    void ingest(List<IngestedEvent> events);
+
+    List<TraceSummary> queryTraces(TraceQuery query);
+
+    TraceDetail getTrace(long traceId, Long sinkTaskId);
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/clickhouse/ClickHouseTraceRepository.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/clickhouse/ClickHouseTraceRepository.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db.clickhouse;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.IngestedEvent;
+import org.apache.seatunnel.trace.collector.db.TraceQuery;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceDetail;
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+import org.apache.seatunnel.trace.collector.model.TraceSummary;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class ClickHouseTraceRepository implements TraceRepository {
+
+    private final TraceCollectorConfig config;
+    private final TraceCollectorMetrics metrics;
+
+    public ClickHouseTraceRepository(TraceCollectorConfig config, TraceCollectorMetrics metrics) {
+        this.config = config;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void init() {
+        try (Connection conn = open();
+                Statement st = conn.createStatement()) {
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS st_trace_event_raw ("
+                            + "received_at DateTime64(3),"
+                            + "job_id String,"
+                            + "event_type String,"
+                            + "body_json String"
+                            + ") ENGINE = MergeTree ORDER BY (job_id, received_at)");
+
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS st_trace ("
+                            + "trace_id Int64,"
+                            + "sink_task_id Int64,"
+                            + "job_id String,"
+                            + "table_id String,"
+                            + "created_time_ms Int64,"
+                            + "received_at DateTime64(3),"
+                            + "payload String,"
+                            + "start_ts_ms Int64,"
+                            + "entry_count Int32"
+                            + ") ENGINE = MergeTree ORDER BY (job_id, received_at, trace_id, sink_task_id)");
+
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS st_trace_entry ("
+                            + "trace_id Int64,"
+                            + "sink_task_id Int64,"
+                            + "entry_index Int32,"
+                            + "stage UInt16,"
+                            + "task_id Int64,"
+                            + "ts_ms Int64,"
+                            + "worker_address String,"
+                            + "task_group_name String,"
+                            + "task_class String"
+                            + ") ENGINE = MergeTree ORDER BY (trace_id, sink_task_id, entry_index)");
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to init clickhouse repository", e);
+        }
+    }
+
+    @Override
+    public void ingest(List<IngestedEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        try (Connection conn = open()) {
+            insertRaw(conn, events);
+            insertTraces(conn, events);
+            insertEntries(conn, events);
+        } catch (Exception e) {
+            metrics.dbWriteFailuresTotal.labels("all").inc();
+            throw new RuntimeException("Failed to ingest events", e);
+        }
+    }
+
+    private void insertRaw(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO st_trace_event_raw(received_at, job_id, event_type, body_json) VALUES (fromUnixTimestamp64Milli(?), ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                ps.setLong(1, e.getReceivedTimeMs());
+                ps.setString(2, nullToEmpty(e.getJobId()));
+                ps.setString(3, nullToEmpty(e.getEventType()));
+                ps.setString(4, nullToEmpty(e.getRawJson()));
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertTraces(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO st_trace(trace_id, sink_task_id, job_id, table_id, created_time_ms, received_at, payload, start_ts_ms, entry_count) "
+                        + "VALUES (?, ?, ?, ?, ?, fromUnixTimestamp64Milli(?), ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null) {
+                    continue;
+                }
+                ps.setLong(1, e.getTraceId());
+                ps.setLong(2, e.getSinkTaskId());
+                ps.setString(3, nullToEmpty(e.getJobId()));
+                ps.setString(4, nullToEmpty(e.getTableId()));
+                ps.setLong(5, e.getCreatedTimeMs() == null ? 0L : e.getCreatedTimeMs());
+                ps.setLong(6, e.getReceivedTimeMs());
+                ps.setString(
+                        7,
+                        e.getPayloadBytes() == null
+                                ? ""
+                                : java.util.Base64.getEncoder()
+                                        .encodeToString(e.getPayloadBytes()));
+                ps.setLong(8, e.getStartTsMs() == null ? 0L : e.getStartTsMs());
+                ps.setInt(9, e.getEntryCount() == null ? 0 : e.getEntryCount());
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertEntries(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO st_trace_entry(trace_id, sink_task_id, entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null || e.getEntries() == null) {
+                    continue;
+                }
+                for (TraceEntry entry : e.getEntries()) {
+                    ps.setLong(1, e.getTraceId());
+                    ps.setLong(2, e.getSinkTaskId());
+                    ps.setInt(3, entry.getIndex());
+                    ps.setInt(4, entry.getStage());
+                    ps.setLong(5, entry.getTaskId());
+                    ps.setLong(6, entry.getTsMs());
+                    ps.setString(7, nullToEmpty(entry.getWorkerAddress()));
+                    ps.setString(8, nullToEmpty(entry.getTaskGroupName()));
+                    ps.setString(9, nullToEmpty(entry.getTaskClass()));
+                    ps.addBatch();
+                }
+            }
+            ps.executeBatch();
+        }
+    }
+
+    @Override
+    public List<TraceSummary> queryTraces(TraceQuery query) {
+        int limit = Math.max(1, Math.min(query.getLimit(), 2000));
+        int offset = Math.max(0, query.getOffset());
+        StringBuilder sql =
+                new StringBuilder(
+                        "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, toUnixTimestamp64Milli(received_at), start_ts_ms, entry_count FROM st_trace WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (query.getJobId() != null && !query.getJobId().isEmpty()) {
+            sql.append(" AND job_id = ?");
+            params.add(query.getJobId());
+        }
+        if (query.getTableId() != null && !query.getTableId().isEmpty()) {
+            sql.append(" AND table_id = ?");
+            params.add(query.getTableId());
+        }
+        if (query.getFromMs() != null) {
+            sql.append(" AND received_at >= fromUnixTimestamp64Milli(?)");
+            params.add(query.getFromMs());
+        }
+        if (query.getToMs() != null) {
+            sql.append(" AND received_at <= fromUnixTimestamp64Milli(?)");
+            params.add(query.getToMs());
+        }
+        sql.append(" ORDER BY received_at DESC LIMIT ? OFFSET ?");
+        params.add(limit);
+        params.add(offset);
+
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            List<TraceSummary> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(
+                            new TraceSummary(
+                                    rs.getLong(1),
+                                    rs.getLong(2),
+                                    rs.getString(3),
+                                    rs.getString(4),
+                                    rs.getLong(5),
+                                    rs.getLong(6),
+                                    rs.getLong(7),
+                                    rs.getInt(8)));
+                }
+            }
+            return out;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to query traces", e);
+        }
+    }
+
+    @Override
+    public TraceDetail getTrace(long traceId, Long sinkTaskId) {
+        // ClickHouse: keep it simple, require sinkTaskId
+        if (sinkTaskId == null) {
+            return new TraceDetail(null, new ArrayList<>());
+        }
+        TraceSummary summary = selectTraceSummary(traceId, sinkTaskId);
+        if (summary == null) {
+            return new TraceDetail(null, new ArrayList<>());
+        }
+        List<TraceEntry> entries = selectEntries(traceId, sinkTaskId);
+        return new TraceDetail(summary, entries);
+    }
+
+    private TraceSummary selectTraceSummary(long traceId, long sinkTaskId) {
+        String sql =
+                "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, toUnixTimestamp64Milli(received_at), start_ts_ms, entry_count "
+                        + "FROM st_trace WHERE trace_id = ? AND sink_task_id = ? ORDER BY received_at DESC LIMIT 1";
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            ps.setLong(2, sinkTaskId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                return new TraceSummary(
+                        rs.getLong(1),
+                        rs.getLong(2),
+                        rs.getString(3),
+                        rs.getString(4),
+                        rs.getLong(5),
+                        rs.getLong(6),
+                        rs.getLong(7),
+                        rs.getInt(8));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to select trace", e);
+        }
+    }
+
+    private List<TraceEntry> selectEntries(long traceId, long sinkTaskId) {
+        String sql =
+                "SELECT entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class "
+                        + "FROM st_trace_entry WHERE trace_id = ? AND sink_task_id = ? ORDER BY entry_index ASC";
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            ps.setLong(2, sinkTaskId);
+            List<TraceEntry> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(
+                            new TraceEntry(
+                                    rs.getInt(1),
+                                    rs.getInt(2),
+                                    rs.getLong(3),
+                                    rs.getLong(4),
+                                    rs.getString(5),
+                                    rs.getString(6),
+                                    rs.getString(7)));
+                }
+            }
+            return out;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to select entries", e);
+        }
+    }
+
+    private Connection open() throws SQLException {
+        return DriverManager.getConnection(
+                config.getJdbcUrl(), config.getJdbcUsername(), config.getJdbcPassword());
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/mysql/MySqlTraceRepository.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/mysql/MySqlTraceRepository.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db.mysql;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.IngestedEvent;
+import org.apache.seatunnel.trace.collector.db.TraceQuery;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceDetail;
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+import org.apache.seatunnel.trace.collector.model.TraceSummary;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class MySqlTraceRepository implements TraceRepository {
+
+    private final TraceCollectorConfig config;
+    private final TraceCollectorMetrics metrics;
+    private final String schema;
+
+    public MySqlTraceRepository(TraceCollectorConfig config, TraceCollectorMetrics metrics) {
+        this.config = config;
+        this.metrics = metrics;
+        this.schema = normalizeSchema(config.getDbSchema());
+    }
+
+    @Override
+    public void init() {
+        try (Connection conn = open();
+                Statement st = conn.createStatement()) {
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS "
+                            + qualify("st_trace_event_raw")
+                            + " ("
+                            + "id BIGINT NOT NULL AUTO_INCREMENT,"
+                            + "received_at DATETIME(3) NOT NULL,"
+                            + "job_id VARCHAR(255) NULL,"
+                            + "event_type VARCHAR(128) NULL,"
+                            + "body_json JSON NOT NULL,"
+                            + "PRIMARY KEY(id),"
+                            + "KEY idx_st_trace_event_job_received(job_id, received_at)"
+                            + ") ENGINE=InnoDB");
+
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS "
+                            + qualify("st_trace")
+                            + " ("
+                            + "trace_id BIGINT NOT NULL,"
+                            + "sink_task_id BIGINT NOT NULL,"
+                            + "job_id VARCHAR(255) NULL,"
+                            + "table_id VARCHAR(255) NULL,"
+                            + "created_time_ms BIGINT NULL,"
+                            + "received_at DATETIME(3) NOT NULL,"
+                            + "payload LONGBLOB NULL,"
+                            + "start_ts_ms BIGINT NULL,"
+                            + "entry_count INT NULL,"
+                            + "PRIMARY KEY(trace_id, sink_task_id),"
+                            + "KEY idx_st_trace_job_received(job_id, received_at)"
+                            + ") ENGINE=InnoDB");
+
+            st.execute(
+                    "CREATE TABLE IF NOT EXISTS "
+                            + qualify("st_trace_entry")
+                            + " ("
+                            + "trace_id BIGINT NOT NULL,"
+                            + "sink_task_id BIGINT NOT NULL,"
+                            + "entry_index INT NOT NULL,"
+                            + "stage SMALLINT NOT NULL,"
+                            + "task_id BIGINT NOT NULL,"
+                            + "ts_ms BIGINT NOT NULL,"
+                            + "worker_address VARCHAR(255) NULL,"
+                            + "task_group_name VARCHAR(255) NULL,"
+                            + "task_class VARCHAR(255) NULL,"
+                            + "PRIMARY KEY(trace_id, sink_task_id, entry_index)"
+                            + ") ENGINE=InnoDB");
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to init mysql repository", e);
+        }
+    }
+
+    @Override
+    public void ingest(List<IngestedEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        try (Connection conn = open()) {
+            insertRaw(conn, events);
+            insertTraces(conn, events);
+            insertEntries(conn, events);
+        } catch (Exception e) {
+            metrics.dbWriteFailuresTotal.labels("all").inc();
+            throw new RuntimeException("Failed to ingest events", e);
+        }
+    }
+
+    private void insertRaw(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO "
+                        + qualify("st_trace_event_raw")
+                        + "(received_at, job_id, event_type, body_json) "
+                        + "VALUES (FROM_UNIXTIME(? / 1000.0), ?, ?, CAST(? AS JSON))";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                ps.setLong(1, e.getReceivedTimeMs());
+                ps.setString(2, e.getJobId());
+                ps.setString(3, e.getEventType());
+                ps.setString(4, e.getRawJson());
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertTraces(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO "
+                        + qualify("st_trace")
+                        + "(trace_id, sink_task_id, job_id, table_id, created_time_ms, received_at, payload, start_ts_ms, entry_count) "
+                        + "VALUES (?, ?, ?, ?, ?, FROM_UNIXTIME(? / 1000.0), ?, ?, ?) "
+                        + "ON DUPLICATE KEY UPDATE "
+                        + "received_at=VALUES(received_at), "
+                        + "payload=VALUES(payload), "
+                        + "start_ts_ms=VALUES(start_ts_ms), "
+                        + "entry_count=VALUES(entry_count)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null) {
+                    continue;
+                }
+                ps.setLong(1, e.getTraceId());
+                ps.setLong(2, e.getSinkTaskId());
+                ps.setString(3, e.getJobId());
+                ps.setString(4, e.getTableId());
+                if (e.getCreatedTimeMs() == null) {
+                    ps.setObject(5, null);
+                } else {
+                    ps.setLong(5, e.getCreatedTimeMs());
+                }
+                ps.setLong(6, e.getReceivedTimeMs());
+                ps.setBytes(7, e.getPayloadBytes());
+                if (e.getStartTsMs() == null) {
+                    ps.setObject(8, null);
+                } else {
+                    ps.setLong(8, e.getStartTsMs());
+                }
+                if (e.getEntryCount() == null) {
+                    ps.setObject(9, null);
+                } else {
+                    ps.setInt(9, e.getEntryCount());
+                }
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertEntries(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT IGNORE INTO "
+                        + qualify("st_trace_entry")
+                        + "(trace_id, sink_task_id, entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null || e.getEntries() == null) {
+                    continue;
+                }
+                for (TraceEntry entry : e.getEntries()) {
+                    ps.setLong(1, e.getTraceId());
+                    ps.setLong(2, e.getSinkTaskId());
+                    ps.setInt(3, entry.getIndex());
+                    ps.setInt(4, entry.getStage());
+                    ps.setLong(5, entry.getTaskId());
+                    ps.setLong(6, entry.getTsMs());
+                    ps.setString(7, entry.getWorkerAddress());
+                    ps.setString(8, entry.getTaskGroupName());
+                    ps.setString(9, entry.getTaskClass());
+                    ps.addBatch();
+                }
+            }
+            ps.executeBatch();
+        }
+    }
+
+    @Override
+    public List<TraceSummary> queryTraces(TraceQuery query) {
+        int limit = Math.max(1, Math.min(query.getLimit(), 2000));
+        int offset = Math.max(0, query.getOffset());
+
+        StringBuilder sql =
+                new StringBuilder(
+                        "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, "
+                                + "(UNIX_TIMESTAMP(received_at) * 1000 + FLOOR(MICROSECOND(received_at)/1000)) AS received_ms, "
+                                + "start_ts_ms, entry_count "
+                                + "FROM "
+                                + qualify("st_trace")
+                                + " WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (query.getJobId() != null && !query.getJobId().isEmpty()) {
+            sql.append(" AND job_id = ?");
+            params.add(query.getJobId());
+        }
+        if (query.getTableId() != null && !query.getTableId().isEmpty()) {
+            sql.append(" AND table_id = ?");
+            params.add(query.getTableId());
+        }
+        if (query.getFromMs() != null) {
+            sql.append(" AND received_at >= FROM_UNIXTIME(? / 1000.0)");
+            params.add(query.getFromMs());
+        }
+        if (query.getToMs() != null) {
+            sql.append(" AND received_at <= FROM_UNIXTIME(? / 1000.0)");
+            params.add(query.getToMs());
+        }
+        sql.append(" ORDER BY received_at DESC LIMIT ? OFFSET ?");
+        params.add(limit);
+        params.add(offset);
+
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            List<TraceSummary> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(
+                            new TraceSummary(
+                                    rs.getLong(1),
+                                    rs.getLong(2),
+                                    rs.getString(3),
+                                    rs.getString(4),
+                                    rs.getObject(5) == null ? null : rs.getLong(5),
+                                    rs.getLong(6),
+                                    rs.getObject(7) == null ? null : rs.getLong(7),
+                                    rs.getObject(8) == null ? null : rs.getInt(8)));
+                }
+            }
+            return out;
+        } catch (SQLException e) {
+            metrics.dbReadFailuresTotal.labels("queryTraces").inc();
+            throw new RuntimeException("Failed to query traces", e);
+        }
+    }
+
+    @Override
+    public TraceDetail getTrace(long traceId, Long sinkTaskId) {
+        if (sinkTaskId == null) {
+            return null;
+        }
+        try (Connection conn = open()) {
+            TraceSummary summary = queryOneTrace(conn, traceId, sinkTaskId);
+            if (summary == null) {
+                return null;
+            }
+            List<TraceEntry> entries = queryEntries(conn, traceId, sinkTaskId);
+            return new TraceDetail(summary, entries);
+        } catch (SQLException e) {
+            metrics.dbReadFailuresTotal.labels("getTrace").inc();
+            throw new RuntimeException("Failed to get trace detail", e);
+        }
+    }
+
+    private TraceSummary queryOneTrace(Connection conn, long traceId, long sinkTaskId)
+            throws SQLException {
+        String sql =
+                "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, "
+                        + "(UNIX_TIMESTAMP(received_at) * 1000 + FLOOR(MICROSECOND(received_at)/1000)) AS received_ms, "
+                        + "start_ts_ms, entry_count "
+                        + "FROM "
+                        + qualify("st_trace")
+                        + " WHERE trace_id = ? AND sink_task_id = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            ps.setLong(2, sinkTaskId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                return new TraceSummary(
+                        rs.getLong(1),
+                        rs.getLong(2),
+                        rs.getString(3),
+                        rs.getString(4),
+                        rs.getObject(5) == null ? null : rs.getLong(5),
+                        rs.getLong(6),
+                        rs.getObject(7) == null ? null : rs.getLong(7),
+                        rs.getObject(8) == null ? null : rs.getInt(8));
+            }
+        }
+    }
+
+    private List<TraceEntry> queryEntries(Connection conn, long traceId, long sinkTaskId)
+            throws SQLException {
+        String sql =
+                "SELECT entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class "
+                        + "FROM "
+                        + qualify("st_trace_entry")
+                        + " WHERE trace_id = ? AND sink_task_id = ? ORDER BY entry_index ASC";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            ps.setLong(2, sinkTaskId);
+            List<TraceEntry> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    TraceEntry e = new TraceEntry();
+                    e.setIndex(rs.getInt(1));
+                    e.setStage(rs.getInt(2));
+                    e.setTaskId(rs.getLong(3));
+                    e.setTsMs(rs.getLong(4));
+                    e.setWorkerAddress(rs.getString(5));
+                    e.setTaskGroupName(rs.getString(6));
+                    e.setTaskClass(rs.getString(7));
+                    out.add(e);
+                }
+            }
+            return out;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op
+    }
+
+    private Connection open() throws SQLException {
+        return DriverManager.getConnection(
+                config.getJdbcUrl(), config.getJdbcUsername(), config.getJdbcPassword());
+    }
+
+    private String qualify(String table) {
+        if (schema.isEmpty()) {
+            return "`" + table + "`";
+        }
+        return "`" + schema + "`.`" + table + "`";
+    }
+
+    private static String normalizeSchema(String schema) {
+        if (schema == null) {
+            return "";
+        }
+        String t = schema.trim();
+        return t.isEmpty() ? "" : t;
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/postgres/PostgresTraceRepository.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/db/postgres/PostgresTraceRepository.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.db.postgres;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.IngestedEvent;
+import org.apache.seatunnel.trace.collector.db.TraceQuery;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceDetail;
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+import org.apache.seatunnel.trace.collector.model.TraceSummary;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class PostgresTraceRepository implements TraceRepository {
+
+    private final TraceCollectorConfig config;
+    private final TraceCollectorMetrics metrics;
+    private final String schema;
+
+    public PostgresTraceRepository(TraceCollectorConfig config, TraceCollectorMetrics metrics) {
+        this.config = config;
+        this.metrics = metrics;
+        this.schema = config.getDbSchema();
+    }
+
+    @Override
+    public void init() {
+        try (Connection conn = open()) {
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE SCHEMA IF NOT EXISTS " + schema);
+                st.execute(
+                        "CREATE TABLE IF NOT EXISTS "
+                                + schema
+                                + ".st_trace_event_raw ("
+                                + "id BIGSERIAL PRIMARY KEY,"
+                                + "received_at TIMESTAMPTZ NOT NULL,"
+                                + "job_id TEXT,"
+                                + "event_type TEXT,"
+                                + "body_json JSONB NOT NULL"
+                                + ")");
+                st.execute(
+                        "CREATE TABLE IF NOT EXISTS "
+                                + schema
+                                + ".st_trace ("
+                                + "trace_id BIGINT NOT NULL,"
+                                + "sink_task_id BIGINT NOT NULL,"
+                                + "job_id TEXT,"
+                                + "table_id TEXT,"
+                                + "created_time_ms BIGINT,"
+                                + "received_at TIMESTAMPTZ NOT NULL,"
+                                + "payload BYTEA,"
+                                + "start_ts_ms BIGINT,"
+                                + "entry_count INT,"
+                                + "PRIMARY KEY(trace_id, sink_task_id)"
+                                + ")");
+                st.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_st_trace_job_received ON "
+                                + schema
+                                + ".st_trace(job_id, received_at DESC)");
+                st.execute(
+                        "CREATE TABLE IF NOT EXISTS "
+                                + schema
+                                + ".st_trace_entry ("
+                                + "trace_id BIGINT NOT NULL,"
+                                + "sink_task_id BIGINT NOT NULL,"
+                                + "entry_index INT NOT NULL,"
+                                + "stage SMALLINT NOT NULL,"
+                                + "task_id BIGINT NOT NULL,"
+                                + "ts_ms BIGINT NOT NULL,"
+                                + "worker_address TEXT,"
+                                + "task_group_name TEXT,"
+                                + "task_class TEXT,"
+                                + "PRIMARY KEY(trace_id, sink_task_id, entry_index)"
+                                + ")");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to init postgres repository", e);
+        }
+    }
+
+    @Override
+    public void ingest(List<IngestedEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        try (Connection conn = open()) {
+            conn.setAutoCommit(false);
+
+            insertRaw(conn, events);
+            insertTraces(conn, events);
+            insertEntries(conn, events);
+
+            conn.commit();
+        } catch (Exception e) {
+            metrics.dbWriteFailuresTotal.labels("all").inc();
+            throw new RuntimeException("Failed to ingest events", e);
+        }
+    }
+
+    private void insertRaw(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO "
+                        + schema
+                        + ".st_trace_event_raw(received_at, job_id, event_type, body_json) "
+                        + "VALUES (to_timestamp(? / 1000.0), ?, ?, ?::jsonb)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                ps.setLong(1, e.getReceivedTimeMs());
+                ps.setString(2, e.getJobId());
+                ps.setString(3, e.getEventType());
+                ps.setString(4, e.getRawJson());
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertTraces(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO "
+                        + schema
+                        + ".st_trace(trace_id, sink_task_id, job_id, table_id, created_time_ms, received_at, payload, start_ts_ms, entry_count) "
+                        + "VALUES (?, ?, ?, ?, ?, to_timestamp(? / 1000.0), ?, ?, ?) "
+                        + "ON CONFLICT(trace_id, sink_task_id) DO UPDATE SET "
+                        + "received_at=EXCLUDED.received_at, payload=EXCLUDED.payload, start_ts_ms=EXCLUDED.start_ts_ms, entry_count=EXCLUDED.entry_count";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null) {
+                    continue;
+                }
+                ps.setLong(1, e.getTraceId());
+                ps.setLong(2, e.getSinkTaskId());
+                ps.setString(3, e.getJobId());
+                ps.setString(4, e.getTableId());
+                if (e.getCreatedTimeMs() == null) {
+                    ps.setObject(5, null);
+                } else {
+                    ps.setLong(5, e.getCreatedTimeMs());
+                }
+                ps.setLong(6, e.getReceivedTimeMs());
+                ps.setBytes(7, e.getPayloadBytes());
+                if (e.getStartTsMs() == null) {
+                    ps.setObject(8, null);
+                } else {
+                    ps.setLong(8, e.getStartTsMs());
+                }
+                if (e.getEntryCount() == null) {
+                    ps.setObject(9, null);
+                } else {
+                    ps.setInt(9, e.getEntryCount());
+                }
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private void insertEntries(Connection conn, List<IngestedEvent> events) throws SQLException {
+        String sql =
+                "INSERT INTO "
+                        + schema
+                        + ".st_trace_entry(trace_id, sink_task_id, entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                        + "ON CONFLICT(trace_id, sink_task_id, entry_index) DO NOTHING";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (IngestedEvent e : events) {
+                if (e.getTraceId() == null || e.getSinkTaskId() == null || e.getEntries() == null) {
+                    continue;
+                }
+                for (TraceEntry entry : e.getEntries()) {
+                    ps.setLong(1, e.getTraceId());
+                    ps.setLong(2, e.getSinkTaskId());
+                    ps.setInt(3, entry.getIndex());
+                    ps.setInt(4, entry.getStage());
+                    ps.setLong(5, entry.getTaskId());
+                    ps.setLong(6, entry.getTsMs());
+                    ps.setString(7, entry.getWorkerAddress());
+                    ps.setString(8, entry.getTaskGroupName());
+                    ps.setString(9, entry.getTaskClass());
+                    ps.addBatch();
+                }
+            }
+            ps.executeBatch();
+        }
+    }
+
+    @Override
+    public List<TraceSummary> queryTraces(TraceQuery query) {
+        int limit = Math.max(1, Math.min(query.getLimit(), 2000));
+        int offset = Math.max(0, query.getOffset());
+
+        StringBuilder sql =
+                new StringBuilder(
+                        "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, extract(epoch from received_at)*1000 as received_ms, start_ts_ms, entry_count "
+                                + "FROM "
+                                + schema
+                                + ".st_trace WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+        if (query.getJobId() != null && !query.getJobId().isEmpty()) {
+            sql.append(" AND job_id = ?");
+            params.add(query.getJobId());
+        }
+        if (query.getTableId() != null && !query.getTableId().isEmpty()) {
+            sql.append(" AND table_id = ?");
+            params.add(query.getTableId());
+        }
+        if (query.getFromMs() != null) {
+            sql.append(" AND received_at >= to_timestamp(? / 1000.0)");
+            params.add(query.getFromMs());
+        }
+        if (query.getToMs() != null) {
+            sql.append(" AND received_at <= to_timestamp(? / 1000.0)");
+            params.add(query.getToMs());
+        }
+        sql.append(" ORDER BY received_at DESC LIMIT ? OFFSET ?");
+        params.add(limit);
+        params.add(offset);
+
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            List<TraceSummary> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(
+                            new TraceSummary(
+                                    rs.getLong(1),
+                                    rs.getLong(2),
+                                    rs.getString(3),
+                                    rs.getString(4),
+                                    rs.getLong(5),
+                                    rs.getLong(6),
+                                    rs.getLong(7),
+                                    rs.getInt(8)));
+                }
+            }
+            return out;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to query traces", e);
+        }
+    }
+
+    @Override
+    public TraceDetail getTrace(long traceId, Long sinkTaskId) {
+        TraceSummary summary = selectTraceSummary(traceId, sinkTaskId);
+        if (summary == null) {
+            return new TraceDetail(null, new ArrayList<>());
+        }
+        List<TraceEntry> entries = selectEntries(traceId, summary.getSinkTaskId());
+        return new TraceDetail(summary, entries);
+    }
+
+    private TraceSummary selectTraceSummary(long traceId, Long sinkTaskId) {
+        String sql =
+                "SELECT trace_id, sink_task_id, job_id, table_id, created_time_ms, extract(epoch from received_at)*1000 as received_ms, start_ts_ms, entry_count "
+                        + "FROM "
+                        + schema
+                        + ".st_trace WHERE trace_id = ?"
+                        + (sinkTaskId == null
+                                ? " ORDER BY received_at DESC LIMIT 1"
+                                : " AND sink_task_id = ?");
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            if (sinkTaskId != null) {
+                ps.setLong(2, sinkTaskId);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                return new TraceSummary(
+                        rs.getLong(1),
+                        rs.getLong(2),
+                        rs.getString(3),
+                        rs.getString(4),
+                        rs.getLong(5),
+                        rs.getLong(6),
+                        rs.getLong(7),
+                        rs.getInt(8));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to select trace", e);
+        }
+    }
+
+    private List<TraceEntry> selectEntries(long traceId, long sinkTaskId) {
+        String sql =
+                "SELECT entry_index, stage, task_id, ts_ms, worker_address, task_group_name, task_class "
+                        + "FROM "
+                        + schema
+                        + ".st_trace_entry WHERE trace_id = ? AND sink_task_id = ? ORDER BY entry_index ASC";
+        try (Connection conn = open();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, traceId);
+            ps.setLong(2, sinkTaskId);
+            List<TraceEntry> out = new ArrayList<>();
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    TraceEntry e =
+                            new TraceEntry(
+                                    rs.getInt(1),
+                                    rs.getInt(2),
+                                    rs.getLong(3),
+                                    rs.getLong(4),
+                                    rs.getString(5),
+                                    rs.getString(6),
+                                    rs.getString(7));
+                    out.add(e);
+                }
+            }
+            return out;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to select entries", e);
+        }
+    }
+
+    private Connection open() throws SQLException {
+        return DriverManager.getConnection(
+                config.getJdbcUrl(), config.getJdbcUsername(), config.getJdbcPassword());
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op (DriverManager based)
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/enrich/TaskMappingCache.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/enrich/TaskMappingCache.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.enrich;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.http.TraceHttpServer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class TaskMappingCache {
+
+    @Value
+    public static class Mapping {
+        String worker;
+        String taskGroupName;
+        String taskClass;
+    }
+
+    private final String urlTemplate;
+    private final String token;
+    private final long ttlMs;
+    private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public TaskMappingCache(TraceCollectorConfig config) {
+        this.urlTemplate = config.getEngineTaskMappingUrlTemplate();
+        this.token = config.getEngineTaskMappingToken();
+        this.ttlMs = config.getEngineTaskMappingCacheTtlMs();
+    }
+
+    public boolean isEnabled() {
+        return urlTemplate != null && urlTemplate.contains("{jobId}");
+    }
+
+    public Map<Long, Mapping> getMapping(String jobId) {
+        if (!isEnabled() || jobId == null || jobId.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        long now = System.currentTimeMillis();
+        CacheEntry current = cache.get(jobId);
+        if (current != null && (now - current.loadedAtMs) <= ttlMs) {
+            return current.mapping;
+        }
+        return cache.compute(
+                        jobId,
+                        (k, old) -> {
+                            long now2 = System.currentTimeMillis();
+                            if (old != null && (now2 - old.loadedAtMs) <= ttlMs) {
+                                return old;
+                            }
+                            Map<Long, Mapping> mapping = fetch(jobId);
+                            if (mapping == null) {
+                                if (old != null) {
+                                    return old;
+                                }
+                                mapping = Collections.emptyMap();
+                            }
+                            return new CacheEntry(now2, mapping);
+                        })
+                .mapping;
+    }
+
+    private Map<Long, Mapping> fetch(String jobId) {
+        String url = urlTemplate.replace("{jobId}", jobId);
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(3000);
+            conn.setReadTimeout(5000);
+            if (token != null && !token.isEmpty()) {
+                conn.setRequestProperty("X-Seatunnel-Token", token);
+            }
+            int code = conn.getResponseCode();
+            if (code == 404) {
+                return Collections.emptyMap();
+            }
+            if (code / 100 != 2) {
+                log.debug("Fetch task mapping failed, code={}, url={}", code, url);
+                return null;
+            }
+            try (InputStream in = conn.getInputStream()) {
+                JsonNode root = TraceHttpServer.MAPPER.readTree(in);
+                JsonNode items = root == null ? null : root.get("items");
+                if (items == null || !items.isArray()) {
+                    return Collections.emptyMap();
+                }
+                Map<Long, Mapping> out = new HashMap<>();
+                for (JsonNode item : items) {
+                    Long taskId = asLongOrNull(item.get("taskId"));
+                    if (taskId == null) {
+                        continue;
+                    }
+                    out.put(
+                            taskId,
+                            new Mapping(
+                                    asText(item.get("worker")),
+                                    asText(item.get("taskGroupName")),
+                                    asText(item.get("taskClass"))));
+                }
+                return out;
+            }
+        } catch (Exception e) {
+            log.debug("Fetch task mapping failed, url={}", url, e);
+            return null;
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static String asText(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        return node.isTextual() ? node.asText() : node.toString();
+    }
+
+    private static Long asLongOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            String s = node.asText();
+            if (s == null || s.isEmpty()) {
+                return null;
+            }
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static class CacheEntry {
+        private final long loadedAtMs;
+        private final Map<Long, Mapping> mapping;
+
+        private CacheEntry(long loadedAtMs, Map<Long, Mapping> mapping) {
+            this.loadedAtMs = loadedAtMs;
+            this.mapping = mapping;
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/EventsIngestHandler.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/EventsIngestHandler.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.IngestedEvent;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.enrich.TaskMappingCache;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+import org.apache.seatunnel.trace.collector.payload.SttrPayloadDecoder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+@Slf4j
+final class EventsIngestHandler implements HttpHandler {
+
+    private final TraceCollectorConfig config;
+    private final TraceRepository repository;
+    private final TraceCollectorMetrics metrics;
+    private final TraceAuth auth;
+    private final TaskMappingCache mappingCache;
+
+    private static final int MAX_STAIN_TRACE_PAYLOAD_BYTES = 8 * 1024;
+
+    EventsIngestHandler(
+            TraceCollectorConfig config,
+            TraceRepository repository,
+            TraceCollectorMetrics metrics,
+            TraceAuth auth,
+            TaskMappingCache mappingCache) {
+        this.config = config;
+        this.repository = repository;
+        this.metrics = metrics;
+        this.auth = auth;
+        this.mappingCache = mappingCache;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long startNanos = System.nanoTime();
+        String method = exchange.getRequestMethod();
+        int code = 200;
+        try {
+            HttpUtils.handlePreflightIfNeeded(exchange);
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                return;
+            }
+            if (!"POST".equalsIgnoreCase(method)) {
+                code = 405;
+                HttpUtils.writeText(exchange, 405, "method not allowed\n");
+                return;
+            }
+            if (!auth.isAuthorized(exchange)) {
+                code = 401;
+                HttpUtils.writeText(exchange, 401, "unauthorized\n");
+                return;
+            }
+
+            byte[] body =
+                    HttpUtils.readAllBytesWithLimit(
+                            exchange.getRequestBody(), config.getMaxRequestBytes());
+            JsonNode root = TraceHttpServer.MAPPER.readTree(body);
+            if (root == null || !root.isArray()) {
+                code = 400;
+                HttpUtils.writeText(exchange, 400, "expect json array\n");
+                return;
+            }
+
+            long receivedMs = System.currentTimeMillis();
+            List<IngestedEvent> events = new ArrayList<>();
+            for (JsonNode node : root) {
+                String eventType = asTextOrNull(node.get("eventType"));
+                String jobId = asTextOrNull(node.get("jobId"));
+                if (eventType == null) {
+                    eventType = "UNKNOWN";
+                }
+                metrics.eventsReceivedTotal.labels(eventType).inc();
+
+                IngestedEvent.IngestedEventBuilder builder =
+                        IngestedEvent.builder()
+                                .receivedTimeMs(receivedMs)
+                                .jobId(jobId)
+                                .eventType(eventType)
+                                .rawJson(node.toString());
+
+                if ("STAIN_TRACE".equalsIgnoreCase(eventType)) {
+                    metrics.stainTraceReceivedTotal.inc();
+                    Long createdTimeMs = asLongOrNull(node.get("createdTime"));
+                    Long traceId = asLongOrNull(node.get("traceId"));
+                    Long sinkTaskId = asLongOrNull(node.get("sinkTaskId"));
+                    String tableId = asTextOrNull(node.get("tableId"));
+                    byte[] payload = decodePayload(node.get("payload"));
+
+                    if (traceId == null || traceId <= 0 || sinkTaskId == null || sinkTaskId <= 0) {
+                        metrics.invalidEventsTotal.labels("stain_trace_missing_ids").inc();
+                    } else {
+                        if (payload != null && payload.length > MAX_STAIN_TRACE_PAYLOAD_BYTES) {
+                            metrics.invalidEventsTotal.labels("stain_trace_payload_oversize").inc();
+                            payload = null;
+                        }
+                        builder.createdTimeMs(createdTimeMs)
+                                .traceId(traceId)
+                                .sinkTaskId(sinkTaskId)
+                                .tableId(tableId)
+                                .payloadBytes(payload);
+
+                        if (config.isParsePayloadEnabled()
+                                && payload != null
+                                && SttrPayloadDecoder.isValid(payload)) {
+                            SttrPayloadDecoder.DecodedPayload decoded =
+                                    SttrPayloadDecoder.decode(payload);
+                            maybeEnrich(jobId, decoded.getEntries());
+                            builder.startTsMs(decoded.getStartTsMs())
+                                    .entryCount(decoded.getEntryCount())
+                                    .entries(decoded.getEntries());
+                        } else if (payload != null) {
+                            metrics.invalidEventsTotal.labels("stain_trace_payload_invalid").inc();
+                        }
+                    }
+                }
+                events.add(builder.build());
+            }
+
+            repository.ingest(events);
+
+            byte[] resp =
+                    TraceHttpServer.MAPPER
+                            .createObjectNode()
+                            .put("received", events.size())
+                            .toString()
+                            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            HttpUtils.writeJson(exchange, 200, resp);
+        } catch (IllegalArgumentException e) {
+            code = 400;
+            HttpUtils.writeText(exchange, 400, e.getMessage() + "\n");
+        } catch (Throwable t) {
+            code = 500;
+            log.warn("Failed to ingest events", t);
+            HttpUtils.writeText(exchange, 500, "internal error\n");
+        } finally {
+            metrics.httpRequestsTotal
+                    .labels("/api/v1/seatunnel/events", method, String.valueOf(code))
+                    .inc();
+            metrics.httpRequestSeconds
+                    .labels("/api/v1/seatunnel/events", method)
+                    .observe((System.nanoTime() - startNanos) / 1e9);
+        }
+    }
+
+    private void maybeEnrich(String jobId, List<TraceEntry> entries) {
+        if (entries == null
+                || entries.isEmpty()
+                || mappingCache == null
+                || !mappingCache.isEnabled()) {
+            return;
+        }
+        java.util.Map<Long, TaskMappingCache.Mapping> mapping = mappingCache.getMapping(jobId);
+        if (mapping.isEmpty()) {
+            return;
+        }
+        for (TraceEntry e : entries) {
+            TaskMappingCache.Mapping m = mapping.get(e.getTaskId());
+            if (m == null) {
+                continue;
+            }
+            e.setWorkerAddress(m.getWorker());
+            e.setTaskGroupName(m.getTaskGroupName());
+            e.setTaskClass(m.getTaskClass());
+        }
+    }
+
+    private static String asTextOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        return node.toString();
+    }
+
+    private static Long asLongOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            String t = node.asText();
+            if (t == null || t.isEmpty()) {
+                return null;
+            }
+            try {
+                return Long.parseLong(t);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static byte[] decodePayload(JsonNode payloadNode) {
+        if (payloadNode == null || payloadNode.isNull()) {
+            return null;
+        }
+        if (payloadNode.isBinary()) {
+            try {
+                return payloadNode.binaryValue();
+            } catch (IOException e) {
+                return null;
+            }
+        }
+        if (payloadNode.isTextual()) {
+            String base64 = payloadNode.asText();
+            if (base64 == null || base64.isEmpty()) {
+                return null;
+            }
+            try {
+                return Base64.getDecoder().decode(base64);
+            } catch (IllegalArgumentException ignored) {
+                return null;
+            }
+        }
+        if (payloadNode.isArray()) {
+            byte[] out = new byte[payloadNode.size()];
+            for (int i = 0; i < payloadNode.size(); i++) {
+                out[i] = (byte) payloadNode.get(i).asInt();
+            }
+            return out;
+        }
+        return null;
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/HealthHandler.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/HealthHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+
+final class HealthHandler implements HttpHandler {
+    private final TraceCollectorMetrics metrics;
+
+    HealthHandler(TraceCollectorMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long startNanos = System.nanoTime();
+        String method = exchange.getRequestMethod();
+        int code = 200;
+        try {
+            HttpUtils.handlePreflightIfNeeded(exchange);
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                return;
+            }
+            HttpUtils.writeText(exchange, 200, "ok\n");
+        } catch (Throwable t) {
+            code = 500;
+            HttpUtils.writeText(exchange, 500, "error\n");
+        } finally {
+            metrics.httpRequestsTotal.labels("/healthz", method, String.valueOf(code)).inc();
+            metrics.httpRequestSeconds
+                    .labels("/healthz", method)
+                    .observe((System.nanoTime() - startNanos) / 1e9);
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/HttpUtils.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/HttpUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+final class HttpUtils {
+    private HttpUtils() {}
+
+    static void addCorsHeaders(HttpExchange exchange) {
+        String origin = exchange.getRequestHeaders().getFirst("Origin");
+        if (origin == null || origin.isEmpty()) {
+            return;
+        }
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", origin);
+        exchange.getResponseHeaders().set("Access-Control-Allow-Credentials", "true");
+        exchange.getResponseHeaders().set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+        exchange.getResponseHeaders()
+                .set("Access-Control-Allow-Headers", "Content-Type,X-Seatunnel-Token");
+        exchange.getResponseHeaders().set("Vary", "Origin");
+    }
+
+    static void handlePreflightIfNeeded(HttpExchange exchange) throws IOException {
+        if (!"OPTIONS".equalsIgnoreCase(exchange.getRequestMethod())) {
+            return;
+        }
+        addCorsHeaders(exchange);
+        exchange.sendResponseHeaders(204, -1);
+        exchange.close();
+    }
+
+    static byte[] readAllBytesWithLimit(InputStream in, int maxBytes) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(Math.min(maxBytes, 16 * 1024));
+        byte[] buf = new byte[8192];
+        int total = 0;
+        for (; ; ) {
+            int n = in.read(buf);
+            if (n < 0) {
+                break;
+            }
+            total += n;
+            if (total > maxBytes) {
+                throw new IllegalArgumentException("request body too large");
+            }
+            bos.write(buf, 0, n);
+        }
+        return bos.toByteArray();
+    }
+
+    static void writeText(HttpExchange exchange, int code, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        addCorsHeaders(exchange);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+        exchange.sendResponseHeaders(code, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    static void writeJson(HttpExchange exchange, int code, byte[] json) throws IOException {
+        addCorsHeaders(exchange);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(code, json.length);
+        exchange.getResponseBody().write(json);
+        exchange.close();
+    }
+
+    static Map<String, String> parseQuery(String rawQuery) {
+        Map<String, String> m = new HashMap<>();
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return m;
+        }
+        String[] parts = rawQuery.split("&");
+        for (String p : parts) {
+            int idx = p.indexOf('=');
+            if (idx <= 0) {
+                m.put(p, "");
+            } else {
+                m.put(urlDecode(p.substring(0, idx)), urlDecode(p.substring(idx + 1)));
+            }
+        }
+        return m;
+    }
+
+    private static String urlDecode(String s) {
+        try {
+            return java.net.URLDecoder.decode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/MetricsHandler.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/MetricsHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+final class MetricsHandler implements HttpHandler {
+    private final TraceCollectorMetrics metrics;
+
+    MetricsHandler(TraceCollectorMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long startNanos = System.nanoTime();
+        String method = exchange.getRequestMethod();
+        int code = 200;
+        try {
+            HttpUtils.handlePreflightIfNeeded(exchange);
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                return;
+            }
+            HttpUtils.addCorsHeaders(exchange);
+            exchange.getResponseHeaders().set("Content-Type", TextFormat.CONTENT_TYPE_004);
+            exchange.sendResponseHeaders(200, 0);
+            try (Writer writer =
+                    new OutputStreamWriter(exchange.getResponseBody(), StandardCharsets.UTF_8)) {
+                TextFormat.write004(
+                        writer, CollectorRegistry.defaultRegistry.metricFamilySamples());
+            }
+        } catch (Throwable t) {
+            code = 500;
+            HttpUtils.writeText(exchange, 500, "error\n");
+        } finally {
+            metrics.httpRequestsTotal.labels("/metrics", method, String.valueOf(code)).inc();
+            metrics.httpRequestSeconds
+                    .labels("/metrics", method)
+                    .observe((System.nanoTime() - startNanos) / 1e9);
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceAuth.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceAuth.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import com.sun.net.httpserver.HttpExchange;
+
+final class TraceAuth {
+    private static final String TOKEN_HEADER = "X-Seatunnel-Token";
+
+    private final String token;
+
+    TraceAuth(String token) {
+        this.token = token;
+    }
+
+    boolean isEnabled() {
+        return token != null && !token.isEmpty();
+    }
+
+    boolean isAuthorized(HttpExchange exchange) {
+        if (!isEnabled()) {
+            return true;
+        }
+        String got = exchange.getRequestHeaders().getFirst(TOKEN_HEADER);
+        return token.equals(got);
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceDetailHandler.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceDetailHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceDetail;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+final class TraceDetailHandler implements HttpHandler {
+    private static final String PREFIX = "/api/v1/traces/";
+
+    private final TraceRepository repository;
+    private final TraceCollectorMetrics metrics;
+    private final TraceAuth auth;
+
+    TraceDetailHandler(TraceRepository repository, TraceCollectorMetrics metrics, TraceAuth auth) {
+        this.repository = repository;
+        this.metrics = metrics;
+        this.auth = auth;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long startNanos = System.nanoTime();
+        String method = exchange.getRequestMethod();
+        int code = 200;
+        try {
+            HttpUtils.handlePreflightIfNeeded(exchange);
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                return;
+            }
+            if (!"GET".equalsIgnoreCase(method)) {
+                code = 405;
+                HttpUtils.writeText(exchange, 405, "method not allowed\n");
+                return;
+            }
+            if (!auth.isAuthorized(exchange)) {
+                code = 401;
+                HttpUtils.writeText(exchange, 401, "unauthorized\n");
+                return;
+            }
+
+            String path = exchange.getRequestURI().getPath();
+            if (path == null || !path.startsWith(PREFIX) || path.length() <= PREFIX.length()) {
+                code = 400;
+                HttpUtils.writeText(exchange, 400, "missing traceId\n");
+                return;
+            }
+            String traceIdStr = path.substring(PREFIX.length());
+            long traceId = Long.parseLong(traceIdStr);
+
+            Map<String, String> q = HttpUtils.parseQuery(exchange.getRequestURI().getRawQuery());
+            Long sinkTaskId = parseLongOrNull(q.get("sinkTaskId"));
+
+            TraceDetail detail = repository.getTrace(traceId, sinkTaskId);
+            byte[] resp =
+                    TraceHttpServer.MAPPER
+                            .valueToTree(detail)
+                            .toString()
+                            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            HttpUtils.writeJson(exchange, 200, resp);
+        } catch (IllegalArgumentException e) {
+            code = 400;
+            HttpUtils.writeText(exchange, 400, "bad request\n");
+        } catch (Throwable t) {
+            code = 500;
+            log.warn("Failed to query trace detail", t);
+            HttpUtils.writeText(exchange, 500, "internal error\n");
+        } finally {
+            metrics.httpRequestsTotal
+                    .labels("/api/v1/traces/{id}", method, String.valueOf(code))
+                    .inc();
+            metrics.httpRequestSeconds
+                    .labels("/api/v1/traces/{id}", method)
+                    .observe((System.nanoTime() - startNanos) / 1e9);
+        }
+    }
+
+    private static Long parseLongOrNull(String s) {
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceHttpServer.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TraceHttpServer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.enrich.TaskMappingCache;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+public class TraceHttpServer implements Closeable {
+
+    public static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final TraceCollectorConfig config;
+    private final TraceRepository repository;
+    private final TraceCollectorMetrics metrics;
+    private final HttpServer server;
+    private final ExecutorService executor;
+    private final TaskMappingCache mappingCache;
+
+    public TraceHttpServer(
+            TraceCollectorConfig config, TraceRepository repository, TraceCollectorMetrics metrics)
+            throws IOException {
+        this.config = config;
+        this.repository = repository;
+        this.metrics = metrics;
+        this.mappingCache = new TaskMappingCache(config);
+        this.server = HttpServer.create(new InetSocketAddress(config.getServerPort()), 0);
+        this.executor =
+                Executors.newFixedThreadPool(
+                        Math.max(4, Runtime.getRuntime().availableProcessors()));
+        this.server.setExecutor(executor);
+
+        TraceAuth auth = new TraceAuth(config.getAuthToken());
+        this.server.createContext("/healthz", new HealthHandler(metrics));
+        this.server.createContext("/metrics", new MetricsHandler(metrics));
+        EventsIngestHandler ingestHandler =
+                new EventsIngestHandler(config, repository, metrics, auth, mappingCache);
+        this.server.createContext("/api/v1/seatunnel/events", ingestHandler);
+        // Compatibility endpoint, keep old default URL working.
+        this.server.createContext("/ingest", ingestHandler);
+        this.server.createContext(
+                "/api/v1/traces", new TracesQueryHandler(repository, metrics, auth));
+        this.server.createContext(
+                "/api/v1/traces/", new TraceDetailHandler(repository, metrics, auth));
+    }
+
+    public void start() {
+        server.start();
+        log.info("Trace collector HTTP server started on port {}", config.getServerPort());
+    }
+
+    @Override
+    public void close() {
+        server.stop(1);
+        executor.shutdownNow();
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TracesQueryHandler.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/http/TracesQueryHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.http;
+
+import org.apache.seatunnel.trace.collector.db.TraceQuery;
+import org.apache.seatunnel.trace.collector.db.TraceRepository;
+import org.apache.seatunnel.trace.collector.metrics.TraceCollectorMetrics;
+import org.apache.seatunnel.trace.collector.model.TraceSummary;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+final class TracesQueryHandler implements HttpHandler {
+    private final TraceRepository repository;
+    private final TraceCollectorMetrics metrics;
+    private final TraceAuth auth;
+
+    TracesQueryHandler(TraceRepository repository, TraceCollectorMetrics metrics, TraceAuth auth) {
+        this.repository = repository;
+        this.metrics = metrics;
+        this.auth = auth;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long startNanos = System.nanoTime();
+        String method = exchange.getRequestMethod();
+        int code = 200;
+        try {
+            HttpUtils.handlePreflightIfNeeded(exchange);
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                return;
+            }
+            if (!"GET".equalsIgnoreCase(method)) {
+                code = 405;
+                HttpUtils.writeText(exchange, 405, "method not allowed\n");
+                return;
+            }
+            if (!auth.isAuthorized(exchange)) {
+                code = 401;
+                HttpUtils.writeText(exchange, 401, "unauthorized\n");
+                return;
+            }
+
+            Map<String, String> q = HttpUtils.parseQuery(exchange.getRequestURI().getRawQuery());
+            TraceQuery query =
+                    TraceQuery.builder()
+                            .jobId(q.get("jobId"))
+                            .tableId(q.get("tableId"))
+                            .fromMs(parseLongOrNull(q.get("fromMs")))
+                            .toMs(parseLongOrNull(q.get("toMs")))
+                            .limit(parseIntOrDefault(q.get("limit"), 100))
+                            .offset(parseIntOrDefault(q.get("offset"), 0))
+                            .build();
+
+            List<TraceSummary> items = repository.queryTraces(query);
+            byte[] resp =
+                    TraceHttpServer.MAPPER
+                            .createObjectNode()
+                            .put("count", items.size())
+                            .set("items", TraceHttpServer.MAPPER.valueToTree(items))
+                            .toString()
+                            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            HttpUtils.writeJson(exchange, 200, resp);
+        } catch (Throwable t) {
+            code = 500;
+            log.warn("Failed to query traces", t);
+            HttpUtils.writeText(exchange, 500, "internal error\n");
+        } finally {
+            metrics.httpRequestsTotal.labels("/api/v1/traces", method, String.valueOf(code)).inc();
+            metrics.httpRequestSeconds
+                    .labels("/api/v1/traces", method)
+                    .observe((System.nanoTime() - startNanos) / 1e9);
+        }
+    }
+
+    private static Long parseLongOrNull(String s) {
+        if (s == null || s.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static int parseIntOrDefault(String s, int def) {
+        if (s == null || s.trim().isEmpty()) {
+            return def;
+        }
+        try {
+            return Integer.parseInt(s.trim());
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/metrics/TraceCollectorMetrics.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/metrics/TraceCollectorMetrics.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.metrics;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
+
+public class TraceCollectorMetrics {
+
+    public final Counter httpRequestsTotal =
+            Counter.build()
+                    .name("st_trace_collector_http_requests_total")
+                    .help("HTTP requests total")
+                    .labelNames("path", "method", "code")
+                    .register();
+
+    public final Histogram httpRequestSeconds =
+            Histogram.build()
+                    .name("st_trace_collector_http_request_seconds")
+                    .help("HTTP request latency in seconds")
+                    .labelNames("path", "method")
+                    .register();
+
+    public final Counter eventsReceivedTotal =
+            Counter.build()
+                    .name("st_trace_collector_events_received_total")
+                    .help("Events received total")
+                    .labelNames("event_type")
+                    .register();
+
+    public final Counter stainTraceReceivedTotal =
+            Counter.build()
+                    .name("st_trace_collector_stain_trace_received_total")
+                    .help("StainTrace events received total")
+                    .register();
+
+    public final Counter invalidEventsTotal =
+            Counter.build()
+                    .name("st_trace_collector_invalid_events_total")
+                    .help("Invalid events total")
+                    .labelNames("reason")
+                    .register();
+
+    public final Counter dbWriteFailuresTotal =
+            Counter.build()
+                    .name("st_trace_collector_db_write_failures_total")
+                    .help("DB write failures total")
+                    .labelNames("table")
+                    .register();
+
+    public final Counter dbReadFailuresTotal =
+            Counter.build()
+                    .name("st_trace_collector_db_read_failures_total")
+                    .help("DB read failures total")
+                    .labelNames("op")
+                    .register();
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceDetail.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceDetail.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraceDetail {
+    private TraceSummary trace;
+    private List<TraceEntry> entries;
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceEntry.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceEntry.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraceEntry {
+    private int index;
+    private int stage;
+    private long taskId;
+    private long tsMs;
+
+    private String workerAddress;
+    private String taskGroupName;
+    private String taskClass;
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceSummary.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/model/TraceSummary.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraceSummary {
+    private long traceId;
+    private long sinkTaskId;
+    private String jobId;
+    private String tableId;
+
+    private long createdTimeMs;
+    private long receivedTimeMs;
+
+    private long startTsMs;
+    private int entryCount;
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/payload/SttrPayloadDecoder.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/java/org/apache/seatunnel/trace/collector/payload/SttrPayloadDecoder.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.payload;
+
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SttrPayloadDecoder {
+    private SttrPayloadDecoder() {}
+
+    private static final int MAGIC = 0x53545452; // 'STTR'
+    private static final short VERSION = 1;
+    private static final int HEADER_LENGTH = 4 + 2 + 8 + 8 + 2;
+    private static final int ENTRY_LENGTH = 1 + 8 + 8;
+    private static final int MAX_ENTRY_COUNT = 2048;
+
+    private static final int TRACE_ID_OFFSET = 4 + 2;
+    private static final int START_TS_OFFSET = TRACE_ID_OFFSET + 8;
+    private static final int COUNT_OFFSET = START_TS_OFFSET + 8;
+
+    public static DecodedPayload decode(byte[] payload) {
+        if (!isValid(payload)) {
+            throw new IllegalArgumentException("Invalid STTR payload");
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN);
+        long traceId = buffer.getLong(TRACE_ID_OFFSET);
+        long startTsMs = buffer.getLong(START_TS_OFFSET);
+        int count = readUnsignedShort(payload, COUNT_OFFSET);
+        List<TraceEntry> entries = new ArrayList<>(count);
+
+        int pos = HEADER_LENGTH;
+        for (int i = 0; i < count; i++) {
+            int stage = payload[pos] & 0xFF;
+            long taskId = buffer.getLong(pos + 1);
+            long tsMs = buffer.getLong(pos + 1 + 8);
+            entries.add(new TraceEntry(i, stage, taskId, tsMs, null, null, null));
+            pos += ENTRY_LENGTH;
+        }
+        return new DecodedPayload(traceId, startTsMs, count, entries);
+    }
+
+    public static boolean isValid(byte[] payload) {
+        if (payload == null || payload.length < HEADER_LENGTH) {
+            return false;
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN);
+        int magic = buffer.getInt(0);
+        if (magic != MAGIC) {
+            return false;
+        }
+        short ver = buffer.getShort(4);
+        if (ver != VERSION) {
+            return false;
+        }
+        int count = readUnsignedShort(payload, COUNT_OFFSET);
+        if (count > MAX_ENTRY_COUNT) {
+            return false;
+        }
+        long expected = (long) HEADER_LENGTH + (long) count * ENTRY_LENGTH;
+        return expected == payload.length;
+    }
+
+    private static int readUnsignedShort(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF);
+    }
+
+    public static final class DecodedPayload {
+        private final long traceId;
+        private final long startTsMs;
+        private final int entryCount;
+        private final List<TraceEntry> entries;
+
+        DecodedPayload(long traceId, long startTsMs, int entryCount, List<TraceEntry> entries) {
+            this.traceId = traceId;
+            this.startTsMs = startTsMs;
+            this.entryCount = entryCount;
+            this.entries = entries;
+        }
+
+        public long getTraceId() {
+            return traceId;
+        }
+
+        public long getStartTsMs() {
+            return startTsMs;
+        }
+
+        public int getEntryCount() {
+            return entryCount;
+        }
+
+        public List<TraceEntry> getEntries() {
+            return entries;
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/resources/init-mysql.sql
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/resources/init-mysql.sql
@@ -1,0 +1,115 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- StainTrace MySQL初始化脚本
+-- 使用方法: mysql -uroot -p'root@123' < init-mysql.sql
+
+-- 创建数据库
+CREATE DATABASE IF NOT EXISTS seatunnel_trace DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE seatunnel_trace;
+
+-- 原始事件表
+CREATE TABLE IF NOT EXISTS st_trace_event_raw (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    received_at DATETIME(3) NOT NULL,
+    job_id VARCHAR(255) NULL,
+    event_type VARCHAR(128) NULL,
+    body_json JSON NOT NULL,
+    PRIMARY KEY(id),
+    KEY idx_st_trace_event_job_received(job_id, received_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='原始StainTrace事件';
+
+-- 追踪摘要表
+CREATE TABLE IF NOT EXISTS st_trace (
+    trace_id BIGINT NOT NULL,
+    sink_task_id BIGINT NOT NULL,
+    job_id VARCHAR(255) NULL,
+    table_id VARCHAR(255) NULL,
+    created_time_ms BIGINT NULL,
+    received_at DATETIME(3) NOT NULL,
+    payload LONGBLOB NULL,
+    start_ts_ms BIGINT NULL,
+    entry_count INT NULL,
+    PRIMARY KEY(trace_id, sink_task_id),
+    KEY idx_st_trace_job_received(job_id, received_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='追踪摘要';
+
+-- 追踪条目表（6个阶段详细信息）
+CREATE TABLE IF NOT EXISTS st_trace_entry (
+    trace_id BIGINT NOT NULL,
+    sink_task_id BIGINT NOT NULL,
+    entry_index INT NOT NULL,
+    stage SMALLINT NOT NULL COMMENT '1=SOURCE_EMIT, 2=QUEUE_IN, 3=QUEUE_OUT, 4=TRANSFORM_IN, 5=TRANSFORM_OUT, 6=SINK_WRITE_DONE',
+    task_id BIGINT NOT NULL,
+    ts_ms BIGINT NOT NULL,
+    worker_address VARCHAR(255) NULL,
+    task_group_name VARCHAR(255) NULL,
+    task_class VARCHAR(255) NULL,
+    PRIMARY KEY(trace_id, sink_task_id, entry_index),
+    KEY idx_stage_ts(stage, ts_ms)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='追踪条目详情';
+
+-- 创建视图：方便查询完整追踪链路
+CREATE OR REPLACE VIEW v_trace_detail AS
+SELECT
+    t.trace_id,
+    t.sink_task_id,
+    t.job_id,
+    t.table_id,
+    t.received_at,
+    t.entry_count,
+    e.entry_index,
+    CASE e.stage
+        WHEN 1 THEN 'SOURCE_EMIT'
+        WHEN 2 THEN 'QUEUE_IN'
+        WHEN 3 THEN 'QUEUE_OUT'
+        WHEN 4 THEN 'TRANSFORM_IN'
+        WHEN 5 THEN 'TRANSFORM_OUT'
+        WHEN 6 THEN 'SINK_WRITE_DONE'
+        ELSE 'UNKNOWN'
+    END AS stage_name,
+    e.stage,
+    e.task_id,
+    FROM_UNIXTIME(e.ts_ms / 1000.0) AS ts,
+    e.ts_ms,
+    e.worker_address,
+    e.task_group_name,
+    e.task_class
+FROM st_trace t
+LEFT JOIN st_trace_entry e ON t.trace_id = e.trace_id AND t.sink_task_id = e.sink_task_id
+ORDER BY t.trace_id, e.entry_index;
+
+-- 创建视图：端到端延迟分析
+CREATE OR REPLACE VIEW v_trace_latency AS
+SELECT
+    t.trace_id,
+    t.job_id,
+    t.table_id,
+    t.received_at,
+    MIN(CASE WHEN e.stage = 1 THEN e.ts_ms END) AS source_emit_ms,
+    MIN(CASE WHEN e.stage = 6 THEN e.ts_ms END) AS sink_done_ms,
+    MIN(CASE WHEN e.stage = 6 THEN e.ts_ms END) - MIN(CASE WHEN e.stage = 1 THEN e.ts_ms END) AS e2e_latency_ms,
+    MIN(CASE WHEN e.stage = 3 THEN e.ts_ms END) - MIN(CASE WHEN e.stage = 2 THEN e.ts_ms END) AS queue_wait_ms,
+    MIN(CASE WHEN e.stage = 5 THEN e.ts_ms END) - MIN(CASE WHEN e.stage = 4 THEN e.ts_ms END) AS transform_ms
+FROM st_trace t
+LEFT JOIN st_trace_entry e ON t.trace_id = e.trace_id AND t.sink_task_id = e.sink_task_id
+GROUP BY t.trace_id, t.job_id, t.table_id, t.received_at;
+
+SHOW TABLES;
+
+SELECT 'MySQL表初始化完成！' AS status;

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/resources/log4j2.xml
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/resources/log4j2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] %-5level %logger{36} - %msg%n%throwable"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+

--- a/seatunnel-trace/seatunnel-trace-collector/src/main/resources/trace-collector.properties
+++ b/seatunnel-trace/seatunnel-trace-collector/src/main/resources/trace-collector.properties
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Trace Collector
+server.port=9808
+server.maxRequestBytes=10485760
+
+# MySQL
+db.type=mysql
+db.jdbcUrl=jdbc:mysql://localhost:3306/seatunnel_trace?useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
+db.username=root
+db.password=root@123
+db.schema=
+
+# db.type=postgres
+#db.type=postgres
+#db.jdbcUrl=jdbc:postgresql://localhost:5432/seatunnel
+#db.username=seatunnel
+#db.password=seatunnel
+#db.schema=public
+
+trace.parsePayload=true

--- a/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/config/TraceCollectorConfigTest.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/config/TraceCollectorConfigTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TraceCollectorConfigTest {
+
+    @Test
+    void testDefaultDbSchemaForMySqlIsEmpty() throws Exception {
+        Path temp = Files.createTempFile("trace-collector-mysql", ".properties");
+        Files.write(
+                temp,
+                ("db.type=mysql\n"
+                                + "db.jdbcUrl=jdbc:mysql://127.0.0.1:3306/seatunnel_trace\n"
+                                + "db.username=u\n"
+                                + "db.password=p\n")
+                        .getBytes(StandardCharsets.UTF_8));
+        String old = System.getProperty("trace.collector.config");
+        try {
+            System.setProperty("trace.collector.config", temp.toString());
+            TraceCollectorConfig cfg = TraceCollectorConfig.load();
+            Assertions.assertTrue(cfg.getDbSchema() == null || cfg.getDbSchema().isEmpty());
+        } finally {
+            if (old == null) {
+                System.clearProperty("trace.collector.config");
+            } else {
+                System.setProperty("trace.collector.config", old);
+            }
+            Files.deleteIfExists(temp);
+        }
+    }
+
+    @Test
+    void testDefaultDbSchemaForPostgresIsPublic() throws Exception {
+        Path temp = Files.createTempFile("trace-collector-postgres", ".properties");
+        Files.write(
+                temp,
+                ("db.type=postgres\n"
+                                + "db.jdbcUrl=jdbc:postgresql://127.0.0.1:5432/seatunnel\n"
+                                + "db.username=u\n"
+                                + "db.password=p\n")
+                        .getBytes(StandardCharsets.UTF_8));
+        String old = System.getProperty("trace.collector.config");
+        try {
+            System.setProperty("trace.collector.config", temp.toString());
+            TraceCollectorConfig cfg = TraceCollectorConfig.load();
+            Assertions.assertEquals("public", cfg.getDbSchema());
+        } finally {
+            if (old == null) {
+                System.clearProperty("trace.collector.config");
+            } else {
+                System.setProperty("trace.collector.config", old);
+            }
+            Files.deleteIfExists(temp);
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/enrich/TaskMappingCacheTest.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/enrich/TaskMappingCacheTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.enrich;
+
+import org.apache.seatunnel.trace.collector.config.TraceCollectorConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TaskMappingCacheTest {
+
+    @Test
+    void testFetchErrorDoesNotOverwriteOldMapping() throws Exception {
+        AtomicInteger call = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/hazelcast/rest/maps/trace/task-mapping/1",
+                exchange -> {
+                    int n = call.incrementAndGet();
+                    if (n == 1) {
+                        byte[] body =
+                                "{\"items\":[{\"taskId\":10,\"worker\":\"w\",\"taskGroupName\":\"g\",\"taskClass\":\"c\"}]}"
+                                        .getBytes(StandardCharsets.UTF_8);
+                        exchange.sendResponseHeaders(200, body.length);
+                        exchange.getResponseBody().write(body);
+                        exchange.close();
+                        return;
+                    }
+                    exchange.sendResponseHeaders(500, -1);
+                    exchange.close();
+                });
+        server.start();
+
+        int port = server.getAddress().getPort();
+        Path temp = Files.createTempFile("trace-collector-config", ".properties");
+        Files.write(
+                temp,
+                ("db.type=postgres\n"
+                                + "db.jdbcUrl=jdbc:postgresql://127.0.0.1:5432/seatunnel\n"
+                                + "db.username=u\n"
+                                + "db.password=p\n"
+                                + "engine.taskMappingUrlTemplate=http://127.0.0.1:"
+                                + port
+                                + "/hazelcast/rest/maps/trace/task-mapping/{jobId}\n"
+                                + "engine.taskMappingCacheTtlMs=0\n")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        String old = System.getProperty("trace.collector.config");
+        try {
+            System.setProperty("trace.collector.config", temp.toString());
+            TraceCollectorConfig cfg = TraceCollectorConfig.load();
+            TaskMappingCache cache = new TaskMappingCache(cfg);
+
+            Map<Long, TaskMappingCache.Mapping> first = cache.getMapping("1");
+            Assertions.assertEquals(1, first.size());
+            Assertions.assertEquals("w", first.get(10L).getWorker());
+
+            Thread.sleep(2);
+            Map<Long, TaskMappingCache.Mapping> second = cache.getMapping("1");
+            Assertions.assertEquals(1, second.size());
+            Assertions.assertEquals("w", second.get(10L).getWorker());
+        } finally {
+            if (old == null) {
+                System.clearProperty("trace.collector.config");
+            } else {
+                System.setProperty("trace.collector.config", old);
+            }
+            Files.deleteIfExists(temp);
+            server.stop(0);
+        }
+    }
+}

--- a/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/payload/SttrPayloadDecoderTest.java
+++ b/seatunnel-trace/seatunnel-trace-collector/src/test/java/org/apache/seatunnel/trace/collector/payload/SttrPayloadDecoderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.trace.collector.payload;
+
+import org.apache.seatunnel.trace.collector.model.TraceEntry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+public class SttrPayloadDecoderTest {
+
+    @Test
+    void testDecode() {
+        long traceId = 123L;
+        long startTs = 1700000000000L;
+        byte[] payload = buildPayload(traceId, startTs);
+
+        Assertions.assertTrue(SttrPayloadDecoder.isValid(payload));
+        SttrPayloadDecoder.DecodedPayload decoded = SttrPayloadDecoder.decode(payload);
+        Assertions.assertEquals(traceId, decoded.getTraceId());
+        Assertions.assertEquals(startTs, decoded.getStartTsMs());
+        Assertions.assertEquals(2, decoded.getEntryCount());
+
+        List<TraceEntry> entries = decoded.getEntries();
+        Assertions.assertEquals(2, entries.size());
+        Assertions.assertEquals(0, entries.get(0).getIndex());
+        Assertions.assertEquals(1, entries.get(0).getStage());
+        Assertions.assertEquals(10L, entries.get(0).getTaskId());
+
+        Assertions.assertEquals(1, entries.get(1).getIndex());
+        Assertions.assertEquals(6, entries.get(1).getStage());
+        Assertions.assertEquals(99L, entries.get(1).getTaskId());
+    }
+
+    @Test
+    void testInvalidPayload() {
+        byte[] bad = new byte[] {1, 2, 3};
+        Assertions.assertFalse(SttrPayloadDecoder.isValid(bad));
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> SttrPayloadDecoder.decode(bad));
+    }
+
+    @Test
+    void testCountOverMaxIsInvalid() {
+        byte[] payload = buildPayloadWithCount(2049);
+        Assertions.assertFalse(SttrPayloadDecoder.isValid(payload));
+    }
+
+    private static byte[] buildPayload(long traceId, long startTsMs) {
+        int headerLen = 4 + 2 + 8 + 8 + 2;
+        int entryLen = 1 + 8 + 8;
+        int count = 2;
+        ByteBuffer buffer =
+                ByteBuffer.allocate(headerLen + count * entryLen).order(ByteOrder.BIG_ENDIAN);
+        buffer.putInt(0x53545452);
+        buffer.putShort((short) 1);
+        buffer.putLong(traceId);
+        buffer.putLong(startTsMs);
+        buffer.putShort((short) count);
+
+        // entry 0: stage=1, taskId=10, ts=startTs+1
+        buffer.put((byte) 1);
+        buffer.putLong(10L);
+        buffer.putLong(startTsMs + 1);
+        // entry 1: stage=6, taskId=99, ts=startTs+2
+        buffer.put((byte) 6);
+        buffer.putLong(99L);
+        buffer.putLong(startTsMs + 2);
+
+        return buffer.array();
+    }
+
+    private static byte[] buildPayloadWithCount(int count) {
+        int headerLen = 4 + 2 + 8 + 8 + 2;
+        int entryLen = 1 + 8 + 8;
+        ByteBuffer buffer =
+                ByteBuffer.allocate(headerLen + count * entryLen).order(ByteOrder.BIG_ENDIAN);
+        buffer.putInt(0x53545452);
+        buffer.putShort((short) 1);
+        buffer.putLong(1L);
+        buffer.putLong(2L);
+        buffer.putShort((short) count);
+        return buffer.array();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR stabilizes the JDBC schema-evolution add-columns checks that are currently blocking unrelated PRs.

The non-exactly-once path was asserting row contents before the sink table metadata had fully caught up after `add_columns`. In CI this shows up as stale sink rows such as `scooter` still being returned where the add-columns case expects the later `hawk9821` data.

This change:
- waits for source and sink column lists to match before asserting add-columns data
- reuses the same add-columns data assertion helper in both exactly-once and non-exactly-once paths
- keeps the scope limited to the shared JDBC schema-evolution test base

## Validation

- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl -am -nsu -Dskip.ui=true spotless:apply`
- `./mvnw -f seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/pom.xml -nsu -Dskip.ui=true -Dmaven.gitcommitid.skip=true -DskipUT=true -DskipIT=false -DfailIfNoTests=false -Dit.test=DmSchemaChangeIT,SqlServerSchemaChangeIT verify`

Notes:
- `seatunnel-engine-ui` was skipped because this PR does not touch UI modules.
- Real IT validation was attempted twice. The `/Volumes/disk2/...` worktree is on `exfat,noowners`, which makes the MySQL init resource path unusable for Testcontainers. Retrying from a Docker-shared POSIX path reached real container execution, but the local host environment then hit `SeaTunnelContainer.getJobStatus()` `Connection reset` errors for both `DmSchemaChangeIT` and `SqlServerSchemaChangeIT` before the add-columns assertions were reached. This host-specific runtime issue is separate from the CI assertion failures this PR addresses.