### PR TITLE
[Fix][Connector-V2] Add Pulsar multi-table sink replica option

### DIFF
--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactory.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.pulsar.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
@@ -48,7 +49,8 @@ public class PulsarSinkFactory implements TableSinkFactory {
                         PulsarSinkOptions.SEMANTICS,
                         PulsarSinkOptions.TRANSACTION_TIMEOUT,
                         PulsarSinkOptions.PULSAR_CONFIG,
-                        PulsarSinkOptions.PARTITION_KEY_FIELDS)
+                        PulsarSinkOptions.PARTITION_KEY_FIELDS,
+                        SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .conditional(
                         PulsarSinkOptions.FORMAT,
                         PulsarSinkOptions.TEXT_FORMAT,

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkFactoryTest.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.connectors.seatunnel.pulsar.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -25,7 +27,9 @@ import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarSinkOptions;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -33,16 +37,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
+/** Verifies the Pulsar sink factory metadata required by connector specification checks. */
 public class PulsarSinkFactoryTest {
 
     @Test
     public void testCreateSinkRequiresTopicForSingleTable() {
         PulsarSinkFactory factory = new PulsarSinkFactory();
 
-        assertThrows(
+        Assertions.assertThrows(
                 IllegalArgumentException.class,
                 () ->
                         factory.createSink(
@@ -54,11 +56,30 @@ public class PulsarSinkFactoryTest {
     public void testCreateSinkAllowsMissingTopicForMultiTable() {
         PulsarSinkFactory factory = new PulsarSinkFactory();
 
-        assertDoesNotThrow(
+        Assertions.assertDoesNotThrow(
                 () ->
                         factory.createSink(
                                 new TableSinkFactoryContext(
                                         null, config(), getClass().getClassLoader())));
+    }
+
+    /** Ensures the factory still exposes the documented Pulsar identifier. */
+    @Test
+    void factoryIdentifier() {
+        PulsarSinkFactory pulsarSinkFactory = new PulsarSinkFactory();
+        Assertions.assertEquals(
+                PulsarSinkOptions.IDENTIFIER, pulsarSinkFactory.factoryIdentifier());
+    }
+
+    /** Guards the option metadata that connector specification checks validate in CI. */
+    @Test
+    void optionRuleContainsMultiTableReplica() {
+        PulsarSinkFactory pulsarSinkFactory = new PulsarSinkFactory();
+        OptionRule optionRule = pulsarSinkFactory.optionRule();
+        Assertions.assertTrue(
+                optionRule
+                        .getOptionalOptions()
+                        .contains(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA));
     }
 
     private ReadonlyConfig config() {


### PR DESCRIPTION
## What does this PR do?

Adds `multi_table_sink_replica` to the Pulsar sink factory option metadata so connector specification checks can recognize the documented multi-table sink option.

## Why is this needed?

Recent PR CI runs were failing in `ConnectorSpecificationCheckTest` because the Pulsar sink option rule did not expose `SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA`.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-pulsar -Dtest=PulsarSinkFactoryTest test`
- `./mvnw -pl seatunnel-dist -Dtest=ConnectorSpecificationCheckTest -DfailIfNoTests=false test`  
  blocked locally by missing snapshot dependencies: `connector-google-bigtable`, `connector-salesforce`, and `connector-bigquery`

## Notes

- `seatunnel-engine-ui` was not revalidated because this change only touches the Pulsar connector metadata and tests.
