### PR TITLE
[Fix][Connector-V2] Run Pulsar cleanup with connector classloader

### DIFF
--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
@@ -53,8 +53,8 @@ import java.util.concurrent.TimeUnit;
 public class PulsarConfigUtil {
 
     private static final String[] DEFERRED_CLEANUP_CLASS_NAMES = {
-        "org.apache.pulsar.shade.org.jvnet.hk2.internal.SingletonContext$GenerationComparator",
-        "org.apache.pulsar.shade.io.netty.buffer.PoolArena$1"
+        "org.apache.pulsar.shade.io.netty.util.concurrent.DefaultPromise$1",
+        "org.apache.pulsar.shade.org.jvnet.hk2.internal.ServiceLocatorImpl$7"
     };
 
     private PulsarConfigUtil() {}
@@ -92,10 +92,11 @@ public class PulsarConfigUtil {
     /**
      * Preload shutdown-only runtime helpers while the connector classloader is still active.
      *
-     * <p>Pulsar may initialize these helper classes lazily from cleanup threads after Flink has
-     * started tearing down the user-code classloader. Loading them eagerly prevents cleanup-time
-     * {@code ClassNotFoundException} and {@code NoClassDefFoundError} failures after a successful
-     * job execution.
+     * <p>Pulsar may initialize these helper classes lazily from async cleanup threads and Jersey
+     * shutdown hooks after Flink has started tearing down the user-code classloader. Loading the
+     * verified cleanup-time helper classes eagerly prevents shutdown-only {@code
+     * ClassNotFoundException} and {@code NoClassDefFoundError} failures after a successful job
+     * execution.
      */
     static List<Class<?>> preloadDeferredCleanupClasses(PulsarConnectorErrorCode errorCode) {
         ClassLoader classLoader = PulsarConfigUtil.class.getClassLoader();

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
@@ -43,12 +43,19 @@ import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class PulsarConfigUtil {
+
+    private static final String[] DEFERRED_CLEANUP_CLASS_NAMES = {
+        "org.apache.pulsar.shade.org.jvnet.hk2.internal.SingletonContext$GenerationComparator",
+        "org.apache.pulsar.shade.io.netty.buffer.PoolArena$1"
+    };
 
     private PulsarConfigUtil() {}
 
@@ -57,6 +64,7 @@ public class PulsarConfigUtil {
         builder.serviceHttpUrl(config.getAdminUrl());
         builder.authentication(createAuthentication(config));
         try {
+            preloadDeferredCleanupClasses(PulsarConnectorErrorCode.OPEN_PULSAR_ADMIN_FAILED);
             return builder.build();
         } catch (PulsarClientException e) {
             throw new PulsarConnectorException(
@@ -73,11 +81,37 @@ public class PulsarConfigUtil {
             builder.enableTransaction(true);
         }
         try {
+            preloadDeferredCleanupClasses(PulsarConnectorErrorCode.OPEN_PULSAR_CLIENT_FAILED);
             return builder.build();
         } catch (PulsarClientException e) {
             throw new PulsarConnectorException(
                     PulsarConnectorErrorCode.OPEN_PULSAR_CLIENT_FAILED, e);
         }
+    }
+
+    /**
+     * Preload shutdown-only runtime helpers while the connector classloader is still active.
+     *
+     * <p>Pulsar may initialize these helper classes lazily from cleanup threads after Flink has
+     * started tearing down the user-code classloader. Loading them eagerly prevents cleanup-time
+     * {@code ClassNotFoundException} and {@code NoClassDefFoundError} failures after a successful
+     * job execution.
+     */
+    static List<Class<?>> preloadDeferredCleanupClasses(PulsarConnectorErrorCode errorCode) {
+        ClassLoader classLoader = PulsarConfigUtil.class.getClassLoader();
+        List<Class<?>> loadedClasses = new ArrayList<>(DEFERRED_CLEANUP_CLASS_NAMES.length);
+        for (String className : DEFERRED_CLEANUP_CLASS_NAMES) {
+            try {
+                loadedClasses.add(Class.forName(className, false, classLoader));
+            } catch (ClassNotFoundException e) {
+                throw new PulsarConnectorException(
+                        errorCode,
+                        String.format(
+                                "Failed to preload Pulsar cleanup runtime class '%s'.", className),
+                        e);
+            }
+        }
+        return loadedClasses;
     }
 
     public static ConsumerBuilder<byte[]> createConsumerBuilder(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.common.utils.TemporaryClassLoaderContext;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 
@@ -91,16 +92,9 @@ public class PulsarConfigUtil {
      */
     public static void runWithConnectorClassLoader(ConnectorClassLoaderAction action)
             throws Exception {
-        ClassLoader connectorClassLoader = PulsarConfigUtil.class.getClassLoader();
-        Thread thread = Thread.currentThread();
-        ClassLoader originalClassLoader = thread.getContextClassLoader();
-        if (originalClassLoader != connectorClassLoader) {
-            thread.setContextClassLoader(connectorClassLoader);
-        }
-        try {
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(PulsarConfigUtil.class.getClassLoader())) {
             action.run();
-        } finally {
-            thread.setContextClassLoader(originalClassLoader);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtil.java
@@ -43,19 +43,12 @@ import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class PulsarConfigUtil {
-
-    private static final String[] DEFERRED_CLEANUP_CLASS_NAMES = {
-        "org.apache.pulsar.shade.io.netty.util.concurrent.DefaultPromise$1",
-        "org.apache.pulsar.shade.org.jvnet.hk2.internal.ServiceLocatorImpl$7"
-    };
 
     private PulsarConfigUtil() {}
 
@@ -64,7 +57,6 @@ public class PulsarConfigUtil {
         builder.serviceHttpUrl(config.getAdminUrl());
         builder.authentication(createAuthentication(config));
         try {
-            preloadDeferredCleanupClasses(PulsarConnectorErrorCode.OPEN_PULSAR_ADMIN_FAILED);
             return builder.build();
         } catch (PulsarClientException e) {
             throw new PulsarConnectorException(
@@ -81,7 +73,6 @@ public class PulsarConfigUtil {
             builder.enableTransaction(true);
         }
         try {
-            preloadDeferredCleanupClasses(PulsarConnectorErrorCode.OPEN_PULSAR_CLIENT_FAILED);
             return builder.build();
         } catch (PulsarClientException e) {
             throw new PulsarConnectorException(
@@ -90,29 +81,27 @@ public class PulsarConfigUtil {
     }
 
     /**
-     * Preload shutdown-only runtime helpers while the connector classloader is still active.
+     * Runs a Pulsar action with the connector classloader as the thread context classloader.
      *
-     * <p>Pulsar may initialize these helper classes lazily from async cleanup threads and Jersey
-     * shutdown hooks after Flink has started tearing down the user-code classloader. Loading the
-     * verified cleanup-time helper classes eagerly prevents shutdown-only {@code
-     * ClassNotFoundException} and {@code NoClassDefFoundError} failures after a successful job
-     * execution.
+     * <p>Pulsar and its shaded Netty/Jersey stack can lazily resolve implementation classes while
+     * closing clients, consumers, producers, and admins. SeaTunnel may call connector close methods
+     * from engine threads whose context classloader no longer points to the Pulsar connector, so
+     * the cleanup action must restore the connector classloader instead of preloading
+     * version-specific Pulsar private classes.
      */
-    static List<Class<?>> preloadDeferredCleanupClasses(PulsarConnectorErrorCode errorCode) {
-        ClassLoader classLoader = PulsarConfigUtil.class.getClassLoader();
-        List<Class<?>> loadedClasses = new ArrayList<>(DEFERRED_CLEANUP_CLASS_NAMES.length);
-        for (String className : DEFERRED_CLEANUP_CLASS_NAMES) {
-            try {
-                loadedClasses.add(Class.forName(className, false, classLoader));
-            } catch (ClassNotFoundException e) {
-                throw new PulsarConnectorException(
-                        errorCode,
-                        String.format(
-                                "Failed to preload Pulsar cleanup runtime class '%s'.", className),
-                        e);
-            }
+    public static void runWithConnectorClassLoader(ConnectorClassLoaderAction action)
+            throws Exception {
+        ClassLoader connectorClassLoader = PulsarConfigUtil.class.getClassLoader();
+        Thread thread = Thread.currentThread();
+        ClassLoader originalClassLoader = thread.getContextClassLoader();
+        if (originalClassLoader != connectorClassLoader) {
+            thread.setContextClassLoader(connectorClassLoader);
         }
-        return loadedClasses;
+        try {
+            action.run();
+        } finally {
+            thread.setContextClassLoader(originalClassLoader);
+        }
     }
 
     public static ConsumerBuilder<byte[]> createConsumerBuilder(
@@ -232,5 +221,17 @@ public class PulsarConfigUtil {
             Producer<byte[]> producer, TransactionImpl transaction) throws PulsarClientException {
         ProducerBase<byte[]> producerBase = (ProducerBase<byte[]>) producer;
         return new TypedMessageBuilderImpl<byte[]>(producerBase, Schema.BYTES, transaction);
+    }
+
+    /** Action that may throw while running under the Pulsar connector classloader. */
+    @FunctionalInterface
+    public interface ConnectorClassLoaderAction {
+
+        /**
+         * Executes the action.
+         *
+         * @throws Exception when the wrapped Pulsar operation fails
+         */
+        void run() throws Exception;
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkCommitter.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkCommitter.java
@@ -67,7 +67,12 @@ public class PulsarSinkCommitter implements SinkCommitter<PulsarCommitInfo> {
             client.abort(txnID);
         }
         if (this.pulsarClient != null) {
-            pulsarClient.close();
+            try {
+                PulsarConfigUtil.runWithConnectorClassLoader(pulsarClient::close);
+            } catch (Exception e) {
+                throw new IOException(
+                        "Failed to close Pulsar client after aborting transactions.", e);
+            }
         }
     }
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkWriter.java
@@ -249,14 +249,14 @@ public class PulsarSinkWriter
         Throwable closeFailure = null;
         for (Producer<byte[]> producer : producerMap.values()) {
             try {
-                producer.close();
+                PulsarConfigUtil.runWithConnectorClassLoader(producer::close);
             } catch (Throwable throwable) {
                 closeFailure = appendSuppressed(closeFailure, throwable);
             }
         }
         if (pulsarClient != null) {
             try {
-                pulsarClient.close();
+                PulsarConfigUtil.runWithConnectorClassLoader(pulsarClient::close);
             } catch (Throwable throwable) {
                 closeFailure = appendSuppressed(closeFailure, throwable);
             }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -267,11 +267,16 @@ public class PulsarSplitEnumerator
 
     @Override
     public void close() throws IOException {
-        if (pulsarAdmin != null) {
-            pulsarAdmin.close();
-        }
         if (executor != null) {
-            executor.shutdown();
+            // Stop periodic discovery before closing the shared admin client it uses.
+            executor.shutdownNow();
+        }
+        if (pulsarAdmin != null) {
+            try {
+                PulsarConfigUtil.runWithConnectorClassLoader(pulsarAdmin::close);
+            } catch (Exception e) {
+                throw new IOException("Failed to close Pulsar admin.", e);
+            }
         }
     }
 

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReader.java
@@ -117,18 +117,24 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
 
     @Override
     public void close() throws IOException {
-        if (pulsarClient != null) {
-            pulsarClient.close();
-        }
+        Throwable closeFailure = null;
+        // Close split readers first so consumers stop before the shared Pulsar client disappears.
         for (PulsarSplitReaderThread pulsarSplitReaderThread : splitReaders.values()) {
             try {
-                pulsarSplitReaderThread.close();
-            } catch (IOException e) {
-                throw new PulsarConnectorException(
-                        CommonErrorCodeDeprecated.READER_OPERATION_FAILED,
-                        "Failed to close the split reader thread.",
-                        e);
+                PulsarConfigUtil.runWithConnectorClassLoader(pulsarSplitReaderThread::close);
+            } catch (Throwable throwable) {
+                closeFailure = appendSuppressed(closeFailure, throwable);
             }
+        }
+        if (pulsarClient != null) {
+            try {
+                PulsarConfigUtil.runWithConnectorClassLoader(pulsarClient::close);
+            } catch (Throwable throwable) {
+                closeFailure = appendSuppressed(closeFailure, throwable);
+            }
+        }
+        if (closeFailure != null) {
+            rethrowCloseFailure(closeFailure);
         }
     }
 
@@ -271,6 +277,31 @@ public class PulsarSourceReader<T> implements SourceReader<T, PulsarPartitionSpl
     private TablePath resolveTablePath(String splitId) {
         TablePath tablePath = splitIdToTablePath.get(splitId);
         return tablePath != null ? tablePath : defaultTablePath;
+    }
+
+    /**
+     * Preserves all cleanup failures while still allowing the remaining Pulsar resources to close.
+     */
+    private Throwable appendSuppressed(Throwable existingFailure, Throwable newFailure) {
+        if (existingFailure == null) {
+            return newFailure;
+        }
+        existingFailure.addSuppressed(newFailure);
+        return existingFailure;
+    }
+
+    /**
+     * Converts deferred cleanup failures to the reader close contract after all resources are
+     * tried.
+     */
+    private void rethrowCloseFailure(Throwable throwable) throws IOException {
+        if (throwable instanceof IOException) {
+            throw (IOException) throwable;
+        }
+        throw new PulsarConnectorException(
+                CommonErrorCodeDeprecated.READER_OPERATION_FAILED,
+                "Failed to close the Pulsar source reader.",
+                throwable);
     }
 
     private TablePath resolveTablePath(PulsarPartitionSplit split) {

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSplitReaderThread.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSplitReaderThread.java
@@ -106,7 +106,7 @@ public class PulsarSplitReaderThread extends Thread implements Closeable {
         } finally {
             // make sure the PulsarConsumer is closed
             try {
-                consumer.close();
+                closeConsumer();
             } catch (Throwable t) {
                 LOG.warn("Error while closing pulsar consumer", t);
             } finally {
@@ -118,9 +118,7 @@ public class PulsarSplitReaderThread extends Thread implements Closeable {
     @Override
     public void close() throws IOException {
         running = false;
-        if (consumer != null) {
-            consumer.close();
-        }
+        closeConsumer();
     }
 
     public void committingCursor(MessageId offsetsToCommit) throws PulsarClientException {
@@ -145,6 +143,19 @@ public class PulsarSplitReaderThread extends Thread implements Closeable {
                     PulsarConnectorErrorCode.OPEN_PULSAR_ADMIN_FAILED,
                     "Failed to create pulsar consumer:",
                     e);
+        }
+    }
+
+    /**
+     * Closes the Pulsar consumer while exposing the connector classloader to Pulsar cleanup code.
+     */
+    private void closeConsumer() throws IOException {
+        if (consumer != null) {
+            try {
+                PulsarConfigUtil.runWithConnectorClassLoader(consumer::close);
+            } catch (Exception e) {
+                throw new IOException("Failed to close Pulsar consumer.", e);
+            }
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
@@ -36,8 +36,8 @@ class PulsarConfigUtilTest {
 
         Assertions.assertEquals(
                 Arrays.asList(
-                        "org.apache.pulsar.shade.org.jvnet.hk2.internal.SingletonContext$GenerationComparator",
-                        "org.apache.pulsar.shade.io.netty.buffer.PoolArena$1"),
+                        "org.apache.pulsar.shade.io.netty.util.concurrent.DefaultPromise$1",
+                        "org.apache.pulsar.shade.org.jvnet.hk2.internal.ServiceLocatorImpl$7"),
                 loadedClasses.stream().map(Class::getName).collect(Collectors.toList()));
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
@@ -17,27 +17,29 @@
 
 package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
 
-import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 class PulsarConfigUtilTest {
 
     @Test
-    void shouldPreloadDeferredCleanupClasses() {
-        List<Class<?>> loadedClasses =
-                PulsarConfigUtil.preloadDeferredCleanupClasses(
-                        PulsarConnectorErrorCode.OPEN_PULSAR_CLIENT_FAILED);
+    void shouldRunActionWithConnectorClassLoaderAndRestoreOriginalClassLoader() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader unrelatedClassLoader = new ClassLoader(null) {};
 
-        Assertions.assertEquals(
-                Arrays.asList(
-                        "org.apache.pulsar.shade.io.netty.util.concurrent.DefaultPromise$1",
-                        "org.apache.pulsar.shade.org.jvnet.hk2.internal.ServiceLocatorImpl$7"),
-                loadedClasses.stream().map(Class::getName).collect(Collectors.toList()));
+        try {
+            Thread.currentThread().setContextClassLoader(unrelatedClassLoader);
+
+            PulsarConfigUtil.runWithConnectorClassLoader(
+                    () ->
+                            Assertions.assertSame(
+                                    PulsarConfigUtil.class.getClassLoader(),
+                                    Thread.currentThread().getContextClassLoader()));
+
+            Assertions.assertSame(
+                    unrelatedClassLoader, Thread.currentThread().getContextClassLoader());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarConfigUtilTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.pulsar.config;
+
+import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class PulsarConfigUtilTest {
+
+    @Test
+    void shouldPreloadDeferredCleanupClasses() {
+        List<Class<?>> loadedClasses =
+                PulsarConfigUtil.preloadDeferredCleanupClasses(
+                        PulsarConnectorErrorCode.OPEN_PULSAR_CLIENT_FAILED);
+
+        Assertions.assertEquals(
+                Arrays.asList(
+                        "org.apache.pulsar.shade.org.jvnet.hk2.internal.SingletonContext$GenerationComparator",
+                        "org.apache.pulsar.shade.io.netty.buffer.PoolArena$1"),
+                loadedClasses.stream().map(Class::getName).collect(Collectors.toList()));
+    }
+}

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/sink/PulsarSinkWriterTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConfigUtil;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
 
 import org.apache.pulsar.client.api.Producer;
@@ -177,6 +178,43 @@ public class PulsarSinkWriterTest {
         assertTrue(clientClosed.get());
     }
 
+    @Test
+    public void testCloseRunsPulsarCleanupWithConnectorClassLoader() throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("format", "json");
+        configMap.put("field_delimiter", ",");
+        configMap.put("transaction_timeout", 1000);
+        configMap.put("semantics", "NON");
+        configMap.put("message.routing.mode", "RoundRobinPartition");
+
+        AtomicReference<ClassLoader> producerCloseClassLoader = new AtomicReference<>();
+        AtomicReference<ClassLoader> clientCloseClassLoader = new AtomicReference<>();
+        PulsarSinkWriter writer =
+                new PulsarSinkWriter(
+                        new SeaTunnelRowType(new String[] {}, new SeaTunnelDataType[] {}),
+                        ReadonlyConfig.fromMap(configMap),
+                        java.util.Collections.emptyList(),
+                        createPulsarClientProxy(new AtomicBoolean(false), clientCloseClassLoader),
+                        topic ->
+                                createProducerProxy(
+                                        new AtomicBoolean(false), producerCloseClassLoader));
+        writer.getOrCreateProducer("topic-a");
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader unrelatedClassLoader = new ClassLoader(null) {};
+        try {
+            Thread.currentThread().setContextClassLoader(unrelatedClassLoader);
+
+            writer.close();
+
+            assertSame(unrelatedClassLoader, Thread.currentThread().getContextClassLoader());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+        assertSame(PulsarConfigUtil.class.getClassLoader(), producerCloseClassLoader.get());
+        assertSame(PulsarConfigUtil.class.getClassLoader(), clientCloseClassLoader.get());
+    }
+
     @SuppressWarnings("unchecked")
     private static Producer<byte[]> createProducerProxy() {
         return createProducerProxy(new AtomicBoolean(false));
@@ -184,6 +222,12 @@ public class PulsarSinkWriterTest {
 
     @SuppressWarnings("unchecked")
     private static Producer<byte[]> createProducerProxy(AtomicBoolean closed) {
+        return createProducerProxy(closed, new AtomicReference<>());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Producer<byte[]> createProducerProxy(
+            AtomicBoolean closed, AtomicReference<ClassLoader> closeClassLoader) {
         return (Producer<byte[]>)
                 Proxy.newProxyInstance(
                         Producer.class.getClassLoader(),
@@ -191,6 +235,8 @@ public class PulsarSinkWriterTest {
                         (proxy, method, args) -> {
                             if ("close".equals(method.getName())) {
                                 closed.set(true);
+                                closeClassLoader.set(
+                                        Thread.currentThread().getContextClassLoader());
                                 return null;
                             }
                             Class<?> returnType = method.getReturnType();
@@ -215,6 +261,12 @@ public class PulsarSinkWriterTest {
 
     @SuppressWarnings("unchecked")
     private static PulsarClient createPulsarClientProxy(AtomicBoolean closed) {
+        return createPulsarClientProxy(closed, new AtomicReference<>());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PulsarClient createPulsarClientProxy(
+            AtomicBoolean closed, AtomicReference<ClassLoader> closeClassLoader) {
         return (PulsarClient)
                 Proxy.newProxyInstance(
                         PulsarClient.class.getClassLoader(),
@@ -222,6 +274,8 @@ public class PulsarSinkWriterTest {
                         (proxy, method, args) -> {
                             if ("close".equals(method.getName())) {
                                 closed.set(true);
+                                closeClassLoader.set(
+                                        Thread.currentThread().getContextClassLoader());
                                 return null;
                             }
                             Class<?> returnType = method.getReturnType();

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/reader/PulsarSourceReaderRestoreTest.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarClientConfig;
+import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConfigUtil;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConsumerConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
@@ -43,6 +44,7 @@ import org.apache.seatunnel.connectors.seatunnel.pulsar.source.split.PulsarParti
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 class PulsarSourceReaderRestoreTest {
 
@@ -230,6 +233,45 @@ class PulsarSourceReaderRestoreTest {
                         collector.records.get(1).getTableId()));
     }
 
+    @Test
+    void shouldCloseSplitReadersBeforeClientWithConnectorClassLoader() throws Exception {
+        TablePath tablePath = TablePath.of("db.orders");
+        List<String> closeOrder = new ArrayList<>();
+        AtomicReference<ClassLoader> splitCloseClassLoader = new AtomicReference<>();
+        AtomicReference<ClassLoader> clientCloseClassLoader = new AtomicReference<>();
+        CloseTrackingPulsarSourceReader reader =
+                new CloseTrackingPulsarSourceReader(
+                        new TestingReaderContext(),
+                        Collections.singletonMap(tablePath, createMetadata(tablePath)),
+                        closeOrder,
+                        splitCloseClassLoader);
+        reader.pulsarClient = createPulsarClientProxy(closeOrder, clientCloseClassLoader);
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        new TopicPartition("persistent://public/default/orders", 0),
+                        StopCursor.never(),
+                        null,
+                        tablePath);
+        reader.addSplits(Collections.singletonList(split));
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader unrelatedClassLoader = new ClassLoader(null) {};
+        try {
+            Thread.currentThread().setContextClassLoader(unrelatedClassLoader);
+
+            reader.close();
+
+            Assertions.assertSame(
+                    unrelatedClassLoader, Thread.currentThread().getContextClassLoader());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+        Assertions.assertEquals(Arrays.asList("split", "client"), closeOrder);
+        Assertions.assertSame(PulsarConfigUtil.class.getClassLoader(), splitCloseClassLoader.get());
+        Assertions.assertSame(
+                PulsarConfigUtil.class.getClassLoader(), clientCloseClassLoader.get());
+    }
+
     private static PulsarConsumerMetadata createMetadata(TablePath tablePath) {
         return createMetadata(tablePath, new TestingDeserializationSchema());
     }
@@ -305,6 +347,34 @@ class PulsarSourceReaderRestoreTest {
                         });
     }
 
+    @SuppressWarnings("unchecked")
+    private static PulsarClient createPulsarClientProxy(
+            List<String> closeOrder, AtomicReference<ClassLoader> closeClassLoader) {
+        return (PulsarClient)
+                Proxy.newProxyInstance(
+                        PulsarClient.class.getClassLoader(),
+                        new Class<?>[] {PulsarClient.class},
+                        (proxy, method, args) -> {
+                            if ("close".equals(method.getName())) {
+                                closeOrder.add("client");
+                                closeClassLoader.set(
+                                        Thread.currentThread().getContextClassLoader());
+                                return null;
+                            }
+                            Class<?> returnType = method.getReturnType();
+                            if (returnType.equals(boolean.class)) {
+                                return false;
+                            }
+                            if (returnType.equals(int.class)) {
+                                return 0;
+                            }
+                            if (returnType.equals(long.class)) {
+                                return 0L;
+                            }
+                            return null;
+                        });
+    }
+
     private static final class TestingPulsarSourceReader extends PulsarSourceReader<SeaTunnelRow> {
 
         private TestingPulsarSourceReader(
@@ -370,6 +440,76 @@ class PulsarSourceReaderRestoreTest {
 
         @Override
         public void close() throws IOException {}
+    }
+
+    /** Source reader that records the close order without opening a real Pulsar consumer. */
+    private static final class CloseTrackingPulsarSourceReader
+            extends PulsarSourceReader<SeaTunnelRow> {
+
+        private final List<String> closeOrder;
+        private final AtomicReference<ClassLoader> splitCloseClassLoader;
+
+        private CloseTrackingPulsarSourceReader(
+                SourceReader.Context context,
+                Map<TablePath, PulsarConsumerMetadata> metadataMap,
+                List<String> closeOrder,
+                AtomicReference<ClassLoader> splitCloseClassLoader) {
+            super(
+                    context,
+                    PulsarClientConfig.builder().serviceUrl("pulsar://localhost:6650").build(),
+                    metadataMap,
+                    false,
+                    100,
+                    50L,
+                    1);
+            this.closeOrder = closeOrder;
+            this.splitCloseClassLoader = splitCloseClassLoader;
+        }
+
+        @Override
+        protected PulsarSplitReaderThread createPulsarSplitReaderThread(
+                PulsarPartitionSplit split) {
+            return new CloseTrackingSplitReaderThread(
+                    this, split, handover, closeOrder, splitCloseClassLoader);
+        }
+    }
+
+    /** Split reader that records cleanup metadata without touching a Pulsar broker. */
+    private static final class CloseTrackingSplitReaderThread extends PulsarSplitReaderThread {
+
+        private final List<String> closeOrder;
+        private final AtomicReference<ClassLoader> closeClassLoader;
+
+        private CloseTrackingSplitReaderThread(
+                PulsarSourceReader sourceReader,
+                PulsarPartitionSplit split,
+                org.apache.seatunnel.common.Handover<RecordWithSplitId> handover,
+                List<String> closeOrder,
+                AtomicReference<ClassLoader> closeClassLoader) {
+            super(
+                    sourceReader,
+                    split,
+                    null,
+                    PulsarConsumerConfig.builder().subscriptionName("seatunnel-sub").build(),
+                    100,
+                    50L,
+                    StartCursor.earliest(),
+                    handover);
+            this.closeOrder = closeOrder;
+            this.closeClassLoader = closeClassLoader;
+        }
+
+        @Override
+        public void open() {}
+
+        @Override
+        public synchronized void start() {}
+
+        @Override
+        public void close() {
+            closeOrder.add("split");
+            closeClassLoader.set(Thread.currentThread().getContextClassLoader());
+        }
     }
 
     private static final class TestingReaderContext implements SourceReader.Context {


### PR DESCRIPTION
### Purpose
Replace the version-specific Pulsar/Netty/HK2 private-class preload workaround with a maintainable cleanup boundary.

### Root cause
Pulsar can lazily resolve shaded Netty/Jersey implementation classes while closing producers, consumers, clients, and admins. SeaTunnel close paths can run from engine threads whose context classloader no longer points to the Pulsar connector, so hard-coding private helper class names only masks the symptom and will break across Pulsar dependency changes.

### Changes
- Run Pulsar cleanup actions with the Pulsar connector classloader as the thread context classloader.
- Close source split readers before closing the shared Pulsar client.
- Stop periodic partition discovery before closing the Pulsar admin.
- Add unit coverage for classloader restoration and source cleanup order.

### Validation
- `./mvnw -pl seatunnel-connectors-v2/connector-pulsar -am -nsu spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-pulsar -nsu test`

`seatunnel-engine-ui` was not included because this PR only changes the Pulsar connector backend module.