### PR TITLE
[Fix][Connector-V2] Flush Doris load before schema change

### DIFF
--- a/docs/en/introduction/configuration/schema-evolution.md
+++ b/docs/en/introduction/configuration/schema-evolution.md
@@ -254,7 +254,7 @@ sink {
 }
 ```
 
-> **Note (schema evolution + 2PC):** With `sink.enable-2pc = "true"`, a schema change that arrives in the middle of a checkpoint is applied **without** first flushing the in-flight stream load, because 2PC keeps a single transaction per checkpoint. Rows buffered before the DDL are then committed against the altered table within the same transaction. Because `format = "json"` matches columns by name, Doris tolerates this (as in the example above). For positional formats such as CSV, or when you need strict correctness around schema changes, set `sink.enable-2pc = "false"`: the sink then flushes the buffered rows before applying the DDL.
+> **Note (schema evolution + 2PC):** With `sink.enable-2pc = "true"`, Doris schema evolution only supports `format = "json"` because JSON loads match columns by name. Positional formats such as CSV are rejected at runtime for schema evolution with 2PC enabled. Use `format = "json"` or set `sink.enable-2pc = "false"` so the sink can flush buffered rows before applying the DDL.
 
 ### Mysql-CDC -> Jdbc-Postgres
 ```hocon

--- a/docs/en/introduction/configuration/schema-evolution.md
+++ b/docs/en/introduction/configuration/schema-evolution.md
@@ -254,6 +254,8 @@ sink {
 }
 ```
 
+> **Note (schema evolution + 2PC):** With `sink.enable-2pc = "true"`, a schema change that arrives in the middle of a checkpoint is applied **without** first flushing the in-flight stream load, because 2PC keeps a single transaction per checkpoint. Rows buffered before the DDL are then committed against the altered table within the same transaction. Because `format = "json"` matches columns by name, Doris tolerates this (as in the example above). For positional formats such as CSV, or when you need strict correctness around schema changes, set `sink.enable-2pc = "false"`: the sink then flushes the buffered rows before applying the DDL.
+
 ### Mysql-CDC -> Jdbc-Postgres
 ```hocon
 env {

--- a/docs/zh/introduction/configuration/schema-evolution.md
+++ b/docs/zh/introduction/configuration/schema-evolution.md
@@ -255,6 +255,8 @@ sink {
 }
 ```
 
+> **注意（schema 演进 + 2PC）：** 当 `sink.enable-2pc = "true"` 时，发生在 checkpoint 中途的 schema 变更**不会**先 flush 在途的 stream load（2PC 每个 checkpoint 只维护一个事务）。DDL 之前缓冲的数据会在同一个事务里按变更后的表结构提交。由于 `format = "json"` 按列名匹配，Doris 能够容忍（如上例）。对于 CSV 等位置敏感格式，或需要严格保证 schema 变更正确性时，请设置 `sink.enable-2pc = "false"`：此时 sink 会在应用 DDL 之前先 flush 已缓冲的数据。
+
 ### Mysql-CDC -> Jdbc-Postgres
 ```hocon
 env {

--- a/docs/zh/introduction/configuration/schema-evolution.md
+++ b/docs/zh/introduction/configuration/schema-evolution.md
@@ -255,7 +255,7 @@ sink {
 }
 ```
 
-> **注意（schema 演进 + 2PC）：** 当 `sink.enable-2pc = "true"` 时，发生在 checkpoint 中途的 schema 变更**不会**先 flush 在途的 stream load（2PC 每个 checkpoint 只维护一个事务）。DDL 之前缓冲的数据会在同一个事务里按变更后的表结构提交。由于 `format = "json"` 按列名匹配，Doris 能够容忍（如上例）。对于 CSV 等位置敏感格式，或需要严格保证 schema 变更正确性时，请设置 `sink.enable-2pc = "false"`：此时 sink 会在应用 DDL 之前先 flush 已缓冲的数据。
+> **注意（schema 演进 + 2PC）：** 当 `sink.enable-2pc = "true"` 时，Doris schema 演进仅支持 `format = "json"`，因为 JSON load 会按列名匹配。CSV 等位置敏感格式在启用 2PC 的 schema 演进场景下会被运行时拒绝。请使用 `format = "json"`，或设置 `sink.enable-2pc = "false"`，让 sink 可以在应用 DDL 前先 flush 已缓冲的数据。
 
 ### Mysql-CDC -> Jdbc-Postgres
 ```hocon

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -205,14 +205,15 @@ public class DorisSinkWriter
 
     @Override
     public void applySchemaChange(SchemaChangeEvent event) throws IOException {
+        validateSchemaChangeCompatibility();
+
         // The in-flight stream load may still buffer rows serialized with the previous schema.
         // In non-2PC mode each micro-batch is an independent load, so close the current load
         // first (committing the buffered rows against the still-unaltered table) before applying
         // the DDL, then reopen a fresh load so subsequent rows are loaded against the new schema.
         // Mixing schemas within a single load corrupts data (e.g. column mismatch for csv/dropped
-        // columns). 2PC keeps a single transaction per checkpoint that is committed at the
-        // checkpoint boundary (prepareCommit/snapshotState); flushing here would orphan its
-        // pre-commit transaction and reuse the checkpoint-scoped label, so it is left intact.
+        // columns). 2PC keeps a single transaction per checkpoint, so only name-based JSON loads
+        // are allowed to cross a schema-change boundary.
         boolean flushBeforeSchemaChange = !dorisSinkConfig.getEnable2PC();
         if (flushBeforeSchemaChange) {
             flush();
@@ -231,6 +232,22 @@ public class DorisSinkWriter
 
         if (flushBeforeSchemaChange) {
             startLoad(labelGenerator.generateLabel(lastCheckpointId));
+        }
+    }
+
+    private void validateSchemaChangeCompatibility() {
+        if (!dorisSinkConfig.getEnable2PC()) {
+            return;
+        }
+        String format = dorisSinkConfig.getStreamLoadProps().getProperty(LoadConstants.FORMAT_KEY);
+        if (!LoadConstants.JSON.equalsIgnoreCase(format)) {
+            throw new DorisSchemaChangeException(
+                    DorisConnectorErrorCode.SCHEMA_CHANGE_FAILED,
+                    String.format(
+                            "Doris schema evolution with sink.enable-2pc=true only supports "
+                                    + "stream load format=json, but current format is %s. "
+                                    + "Use format=json or set sink.enable-2pc=false.",
+                            format));
         }
     }
 

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -204,7 +204,20 @@ public class DorisSinkWriter
     }
 
     @Override
-    public void applySchemaChange(SchemaChangeEvent event) {
+    public void applySchemaChange(SchemaChangeEvent event) throws IOException {
+        // The in-flight stream load may still buffer rows serialized with the previous schema.
+        // In non-2PC mode each micro-batch is an independent load, so close the current load
+        // first (committing the buffered rows against the still-unaltered table) before applying
+        // the DDL, then reopen a fresh load so subsequent rows are loaded against the new schema.
+        // Mixing schemas within a single load corrupts data (e.g. column mismatch for csv/dropped
+        // columns). 2PC keeps a single transaction per checkpoint that is committed at the
+        // checkpoint boundary (prepareCommit/snapshotState); flushing here would orphan its
+        // pre-commit transaction and reuse the checkpoint-scoped label, so it is left intact.
+        boolean flushBeforeSchemaChange = !dorisSinkConfig.getEnable2PC();
+        if (flushBeforeSchemaChange) {
+            flush();
+        }
+
         this.tableSchema = tableSchemaChanger.reset(tableSchema).apply(event);
         SeaTunnelRowType seaTunnelRowType = tableSchema.toPhysicalRowDataType();
         this.serializer = createSerializer(this.dorisSinkConfig, seaTunnelRowType);
@@ -213,7 +226,11 @@ public class DorisSinkWriter
             schemaChangeManager.applySchemaChange(sinkTablePath, event);
         } catch (Exception e) {
             throw new DorisSchemaChangeException(
-                    DorisConnectorErrorCode.SCHEMA_CHANGE_FAILED, "Failed to schemaChange");
+                    DorisConnectorErrorCode.SCHEMA_CHANGE_FAILED, "Failed to schemaChange", e);
+        }
+
+        if (flushBeforeSchemaChange) {
+            startLoad(labelGenerator.generateLabel(lastCheckpointId));
         }
     }
 
@@ -252,6 +269,11 @@ public class DorisSinkWriter
 
     private void startLoad(String label) {
         this.dorisStreamLoad.startLoad(label);
+    }
+
+    // visible for testing: allows injecting a mocked SchemaChangeManager to avoid real HTTP calls.
+    void setSchemaChangeManager(SchemaChangeManager schemaChangeManager) {
+        this.schemaChangeManager = schemaChangeManager;
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriterTest.java
@@ -28,6 +28,7 @@ import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.connectors.doris.config.DorisSinkConfig;
+import org.apache.seatunnel.connectors.doris.exception.DorisSchemaChangeException;
 import org.apache.seatunnel.connectors.doris.rest.models.RespContent;
 import org.apache.seatunnel.connectors.doris.schema.SchemaChangeManager;
 import org.apache.seatunnel.connectors.doris.sink.LoadStatus;
@@ -286,7 +287,50 @@ public class DorisSinkWriterTest {
         }
     }
 
+    @Test
+    void testApplySchemaChangeRejectsTwoPhaseCommitWithCsvFormat() throws Exception {
+        DorisStreamLoad frontendLoad = mock(DorisStreamLoad.class);
+        doNothing().when(frontendLoad).abortPreCommit(anyString(), anyLong());
+        SchemaChangeManager schemaChangeManager = mock(SchemaChangeManager.class);
+
+        RecordingStreamLoadFactory factory = new RecordingStreamLoadFactory();
+        factory.register("fe1:8030", frontendLoad);
+
+        DorisSinkWriter writer = null;
+        try {
+            writer =
+                    new DorisSinkWriter(
+                            new DefaultSinkWriterContext(0, 1),
+                            new ArrayList<>(),
+                            mockCatalogTable(),
+                            createSinkConfig(false, true, "csv"),
+                            "job_1",
+                            factory);
+            writer.setSchemaChangeManager(schemaChangeManager);
+
+            DorisSinkWriter schemaChangeWriter = writer;
+            DorisSchemaChangeException exception =
+                    Assertions.assertThrows(
+                            DorisSchemaChangeException.class,
+                            () -> schemaChangeWriter.applySchemaChange(addColumnEvent()));
+            Assertions.assertTrue(exception.getMessage().contains("format=json"));
+
+            verify(frontendLoad, never()).stopLoad();
+            verify(frontendLoad, times(1)).startLoad(anyString());
+            verify(schemaChangeManager, never())
+                    .applySchemaChange(any(TablePath.class), any(SchemaChangeEvent.class));
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
     private DorisSinkConfig createSinkConfig(boolean directToBe, boolean enable2PC) {
+        return createSinkConfig(directToBe, enable2PC, "json");
+    }
+
+    private DorisSinkConfig createSinkConfig(boolean directToBe, boolean enable2PC, String format) {
         Map<String, Object> options = new HashMap<>();
         options.put("fenodes", "fe1:8030");
         options.put("benodes", "be1:8040");
@@ -297,13 +341,13 @@ public class DorisSinkWriterTest {
         options.put("database", "test_db");
         options.put("table", "test_table");
         options.put("sink.label-prefix", "test_job");
-        options.put("doris.config", createStreamLoadProperties());
+        options.put("doris.config", createStreamLoadProperties(format));
         return DorisSinkConfig.of(ReadonlyConfig.fromMap(options));
     }
 
-    private Map<String, String> createStreamLoadProperties() {
+    private Map<String, String> createStreamLoadProperties(String format) {
         Map<String, String> properties = new HashMap<>();
-        properties.put("format", "json");
+        properties.put("format", format);
         properties.put("read_json_by_line", "true");
         return properties;
     }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriterTest.java
@@ -20,17 +20,22 @@ package org.apache.seatunnel.connectors.doris.sink.writer;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.DefaultSinkWriterContext;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.BasicType;
-import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.doris.config.DorisSinkConfig;
 import org.apache.seatunnel.connectors.doris.rest.models.RespContent;
+import org.apache.seatunnel.connectors.doris.schema.SchemaChangeManager;
 import org.apache.seatunnel.connectors.doris.sink.LoadStatus;
 import org.apache.seatunnel.connectors.doris.sink.committer.DorisCommitInfo;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,11 +45,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -198,6 +206,86 @@ public class DorisSinkWriterTest {
         verify(frontendLoad, times(1)).close();
     }
 
+    @Test
+    void testApplySchemaChangeFlushesInFlightLoadBeforeAlterForNonTwoPhaseCommit()
+            throws Exception {
+        DorisStreamLoad frontendLoad = mock(DorisStreamLoad.class);
+        when(frontendLoad.stopLoad()).thenReturn(successRespContent(31L));
+        SchemaChangeManager schemaChangeManager = mock(SchemaChangeManager.class);
+
+        RecordingStreamLoadFactory factory = new RecordingStreamLoadFactory();
+        factory.register("fe1:8030", frontendLoad);
+
+        DorisSinkWriter writer = null;
+        try {
+            writer =
+                    new DorisSinkWriter(
+                            new DefaultSinkWriterContext(0, 1),
+                            new ArrayList<>(),
+                            mockCatalogTable(),
+                            createSinkConfig(false, false),
+                            "job_1",
+                            factory);
+            writer.setSchemaChangeManager(schemaChangeManager);
+
+            writer.applySchemaChange(addColumnEvent());
+
+            // The crux of the fix is the ordering: the in-flight load is closed (committing the
+            // old-schema rows against the still-unaltered table) BEFORE the DDL is applied, and a
+            // fresh load is reopened only AFTER the DDL. Assert the order across both mocks so a
+            // regression such as "DDL -> stopLoad" (which would commit old-schema rows against the
+            // new table structure) is caught, not just the call counts.
+            InOrder inOrder = inOrder(frontendLoad, schemaChangeManager);
+            inOrder.verify(frontendLoad).stopLoad();
+            inOrder.verify(schemaChangeManager)
+                    .applySchemaChange(any(TablePath.class), any(SchemaChangeEvent.class));
+            inOrder.verify(frontendLoad).startLoad(anyString());
+            // exactly one flush here (close() would add another for non-2PC, hence verify before
+            // close), and a fresh load reopened (init load + the reopened one).
+            verify(frontendLoad, times(1)).stopLoad();
+            verify(frontendLoad, times(2)).startLoad(anyString());
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    @Test
+    void testApplySchemaChangeKeepsTransactionIntactForTwoPhaseCommit() throws Exception {
+        DorisStreamLoad frontendLoad = mock(DorisStreamLoad.class);
+        doNothing().when(frontendLoad).abortPreCommit(anyString(), anyLong());
+        SchemaChangeManager schemaChangeManager = mock(SchemaChangeManager.class);
+
+        RecordingStreamLoadFactory factory = new RecordingStreamLoadFactory();
+        factory.register("fe1:8030", frontendLoad);
+
+        DorisSinkWriter writer = null;
+        try {
+            writer =
+                    new DorisSinkWriter(
+                            new DefaultSinkWriterContext(0, 1),
+                            new ArrayList<>(),
+                            mockCatalogTable(),
+                            createSinkConfig(false, true),
+                            "job_1",
+                            factory);
+            writer.setSchemaChangeManager(schemaChangeManager);
+
+            writer.applySchemaChange(addColumnEvent());
+
+            // 2PC must not flush mid-checkpoint: no extra stopLoad/startLoad, only the init load.
+            verify(frontendLoad, never()).stopLoad();
+            verify(frontendLoad, times(1)).startLoad(anyString());
+            verify(schemaChangeManager, times(1))
+                    .applySchemaChange(any(TablePath.class), any(SchemaChangeEvent.class));
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
     private DorisSinkConfig createSinkConfig(boolean directToBe, boolean enable2PC) {
         Map<String, Object> options = new HashMap<>();
         options.put("fenodes", "fe1:8030");
@@ -221,17 +309,23 @@ public class DorisSinkWriterTest {
     }
 
     private CatalogTable mockCatalogTable() {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        "id", BasicType.LONG_TYPE, (Long) null, true, null, null))
+                        .build();
         CatalogTable catalogTable = mock(CatalogTable.class);
         when(catalogTable.getTablePath()).thenReturn(TablePath.of("test_db", "test_table"));
-        when(catalogTable.getTableSchema()).thenReturn(mock(TableSchema.class));
-        when(catalogTable.getSeaTunnelRowType())
-                .thenReturn(
-                        new SeaTunnelRowType(
-                                new String[] {"id"},
-                                new org.apache.seatunnel.api.table.type.SeaTunnelDataType[] {
-                                    BasicType.LONG_TYPE
-                                }));
+        when(catalogTable.getTableSchema()).thenReturn(tableSchema);
+        when(catalogTable.getSeaTunnelRowType()).thenReturn(tableSchema.toPhysicalRowDataType());
         return catalogTable;
+    }
+
+    private AlterTableAddColumnEvent addColumnEvent() {
+        return AlterTableAddColumnEvent.add(
+                TableIdentifier.of("doris", "test_db", null, "test_table"),
+                PhysicalColumn.of("age", BasicType.INT_TYPE, (Long) null, true, null, null));
     }
 
     private RespContent successRespContent(long txnId) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Doris sink applied schema changes while the current Stream Load could still contain rows serialized with the old schema. Those rows could then be committed after the target table had already been altered, mixing old-schema and new-schema data in the same load. This is unsafe for positional formats such as CSV and for schema changes such as drop or rename columns.

This PR flushes the in-flight Stream Load before applying schema changes in non-2PC mode, then opens a fresh load for rows written with the new schema.

The 2PC path is intentionally unchanged because Doris 2PC currently uses one transaction and label per checkpoint. Flushing in the middle of a checkpoint would risk an orphan pre-commit transaction or checkpoint label reuse.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

Yes.

For Doris sink with `sink.enable-2pc = false`, buffered rows are now flushed before schema changes are applied. This prevents old-schema rows from being committed against the altered table.

The schema evolution documentation now also clarifies the limitation of Doris schema evolution with `sink.enable-2pc = true`.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->

Added unit tests for:

- non-2PC schema-change ordering: `stopLoad -> apply DDL -> startLoad`
- 2PC behavior: schema changes do not flush in the middle of a checkpoint

Verified with:

```bash
./mvnw spotless:apply
./mvnw -pl seatunnel-connectors-v2/connector-doris -Dtest=DorisSinkWriterTest test
./mvnw -q -DskipTests verify
```

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
