### PR TITLE
[Fix][Core] Use github token in website build workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -377,8 +377,8 @@ jobs:
           node-version: 18.20.7
       - name: Run docusaurus build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           cd seatunnel-website
           npm set strict-ssl false


### PR DESCRIPTION
## What does this PR do?

Fix the shared `Build website` CI failure that appears on recent PRs unrelated to website logic.

The failing website build job currently passes `${{ secrets.GITHUB_TOKEN }}` into the `seatunnel-website` prebuild step. On contributor fork runs this value is empty, and `tools/generate-team-pr-contributors.js` exits with:

`GitHub token not found. Set GITHUB_TOKEN/GH_TOKEN or run gh auth login first.`

This change switches the workflow env wiring to `${{ github.token }}`, which is the token GitHub Actions provides for the running workflow context.

## Why is this change needed?

`seatunnel-website/tools/generate-team-pr-contributors.js` only reads `GITHUB_TOKEN` or `GH_TOKEN` before trying `gh auth token`. When the workflow passes an empty env value, the website build fails before the real docusaurus build starts.

## Verification

- `./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true -Dskip.ui=true -T 3C`
- Inspected `apache/seatunnel-website/tools/generate-team-pr-contributors.js` to confirm the script reads only `GITHUB_TOKEN` / `GH_TOKEN` and throws the same error from the failing CI log when neither is present.

## Notes

- This change only updates CI workflow env wiring.
- `seatunnel-engine-ui` was not changed, but this root `spotless:apply` reactor still executed that module.
- No full local website build was rerun in this repo because the actual failing code path lives in the GitHub Actions workflow plus the external `apache/seatunnel-website` checkout.
