### PR TITLE
[Fix][API] Correct numeric epoch timestamp conversion

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/converter/BasicDataConverter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/converter/BasicDataConverter.java
@@ -495,7 +495,9 @@ public interface BasicDataConverter<T> extends DataConverter<T> {
     }
 
     default LocalDateTime convertLocalDateTime(T typeDefine, Number value) {
-        return convertLocalDateTime(value);
+        return EpochTimeUtils.convertToInstant(typeDefine, value)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
     }
 
     default LocalDateTime convertLocalDateTime(Object value) throws UnsupportedOperationException {
@@ -604,14 +606,7 @@ public interface BasicDataConverter<T> extends DataConverter<T> {
     }
 
     default LocalDateTime convertLocalDateTime(Number value) {
-        if (value.longValue() < 999999999) {
-            return LocalDateTime.ofEpochSecond(
-                    value.longValue(),
-                    0,
-                    ZoneId.systemDefault().getRules().getOffset(LocalDateTime.now()));
-        }
-        return new Date(value.longValue())
-                .toInstant()
+        return EpochTimeUtils.convertToInstant(value)
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
     }
@@ -763,7 +758,9 @@ public interface BasicDataConverter<T> extends DataConverter<T> {
     }
 
     default LocalDate convertLocalDate(T typeDefine, Number value) {
-        return convertLocalDate(value);
+        return EpochTimeUtils.convertToInstant(typeDefine, value)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
     }
 
     default LocalDate convertLocalDate(Object value) throws UnsupportedOperationException {
@@ -798,14 +795,7 @@ public interface BasicDataConverter<T> extends DataConverter<T> {
     }
 
     default LocalDate convertLocalDate(Number value) {
-        if (value.longValue() < 999999999) {
-            return LocalDateTime.ofEpochSecond(
-                            value.longValue(),
-                            0,
-                            ZoneId.systemDefault().getRules().getOffset(LocalDateTime.now()))
-                    .toLocalDate();
-        }
-        return new Date(value.longValue()).toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        return EpochTimeUtils.convertToInstant(value).atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
     default BigDecimal convertDecimal(T typeDefine, Object value)

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/converter/EpochTimeUtils.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/converter/EpochTimeUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.table.converter;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+final class EpochTimeUtils {
+
+    private static final long LEGACY_EPOCH_MILLIS_LOWER_BOUND = 999_999_999L;
+    private static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
+    private static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+
+    private EpochTimeUtils() {}
+
+    /**
+     * Converts a numeric epoch value using timestamp precision metadata when it is available. Scale
+     * 0, 3, 6 and 9 are treated as seconds, milliseconds, microseconds and nanoseconds. Other
+     * scales fall back to the legacy shared heuristic.
+     */
+    static Instant convertToInstant(Object typeDefine, Number value) {
+        if (!(typeDefine instanceof BasicTypeDefine)) {
+            return convertToInstant(value);
+        }
+        Integer scale = ((BasicTypeDefine<?>) typeDefine).getScale();
+        if (scale == null) {
+            return convertToInstant(value);
+        }
+        switch (scale) {
+            case 0:
+                return Instant.ofEpochSecond(value.longValue());
+            case 3:
+                return Instant.ofEpochMilli(value.longValue());
+            case 6:
+                return ofEpochMicro(value.longValue());
+            case 9:
+                return ofEpochNano(value.longValue());
+            default:
+                return convertToInstant(value);
+        }
+    }
+
+    /**
+     * Preserves the existing no-metadata conversion contract: values below 999999999 are epoch
+     * seconds, while larger values are epoch milliseconds. This keeps early-epoch millisecond
+     * values such as 1000000000 from being reinterpreted as seconds.
+     */
+    static Instant convertToInstant(Number value) {
+        long epochValue = value.longValue();
+        if (epochValue < LEGACY_EPOCH_MILLIS_LOWER_BOUND) {
+            return Instant.ofEpochSecond(epochValue);
+        }
+        return Instant.ofEpochMilli(epochValue);
+    }
+
+    private static Instant ofEpochMicro(long epochMicro) {
+        long seconds = Math.floorDiv(epochMicro, MICROSECONDS_PER_SECOND);
+        long micros = Math.floorMod(epochMicro, MICROSECONDS_PER_SECOND);
+        return Instant.ofEpochSecond(seconds, TimeUnit.MICROSECONDS.toNanos(micros));
+    }
+
+    private static Instant ofEpochNano(long epochNano) {
+        long seconds = Math.floorDiv(epochNano, NANOSECONDS_PER_SECOND);
+        long nanos = Math.floorMod(epochNano, NANOSECONDS_PER_SECOND);
+        return Instant.ofEpochSecond(seconds, nanos);
+    }
+}

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/converter/BasicDataConverterTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/converter/BasicDataConverterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.table.converter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class BasicDataConverterTest {
+
+    private static final BasicDataConverter<Object> CONVERTER =
+            new BasicDataConverter<Object>() {
+                @Override
+                public String identifier() {
+                    return "test";
+                }
+            };
+
+    @Test
+    void testConvertEpochSecondsToLocalDateTime() {
+        long epochSeconds = 1_700_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDateTime(Instant.ofEpochSecond(epochSeconds)),
+                CONVERTER.convertLocalDateTime(timestampWithScale(0), epochSeconds));
+    }
+
+    @Test
+    void testConvertEpochMillisToLocalDateTime() {
+        long epochMillis = 1_700_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDateTime(Instant.ofEpochMilli(epochMillis)),
+                CONVERTER.convertLocalDateTime(timestampWithScale(3), epochMillis));
+    }
+
+    @Test
+    void testConvertEpochMicrosToLocalDateTime() {
+        long epochMicros = 1_700_000_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDateTime(Instant.ofEpochSecond(1_700_000_000L)),
+                CONVERTER.convertLocalDateTime(timestampWithScale(6), epochMicros));
+    }
+
+    @Test
+    void testConvertEpochNanosToLocalDateTime() {
+        long epochNanos = 1_700_000_000_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDateTime(Instant.ofEpochSecond(1_700_000_000L)),
+                CONVERTER.convertLocalDateTime(timestampWithScale(9), epochNanos));
+    }
+
+    @Test
+    void testConvertEarlyEpochMillisWithoutScaleToLocalDateTime() {
+        long epochMillis = 1_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDateTime(Instant.ofEpochMilli(epochMillis)),
+                CONVERTER.convertLocalDateTime(epochMillis));
+    }
+
+    @Test
+    void testConvertEpochSecondsToLocalDate() {
+        long epochSeconds = 1_700_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDate(Instant.ofEpochSecond(epochSeconds)),
+                CONVERTER.convertLocalDate(timestampWithScale(0), epochSeconds));
+    }
+
+    @Test
+    void testConvertEpochMillisToLocalDate() {
+        long epochMillis = 1_700_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDate(Instant.ofEpochMilli(epochMillis)),
+                CONVERTER.convertLocalDate(timestampWithScale(3), epochMillis));
+    }
+
+    @Test
+    void testConvertEarlyEpochMillisWithoutScaleToLocalDate() {
+        long epochMillis = 1_000_000_000L;
+
+        Assertions.assertEquals(
+                toLocalDate(Instant.ofEpochMilli(epochMillis)),
+                CONVERTER.convertLocalDate(epochMillis));
+    }
+
+    private static BasicTypeDefine<?> timestampWithScale(int scale) {
+        return BasicTypeDefine.builder().scale(scale).build();
+    }
+
+    private static LocalDateTime toLocalDateTime(Instant instant) {
+        return instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
+    private static LocalDate toLocalDate(Instant instant) {
+        return instant.atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes numeric `DATE`/`TIMESTAMP` conversion in `BasicDataConverter` when source data may carry timestamp precision metadata.

### What changed
- Route numeric epoch conversion for `DATE` and `TIMESTAMP` fields through a shared `EpochTimeUtils` helper.
- Add optional scale-aware conversion when `BasicTypeDefine` includes precision metadata:
  - `0` => epoch seconds
  - `3` => epoch milliseconds
  - `6` => epoch microseconds
  - `9` => epoch nanoseconds
- Preserve metadata-less behavior for compatibility:
  - values `< 999_999_999` are interpreted as epoch seconds
  - values `>= 999_999_999` are interpreted as epoch milliseconds
- Keep legacy conversion for non-metadata paths unchanged.
- Expand `BasicDataConverterTest` coverage for typed and non-typed conversions, including the early-epoch millisecond regression guard (`1_000_000_000`).

### Why this change
- Prevents incorrect interpretation of modern epoch values when precision metadata is present.
- Avoids changing behavior for existing metadata-less consumers.
- Centralizes epoch conversion logic to keep DATE/TIMESTAMP handling consistent.

### Compatibility
- Does this PR introduce any user-facing change?
  - Yes. Numeric DATE/TIMESTAMP values with timestamp scale metadata now convert using the provided unit.
  - No-metadata conversion keeps the existing fallback contract.

### Check list
- No new JAR package is added.
- Documentation is not needed for this bug fix.
- No incompatible change is introduced.
- No connector packaging changes are needed.
