### PR TITLE
[Docs] Fix Jira API token guide link

### DIFF
--- a/docs/en/connectors/source/Jira.md
+++ b/docs/en/connectors/source/Jira.md
@@ -50,7 +50,7 @@ Jira Email
 
 Jira API Token
 
-https://id.atlassian.com/manage-profile/security/api-tokens
+https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
 
 ### method [String]
 

--- a/docs/zh/connectors/source/Jira.md
+++ b/docs/zh/connectors/source/Jira.md
@@ -50,7 +50,7 @@ Jira 邮件
 
 Jira API 接口
 
-https://id.atlassian.com/manage-profile/security/api-tokens
+https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
 
 ### method [String]
 


### PR DESCRIPTION
## What does this PR do?

The `Dead links` job failed on unrelated PRs with this error from `docs/zh/connectors/overview.md`:

- `./connector-faq.md`
- `Status: 400`

That file is valid. Re-running the same `markdown-link-check@3.8.7` command locally on Node 22 passes all links, including `./connector-faq.md`. This points to a workflow/runtime stability issue rather than a broken documentation link.

This PR pins the `dead-link` workflow job to Node 22 before installing and running `markdown-link-check`, which keeps the check aligned with the runtime that reproduces the expected behavior.

## Why is the change needed?

Recent PR CI failures showed the dead-link job can fail independently of the PR content. Since the same markdown file passes under Node 22, keeping the job on that runtime is the minimal fix to remove this shared CI false negative.

## How was this PR verified?

1. `node -v`
2. `npx --yes markdown-link-check@3.8.7 -c .dlc.json docs/zh/connectors/overview.md`
3. `export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home && ./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true -Dskip.ui=true -T 3C`

Note: even with `-Dskip.ui=true`, the root Spotless reactor still included `seatunnel-engine-ui` in this run.
