### PR TITLE
[Fix][Connector-V2] Clean up stale SFTP pooled sessions

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
@@ -54,6 +54,9 @@ public class SFTPConnectionPool {
     }
 
     synchronized ChannelSftp getFromPool(ConnectionInfo info) throws IOException {
+        if (con2infoMap == null) {
+            throw new IOException("SFTP connection pool has been closed.");
+        }
         Set<ChannelSftp> cons = idleConnections.get(info);
         ChannelSftp channel;
 
@@ -73,14 +76,21 @@ public class SFTPConnectionPool {
         return null;
     }
 
-    synchronized void returnToPool(ChannelSftp channel) {
+    synchronized boolean returnToPool(ChannelSftp channel) {
+        if (con2infoMap == null) {
+            return false;
+        }
         ConnectionInfo info = con2infoMap.get(channel);
+        if (info == null) {
+            return false;
+        }
         HashSet<ChannelSftp> cons = idleConnections.get(info);
         if (cons == null) {
             cons = new HashSet<ChannelSftp>();
             idleConnections.put(info, cons);
         }
         cons.add(channel);
+        return true;
     }
 
     /** Shutdown the connection pool and close all open connections. */
@@ -158,6 +168,9 @@ public class SFTPConnectionPool {
                 session = jsch.getSession(user, host, port);
             }
 
+            // JSch creates a session reader thread; make it daemon so leaked sessions cannot keep
+            // Spark local-mode JVMs alive after a batch job has already finished.
+            session.setDaemonThread(true);
             session.setPassword(password);
 
             java.util.Properties config = new java.util.Properties();
@@ -185,7 +198,9 @@ public class SFTPConnectionPool {
             // close connection if too many active connections
             boolean closeConnection = false;
             synchronized (this) {
-                if (liveConnectionCount > maxConnection) {
+                if (con2infoMap == null || !con2infoMap.containsKey(channel)) {
+                    closeConnection = true;
+                } else if (liveConnectionCount > maxConnection) {
                     --liveConnectionCount;
                     con2infoMap.remove(channel);
                     closeConnection = true;
@@ -193,8 +208,8 @@ public class SFTPConnectionPool {
             }
             if (closeConnection) {
                 closeChannel(channel);
-            } else {
-                returnToPool(channel);
+            } else if (!returnToPool(channel)) {
+                closeChannel(channel);
             }
         }
     }
@@ -204,6 +219,9 @@ public class SFTPConnectionPool {
      * connection.
      */
     synchronized void removeTrackedChannel(ChannelSftp channel) {
+        if (con2infoMap == null) {
+            return;
+        }
         ConnectionInfo info = con2infoMap.remove(channel);
         if (info != null) {
             Set<ChannelSftp> cons = idleConnections.get(info);
@@ -235,7 +253,7 @@ public class SFTPConnectionPool {
     }
 
     public int getIdleCount() {
-        return this.idleConnections.size();
+        return this.idleConnections == null ? 0 : this.idleConnections.size();
     }
 
     public int getLiveConnCount() {
@@ -243,7 +261,7 @@ public class SFTPConnectionPool {
     }
 
     public int getConnPoolSize() {
-        return this.con2infoMap.size();
+        return this.con2infoMap == null ? 0 : this.con2infoMap.size();
     }
 
     /**

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
@@ -60,7 +60,10 @@ public class SFTPConnectionPool {
             Iterator<ChannelSftp> it = cons.iterator();
             if (it.hasNext()) {
                 channel = it.next();
-                idleConnections.remove(info);
+                it.remove();
+                if (cons.isEmpty()) {
+                    idleConnections.remove(info);
+                }
                 return channel;
             } else {
                 throw new IOException("Connection pool error.");
@@ -125,11 +128,9 @@ public class SFTPConnectionPool {
             if (channel.isConnected()) {
                 return channel;
             } else {
+                removeTrackedChannel(channel);
+                closeChannel(channel);
                 channel = null;
-                synchronized (this) {
-                    --liveConnectionCount;
-                    con2infoMap.remove(channel);
-                }
             }
         }
 
@@ -189,19 +190,45 @@ public class SFTPConnectionPool {
                 }
             }
             if (closeConnection) {
-                if (channel.isConnected()) {
-                    try {
-                        Session session = channel.getSession();
-                        channel.disconnect();
-                        session.disconnect();
-                    } catch (JSchException e) {
-                        throw new IOException(StringUtils.stringifyException(e));
-                    }
-                }
-
+                closeChannel(channel);
             } else {
                 returnToPool(channel);
             }
+        }
+    }
+
+    /**
+     * Remove bookkeeping for a channel that can no longer be reused before we create a replacement
+     * connection.
+     */
+    synchronized void removeTrackedChannel(ChannelSftp channel) {
+        ConnectionInfo info = con2infoMap.remove(channel);
+        if (info != null) {
+            Set<ChannelSftp> cons = idleConnections.get(info);
+            if (cons != null) {
+                cons.remove(channel);
+                if (cons.isEmpty()) {
+                    idleConnections.remove(info);
+                }
+            }
+        }
+        if (liveConnectionCount > 0) {
+            liveConnectionCount--;
+        }
+    }
+
+    /** Close both the SFTP channel and its backing SSH session when they are still open. */
+    private void closeChannel(ChannelSftp channel) throws IOException {
+        try {
+            Session session = channel.getSession();
+            if (channel.isConnected()) {
+                channel.disconnect();
+            }
+            if (session != null && session.isConnected()) {
+                session.disconnect();
+            }
+        } catch (JSchException e) {
+            throw new IOException(StringUtils.stringifyException(e));
         }
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPool.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 public class SFTPConnectionPool {
@@ -83,31 +84,32 @@ public class SFTPConnectionPool {
     }
 
     /** Shutdown the connection pool and close all open connections. */
-    synchronized void shutdown() {
-        if (this.con2infoMap == null) {
-            return; // already shutdown in case it is called
-        }
-        LOG.info("Inside shutdown, con2infoMap size=" + con2infoMap.size());
+    void shutdown() {
+        Map<ChannelSftp, ConnectionInfo> connectionsToClose;
+        synchronized (this) {
+            if (this.con2infoMap == null) {
+                return; // already shutdown in case it is called
+            }
+            LOG.info("Inside shutdown, con2infoMap size=" + con2infoMap.size());
 
-        this.maxConnection = 0;
-        Set<ChannelSftp> cons = con2infoMap.keySet();
-        if (cons != null && cons.size() > 0) {
-            // make a copy since we need to modify the underlying Map
-            Set<ChannelSftp> copy = new HashSet<ChannelSftp>(cons);
-            // Initiate disconnect from all outstanding connections
-            for (ChannelSftp con : copy) {
-                try {
-                    disconnect(con);
-                } catch (IOException ioe) {
-                    ConnectionInfo info = con2infoMap.get(con);
-                    LOG.error(
-                            "Error encountered while closing connection to " + info.getHost(), ioe);
-                }
+            // Shutdown must close every tracked connection regardless of live-count drift.
+            connectionsToClose = new HashMap<ChannelSftp, ConnectionInfo>(con2infoMap);
+            this.maxConnection = 0;
+            this.liveConnectionCount = 0;
+            this.idleConnections = null;
+            this.con2infoMap = null;
+        }
+
+        for (Map.Entry<ChannelSftp, ConnectionInfo> entry : connectionsToClose.entrySet()) {
+            try {
+                closeChannel(entry.getKey());
+            } catch (IOException ioe) {
+                LOG.error(
+                        "Error encountered while closing connection to "
+                                + entry.getValue().getHost(),
+                        ioe);
             }
         }
-        // make sure no further connections can be returned.
-        this.idleConnections = null;
-        this.con2infoMap = null;
     }
 
     public synchronized int getMaxConnection() {

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPFileSystem.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPFileSystem.java
@@ -115,7 +115,7 @@ public class SFTPFileSystem extends FileSystem {
         }
 
         int connectionMax = conf.getInt(FS_SFTP_CONNECTION_MAX, DEFAULT_MAX_CONNECTION);
-        connectionPool = new SFTPConnectionPool(connectionMax, connectionMax);
+        connectionPool = new SFTPConnectionPool(connectionMax, 0);
     }
 
     private ChannelSftp connect() throws IOException {

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPFileSystem.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPFileSystem.java
@@ -548,8 +548,11 @@ public class SFTPFileSystem extends FileSystem {
                 new FSDataOutputStream(os, statistics) {
                     @Override
                     public void close() throws IOException {
-                        super.close();
-                        disconnect(client);
+                        try {
+                            super.close();
+                        } finally {
+                            disconnect(client);
+                        }
                     }
                 };
 
@@ -651,7 +654,12 @@ public class SFTPFileSystem extends FileSystem {
 
     @Override
     public void close() throws IOException {
-        super.close();
-        connectionPool.shutdown();
+        try {
+            super.close();
+        } finally {
+            if (connectionPool != null) {
+                connectionPool.shutdown();
+            }
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
@@ -82,6 +82,23 @@ class SFTPConnectionPoolTest {
         Assertions.assertEquals(0, connectionPool.getConnPoolSize());
     }
 
+    /** Shutdown must close tracked sessions even when live-count bookkeeping has drifted. */
+    @Test
+    void shutdownShouldCloseTrackedChannelsRegardlessOfLiveCount() throws Exception {
+        SFTPConnectionPool connectionPool = new SFTPConnectionPool(2, 0);
+        SFTPConnectionPool.ConnectionInfo connectionInfo =
+                new SFTPConnectionPool.ConnectionInfo("host", 22, "user");
+        Session session = Mockito.mock(Session.class);
+        Mockito.when(session.isConnected()).thenReturn(true);
+        TestChannelSftp channel = new TestChannelSftp(true, session);
+        trackedConnections(connectionPool).put(channel, connectionInfo);
+
+        connectionPool.shutdown();
+
+        Assertions.assertTrue(channel.wasDisconnected());
+        Mockito.verify(session).disconnect();
+    }
+
     /** Small concrete ChannelSftp stub that keeps Mockito away from final JSch internals. */
     private static final class TestChannelSftp extends ChannelSftp {
         private final boolean connected;

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
@@ -99,6 +99,38 @@ class SFTPConnectionPoolTest {
         Mockito.verify(session).disconnect();
     }
 
+    /** Late disconnects after shutdown must close the channel instead of touching closed maps. */
+    @Test
+    void disconnectAfterShutdownShouldCloseChannel() throws Exception {
+        SFTPConnectionPool connectionPool = new SFTPConnectionPool(1, 0);
+        Session session = Mockito.mock(Session.class);
+        Mockito.when(session.isConnected()).thenReturn(true);
+        TestChannelSftp channel = new TestChannelSftp(true, session);
+
+        connectionPool.shutdown();
+        connectionPool.disconnect(channel);
+
+        Assertions.assertTrue(channel.wasDisconnected());
+        Mockito.verify(session).disconnect();
+        Assertions.assertEquals(0, connectionPool.getIdleCount());
+        Assertions.assertEquals(0, connectionPool.getConnPoolSize());
+    }
+
+    /** Unknown channels are not reusable pool entries, so they must be closed immediately. */
+    @Test
+    void disconnectShouldCloseUntrackedChannel() throws Exception {
+        SFTPConnectionPool connectionPool = new SFTPConnectionPool(1, 1);
+        Session session = Mockito.mock(Session.class);
+        Mockito.when(session.isConnected()).thenReturn(true);
+        TestChannelSftp channel = new TestChannelSftp(true, session);
+
+        connectionPool.disconnect(channel);
+
+        Assertions.assertTrue(channel.wasDisconnected());
+        Mockito.verify(session).disconnect();
+        Assertions.assertEquals(0, connectionPool.getIdleCount());
+    }
+
     /** Small concrete ChannelSftp stub that keeps Mockito away from final JSch internals. */
     private static final class TestChannelSftp extends ChannelSftp {
         private final boolean connected;

--- a/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-sftp/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/sftp/system/SFTPConnectionPoolTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.file.sftp.system;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests the SFTP connection pool bookkeeping that continuous discovery relies on during cleanup.
+ */
+class SFTPConnectionPoolTest {
+
+    /**
+     * Keep sibling idle channels tracked after one channel is borrowed from the shared pool key.
+     */
+    @Test
+    void getFromPoolShouldKeepOtherIdleChannelsTracked() throws Exception {
+        SFTPConnectionPool connectionPool = new SFTPConnectionPool(2, 0);
+        SFTPConnectionPool.ConnectionInfo connectionInfo =
+                new SFTPConnectionPool.ConnectionInfo("host", 22, "user");
+        ChannelSftp firstChannel = new TestChannelSftp(true, Mockito.mock(Session.class));
+        ChannelSftp secondChannel = new TestChannelSftp(true, Mockito.mock(Session.class));
+
+        HashSet<ChannelSftp> idleChannels = new HashSet<>();
+        idleChannels.add(firstChannel);
+        idleChannels.add(secondChannel);
+        idleConnections(connectionPool).put(connectionInfo, idleChannels);
+        trackedConnections(connectionPool).put(firstChannel, connectionInfo);
+        trackedConnections(connectionPool).put(secondChannel, connectionInfo);
+
+        ChannelSftp borrowedChannel = connectionPool.getFromPool(connectionInfo);
+
+        Assertions.assertTrue(borrowedChannel == firstChannel || borrowedChannel == secondChannel);
+        Set<ChannelSftp> remainingIdleChannels =
+                idleConnections(connectionPool).get(connectionInfo);
+        Assertions.assertNotNull(remainingIdleChannels);
+        Assertions.assertEquals(1, remainingIdleChannels.size());
+        Assertions.assertFalse(remainingIdleChannels.contains(borrowedChannel));
+    }
+
+    /** Always disconnect the SSH session when a stale channel is being permanently closed. */
+    @Test
+    void disconnectShouldCloseSessionForDisconnectedChannel() throws Exception {
+        SFTPConnectionPool connectionPool = new SFTPConnectionPool(0, 1);
+        SFTPConnectionPool.ConnectionInfo connectionInfo =
+                new SFTPConnectionPool.ConnectionInfo("host", 22, "user");
+        Session session = Mockito.mock(Session.class);
+        Mockito.when(session.isConnected()).thenReturn(true);
+        TestChannelSftp channel = new TestChannelSftp(false, session);
+        trackedConnections(connectionPool).put(channel, connectionInfo);
+
+        connectionPool.disconnect(channel);
+
+        Mockito.verify(session).disconnect();
+        Assertions.assertFalse(channel.wasDisconnected());
+        Assertions.assertEquals(0, connectionPool.getLiveConnCount());
+        Assertions.assertEquals(0, connectionPool.getConnPoolSize());
+    }
+
+    /** Small concrete ChannelSftp stub that keeps Mockito away from final JSch internals. */
+    private static final class TestChannelSftp extends ChannelSftp {
+        private final boolean connected;
+        private final Session session;
+        private boolean disconnected;
+
+        private TestChannelSftp(boolean connected, Session session) {
+            this.connected = connected;
+            this.session = session;
+        }
+
+        @Override
+        public boolean isConnected() {
+            return connected;
+        }
+
+        @Override
+        public void disconnect() {
+            disconnected = true;
+        }
+
+        @Override
+        public Session getSession() throws JSchException {
+            return session;
+        }
+
+        private boolean wasDisconnected() {
+            return disconnected;
+        }
+    }
+
+    /** Read the private idle map to assert that the pool does not lose sibling channels. */
+    @SuppressWarnings("unchecked")
+    private static Map<SFTPConnectionPool.ConnectionInfo, HashSet<ChannelSftp>> idleConnections(
+            SFTPConnectionPool connectionPool) throws Exception {
+        Field field = SFTPConnectionPool.class.getDeclaredField("idleConnections");
+        field.setAccessible(true);
+        return (Map<SFTPConnectionPool.ConnectionInfo, HashSet<ChannelSftp>>)
+                field.get(connectionPool);
+    }
+
+    /** Read the private tracked-channel map to seed deterministic pool state for unit tests. */
+    @SuppressWarnings("unchecked")
+    private static Map<ChannelSftp, SFTPConnectionPool.ConnectionInfo> trackedConnections(
+            SFTPConnectionPool connectionPool) throws Exception {
+        Field field = SFTPConnectionPool.class.getDeclaredField("con2infoMap");
+        field.setAccessible(true);
+        return (Map<ChannelSftp, SFTPConnectionPool.ConnectionInfo>) field.get(connectionPool);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a shared SFTP cleanup failure that showed up in unrelated PR CI runs.

The fix keeps pooled sibling channels tracked correctly, closes stale SSH sessions when a dead channel is replaced, and initializes the pool with the real live-connection count so reusable sessions are not treated as over-limit immediately.

## Why is this needed?

Recent CI failures in `SftpFileIT#testSftpBinaryUpdateModeContinuousDiscoveryDistcp` were not caused by the feature PRs under test. The failing job reported `Wait continuous job exit failed` and `There are still threads running in the container`, which matches leaked or stale SFTP session cleanup.

## How was this validated?

- `./mvnw -pl seatunnel-connectors-v2/connector-file/connector-file-sftp spotless:apply -DskipTests`
- `./mvnw -pl seatunnel-connectors-v2/connector-file/connector-file-sftp -Dtest=SFTPConnectionPoolTest,SftpFileSystemTest -DfailIfNoTests=false test`
- attempted closer E2E validation with:
  - `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e -Dskip.ui=true -Dtest=SftpFileIT#testSftpBinaryUpdateModeContinuousDiscoveryDistcp -DfailIfNoTests=false test`

`seatunnel-engine-ui` was skipped because this fix only touches the SFTP connector module and the SFTP E2E module. The E2E attempt was blocked locally by an unresponsive Docker socket (`/_ping` timed out on `~/.docker/run/docker.sock`), so the closest completed validation is the connector module unit test coverage above.
