### PR TITLE
[CI][Core] Inject GitHub token for website build workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -376,6 +376,9 @@ jobs:
         with:
           node-version: 18.20.7
       - name: Run docusaurus build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd seatunnel-website
           npm set strict-ssl false


### PR DESCRIPTION
## What does this PR do?

Fix the docs website build workflow by explicitly injecting `GITHUB_TOKEN` and `GH_TOKEN` into the `Run docusaurus build` step.

## Why is this needed?

The current `Build website` job fails during `seatunnel-website` prebuild because `tools/generate-team-pr-contributors.js` requires a GitHub token and does not automatically receive one from the workflow shell environment.

## Verification

- Reproduced the current failure path locally on a fresh `seatunnel-website` checkout by removing env tokens and hiding `gh` from `PATH`: `GitHub token not found. Set GITHUB_TOKEN/GH_TOKEN or run `gh auth login` first.`
- Re-ran the same script with explicit `GITHUB_TOKEN` and `GH_TOKEN` injection and confirmed it succeeded: `Generated 88 PR contributors in src/pages/team/pr-contributors.json.`
- Ran `./mvnw spotless:apply` in this worktree and it completed with `BUILD SUCCESS`.

## Notes

- This is a workflow-only change.
- No `seatunnel-engine-ui` code path was changed or specially rebuilt in this task.