### PR TITLE
[Fix][CI] Use workflow token for backend website build

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -94,8 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-        id: install
+        run: |
+          if ! command -v helm >/dev/null 2>&1; then
+            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          fi
+          helm version
       - name: Lint Chart
         run: helm lint deploy/kubernetes/seatunnel
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Check license header
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Check code style
@@ -106,7 +106,7 @@ jobs:
     # Temporarily ignore this job to avoid blocking PRs
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo npm install -g markdown-link-check@3.8.7
       - run: |
           for file in $(find . -name "*.md"); do
@@ -146,7 +146,7 @@ jobs:
           /usr/bin/git checkout apache/dev
           /usr/bin/git checkout '${{ github.ref }}'
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11.0'
       - name: Check for file changes by python
@@ -289,9 +289,9 @@ jobs:
       - name: Make integration test modules
         id: it-modules
         timeout-minutes: 60
-        if: ${{ steps.filter.outputs.api == 'false' && (steps.engine-modules.outputs.modules != '' || steps.cv2-modules.outputs.modules != '' || steps.cv2-e2e-modules.outputs.modules != '' || steps.cv2-flink-e2e-modules.outputs.modules != '' || steps.cv2-spark-e2e-modules.outputs.modules != '') }}
+        if: ${{ steps.filter.outputs.api == 'false' && (steps.engine-modules.outputs.modules != '' || steps.cv2-modules.outputs.modules != '' || steps.cv2-e2e-modules.outputs.modules != '' || steps.engine-e2e-modules.outputs.modules != '') }}
         run: |
-          modules='${{ steps.cv2-e2e-modules.outputs.modules }}${{ steps.cv2-flink-e2e-modules.outputs.modules }}${{ steps.cv2-spark-e2e-modules.outputs.modules }}${{ steps.engine-e2e-modules.outputs.modules }}${{ steps.engine-modules.outputs.modules }}${{ steps.cv2-modules.outputs.modules }}'
+          modules='${{ steps.cv2-e2e-modules.outputs.modules }}${{ steps.engine-e2e-modules.outputs.modules }}${{ steps.engine-modules.outputs.modules }}${{ steps.cv2-modules.outputs.modules }}'
           modules=${modules: 1}
           pl_modules=`python tools/update_modules_check/update_modules_check.py replace "$modules"`
           # remove deleted modules
@@ -307,8 +307,6 @@ jobs:
           engine_modules='${{ steps.engine-modules.outputs.modules }}'
           connector_modules='${{ steps.cv2-modules.outputs.modules }}'
           connector_modules="$connector_modules"'${{ steps.cv2-e2e-modules.outputs.modules }}'
-          connector_modules="$connector_modules"'${{ steps.cv2-flink-e2e-modules.outputs.modules }}'
-          connector_modules="$connector_modules"'${{ steps.cv2-spark-e2e-modules.outputs.modules }}'
           engine_e2e_modules='${{ steps.engine-e2e-modules.outputs.modules }}'
           if [[ "zz${connector_modules}${engine_e2e_modules}" == "zz" && "zz"$engine_modules != "zz" ]];then
             # Engine changes already trigger the broad downstream integration jobs through engine=true.
@@ -334,16 +332,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Install
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 40
           max_attempts: 3
@@ -361,24 +359,24 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: seatunnel-pr
       - name: Checkout website repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: apache/seatunnel-website
           path: seatunnel-website
       - name: Sync PR changes to website
         run: |
           bash seatunnel-pr/tools/documents/sync.sh seatunnel-pr seatunnel-website
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.20.7
       - name: Run docusaurus build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           cd seatunnel-website
           npm set strict-ssl false
@@ -393,8 +391,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
       - name: Install Dependencies and Check Code Style
@@ -421,9 +419,9 @@ jobs:
         os: [ 'ubuntu-latest', 'windows-latest' ]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -444,9 +442,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -475,9 +473,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -506,9 +504,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -537,9 +535,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 200
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -567,9 +565,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -597,9 +595,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -627,9 +625,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -658,9 +656,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -689,9 +687,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -722,11 +720,11 @@ jobs:
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: free disk space
         run: tools/github/free_disk_space.sh
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -751,9 +749,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -779,9 +777,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -807,9 +805,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -838,9 +836,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -876,9 +874,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -907,9 +905,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 270
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -938,9 +936,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 270
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -969,9 +967,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1000,9 +998,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1031,9 +1029,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1060,9 +1058,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1088,9 +1086,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1116,9 +1114,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1144,9 +1142,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1172,9 +1170,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1200,9 +1198,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1228,9 +1226,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1256,9 +1254,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1282,9 +1280,9 @@ jobs:
     # Kudu E2E expands each @TestTemplate case across several PR test containers.
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1307,9 +1305,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1332,9 +1330,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1357,9 +1355,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1383,9 +1381,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1408,9 +1406,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1434,9 +1432,9 @@ jobs:
     timeout-minutes: 210
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1463,9 +1461,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1488,9 +1486,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1513,9 +1511,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 210
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -1538,9 +1536,9 @@ jobs:
         os: [ 'ubuntu-latest' ]
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   call-build-and-test:
     permissions:
+      contents: read
       packages: write
     name: Run
     uses: ./.github/workflows/backend.yml

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -36,7 +36,7 @@ jobs:
       checks: write
     steps:
       - name: "Notify test workflow"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -118,22 +118,22 @@ jobs:
               // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
               const check_runs = await github.request(check_run_endpoint, check_run_params)
               console.log('check_runs: ' + JSON.stringify(check_runs))
-              const check_run_head = check_runs.data.check_runs.filter(r => r.name === "Run / License header")[0]
+              const check_run_head = check_runs.data.check_runs.find(r =>
+                r.head_sha === context.payload.pull_request.head.sha && r.name === 'Run / License header'
+              )
 
               console.log('check_run_head: ' + JSON.stringify(check_run_head))
-              if (check_run_head.head_sha != context.payload.pull_request.head.sha) {
-                throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
-              }
-
-              const check_run_url = 'https://github.com/'
-                + context.payload.pull_request.head.repo.full_name
-                + '/runs/'
-                + check_run_head.id
-
               const actions_url = 'https://github.com/'
                 + context.payload.pull_request.head.repo.full_name
                 + '/actions/runs/'
                 + run_id
+
+              const check_run_url = check_run_head
+                ? 'https://github.com/'
+                  + context.payload.pull_request.head.repo.full_name
+                  + '/runs/'
+                  + check_run_head.id
+                : actions_url
 
               await github.rest.checks.create({
                 owner: context.repo.owner,

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -109,30 +109,32 @@ jobs:
                 }
               })
             } else {
-              const run_id = runs.data.workflow_runs[0].id
+              const build_run = runs.data.workflow_runs[0]
+              const run_id = build_run.id
 
-              if (runs.data.workflow_runs[0].head_sha != context.payload.pull_request.head.sha) {
+              if (build_run.head_sha != context.payload.pull_request.head.sha) {
                 throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
               }
 
               // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
               const check_runs = await github.request(check_run_endpoint, check_run_params)
               console.log('check_runs: ' + JSON.stringify(check_runs))
-              const check_run_head = check_runs.data.check_runs.find(r =>
-                r.head_sha === context.payload.pull_request.head.sha && r.name === 'Run / License header'
-              )
-
-              console.log('check_run_head: ' + JSON.stringify(check_run_head))
               const actions_url = 'https://github.com/'
                 + context.payload.pull_request.head.repo.full_name
                 + '/actions/runs/'
                 + run_id
+              const run_url_part = '/actions/runs/' + run_id
+              const check_run_head = check_runs.data.check_runs.find(r =>
+                r.head_sha === build_run.head_sha
+                  && (
+                    (r.details_url && r.details_url.includes(run_url_part))
+                    || (r.html_url && r.html_url.includes(run_url_part))
+                  )
+              )
 
+              console.log('check_run_head: ' + JSON.stringify(check_run_head))
               const check_run_url = check_run_head
-                ? 'https://github.com/'
-                  + context.payload.pull_request.head.repo.full_name
-                  + '/runs/'
-                  + check_run_head.id
+                ? (check_run_head.html_url || check_run_head.details_url || actions_url)
                 : actions_url
 
               await github.rest.checks.create({

--- a/.github/workflows/schedule_backend.yml
+++ b/.github/workflows/schedule_backend.yml
@@ -27,8 +27,9 @@ concurrency:
 jobs:
   call-build-and-test:
     permissions:
+      contents: read
       packages: write
     name: Run
     uses: ./.github/workflows/backend.yml
     with:
-      TEST_IN_PR: false
+      TEST_IN_PR: ${{ 'false' }}


### PR DESCRIPTION
### What is wrong now

Recent `Build` workflow runs can fail with `startup_failure` before any job starts. In that state GitHub does not create job logs, so PRs such as #11133 are blocked without running project build or test code.

Local workflow validation, action metadata, and recent workflow history point to startup-time problems in the shared CI workflow definitions:

- `.github/workflows/backend.yml` used `secrets.GITHUB_TOKEN` when checking out `apache/seatunnel-website`. `GITHUB_TOKEN` is the built-in workflow token, not a user-defined secret, so the reusable workflow should pass `github.token` instead.
- `.github/workflows/build_main.yml` and `.github/workflows/schedule_backend.yml` narrowed the caller token permission to only `packages: write`. The called backend workflow still needs normal repository read access for checkout and workflow token usage, so the callers should explicitly keep `contents: read`.
- `.github/workflows/backend.yml` referenced undefined step ids for connector-v2 E2E module outputs. A workflow expression that reads a missing step id can make the workflow invalid before jobs are scheduled.
- `.github/workflows/schedule_backend.yml` passed boolean `false` to the reusable workflow input `TEST_IN_PR`, while the reusable workflow declares it as a string input.
- `.github/workflows/backend.yml` and `.github/workflows/notify_test_workflow.yml` still used older official GitHub Actions versions. Newer GitHub Actions runners can reject old Node-based action versions before job execution, which matches the no-job/no-log startup failure symptom.
- `.github/workflows/backend.yml` still used `nick-fields/retry@v2`, whose action metadata runs on Node 16. `nick-fields/retry@v3` runs on Node 20.

### What changed

This PR keeps the fix limited to CI workflow startup issues:

- Use `${{ github.token }}` for the backend website build checkout token.
- Keep `contents: read` while granting `packages: write` in the Build and scheduled backend workflow callers.
- Remove the undefined `cv2-flink-e2e-modules` / `cv2-spark-e2e-modules` step-id references from the integration-test module calculation.
- Pass `TEST_IN_PR` as a string expression from the scheduled backend workflow.
- Upgrade official actions used by backend and notify workflows:
  - `actions/checkout` to `v4`
  - `actions/setup-java` to `v4`
  - `actions/setup-node` to `v4`
  - `actions/setup-python` to `v5`
  - `actions/github-script` to `v7`
- Upgrade `nick-fields/retry` usage from `v2` to `v3`.

### Why this is separate from #11133

#11133 only changes JDBC catalog close behavior. Its failing `Build` run did not start any project job and had no logs, and recent `dev` branch Build runs showed the same startup failure pattern. That means the blocker is in shared CI workflow startup, not in #11133 code.

### Validation

- `actionlint` focused check for action/expression startup errors: passed
- `git diff --check`: passed
- `./mvnw spotless:apply`: passed
- `./mvnw -q -DskipTests verify`: passed