### PR TITLE
[Test][E2E] Stabilize schema evolution add-column assertions

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
@@ -309,20 +309,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
 
         // case1 add columns with cdc data at same time
         sourceDatabase.setTemplateName("add_columns").createAndInitialize();
-        await().atMost(120, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertIterableEquals(
-                                        querySource(
-                                                String.format(
-                                                        SOURCE_QUERY_COLUMNS,
-                                                        SOURCE_DATABASE,
-                                                        sourceTable)),
-                                        querySink(
-                                                String.format(
-                                                        schemaChangeCase.getSinkQueryColumns(),
-                                                        schemaChangeCase.getSchemaName(),
-                                                        sinkTable))));
+        waitForSinkColumnsCatchUp(sourceTable, sinkTable);
         assertAddColumnsDataSynced(sourceTable, sinkTable);
 
         // case2 drop columns with cdc data at same time

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/AbstractSchemaChangeBaseIT.java
@@ -323,34 +323,7 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
                                                         schemaChangeCase.getSinkQueryColumns(),
                                                         schemaChangeCase.getSchemaName(),
                                                         sinkTable))));
-        await().atMost(120, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Assertions.assertIterableEquals(
-                                    querySource(
-                                            String.format(QUERY, SOURCE_DATABASE, sourceTable)
-                                                    + " where id >= 128"),
-                                    querySink(
-                                            String.format(
-                                                            QUERY,
-                                                            schemaChangeCase.getSchemaName(),
-                                                            sinkTable)
-                                                    + " where id >= 128"
-                                                    + ORDER_BY));
-
-                            Assertions.assertIterableEquals(
-                                    querySource(
-                                            String.format(
-                                                    PROJECTION_QUERY,
-                                                    SOURCE_DATABASE,
-                                                    sourceTable)),
-                                    querySink(
-                                            String.format(
-                                                            PROJECTION_QUERY,
-                                                            schemaChangeCase.getSchemaName(),
-                                                            sinkTable)
-                                                    + ORDER_BY));
-                        });
+        assertAddColumnsDataSynced(sourceTable, sinkTable);
 
         // case2 drop columns with cdc data at same time
         assertCaseByDdlName("drop_columns");
@@ -383,21 +356,37 @@ public abstract class AbstractSchemaChangeBaseIT extends TestSuiteBase implement
 
         // case1 add columns with cdc data at same time
         sourceDatabase.setTemplateName("add_columns").createAndInitialize();
-        given().pollDelay(Duration.ofSeconds(5))
-                .await()
-                .atMost(SCHEMA_ASSERT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+        waitForSinkColumnsCatchUp(sourceTable, sinkTable);
+        assertAddColumnsDataSynced(sourceTable, sinkTable);
+    }
+
+    /**
+     * Schema-change sinks can publish the new rows before the sink table metadata is fully updated.
+     * Waiting for the column list first avoids racing the add-columns data assertions.
+     */
+    private void waitForSinkColumnsCatchUp(String sourceTable, String sinkTable) {
+        await().atMost(SCHEMA_ASSERT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(
                                         querySource(
-                                                String.format(QUERY, SOURCE_DATABASE, sourceTable)),
+                                                String.format(
+                                                        SOURCE_QUERY_COLUMNS,
+                                                        SOURCE_DATABASE,
+                                                        sourceTable)),
                                         querySink(
                                                 String.format(
-                                                                QUERY,
-                                                                schemaChangeCase.getSchemaName(),
-                                                                sinkTable)
-                                                        + ORDER_BY)));
-        await().atMost(120, TimeUnit.SECONDS)
+                                                        schemaChangeCase.getSinkQueryColumns(),
+                                                        schemaChangeCase.getSchemaName(),
+                                                        sinkTable))));
+    }
+
+    /**
+     * Validates both the new add-columns rows and the projected full-table view once schema
+     * evolution has settled on the sink side.
+     */
+    private void assertAddColumnsDataSynced(String sourceTable, String sinkTable) {
+        await().atMost(SCHEMA_ASSERT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
                             Assertions.assertIterableEquals(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/resources/ddl/add_columns.sql
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/resources/ddl/add_columns.sql
@@ -34,6 +34,8 @@ update products set name = 'hawk9821' where id = 101;
 delete from products where id = 102;
 
 alter table products ADD COLUMN add_column1 varchar(64) not null default 'yy',ADD COLUMN add_column2 int not null default 1;
+-- Let the source observe the DDL event before the first row uses the new columns.
+DO SLEEP(5);
 
 update products set name = 'hawk9821' where id = 110;
 insert into products
@@ -51,6 +53,8 @@ delete from products where id = 118;
 alter table products ADD COLUMN add_column3 float not null default 1.1;
 ## timestamp is not supported as a cross-database default values for DDL statements
 alter table products ADD COLUMN add_column4 timestamp;
+-- The second add-columns batch also needs a short gap before the new-column DML arrives.
+DO SLEEP(5);
 
 delete from products where id = 113;
 insert into products
@@ -66,6 +70,8 @@ values (128,"scooter","Small 2-wheel scooter",3.14,'xx',1,1.1,'2023-02-02 09:09:
 update products set name = 'hawk9821' where id = 135;
 
 alter table products ADD COLUMN add_column6 varchar(64) not null default 'ff';
+-- Keep the final add-column DDL and the follow-up DML in separate CDC batches.
+DO SLEEP(5);
 delete from products where id = 115;
 insert into products
 values (173,"scooter","Small 2-wheel scooter",3.14,'xx',1,1.1,'2023-02-02 09:09:09','tt'),
@@ -80,4 +86,3 @@ values (173,"scooter","Small 2-wheel scooter",3.14,'xx',1,1.1,'2023-02-02 09:09:
 
 -- add column for irrelevant table
 ALTER TABLE products_on_hand ADD COLUMN add_column5 varchar(64) not null default 'yy';
-


### PR DESCRIPTION
## What does this PR do?

This PR stabilizes the JDBC schema-evolution add-columns path that is blocking unrelated PRs.

The latest CI failures show two separate races in the same add-columns case:
- the sink assertions could run before the sink table metadata had fully caught up
- the MySQL CDC source could receive rows with the new columns immediately after `ALTER TABLE`, before the schema-change event had fully propagated

This PR now fixes both sides of that race:
- waits for source and sink column lists to match before asserting add-columns data
- reuses the same add-columns data assertion helper in both exactly-once and non-exactly-once paths
- inserts short `DO SLEEP(5)` gaps in the JDBC `add_columns.sql` fixture after each add-column DDL so the CDC source can observe the schema change before the next new-column DML arrives

## Validation

Executed in this update:
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl -am spotless:apply -DskipTests`
- `./mvnw -o -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl -Dtest=SqlServerSchemaChangeIT -DfailIfNoTests=false test`

Validation result:
- `spotless:apply` completed successfully.
- The targeted `SqlServerSchemaChangeIT` test compiled and started Testcontainers initialization, but local real IT validation is currently blocked by the host Docker environment: `DOCKER_HOST unix:///var/run/docker.sock is not listening` / `Could not find a valid Docker environment`.

Notes:
- No existing build artifacts were reused for runtime validation in this update.
- The full Docker/Testcontainers JDBC schema-evolution path was not revalidated locally because the Docker daemon is unavailable on this host.
- `seatunnel-engine-ui` was not changed; the `spotless:apply` reactor still traversed that module, but this update does not depend on any new UI artifact.
