### PR TITLE
[Fix][API] Fix backward compatibility issue in CatalogFactory optionRule validation

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -61,6 +61,17 @@ You need to check this document before you upgrade to related version.
 
 ### Configuration Changes
 
+- **Breaking Change: CatalogFactory creation path now validates `optionRule()`**
+  - **Affected component**: `seatunnel-api` — `FactoryUtil.createOptionalCatalog()`
+  - **Description**: The `FactoryUtil.createOptionalCatalog()` method now calls `ConfigValidator.validate(catalogFactory.optionRule())` before creating a catalog instance. Previously, no validation was performed on the catalog factory's option rules during catalog creation.
+  - **Impact**: Catalog factories whose `optionRule()` declares options as `required` that are not always present in the config passed to `createOptionalCatalog()` will now throw `OptionValidationException`. This primarily affects the JDBC connector path via `JdbcCatalogUtils.findCatalog()`.
+  - **Migration Guide**: If you have a custom `CatalogFactory` implementation, ensure that its `optionRule()` accurately reflects which options are truly mandatory vs optional in the config that reaches it at runtime.
+
+- **Breaking Change: DuckDB CatalogFactory no longer requires username/password**
+  - **Affected component**: `seatunnel-connectors-v2/connector-jdbc` — `DuckDBCatalogFactory`
+  - **Description**: `DuckDBCatalogFactory.optionRule()` previously inherited `BASE_CATALOG_RULE` which required `username` and `password`. Since DuckDB is an embedded database with no credentials, it now defines its own rule with only `url` as required.
+  - **Impact**: No user-facing impact (this is a relaxation, not a tightening).
+
 ### Connector Changes
 
 - **Breaking Change: Iceberg Connector — source table primary key is no longer silently inherited**

--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -67,10 +67,6 @@ You need to check this document before you upgrade to related version.
   - **Impact**: Catalog factories whose `optionRule()` declares options as `required` that are not always present in the config passed to `createOptionalCatalog()` will now throw `OptionValidationException`. This primarily affects the JDBC connector path via `JdbcCatalogUtils.findCatalog()`.
   - **Migration Guide**: If you have a custom `CatalogFactory` implementation, ensure that its `optionRule()` accurately reflects which options are truly mandatory vs optional in the config that reaches it at runtime.
 
-- **Breaking Change: DuckDB CatalogFactory no longer requires username/password**
-  - **Affected component**: `seatunnel-connectors-v2/connector-jdbc` — `DuckDBCatalogFactory`
-  - **Description**: `DuckDBCatalogFactory.optionRule()` previously inherited `BASE_CATALOG_RULE` which required `username` and `password`. Since DuckDB is an embedded database with no credentials, it now defines its own rule with only `url` as required.
-  - **Impact**: No user-facing impact (this is a relaxation, not a tightening).
 
 ### Connector Changes
 

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -60,6 +60,17 @@
 
 ### 配置变更
 
+- **破坏性变更：CatalogFactory 创建路径现在会校验 `optionRule()`**
+  - **影响范围**：`seatunnel-api` — `FactoryUtil.createOptionalCatalog()`
+  - **变更说明**：`FactoryUtil.createOptionalCatalog()` 方法现在在创建 catalog 实例之前会调用 `ConfigValidator.validate(catalogFactory.optionRule())` 进行校验。此前，catalog 创建路径不会对 catalog factory 的 option rules 执行任何校验。
+  - **影响**：如果 catalog factory 的 `optionRule()` 将某些选项声明为 `required`，而传入 `createOptionalCatalog()` 的配置中这些选项并不总是存在，则会抛出 `OptionValidationException`。这主要影响通过 `JdbcCatalogUtils.findCatalog()` 触发的 JDBC 连接器路径。
+  - **迁移指南**：如果您有自定义的 `CatalogFactory` 实现，请确保其 `optionRule()` 准确反映在运行时到达它的配置中，哪些选项是真正必填的，哪些是可选的。
+
+- **破坏性变更：DuckDB CatalogFactory 不再要求 username/password**
+  - **影响范围**：`seatunnel-connectors-v2/connector-jdbc` — `DuckDBCatalogFactory`
+  - **变更说明**：`DuckDBCatalogFactory.optionRule()` 此前继承了 `BASE_CATALOG_RULE`，该规则要求 `username` 和 `password`。由于 DuckDB 是嵌入式数据库，不需要凭据，现在它定义了自己的规则，仅将 `url` 设为必填。
+  - **影响**：无用户可感知的影响（这是放宽限制，而非收紧）。
+
 ### 连接器变更
 
 - **破坏性变更：Iceberg 连接器 — 不再自动继承源表主键**

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -66,10 +66,6 @@
   - **影响**：如果 catalog factory 的 `optionRule()` 将某些选项声明为 `required`，而传入 `createOptionalCatalog()` 的配置中这些选项并不总是存在，则会抛出 `OptionValidationException`。这主要影响通过 `JdbcCatalogUtils.findCatalog()` 触发的 JDBC 连接器路径。
   - **迁移指南**：如果您有自定义的 `CatalogFactory` 实现，请确保其 `optionRule()` 准确反映在运行时到达它的配置中，哪些选项是真正必填的，哪些是可选的。
 
-- **破坏性变更：DuckDB CatalogFactory 不再要求 username/password**
-  - **影响范围**：`seatunnel-connectors-v2/connector-jdbc` — `DuckDBCatalogFactory`
-  - **变更说明**：`DuckDBCatalogFactory.optionRule()` 此前继承了 `BASE_CATALOG_RULE`，该规则要求 `username` 和 `password`。由于 DuckDB 是嵌入式数据库，不需要凭据，现在它定义了自己的规则，仅将 `url` 设为必填。
-  - **影响**：无用户可感知的影响（这是放宽限制，而非收紧）。
 
 ### 连接器变更
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/SqlServerIncrementalSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/source/SqlServerIncrementalSourceFactoryTest.java
@@ -17,12 +17,45 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cdc.sqlserver.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.Catalog;
+import org.apache.seatunnel.api.table.factory.FactoryUtil;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 class SqlServerIncrementalSourceFactoryTest {
     @Test
     public void testOptionRule() {
         Assertions.assertNotNull((new SqlServerIncrementalSourceFactory()).optionRule());
+    }
+
+    /**
+     * SQLServer CDC source creation must accept the driver-specific databaseName URL syntax during
+     * the submission-time catalog validation step.
+     */
+    @Test
+    public void testCreateOptionalCatalogWithSqlServerStyleUrl() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("url", "jdbc:sqlserver://localhost:1433;databaseName=seatunnel");
+        config.put("username", "sa");
+        config.put("password", "Password!");
+        config.put("database-names", Arrays.asList("seatunnel"));
+        config.put("table-names", Arrays.asList("seatunnel.dbo.orders"));
+
+        Optional<Catalog> catalog =
+                FactoryUtil.createOptionalCatalog(
+                        "SqlServer",
+                        ReadonlyConfig.fromMap(config),
+                        Thread.currentThread().getContextClassLoader(),
+                        "SqlServer");
+
+        Assertions.assertTrue(catalog.isPresent());
+        catalog.ifPresent(Catalog::close);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
@@ -62,7 +62,7 @@ public class DamengCatalogFactory implements CatalogFactory {
     static class DamengUrlValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "Dameng JDBC URL must be a valid jdbc:dm://host:port format";
+            return "Dameng JDBC URL must be a valid format (e.g. jdbc:dm://host:port)";
         }
 
         @Override
@@ -72,9 +72,13 @@ public class DamengCatalogFactory implements CatalogFactory {
             }
             try {
                 JdbcUrlUtil.UrlInfo info = JdbcUrlUtil.getUrlInfo(url);
-                return info != null && StringUtils.isNotBlank(info.getHost());
+                return StringUtils.isNotBlank(info.getHost());
             } catch (IllegalArgumentException e) {
-                throw new OptionValidationException("Invalid Dameng JDBC URL format: " + url, e);
+                throw new OptionValidationException(
+                        String.format(
+                                "Invalid Dameng JDBC URL format: [%s], "
+                                        + "expected pattern: jdbc:dm://host:port",
+                                url));
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
@@ -17,12 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.dm;
 
-import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
-
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
-import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -55,31 +51,6 @@ public class DamengCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.baseCatalogRule(new DamengUrlValidator()).build();
-    }
-
-    /** Validates URL format only; Dameng does not require a database name in the URL. */
-    static class DamengUrlValidator implements ConditionExtension<String> {
-        @Override
-        public String description() {
-            return "Dameng JDBC URL must be a valid format (e.g. jdbc:dm://host:port)";
-        }
-
-        @Override
-        public boolean evaluate(ReadonlyConfig config, String url) {
-            if (url == null || url.trim().isEmpty()) {
-                return false;
-            }
-            try {
-                JdbcUrlUtil.UrlInfo info = JdbcUrlUtil.getUrlInfo(url);
-                return StringUtils.isNotBlank(info.getHost());
-            } catch (IllegalArgumentException e) {
-                throw new OptionValidationException(
-                        String.format(
-                                "Invalid Dameng JDBC URL format: [%s], "
-                                        + "expected pattern: jdbc:dm://host:port",
-                                url));
-            }
-        }
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/dm/DamengCatalogFactory.java
@@ -17,8 +17,12 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.dm;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -51,6 +55,27 @@ public class DamengCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule(new DamengUrlValidator()).build();
+    }
+
+    /** Validates URL format only; Dameng does not require a database name in the URL. */
+    static class DamengUrlValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "Dameng JDBC URL must be a valid jdbc:dm://host:port format";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String url) {
+            if (url == null || url.trim().isEmpty()) {
+                return false;
+            }
+            try {
+                JdbcUrlUtil.UrlInfo info = JdbcUrlUtil.getUrlInfo(url);
+                return info != null && StringUtils.isNotBlank(info.getHost());
+            } catch (IllegalArgumentException e) {
+                throw new OptionValidationException("Invalid Dameng JDBC URL format: " + url, e);
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/duckdb/DuckDBCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/duckdb/DuckDBCatalogFactory.java
@@ -28,13 +28,6 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseI
 
 import com.google.auto.service.AutoService;
 
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.DECIMAL_TYPE_NARROWING;
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.HANDLE_BLOB_AS_STRING;
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.PASSWORD;
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.SCHEMA;
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.URL;
-import static org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions.USERNAME;
-
 /** Factory for {@link DuckDBCatalog} */
 @AutoService(Factory.class)
 public class DuckDBCatalogFactory implements CatalogFactory {
@@ -58,8 +51,13 @@ public class DuckDBCatalogFactory implements CatalogFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(URL)
-                .optional(USERNAME, PASSWORD, SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING)
+                .required(JdbcCommonOptions.URL)
+                .optional(
+                        JdbcCommonOptions.USERNAME,
+                        JdbcCommonOptions.PASSWORD,
+                        JdbcCommonOptions.SCHEMA,
+                        JdbcCommonOptions.DECIMAL_TYPE_NARROWING,
+                        JdbcCommonOptions.HANDLE_BLOB_AS_STRING)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/highgo/HighGoCatalogFactory.java
@@ -45,6 +45,6 @@ public class HighGoCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/iris/IrisCatalogFactory.java
@@ -50,6 +50,6 @@ public class IrisCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalogFactory.java
@@ -51,6 +51,6 @@ public class KingbaseCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalogFactory.java
@@ -51,6 +51,6 @@ public class MySqlCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/opengauss/OpenGaussCatalogFactory.java
@@ -51,6 +51,6 @@ public class OpenGaussCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
@@ -17,8 +17,12 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -53,6 +57,28 @@ public class OracleCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule(new OracleUrlValidator()).build();
+    }
+
+    static class OracleUrlValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "Oracle JDBC URL must contain a database/service name";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String url) {
+            if (url == null || url.trim().isEmpty()) {
+                return false;
+            }
+            try {
+                JdbcUrlUtil.UrlInfo info = OracleURLParser.parse(url);
+                return info != null
+                        && StringUtils.isNotBlank(info.getHost())
+                        && info.getDefaultDatabase().isPresent();
+            } catch (IllegalArgumentException e) {
+                throw new OptionValidationException("Invalid Oracle JDBC URL format: " + url, e);
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalogFactory.java
@@ -63,7 +63,7 @@ public class OracleCatalogFactory implements CatalogFactory {
     static class OracleUrlValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "Oracle JDBC URL must contain a database/service name";
+            return "Oracle JDBC URL must contain a service name (e.g. jdbc:oracle:thin:@host:port/service)";
         }
 
         @Override
@@ -73,11 +73,14 @@ public class OracleCatalogFactory implements CatalogFactory {
             }
             try {
                 JdbcUrlUtil.UrlInfo info = OracleURLParser.parse(url);
-                return info != null
-                        && StringUtils.isNotBlank(info.getHost())
+                return StringUtils.isNotBlank(info.getHost())
                         && info.getDefaultDatabase().isPresent();
             } catch (IllegalArgumentException e) {
-                throw new OptionValidationException("Invalid Oracle JDBC URL format: " + url, e);
+                throw new OptionValidationException(
+                        String.format(
+                                "Invalid Oracle JDBC URL format: [%s], "
+                                        + "expected pattern: jdbc:oracle:thin:@host:port/service",
+                                url));
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/psql/PostgresCatalogFactory.java
@@ -51,6 +51,6 @@ public class PostgresCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/redshift/RedshiftCatalogFactory.java
@@ -51,6 +51,6 @@ public class RedshiftCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
@@ -61,7 +61,7 @@ public class SapHanaCatalogFactory implements CatalogFactory {
     static class SapHanaUrlValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "SapHana JDBC URL must contain a database name";
+            return "SAP HANA JDBC URL must be a valid format (e.g. jdbc:sap://host:port)";
         }
 
         @Override
@@ -71,11 +71,14 @@ public class SapHanaCatalogFactory implements CatalogFactory {
             }
             try {
                 JdbcUrlUtil.UrlInfo info = SapHanaURLParser.parse(url);
-                return info != null
-                        && StringUtils.isNotBlank(info.getHost())
+                return StringUtils.isNotBlank(info.getHost())
                         && info.getDefaultDatabase().isPresent();
             } catch (IllegalArgumentException e) {
-                throw new OptionValidationException("Invalid SapHana JDBC URL format: " + url, e);
+                throw new OptionValidationException(
+                        String.format(
+                                "Invalid SAP HANA JDBC URL format: [%s], "
+                                        + "expected pattern: jdbc:sap://host:port",
+                                url));
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
@@ -17,8 +17,12 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.saphana;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -51,6 +55,28 @@ public class SapHanaCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule(new SapHanaUrlValidator()).build();
+    }
+
+    static class SapHanaUrlValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "SapHana JDBC URL must contain a database name";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String url) {
+            if (url == null || url.trim().isEmpty()) {
+                return false;
+            }
+            try {
+                JdbcUrlUtil.UrlInfo info = SapHanaURLParser.parse(url);
+                return info != null
+                        && StringUtils.isNotBlank(info.getHost())
+                        && info.getDefaultDatabase().isPresent();
+            } catch (IllegalArgumentException e) {
+                throw new OptionValidationException("Invalid SapHana JDBC URL format: " + url, e);
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaCatalogFactory.java
@@ -71,8 +71,7 @@ public class SapHanaCatalogFactory implements CatalogFactory {
             }
             try {
                 JdbcUrlUtil.UrlInfo info = SapHanaURLParser.parse(url);
-                return StringUtils.isNotBlank(info.getHost())
-                        && info.getDefaultDatabase().isPresent();
+                return StringUtils.isNotBlank(info.getHost());
             } catch (IllegalArgumentException e) {
                 throw new OptionValidationException(
                         String.format(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaURLParser.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/saphana/SapHanaURLParser.java
@@ -25,7 +25,8 @@ import java.util.regex.Pattern;
 public class SapHanaURLParser {
 
     private static final Pattern HANA_URL_PATTERN =
-            Pattern.compile("^(?<url>jdbc:sap://(?<host>[^:]+):(?<port>\\d+)/\\?(?<params>.*?))$");
+            Pattern.compile(
+                    "^(?<url>jdbc:sap://(?<host>[^:]+):(?<port>\\d+)(/\\?(?<params>.*?))?)$");
 
     public static JdbcUrlUtil.UrlInfo parse(String url) {
         Matcher matcher = HANA_URL_PATTERN.matcher(url);

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
@@ -62,7 +62,7 @@ public class SqlServerCatalogFactory implements CatalogFactory {
     static class SqlServerUrlValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "SqlServer JDBC URL must be a valid jdbc:sqlserver://host format";
+            return "SqlServer JDBC URL must be a valid format (e.g. jdbc:sqlserver://host:port;databaseName=db)";
         }
 
         @Override
@@ -74,7 +74,11 @@ public class SqlServerCatalogFactory implements CatalogFactory {
                 JdbcUrlUtil.UrlInfo info = SqlServerURLParser.parse(url);
                 return info != null && StringUtils.isNotBlank(info.getHost());
             } catch (IllegalArgumentException e) {
-                throw new OptionValidationException("Invalid SqlServer JDBC URL format: " + url, e);
+                throw new OptionValidationException(
+                        String.format(
+                                "Invalid SqlServer JDBC URL format: [%s], "
+                                        + "expected pattern: jdbc:sqlserver://host:port[;databaseName=db]",
+                                url));
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
@@ -17,8 +17,12 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.sqlserver;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -51,6 +55,27 @@ public class SqlServerCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule(new SqlServerUrlValidator()).build();
+    }
+
+    /** Validates URL format only; database may be provided via separate config option. */
+    static class SqlServerUrlValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "SqlServer JDBC URL must be a valid jdbc:sqlserver://host format";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String url) {
+            if (url == null || url.trim().isEmpty()) {
+                return false;
+            }
+            try {
+                JdbcUrlUtil.UrlInfo info = SqlServerURLParser.parse(url);
+                return info != null && StringUtils.isNotBlank(info.getHost());
+            } catch (IllegalArgumentException e) {
+                throw new OptionValidationException("Invalid SqlServer JDBC URL format: " + url, e);
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/tidb/TiDBCatalogFactory.java
@@ -50,6 +50,6 @@ public class TiDBCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/xugu/XuguCatalogFactory.java
@@ -23,7 +23,6 @@ import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle.OracleURLParser;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 
@@ -40,7 +39,7 @@ public class XuguCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
         String urlWithDatabase = options.get(JdbcCommonOptions.URL);
-        JdbcUrlUtil.UrlInfo urlInfo = OracleURLParser.parse(urlWithDatabase);
+        JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(urlWithDatabase);
         return new XuguCatalog(
                 catalogName,
                 options.get(JdbcCommonOptions.USERNAME),
@@ -52,6 +51,6 @@ public class XuguCatalogFactory implements CatalogFactory {
 
     @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.BASE_CATALOG_RULE.build();
+        return JdbcCommonOptions.baseCatalogRule().build();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.config;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
@@ -24,6 +26,9 @@ import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle.OracleURLParser;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.saphana.SapHanaURLParser;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.sqlserver.SqlServerURLParser;
 
 import java.util.Map;
 
@@ -206,10 +211,30 @@ public class JdbcCommonOptions {
                 return false;
             }
             try {
-                return JdbcUrlUtil.getUrlInfo(url).getDefaultDatabase().isPresent();
+                JdbcUrlUtil.UrlInfo urlInfo = parseUrlInfo(url);
+                return urlInfo != null
+                        && StringUtils.isNotBlank(urlInfo.getHost())
+                        && urlInfo.getDefaultDatabase().isPresent();
             } catch (IllegalArgumentException e) {
                 return false;
             }
+        }
+
+        /**
+         * Delegate to the dialect-specific parser when the catalog URL does not follow the generic
+         * host:port/database JDBC shape.
+         */
+        private JdbcUrlUtil.UrlInfo parseUrlInfo(String url) {
+            if (url.startsWith("jdbc:sqlserver:")) {
+                return SqlServerURLParser.parse(url);
+            }
+            if (url.startsWith("jdbc:oracle:")) {
+                return OracleURLParser.parse(url);
+            }
+            if (url.startsWith("jdbc:sap:")) {
+                return SapHanaURLParser.parse(url);
+            }
+            return JdbcUrlUtil.getUrlInfo(url);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -25,10 +25,8 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.common.utils.JdbcUrlUtil;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle.OracleURLParser;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.saphana.SapHanaURLParser;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.sqlserver.SqlServerURLParser;
 
 import java.util.Map;
 
@@ -167,37 +165,37 @@ public class JdbcCommonOptions {
     public static final Option<String> REGION =
             Options.key("region").stringType().noDefaultValue().withDescription("region");
 
-    /** @deprecated Use {@link #baseCatalogRule()} instead to avoid shared mutable state. */
-    @Deprecated public static final OptionRule.Builder BASE_CATALOG_RULE = baseCatalogRule();
-
     /**
-     * Returns a fresh {@link OptionRule.Builder} with the base validation rules shared by all JDBC
-     * catalog factories (MySQL, PostgreSQL, Oracle, etc.).
+     * Returns a fresh {@link OptionRule.Builder} with the base validation rules shared by standard
+     * JDBC catalog factories (MySQL, PostgreSQL, etc.) that use generic {@code host:port/database}
+     * URL format and require username/password authentication.
      *
-     * <p>These rules are evaluated at <b>catalog creation time</b> via {@code
-     * ConfigValidator.validate(factory.optionRule())} in the {@code FactoryUtil} entry path. They
-     * enforce that the JDBC URL contains a database name.
+     * <p>Catalog factories with non-standard URL formats (SqlServer, Oracle, SapHana) should use
+     * {@link #baseCatalogRule(ConditionExtension)} with their own URL validator.
      *
-     * <p>Username and password are optional because JDBC connections may use alternative
-     * authentication (Kerberos, passwordless local DB, OS authentication, etc.). The catalog
-     * implementation validates credentials at connection time.
-     *
-     * <p>Individual catalog factories may append additional rules (e.g. OceanBase requires {@code
-     * compatible_mode}) before calling {@code .build()}.
+     * <p>Catalog factories that do not require authentication (e.g. DuckDB) should define their own
+     * {@code optionRule()} directly.
      */
     public static OptionRule.Builder baseCatalogRule() {
-        return OptionRule.builder()
-                .required(URL, Conditions.extension(URL, new UrlContainsDatabaseValidator()))
-                .optional(
-                        USERNAME, PASSWORD, SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
+        return baseCatalogRule(new UrlContainsDatabaseValidator());
     }
 
     /**
-     * Submission-time validator that ensures the JDBC URL contains a database name.
-     *
-     * <p>This validator is attached to the {@code url} option via {@link
-     * Conditions#extension(Option, ConditionExtension)} and is evaluated by {@code ConfigValidator}
-     * before the catalog/source/sink factory creates its connector instance.
+     * Returns a fresh {@link OptionRule.Builder} with a custom URL validator. Use this for
+     * databases whose JDBC URL does not follow the standard {@code host:port/database} format (e.g.
+     * SqlServer, Oracle, SapHana).
+     */
+    public static OptionRule.Builder baseCatalogRule(ConditionExtension<String> urlValidator) {
+        return OptionRule.builder()
+                .required(URL, Conditions.extension(URL, urlValidator))
+                .required(USERNAME, PASSWORD)
+                .optional(SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
+    }
+
+    /**
+     * Validates that the JDBC URL contains a database name for standard {@code host:port/database}
+     * URLs. Dialect-specific CatalogFactories (SqlServer, Oracle, SapHana) provide their own
+     * validators via {@link #baseCatalogRule(ConditionExtension)}.
      */
     public static class UrlContainsDatabaseValidator implements ConditionExtension<String> {
         @Override
@@ -211,30 +209,12 @@ public class JdbcCommonOptions {
                 return false;
             }
             try {
-                JdbcUrlUtil.UrlInfo urlInfo = parseUrlInfo(url);
-                return urlInfo != null
-                        && StringUtils.isNotBlank(urlInfo.getHost())
+                JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(url);
+                return StringUtils.isNotBlank(urlInfo.getHost())
                         && urlInfo.getDefaultDatabase().isPresent();
             } catch (IllegalArgumentException e) {
-                return false;
+                throw new OptionValidationException("Invalid JDBC URL format: " + url, e);
             }
-        }
-
-        /**
-         * Delegate to the dialect-specific parser when the catalog URL does not follow the generic
-         * host:port/database JDBC shape.
-         */
-        private JdbcUrlUtil.UrlInfo parseUrlInfo(String url) {
-            if (url.startsWith("jdbc:sqlserver:")) {
-                return SqlServerURLParser.parse(url);
-            }
-            if (url.startsWith("jdbc:oracle:")) {
-                return OracleURLParser.parse(url);
-            }
-            if (url.startsWith("jdbc:sap:")) {
-                return SapHanaURLParser.parse(url);
-            }
-            return JdbcUrlUtil.getUrlInfo(url);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -200,7 +200,7 @@ public class JdbcCommonOptions {
     public static class UrlContainsDatabaseValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "JDBC URL must contain a database name";
+            return "JDBC URL must contain a database name, expected pattern: jdbc:<scheme>://host:port/database";
         }
 
         @Override
@@ -213,7 +213,11 @@ public class JdbcCommonOptions {
                 return StringUtils.isNotBlank(urlInfo.getHost())
                         && urlInfo.getDefaultDatabase().isPresent();
             } catch (IllegalArgumentException e) {
-                throw new OptionValidationException("Invalid JDBC URL format: " + url, e);
+                throw new OptionValidationException(
+                        String.format(
+                                "Invalid JDBC URL format: [%s], "
+                                        + "expected pattern: jdbc:<scheme>://host:port/database",
+                                url));
             }
         }
     }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -169,9 +169,13 @@ public class JdbcCommonOptions {
      * Returns a fresh {@link OptionRule.Builder} with the base validation rules shared by all JDBC
      * catalog factories (MySQL, PostgreSQL, Oracle, etc.).
      *
-     * <p>These rules are evaluated at <b>submission time</b> via {@code
+     * <p>These rules are evaluated at <b>catalog creation time</b> via {@code
      * ConfigValidator.validate(factory.optionRule())} in the {@code FactoryUtil} entry path. They
-     * enforce that the JDBC URL contains a database name, and that username/password are provided.
+     * enforce that the JDBC URL contains a database name.
+     *
+     * <p>Username and password are optional because JDBC connections may use alternative
+     * authentication (Kerberos, passwordless local DB, OS authentication, etc.). The catalog
+     * implementation validates credentials at connection time.
      *
      * <p>Individual catalog factories may append additional rules (e.g. OceanBase requires {@code
      * compatible_mode}) before calling {@code .build()}.
@@ -179,8 +183,8 @@ public class JdbcCommonOptions {
     public static OptionRule.Builder baseCatalogRule() {
         return OptionRule.builder()
                 .required(URL, Conditions.extension(URL, new UrlContainsDatabaseValidator()))
-                .required(USERNAME, PASSWORD)
-                .optional(SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
+                .optional(
+                        USERNAME, PASSWORD, SCHEMA, DECIMAL_TYPE_NARROWING, HANDLE_BLOB_AS_STRING);
     }
 
     /**

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcCommonOptions.java
@@ -193,14 +193,14 @@ public class JdbcCommonOptions {
     }
 
     /**
-     * Validates that the JDBC URL contains a database name for standard {@code host:port/database}
-     * URLs. Dialect-specific CatalogFactories (SqlServer, Oracle, SapHana) provide their own
-     * validators via {@link #baseCatalogRule(ConditionExtension)}.
+     * Validates that the JDBC URL has a valid format with at least a host component. Database name
+     * is optional to maintain backward compatibility with connectors (e.g. StarRocks, Doris) that
+     * specify the database in the query or table_path instead of the URL.
      */
     public static class UrlContainsDatabaseValidator implements ConditionExtension<String> {
         @Override
         public String description() {
-            return "JDBC URL must contain a database name, expected pattern: jdbc:<scheme>://host:port/database";
+            return "JDBC URL must be a valid format: jdbc:<scheme>://host:port[/database]";
         }
 
         @Override
@@ -210,13 +210,12 @@ public class JdbcCommonOptions {
             }
             try {
                 JdbcUrlUtil.UrlInfo urlInfo = JdbcUrlUtil.getUrlInfo(url);
-                return StringUtils.isNotBlank(urlInfo.getHost())
-                        && urlInfo.getDefaultDatabase().isPresent();
+                return StringUtils.isNotBlank(urlInfo.getHost());
             } catch (IllegalArgumentException e) {
                 throw new OptionValidationException(
                         String.format(
                                 "Invalid JDBC URL format: [%s], "
-                                        + "expected pattern: jdbc:<scheme>://host:port/database",
+                                        + "expected pattern: jdbc:<scheme>://host:port[/database]",
                                 url));
             }
         }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
@@ -75,15 +75,6 @@ class JdbcCatalogFactoryTest {
     }
 
     @Test
-    void testUrlWithoutDatabaseFails() {
-        Map<String, Object> cfg = new HashMap<>();
-        cfg.put("url", "jdbc:mysql://host:3306");
-        cfg.put("username", "root");
-        cfg.put("password", "pass");
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
-    }
-
-    @Test
     void testBlankUrlFails() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "");

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.duckdb.DuckDBCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oceanbase.OceanBaseCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.psql.PostgresCatalogFactory;
@@ -86,19 +87,36 @@ class JdbcCatalogFactoryTest {
     }
 
     @Test
-    void testMissingUsernameFails() {
+    void testCatalogConfigWithUrlOnly() {
         Map<String, Object> cfg = new HashMap<>();
-        cfg.put("url", "jdbc:mysql://host:3306/mydb");
-        cfg.put("password", "pass");
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+        cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
+        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
     }
 
     @Test
-    void testMissingPasswordFails() {
+    void testCatalogConfigWithUsernameOnly() {
         Map<String, Object> cfg = new HashMap<>();
-        cfg.put("url", "jdbc:mysql://host:3306/mydb");
+        cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
         cfg.put("username", "root");
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
+        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testCatalogConfigMimicsExtractCatalogConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
+        cfg.put("username", "root");
+        cfg.put("decimal_type_narrowing", true);
+        cfg.put("handle_blob_as_string", false);
+        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+    }
+
+    @Test
+    void testPostgresCatalogConfigWithoutPassword() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:postgresql://localhost:5432/mydb");
+        cfg.put("username", "postgres");
+        Assertions.assertDoesNotThrow(() -> validate(pgRule, cfg));
     }
 
     @Test
@@ -109,5 +127,23 @@ class JdbcCatalogFactoryTest {
         cfg.put("username", "root");
         cfg.put("password", "pass");
         Assertions.assertThrows(OptionValidationException.class, () -> validate(obRule, cfg));
+    }
+
+    @Test
+    void testOceanBaseCatalogConfigWithoutPassword() {
+        OptionRule obRule = new OceanBaseCatalogFactory().optionRule();
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:oceanbase://localhost:2881/mydb");
+        cfg.put("username", "root");
+        cfg.put("compatible_mode", "mysql");
+        Assertions.assertDoesNotThrow(() -> validate(obRule, cfg));
+    }
+
+    @Test
+    void testDuckDBCatalogConfigNoCredentials() {
+        OptionRule rule = new DuckDBCatalogFactory().optionRule();
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:duckdb:/tmp/test.db");
+        Assertions.assertDoesNotThrow(() -> validate(rule, cfg));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.dm.DamengCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.duckdb.DuckDBCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oceanbase.OceanBaseCatalogFactory;
@@ -43,6 +44,8 @@ class JdbcCatalogFactoryTest {
     private void validate(OptionRule rule, Map<String, Object> config) {
         ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
     }
+
+    // ==================== Standard URL validators (MySQL / Postgres) ====================
 
     @Test
     void testValidCatalogConfig() {
@@ -90,18 +93,18 @@ class JdbcCatalogFactoryTest {
     }
 
     @Test
-    void testCatalogConfigWithUrlOnly() {
+    void testMissingCredentialsFails() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
-        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
     }
 
     @Test
-    void testCatalogConfigWithUsernameOnly() {
+    void testMissingPasswordFails() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
         cfg.put("username", "root");
-        Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(mysqlRule, cfg));
     }
 
     @Test
@@ -109,18 +112,13 @@ class JdbcCatalogFactoryTest {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:mysql://localhost:3306/mydb");
         cfg.put("username", "root");
+        cfg.put("password", "pass");
         cfg.put("decimal_type_narrowing", true);
         cfg.put("handle_blob_as_string", false);
         Assertions.assertDoesNotThrow(() -> validate(mysqlRule, cfg));
     }
 
-    @Test
-    void testPostgresCatalogConfigWithoutPassword() {
-        Map<String, Object> cfg = new HashMap<>();
-        cfg.put("url", "jdbc:postgresql://localhost:5432/mydb");
-        cfg.put("username", "postgres");
-        Assertions.assertDoesNotThrow(() -> validate(pgRule, cfg));
-    }
+    // ==================== OceanBase ====================
 
     @Test
     void testOceanBaseWithoutCompatibleModeFails() {
@@ -133,14 +131,29 @@ class JdbcCatalogFactoryTest {
     }
 
     @Test
-    void testOceanBaseCatalogConfigWithoutPassword() {
+    void testOceanBaseValidConfig() {
         OptionRule obRule = new OceanBaseCatalogFactory().optionRule();
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:oceanbase://localhost:2881/mydb");
         cfg.put("username", "root");
+        cfg.put("password", "pass");
         cfg.put("compatible_mode", "mysql");
         Assertions.assertDoesNotThrow(() -> validate(obRule, cfg));
     }
+
+    // ==================== Dameng (no database in URL) ====================
+
+    @Test
+    void testDamengCatalogUrlWithoutDatabase() {
+        OptionRule dmRule = new DamengCatalogFactory().optionRule();
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:dm://e2e_dmdb:5236");
+        cfg.put("username", "SYSDBA");
+        cfg.put("password", "SYSDBA");
+        Assertions.assertDoesNotThrow(() -> validate(dmRule, cfg));
+    }
+
+    // ==================== DuckDB (no credentials required) ====================
 
     @Test
     void testDuckDBCatalogConfigNoCredentials() {
@@ -150,10 +163,8 @@ class JdbcCatalogFactoryTest {
         Assertions.assertDoesNotThrow(() -> validate(rule, cfg));
     }
 
-    /**
-     * SQLServer catalog validation must understand the databaseName property syntax used by the
-     * JDBC driver and the CDC E2E configs.
-     */
+    // ==================== SqlServer dialect validator ====================
+
     @Test
     void testSqlServerCatalogUrlWithDatabaseNameProperty() {
         Map<String, Object> cfg = new HashMap<>();
@@ -164,22 +175,18 @@ class JdbcCatalogFactoryTest {
                 () -> validate(new SqlServerCatalogFactory().optionRule(), cfg));
     }
 
-    /** SQLServer catalog validation should still reject URLs that omit the target database. */
     @Test
-    void testSqlServerCatalogUrlWithoutDatabaseFails() {
+    void testSqlServerCatalogUrlWithoutDatabasePasses() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:sqlserver://localhost:1433;encrypt=false");
         cfg.put("username", "sa");
         cfg.put("password", "Password!");
-        Assertions.assertThrows(
-                OptionValidationException.class,
+        Assertions.assertDoesNotThrow(
                 () -> validate(new SqlServerCatalogFactory().optionRule(), cfg));
     }
 
-    /**
-     * Oracle thin URLs may omit the double-slash segment, so catalog validation must not rely on
-     * the generic host:port/database parser.
-     */
+    // ==================== Oracle dialect validator ====================
+
     @Test
     void testOracleCatalogThinUrlWithoutDoubleSlash() {
         Map<String, Object> cfg = new HashMap<>();
@@ -189,14 +196,22 @@ class JdbcCatalogFactoryTest {
         Assertions.assertDoesNotThrow(() -> validate(new OracleCatalogFactory().optionRule(), cfg));
     }
 
-    /**
-     * SAP HANA catalog discovery uses the fixed SYSTEM database even when the JDBC URL only
-     * contains the host and port.
-     */
+    // ==================== SapHana dialect validator ====================
+
     @Test
     void testSapHanaCatalogHostOnlyUrl() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:sap://localhost:39017");
+        cfg.put("username", "SYSTEM");
+        cfg.put("password", "Password1");
+        Assertions.assertDoesNotThrow(
+                () -> validate(new SapHanaCatalogFactory().optionRule(), cfg));
+    }
+
+    @Test
+    void testSapHanaCatalogWithDatabaseParam() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:sap://localhost:39017/?databaseName=HXE");
         cfg.put("username", "SYSTEM");
         cfg.put("password", "Password1");
         Assertions.assertDoesNotThrow(

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/JdbcCatalogFactoryTest.java
@@ -24,7 +24,10 @@ import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.duckdb.DuckDBCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.mysql.MySqlCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oceanbase.OceanBaseCatalogFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle.OracleCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.psql.PostgresCatalogFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.saphana.SapHanaCatalogFactory;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.sqlserver.SqlServerCatalogFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -145,5 +148,58 @@ class JdbcCatalogFactoryTest {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("url", "jdbc:duckdb:/tmp/test.db");
         Assertions.assertDoesNotThrow(() -> validate(rule, cfg));
+    }
+
+    /**
+     * SQLServer catalog validation must understand the databaseName property syntax used by the
+     * JDBC driver and the CDC E2E configs.
+     */
+    @Test
+    void testSqlServerCatalogUrlWithDatabaseNameProperty() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:sqlserver://localhost:1433;databaseName=seatunnel");
+        cfg.put("username", "sa");
+        cfg.put("password", "Password!");
+        Assertions.assertDoesNotThrow(
+                () -> validate(new SqlServerCatalogFactory().optionRule(), cfg));
+    }
+
+    /** SQLServer catalog validation should still reject URLs that omit the target database. */
+    @Test
+    void testSqlServerCatalogUrlWithoutDatabaseFails() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:sqlserver://localhost:1433;encrypt=false");
+        cfg.put("username", "sa");
+        cfg.put("password", "Password!");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> validate(new SqlServerCatalogFactory().optionRule(), cfg));
+    }
+
+    /**
+     * Oracle thin URLs may omit the double-slash segment, so catalog validation must not rely on
+     * the generic host:port/database parser.
+     */
+    @Test
+    void testOracleCatalogThinUrlWithoutDoubleSlash() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:oracle:thin:@localhost:1521/ORCLCDB");
+        cfg.put("username", "system");
+        cfg.put("password", "oracle");
+        Assertions.assertDoesNotThrow(() -> validate(new OracleCatalogFactory().optionRule(), cfg));
+    }
+
+    /**
+     * SAP HANA catalog discovery uses the fixed SYSTEM database even when the JDBC URL only
+     * contains the host and port.
+     */
+    @Test
+    void testSapHanaCatalogHostOnlyUrl() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put("url", "jdbc:sap://localhost:39017");
+        cfg.put("username", "SYSTEM");
+        cfg.put("password", "Password1");
+        Assertions.assertDoesNotThrow(
+                () -> validate(new SapHanaCatalogFactory().optionRule(), cfg));
     }
 }

--- a/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/catalog/LanceCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/catalog/LanceCatalogFactory.java
@@ -21,7 +21,11 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
+import org.apache.seatunnel.api.table.factory.Factory;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(Factory.class)
 public class LanceCatalogFactory implements CatalogFactory {
     @Override
     public Catalog createCatalog(String catalogName, ReadonlyConfig readonlyConfig) {


### PR DESCRIPTION
## Purpose of this pull request

Related #11127

PR #11127 made `FactoryUtil.createOptionalCatalog()` enforce `optionRule()` during catalog creation. For JDBC catalogs, that introduced two compatibility regressions:

1. The generic `UrlContainsDatabaseValidator` required `host:port/database` in the URL, breaking backward compatibility for connectors like StarRocks and Doris that specify the database in the query or table_path instead of the URL (e.g. `jdbc:mysql://host:9030`). Additionally, dialect-specific formats like SqlServer (`jdbc:sqlserver://host;databaseName=db`), Oracle (`jdbc:oracle:thin:@host:port/service`), SAP HANA (`jdbc:sap://host:port`), and Dameng (`jdbc:dm://host:port`) were rejected before the job could start.
2. `AbstractJdbcCatalog` requires non-blank `username` at construction time, but the catalog `optionRule` declared `USERNAME`/`PASSWORD` as optional — a mismatch between declaration and runtime behavior.

This PR fixes both issues by relaxing the base URL validator, introducing dialect-aware URL validators for non-standard formats, and aligning credential requirements.

## Changes

- Relax `UrlContainsDatabaseValidator` in `JdbcCommonOptions`: only validate that the URL has a parseable format with a valid host; database is optional to maintain backward compatibility with connectors that specify the database elsewhere (query, table_path, etc.).
- Refactor `baseCatalogRule()` in `JdbcCommonOptions`: declare `USERNAME`/`PASSWORD` as required; add `baseCatalogRule(ConditionExtension)` overload for custom URL validators.
- Add `SqlServerUrlValidator` in `SqlServerCatalogFactory`: use `SqlServerURLParser.parse()`, only validate host format; database may come from `;databaseName=` property or separate config.
- Add `OracleUrlValidator` in `OracleCatalogFactory`: use `OracleURLParser.parse()`, require URL to contain service name.
- Add `SapHanaUrlValidator` in `SapHanaCatalogFactory`: use `SapHanaURLParser.parse()`, parser hardcodes `"SYSTEM"` as default database so host-only URLs pass.
- Add `DamengUrlValidator` in `DamengCatalogFactory`: only validate host format; Dameng URLs never contain a database name.
- Define inline `optionRule()` in `DuckDBCatalogFactory`: `URL` required, `USERNAME`/`PASSWORD` optional (embedded database, no credentials needed).
- Fix `XuguCatalogFactory.createCatalog()`: change URL parser from `OracleURLParser.parse()` to `JdbcUrlUtil.getUrlInfo()` since Xugu uses standard `host:port/database` format.
- Revert `database` parameter injection in `JdbcCatalogUtils.extractCatalogConfig()`, `JdbcCatalogUtils.findCatalog()`, and `JdbcSink.getCatalog()`.
- Restore `JdbcSinkOptions.DATABASE` to its original definition (not promoted to `JdbcCommonOptions`).
- Add regression coverage in `JdbcCatalogFactoryTest` for MySQL, Postgres, SqlServer, Oracle, SAP HANA, Dameng, DuckDB, and OceanBase.

### All CatalogFactory optionRule status

| CatalogFactory | optionRule Strategy | URL Validator | Credentials | Changed? |
|---|---|---|---|---|
| SqlServer | `baseCatalogRule(new SqlServerUrlValidator())` | `SqlServerURLParser`, host only | required | ✅ |
| Oracle | `baseCatalogRule(new OracleUrlValidator())` | `OracleURLParser`, requires service name | required | ✅ |
| SAP HANA | `baseCatalogRule(new SapHanaUrlValidator())` | `SapHanaURLParser`, default `SYSTEM` | required | ✅ |
| Dameng | `baseCatalogRule(new DamengUrlValidator())` | `JdbcUrlUtil`, host only | required | ✅ |
| DuckDB | Inline `optionRule()` | None | optional | ✅ |
| Xugu | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (parser fix) |
| MySQL | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| Postgres | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| OceanBase | `baseCatalogRule().required(COMPATIBLE_MODE).build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| TiDB | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| KingBase | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| IRIS | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| Redshift | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| OpenGauss | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |
| HighGo | `baseCatalogRule().build()` | Generic (host only, database optional) | required | ✅ (relaxed) |

## Validation

```bash

./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=JdbcCatalogFactoryTest  -DfailIfNoTests=false -Dskip.ui=true
```
