### PR TITLE
[Bug][Connector-V2][Postgres-CDC] Handle duplicate replication slot by SQL state

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContext.java
@@ -83,6 +83,7 @@ import static org.apache.seatunnel.connectors.seatunnel.cdc.postgres.utils.Postg
 public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
 
     private static final String CONTEXT_NAME = "postgres-cdc-connector-task";
+    private static final String DUPLICATE_OBJECT_SQL_STATE = "42710";
 
     private final PostgresConnection dataConnection;
 
@@ -211,10 +212,7 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                         replicationConnection.createReplicationSlot().orElse(null);
                     } catch (SQLException ex) {
                         String message = "Creation of replication slot failed";
-                        // PostgreSQL errors all have a 5-character SQLSTATE code, following the SQL
-                        // standard specification
-                        // https://www.postgresql.org/docs/current/errcodes-appendix.html
-                        if ("42710".equals(ex.getSQLState())) {
+                        if (isReplicationSlotAlreadyExists(ex)) {
                             message +=
                                     "; when setting up multiple connectors for the same database host, please make sure to use a distinct replication slot name for each.";
                             log.warn(message);
@@ -285,6 +283,12 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
         } finally {
             previousContext.restore();
         }
+    }
+
+    public static boolean isReplicationSlotAlreadyExists(SQLException ex) {
+        String message = ex.getMessage();
+        return DUPLICATE_OBJECT_SQL_STATE.equals(ex.getSQLState())
+                || (message != null && message.contains("already exists"));
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContextTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/PostgresSourceFetchTaskContextTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.reader;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+public class PostgresSourceFetchTaskContextTest {
+
+    @Test
+    public void testReplicationSlotAlreadyExistsWithSqlState() {
+        SQLException exception = new SQLException("错误: 复制槽名 \"seatunnel\" 已经存在", "42710");
+
+        Assertions.assertTrue(
+                PostgresSourceFetchTaskContext.isReplicationSlotAlreadyExists(exception));
+    }
+
+    @Test
+    public void testReplicationSlotAlreadyExistsWithEnglishMessage() {
+        SQLException exception =
+                new SQLException("ERROR: replication slot \"seatunnel\" already exists");
+
+        Assertions.assertTrue(
+                PostgresSourceFetchTaskContext.isReplicationSlotAlreadyExists(exception));
+    }
+
+    @Test
+    public void testReplicationSlotCreateOtherFailure() {
+        SQLException exception =
+                new SQLException("ERROR: all replication slots are in use", "53400");
+
+        Assertions.assertFalse(
+                PostgresSourceFetchTaskContext.isReplicationSlotAlreadyExists(exception));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10992.

Postgres CDC should not depend on a localized error message to detect an existing replication slot. This PR keeps the SQLState `42710` check and moves it into a helper, with the old English message check as a fallback.

Basis:
- PostgreSQL documents `42710` as `duplicate_object` in [PG 13](https://www.postgresql.org/docs/13/errcodes-appendix.html) and [current PG](https://www.postgresql.org/docs/current/errcodes-appendix.html).
- PostgreSQL replication slot creation reports a duplicate slot name with `ERRCODE_DUPLICATE_OBJECT`: [slot.c](https://github.com/postgres/postgres/blob/master/src/backend/replication/slot.c#L2976-L2982).

### Does this PR introduce _any_ user-facing change?

Yes. When the replication slot already exists and PostgreSQL returns a localized message, Postgres CDC logs a warning and continues.

### How was this patch tested?

```
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home ./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres -am -DskipITs -Dcheckstyle.skip -Dspotless.check.skip=true -Dlicense.skip=true -DskipTests install
```

```
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home ./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres -DskipITs -Dcheckstyle.skip -Dspotless.check.skip=true -Dlicense.skip=true -Dtest=PostgresSourceFetchTaskContextTest test
```

```
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home ./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres -DskipITs -Dcheckstyle.skip -Dlicense.skip=true spotless:check
git diff --check
```

Local reproduction:
- PG 13 zh_CN returned `sqlState=42710` and message `错误: 复制槽名 "seatunnel" 已经存在`.
- Before the fix, SeaTunnel failed at `PostgresSourceFetchTaskContext`.
- After the fix, SeaTunnel logged the existing-slot warning, entered incremental mode, and Console received `INSERT : 4, delta_fix`.
- PG 18.3 also returned `sqlState=42710` for a duplicated replication slot.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
