### PR TITLE
[Fix][Doc] Fix connector doc dead link

### DIFF
--- a/docs/en/connectors/overview.md
+++ b/docs/en/connectors/overview.md
@@ -35,5 +35,5 @@ This page is the shortest path for choosing the right SeaTunnel connector entry 
 
 - [Job Configuration Guide](../getting-started/job-configuration-guide.md)
 - [Scenario Recipes](../getting-started/recipes/overview.md)
-- [Transforms Overview](../transforms)
+- [Transforms Overview](../transforms/overview.md)
 - [Quick Start With SeaTunnel Engine](../getting-started/locally/quick-start-seatunnel-engine.md)

--- a/docs/en/connectors/sink-overview.md
+++ b/docs/en/connectors/sink-overview.md
@@ -16,6 +16,6 @@ Use this page when your first question is "where should SeaTunnel write data?" S
 
 ## Useful Next Pages
 
-- [Sink Common Options](../common-options/sink-common-options.md)
-- [Connector FAQ](../connector-faq.md)
-- [Connector Isolated Dependency Loading](../connector-isolated-dependency.md)
+- [Sink Common Options](./common-options/sink-common-options.md)
+- [Connector FAQ](./connector-faq.md)
+- [Connector Isolated Dependency Loading](./connector-isolated-dependency.md)

--- a/docs/en/connectors/source-overview.md
+++ b/docs/en/connectors/source-overview.md
@@ -16,6 +16,6 @@ Use this page when your first question is "where should SeaTunnel read data from
 
 ## Useful Next Pages
 
-- [Source Common Options](../common-options/source-common-options.md)
-- [CDC Production Cookbook](../cdc-production-cookbook.md)
-- [Connector FAQ](../connector-faq.md)
+- [Source Common Options](./common-options/source-common-options.md)
+- [CDC Production Cookbook](./cdc-production-cookbook.md)
+- [Connector FAQ](./connector-faq.md)

--- a/docs/zh/connectors/connector-faq.md
+++ b/docs/zh/connectors/connector-faq.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 10
+---
+
+# 连接器常见问题
+
+本页按连接器类别整理了常见问题的索引。每条目会链接到对应连接器文档页面内的 FAQ 章节。
+
+这些 FAQ 章节主要用于快速导航，并非第二套权威说明。如需准确的参数名、默认值和完整示例，请以连接器页面中的参数表及链接的详细章节为准。
+
+关于 SeaTunnel 的通用问题（引擎部署、变量替换、调度等），请参阅[通用常见问题](../faq.md)。
+
+---
+
+## CDC 连接器
+
+CDC（Change Data Capture）连接器从数据库事务日志中读取实时变更事件（INSERT / UPDATE / DELETE）。
+
+| 连接器 | 常见 FAQ 主题 |
+|---|---|
+| [MySQL CDC](./source/MySQL-CDC.md#faq) | 所需权限、binlog 配置、从库支持、无主键表、快照阶段、DDL 传播、`server-id` 冲突、快照性能、时区/字符集 |
+| [PostgreSQL CDC](./source/PostgreSQL-CDC.md#faq) | 所需权限、逻辑解码插件、从库支持、无主键表、复制槽管理、复制延迟 |
+| [Oracle CDC](./source/Oracle-CDC.md#faq) | LogMiner 权限、补充日志、CDB/PDB 多租户、无主键表、LogMiner 性能、支持的 Oracle 版本 |
+
+---
+
+## 消息队列连接器
+
+| 连接器 | 常见 FAQ 主题 |
+|---|---|
+| [Kafka Source](./source/Kafka.md#faq) | `start_mode` 选项、按消息 key 过滤、支持的格式、SASL/Kerberos 认证、消费组 offset 提交 |
+| [Kafka Sink](./sink/Kafka.md#faq) | 自动创建 Topic、`partition_key_fields` 行为、精确一次投递、SASL/Kerberos 认证、支持的格式 |
+
+---
+
+## Sink 连接器
+
+### OLAP / 分析型存储
+
+| 连接器 | 常见 FAQ 主题 |
+|---|---|
+| [Doris Sink](./sink/Doris.md#faq) | 自动建表、2PC 精确一次、"Label already exists" 错误、DELETE 传播、列名大小写、Stream Load 格式 |
+| [StarRocks Sink](./sink/StarRocks.md#faq) | 自动建表、Upsert 与 DELETE 支持、`labelPrefix` 用法、列名大小写、`nodeUrls` 与 `base-url` |
+| [ClickHouse Sink](./sink/Clickhouse.md#faq) | 自动建表、批量写入性能、支持的数据类型、"Table doesn't exist" 错误 |
+
+### 关系型数据库
+
+| 连接器 | 常见 FAQ 主题 |
+|---|---|
+| [JDBC Sink](./sink/Jdbc.md#faq) | 自动建表、XA 事务精确一次、Upsert / 主键配置、多表写入、缺少 JDBC 驱动 |
+
+### 数据湖 / 文件系统
+
+| 连接器 | 常见 FAQ 主题 |
+|---|---|
+| [Hive Sink](./sink/Hive.md#faq) | 支持的文件格式、分区表、Kerberos 认证、小文件问题、Schema 演进 |
+
+---
+
+## 查找答案的技巧
+
+1. **连接器相关问题** → 直接进入对应连接器页面，滚动到 **FAQ** 章节。
+2. **跨连接器主题**（例如「SeaTunnel 是否支持 CDC？」「`schema_save_mode` 是什么？」）→ 参阅[通用常见问题](../faq.md)。
+3. **仍未解决？** → 在 [GitHub Issues](https://github.com/apache/seatunnel/issues) 中搜索，或通过[邮件列表](https://lists.apache.org/list.html?dev@seatunnel.apache.org)联系社区。

--- a/docs/zh/connectors/overview.md
+++ b/docs/zh/connectors/overview.md
@@ -8,14 +8,14 @@ slug: /connectors
 
 ## 先按任务目标选入口
 
-| 你现在要做什么 | 先看这里 |
-| --- | --- |
-| 从外部系统读取数据 | [数据来源连接器](./source-overview.md) |
-| 把数据写入目标系统 | [数据写入连接器](./sink-overview.md) |
-| 先找一条接近真实业务的链路示例 | [场景示例](../getting-started/recipes/overview.md) |
+| 你现在要做什么 | 先看这里                                                                                                      |
+| --- |-----------------------------------------------------------------------------------------------------------|
+| 从外部系统读取数据 | [数据来源连接器](./source-overview.md)                                                                           |
+| 把数据写入目标系统 | [数据写入连接器](./sink-overview.md)                                                                             |
+| 先找一条接近真实业务的链路示例 | [场景示例](../getting-started/recipes/overview.md)                                                            |
 | 先理解连接器共有参数 | [来源端通用参数](./common-options/source-common-options.md) 和 [写入端通用参数](./common-options/sink-common-options.md) |
-| 构建 CDC 链路 | [CDC 生产实战手册](./cdc-production-cookbook.md) |
-| 排查插件安装或依赖冲突 | [连接器常见问题](./connector-faq.md) 和 [连接器依赖隔离加载机制](./connector-isolated-dependency.md) |
+| 构建 CDC 链路 | [CDC 生产实战手册](./cdc-production-cookbook.md)                                                                |
+| 排查插件安装或依赖冲突 | [连接器常见问题](./connector-faq.md) 和 [连接器依赖隔离加载机制](./connector-isolated-dependency.md)                        |
 
 ## 新用户推荐顺序
 
@@ -35,5 +35,5 @@ slug: /connectors
 
 - [作业配置指南](../getting-started/job-configuration-guide.md)
 - [场景示例](../getting-started/recipes/overview.md)
-- [数据转换总览](../transforms)
+- [数据转换总览](../transforms/overview.md)
 - [SeaTunnel 引擎快速开始](../getting-started/locally/quick-start-seatunnel-engine.md)

--- a/docs/zh/connectors/sink-overview.md
+++ b/docs/zh/connectors/sink-overview.md
@@ -16,6 +16,6 @@ sidebar_position: 1
 
 ## 常用下一步
 
-- [Sink 常用选项](../common-options/sink-common-options.md)
-- [连接器常见问题](../connector-faq.md)
-- [连接器依赖隔离加载机制](../connector-isolated-dependency.md)
+- [Sink 常用选项](./common-options/sink-common-options.md)
+- [连接器常见问题](./connector-faq.md)
+- [连接器依赖隔离加载机制](./connector-isolated-dependency.md)

--- a/docs/zh/connectors/source-overview.md
+++ b/docs/zh/connectors/source-overview.md
@@ -16,6 +16,6 @@ sidebar_position: 1
 
 ## 常用下一步
 
-- [Source 常用选项](../common-options/source-common-options.md)
-- [CDC 生产实战手册](../cdc-production-cookbook.md)
-- [连接器常见问题](../connector-faq.md)
+- [Source 常用选项](./common-options/source-common-options.md)
+- [CDC 生产实战手册](./cdc-production-cookbook.md)
+- [连接器常见问题](./connector-faq.md)


### PR DESCRIPTION
### Purpose of this pull request

Fix broken links to the Chinese Connector FAQ page. The links previously pointed to a non-existent `docs/zh/connector-faq.md`; this PR adds the missing Chinese page and corrects the related relative paths.

**Changes**:
- Add `docs/zh/connectors/connector-faq.md`, translated from `docs/en/connectors/connector-faq.md`
- Fix relative links in `docs/zh/connectors/overview.md`, `source-overview.md`, and `sink-overview.md` for connector-faq and sibling connector docs (`../` → `./`)

### Does this PR introduce _any_ user-facing change?

Yes. The Chinese docs site now serves the Connector FAQ page correctly, and navigation links on the connector overview, source overview, and sink overview pages no longer 404.