### PR TITLE
[Docs] Fix Chinese engine architecture page rendering

### DIFF
--- a/docs/zh/architecture/engine/engine-architecture.md
+++ b/docs/zh/architecture/engine/engine-architecture.md
@@ -77,7 +77,6 @@ flowchart TB
     style master fill:#081425,stroke:#5db8e2,stroke-width:1.5px,color:#f8fbff;
     style worker fill:#081425,stroke:#8d7cf6,stroke-width:1.5px,color:#f8fbff;
 ```
-```
 
 ### 2.2 核心组件
 


### PR DESCRIPTION
## Purpose

Fix the Chinese engine architecture documentation page rendering issue where normal body content was displayed as raw Markdown/code block content.
<img width="1404" height="1019" alt="image" src="https://github.com/user-attachments/assets/01d97827-aa2f-4d62-883e-3b7024a922e4" />

## Root cause

The Chinese Markdown file had an extra closing code fence immediately after the first Mermaid diagram. That extra ``` opened a new empty fenced code block, causing the following sections to be rendered as code until a later fence closed it.

## Changes

- Removed the redundant code fence in `docs/zh/architecture/engine/engine-architecture.md`.

## Verification

- `git diff --check`
- `awk '/^```/{n++} END{print n}' docs/zh/architecture/engine/engine-architecture.md` => `16`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./mvnw spotless:apply`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./mvnw -q -DskipTests verify`