### PR TITLE
[Improve][Connector-V2] Migrate RocketMQ Source validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceConfig.java
@@ -103,11 +103,6 @@ public class RocketMqSourceConfig implements Serializable {
 
     private void parseTableConfig(ReadonlyConfig tableConfig, List<String> allTopics) {
         String topicsStr = tableConfig.get(RocketMqSourceOptions.TOPICS);
-        if (topicsStr == null || topicsStr.trim().isEmpty()) {
-            throw new IllegalArgumentException(
-                    "'topics' must be configured in each tables_configs entry, but got: "
-                            + tableConfig);
-        }
         List<String> topics =
                 Arrays.stream(topicsStr.split(RocketMqSourceOptions.DEFAULT_FIELD_DELIMITER))
                         .map(String::trim)
@@ -135,30 +130,16 @@ public class RocketMqSourceConfig implements Serializable {
             switch (startMode) {
                 case CONSUME_FROM_TIMESTAMP:
                     startTimestamp = tableConfig.get(RocketMqSourceOptions.START_MODE_TIMESTAMP);
-                    if (startTimestamp == null) {
-                        throw new IllegalArgumentException(
-                                "When 'start.mode' is set to 'CONSUME_FROM_TIMESTAMP' in tables_configs, "
-                                        + "'start.mode.timestamp' must also be specified in the same table config entry. "
-                                        + "Topics: "
-                                        + topicsStr);
-                    }
+                    // Runtime check: cannot be declarative (depends on current time)
                     long currentTimestamp = System.currentTimeMillis();
-                    if (startTimestamp < 0 || startTimestamp > currentTimestamp) {
+                    if (startTimestamp > currentTimestamp) {
                         throw new IllegalArgumentException(
-                                "The offsets timestamp value is smaller than 0 or larger"
-                                        + " than the current time");
+                                "start.mode.timestamp must not be greater than the current time");
                     }
                     break;
                 case CONSUME_FROM_SPECIFIC_OFFSETS:
                     Map<String, Long> offsetConfigMap =
                             tableConfig.get(RocketMqSourceOptions.START_MODE_OFFSETS);
-                    if (offsetConfigMap == null || offsetConfigMap.isEmpty()) {
-                        throw new IllegalArgumentException(
-                                "When 'start.mode' is set to 'CONSUME_FROM_SPECIFIC_OFFSETS' in tables_configs, "
-                                        + "'start.mode.offsets' must also be specified in the same table config entry. "
-                                        + "Topics: "
-                                        + topicsStr);
-                    }
                     Map<MessageQueue, Long> specificOffsets = metadata.getSpecificStartOffsets();
                     if (specificOffsets == null) {
                         specificOffsets = new HashMap<>();
@@ -233,10 +214,10 @@ public class RocketMqSourceConfig implements Serializable {
                 long startOffsetsTimestamp =
                         readonlyConfig.get(RocketMqSourceOptions.START_MODE_TIMESTAMP);
                 long currentTimestamp = System.currentTimeMillis();
-                if (startOffsetsTimestamp < 0 || startOffsetsTimestamp > currentTimestamp) {
+                // Runtime check: cannot be declarative (depends on current time)
+                if (startOffsetsTimestamp > currentTimestamp) {
                     throw new IllegalArgumentException(
-                            "The offsets timestamp value is smaller than 0 or larger"
-                                    + " than the current time");
+                            "start.mode.timestamp must not be greater than the current time");
                 }
                 consumerMetadata.setStartOffsetsTimestamp(startOffsetsTimestamp);
                 break;

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.rocketmq.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.connector.TableSource;
@@ -31,6 +35,8 @@ import org.apache.seatunnel.connectors.seatunnel.rocketmq.config.RocketMqSourceO
 import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 @AutoService(Factory.class)
 public class RocketMqSourceFactory implements TableSourceFactory {
@@ -67,8 +73,24 @@ public class RocketMqSourceFactory implements TableSourceFactory {
                         RocketMqSourceOptions.START_MODE_TIMESTAMP)
                 .conditional(
                         RocketMqSourceOptions.START_MODE,
+                        StartMode.CONSUME_FROM_TIMESTAMP,
+                        Conditions.greaterOrEqual(RocketMqSourceOptions.START_MODE_TIMESTAMP, 0L))
+                .conditional(
+                        RocketMqSourceOptions.START_MODE,
                         StartMode.CONSUME_FROM_SPECIFIC_OFFSETS,
                         RocketMqSourceOptions.START_MODE_OFFSETS)
+                .conditional(
+                        RocketMqSourceOptions.START_MODE,
+                        StartMode.CONSUME_FROM_SPECIFIC_OFFSETS,
+                        Conditions.mapNotEmpty(RocketMqSourceOptions.START_MODE_OFFSETS))
+                .optional(
+                        RocketMqSourceOptions.TABLE_CONFIGS,
+                        Conditions.extension(
+                                RocketMqSourceOptions.TABLE_CONFIGS, new TableConfigsValidator()))
+                .optional(
+                        RocketMqSourceOptions.TABLE_LIST,
+                        Conditions.extension(
+                                RocketMqSourceOptions.TABLE_LIST, new TableConfigsValidator()))
                 .conditional(
                         RocketMqBaseOptions.ACL_ENABLED,
                         true,
@@ -86,5 +108,62 @@ public class RocketMqSourceFactory implements TableSourceFactory {
     public <T, SplitT extends SourceSplit, StateT extends Serializable>
             TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
         return () -> (SeaTunnelSource<T, SplitT, StateT>) new RocketMqSource(context.getOptions());
+    }
+
+    static class TableConfigsValidator implements ConditionExtension<List<Map<String, Object>>> {
+
+        @Override
+        public String description() {
+            return "each tables_configs entry must have valid topics, "
+                    + "start.mode.timestamp (>= 0) when CONSUME_FROM_TIMESTAMP, "
+                    + "and non-empty start.mode.offsets when CONSUME_FROM_SPECIFIC_OFFSETS";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> entries)
+                throws OptionValidationException {
+            if (entries == null || entries.isEmpty()) {
+                return true;
+            }
+            for (int i = 0; i < entries.size(); i++) {
+                ReadonlyConfig tableConfig = ReadonlyConfig.fromMap(entries.get(i));
+                String topics = tableConfig.get(RocketMqSourceOptions.TOPICS);
+                if (topics == null || topics.trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            "tables_configs[%d]: 'topics' must not be empty", i);
+                }
+                StartMode startMode =
+                        tableConfig.getOptional(RocketMqSourceOptions.START_MODE).orElse(null);
+                if (startMode == StartMode.CONSUME_FROM_TIMESTAMP) {
+                    Long ts =
+                            tableConfig
+                                    .getOptional(RocketMqSourceOptions.START_MODE_TIMESTAMP)
+                                    .orElse(null);
+                    if (ts == null) {
+                        throw new OptionValidationException(
+                                "tables_configs[%d]: 'start.mode.timestamp' required "
+                                        + "when start.mode=CONSUME_FROM_TIMESTAMP",
+                                i);
+                    }
+                    if (ts < 0) {
+                        throw new OptionValidationException(
+                                "tables_configs[%d]: 'start.mode.timestamp' must be >= 0, got: %d",
+                                i, ts);
+                    }
+                } else if (startMode == StartMode.CONSUME_FROM_SPECIFIC_OFFSETS) {
+                    Map<String, Long> offsets =
+                            tableConfig
+                                    .getOptional(RocketMqSourceOptions.START_MODE_OFFSETS)
+                                    .orElse(null);
+                    if (offsets == null || offsets.isEmpty()) {
+                        throw new OptionValidationException(
+                                "tables_configs[%d]: 'start.mode.offsets' must not be empty "
+                                        + "when start.mode=CONSUME_FROM_SPECIFIC_OFFSETS",
+                                i);
+                    }
+                }
+            }
+            return true;
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqFactoryTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.rocketmq.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class RocketMqFactoryTest {
+
+    private final OptionRule sourceRule = new RocketMqSourceFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(sourceRule);
+    }
+
+    private Map<String, Object> validTimestampConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        cfg.put("topics", "test-topic");
+        cfg.put("start.mode", "CONSUME_FROM_TIMESTAMP");
+        cfg.put("start.mode.timestamp", 1000L);
+        return cfg;
+    }
+
+    private Map<String, Object> validSpecificOffsetsConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        cfg.put("topics", "test-topic");
+        cfg.put("start.mode", "CONSUME_FROM_SPECIFIC_OFFSETS");
+        Map<String, Long> offsets = new HashMap<>();
+        offsets.put("test-topic-0", 100L);
+        cfg.put("start.mode.offsets", offsets);
+        return cfg;
+    }
+
+    private Map<String, Object> validMultiTableConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        List<Map<String, Object>> tableConfigs = new ArrayList<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("topics", "topic-a,topic-b");
+        tableConfigs.add(entry);
+        cfg.put("tables_configs", tableConfigs);
+        return cfg;
+    }
+
+    @Test
+    void testValidTimestampConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validTimestampConfig()));
+    }
+
+    @Test
+    void testNegativeTimestampRejected() {
+        Map<String, Object> cfg = validTimestampConfig();
+        cfg.put("start.mode.timestamp", -1L);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testValidSpecificOffsetsConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validSpecificOffsetsConfig()));
+    }
+
+    @Test
+    void testEmptyOffsetsMapRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        cfg.put("topics", "test-topic");
+        cfg.put("start.mode", "CONSUME_FROM_SPECIFIC_OFFSETS");
+        cfg.put("start.mode.offsets", Collections.emptyMap());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMultiTableValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validMultiTableConfig()));
+    }
+
+    @Test
+    void testMultiTableMissingTopicsRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        List<Map<String, Object>> tableConfigs = new ArrayList<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("topics", "");
+        tableConfigs.add(entry);
+        cfg.put("tables_configs", tableConfigs);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMultiTableTimestampModeWithoutTimestampRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        List<Map<String, Object>> tableConfigs = new ArrayList<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("topics", "topic-a");
+        entry.put("start.mode", "CONSUME_FROM_TIMESTAMP");
+        tableConfigs.add(entry);
+        cfg.put("tables_configs", tableConfigs);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMultiTableNegativeTimestampRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        List<Map<String, Object>> tableConfigs = new ArrayList<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("topics", "topic-a");
+        entry.put("start.mode", "CONSUME_FROM_TIMESTAMP");
+        entry.put("start.mode.timestamp", -5L);
+        tableConfigs.add(entry);
+        cfg.put("tables_configs", tableConfigs);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testMultiTableEmptyOffsetsRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("name.srv.addr", "localhost:9876");
+        List<Map<String, Object>> tableConfigs = new ArrayList<>();
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("topics", "topic-a");
+        entry.put("start.mode", "CONSUME_FROM_SPECIFIC_OFFSETS");
+        entry.put("start.mode.offsets", Collections.emptyMap());
+        tableConfigs.add(entry);
+        cfg.put("tables_configs", tableConfigs);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+}


### PR DESCRIPTION
## Purpose of this pull request

Related #11007
Depends on #11121

1. Add `greaterOrEqual(START_MODE_TIMESTAMP, 0L)` constraint when `start.mode = CONSUME_FROM_TIMESTAMP`
2. Add `mapNotEmpty(START_MODE_OFFSETS)` constraint when `start.mode = CONSUME_FROM_SPECIFIC_OFFSETS`
3. Add `TableConfigsValidator` (`ConditionExtension`) to validate nested `tables_configs` / `table_list` entries: topics non-empty, per-entry start.mode conditional dependencies, timestamp >= 0, offsets non-empty
4. Remove migrated imperative checks from `RocketMqSourceConfig`, retain runtime-only `> currentTimestamp` checks with comments
5. Add `RocketMqFactoryTest` covering single-table and multi-table positive/negative validation paths

## Does this PR introduce _any_ user-facing change?

Yes — previously invalid configurations (negative timestamps, empty offsets, missing topics in tables_configs entries) were rejected at task execution time with generic `IllegalArgumentException`. Now they are rejected earlier at job submission time with structured `OptionValidationException` including option name, constraint type, and violation details. Multiple errors are reported together thanks to the aggregation support from #11121.

## How was this patch tested?

Unit tests in `RocketMqFactoryTest`:

- `testValidTimestampConfig` — valid CONSUME_FROM_TIMESTAMP mode passes validation
- `testNegativeTimestampRejected` — negative `start.mode.timestamp` is rejected
- `testValidSpecificOffsetsConfig` — valid CONSUME_FROM_SPECIFIC_OFFSETS mode passes validation
- `testEmptyOffsetsMapRejected` — empty offsets map is rejected
- `testMultiTableValidConfig` — valid multi-table config passes validation
- `testMultiTableMissingTopicsRejected` — empty topics in tables_configs entry is rejected
- `testMultiTableTimestampModeWithoutTimestampRejected` — TIMESTAMP mode without timestamp in entry is rejected
- `testMultiTableNegativeTimestampRejected` — negative timestamp in tables_configs entry is rejected
- `testMultiTableEmptyOffsetsRejected` — empty offsets in tables_configs entry is rejected

Existing tests continue to pass.

```bash
./mvnw test -pl seatunnel-connectors-v2/connector-rocketmq -Dtest="RocketMqFactoryTest" -DfailIfNoTests=false
```
