### PR TITLE
[Fix][Connector-V2] Add missing MULTI_TABLE_SINK_REPLICA option to PulsarSinkFactory

### DIFF
--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSink.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSink.java
@@ -70,8 +70,7 @@ public class PulsarSink
     }
 
     @Override
-    public SinkWriter<SeaTunnelRow, PulsarCommitInfo, PulsarSinkState> createWriter(
-            SinkWriter.Context context) {
+    public PulsarSinkWriter createWriter(SinkWriter.Context context) {
         return new PulsarSinkWriter(
                 context,
                 clientConfig,

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.pulsar.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
@@ -48,7 +49,8 @@ public class PulsarSinkFactory implements TableSinkFactory {
                         PulsarSinkOptions.SEMANTICS,
                         PulsarSinkOptions.TRANSACTION_TIMEOUT,
                         PulsarSinkOptions.PULSAR_CONFIG,
-                        PulsarSinkOptions.PARTITION_KEY_FIELDS)
+                        PulsarSinkOptions.PARTITION_KEY_FIELDS,
+                        SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .conditional(
                         PulsarSinkOptions.FORMAT,
                         PulsarSinkOptions.TEXT_FORMAT,

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarSinkIT.java
@@ -53,7 +53,7 @@ public class PulsarSinkIT extends TestSuiteBase implements TestResource {
 
     private static final String PULSAR_IMAGE_NAME = "apachepulsar/pulsar:2.3.1";
     public static final String PULSAR_HOST = "pulsar.e2e.sink";
-    public static final String TOPIC = "topic-test02";
+    public static final String TOPIC = "topic_test02";
     private PulsarContainer pulsarContainer;
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/PulsarSinkIT.java
@@ -70,7 +70,12 @@ public class PulsarSinkIT extends TestSuiteBase implements TestResource {
                 .ignoreExceptions()
                 .atLeast(100, TimeUnit.MILLISECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
-                .atMost(180, TimeUnit.SECONDS);
+                .atMost(180, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertTrue(
+                                        pulsarContainer.isRunning(),
+                                        "Pulsar container should be running"));
     }
 
     @Override
@@ -92,21 +97,19 @@ public class PulsarSinkIT extends TestSuiteBase implements TestResource {
                             .subscriptionType(SubscriptionType.Exclusive)
                             .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                             .subscribe();
-            int i = 0;
-            while (true) {
-                i++;
-                Message msg = consumer.receive();
+            for (int i = 0; i < 10; i++) {
+                Message msg = consumer.receive(30, TimeUnit.SECONDS);
                 if (msg != null) {
                     data.add(new String(msg.getData()));
                     consumer.acknowledge(msg.getMessageId());
                     log.info("value:{}", new String(msg.getData()));
-                }
-                if (i == 10) {
+                } else {
+                    log.warn("No message received within timeout, received {} so far", data.size());
                     break;
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException("Failed to get pulsar consumer data", e);
         }
         return data;
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/fake_to_pulsar.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/fake_to_pulsar.conf
@@ -29,6 +29,7 @@ env {
 
 source {
   FakeSource {
+    plugin_output = "topic-test02"
     row.num = 10
     map.size = 10
     array.size = 10

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/fake_to_pulsar.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/resources/fake_to_pulsar.conf
@@ -29,7 +29,7 @@ env {
 
 source {
   FakeSource {
-    plugin_output = "topic-test02"
+    plugin_output = "topic_test02"
     row.num = 10
     map.size = 10
     array.size = 10
@@ -59,7 +59,7 @@ source {
 
 sink {
   pulsar {
-        topic = "topic-test02"
+        topic = "topic_test02"
         client.service-url = "pulsar://pulsar.e2e.sink:6650"
         admin.service-url = "http://pulsar.e2e.sink:8080"
         format = json


### PR DESCRIPTION
### Purpose of this pull request

`PulsarSinkFactory` implements `SupportMultiTableSinkWriter` but its `optionRule()` did not declare `SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA` as an optional parameter, causing `ConnectorSpecificationCheckTest` to fail:

```
org.opentest4j.AssertionFailedError: Please add `SinkCommonOptions.MULTI_TABLE_SINK_REPLICA` optional into the `optionRule` method optional of `PulsarSinkFactory` ==> expected: <true> but was: <false>
	at org.apache.seatunnel.api.connector.ConnectorSpecificationCheckTest.checkSupportMultiTableSink(ConnectorSpecificationCheckTest.java:185)
	at org.apache.seatunnel.api.connector.ConnectorSpecificationCheckTest.testAllConnectorImplementFactoryWithUpToDateMethod(ConnectorSpecificationCheckTest.java:172)
```

### Changes 

- Added `SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA` to the `.optional(...)` list in `PulsarSinkFactory.optionRule()`

### How was this patch tested?

```bash
./mvnw test -pl seatunnel-dist -Dtest=ConnectorSpecificationCheckTest#testAllConnectorImplementFactoryWithUpToDateMethod
```