### PR TITLE
[Fix][Connector-V2] Fix Hudi null struct field conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/convert/AvroSchemaConverter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/convert/AvroSchemaConverter.java
@@ -64,6 +64,11 @@ public class AvroSchemaConverter implements Serializable {
      * @return Avro's {@link Schema} matching this logical type.
      */
     public static Schema convertToSchema(SeaTunnelDataType<?> dataType, String rowName) {
+        return convertToSchema(dataType, rowName, false);
+    }
+
+    private static Schema convertToSchema(
+            SeaTunnelDataType<?> dataType, String rowName, boolean nullableRow) {
         switch (dataType.getSqlType()) {
             case BOOLEAN:
                 Schema bool = SchemaBuilder.builder().booleanType();
@@ -126,25 +131,30 @@ public class AvroSchemaConverter implements Serializable {
                     SeaTunnelDataType<?> fieldType = rowType.getFieldType(i);
                     SchemaBuilder.GenericDefault<Schema> fieldBuilder =
                             builder.name(fieldName)
-                                    .type(convertToSchema(fieldType, rowName + "." + fieldName));
+                                    .type(
+                                            convertToSchema(
+                                                    fieldType, rowName + "." + fieldName, true));
 
                     builder = fieldBuilder.withDefault(null);
                 }
-                return builder.endRecord();
+                Schema record = builder.endRecord();
+                return nullableRow ? nullableSchema(record) : record;
             case MAP:
                 Schema map =
                         SchemaBuilder.builder()
                                 .map()
                                 .values(
                                         convertToSchema(
-                                                extractValueTypeToAvroMap(dataType), rowName));
+                                                extractValueTypeToAvroMap(dataType),
+                                                rowName,
+                                                true));
                 return nullableSchema(map);
             case ARRAY:
                 ArrayType<?, ?> arrayType = (ArrayType<?, ?>) dataType;
                 Schema array =
                         SchemaBuilder.builder()
                                 .array()
-                                .items(convertToSchema(arrayType.getElementType(), rowName));
+                                .items(convertToSchema(arrayType.getElementType(), rowName, true));
                 return nullableSchema(array);
             default:
                 throw new UnsupportedOperationException(

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/convert/HudiRecordConverter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/convert/HudiRecordConverter.java
@@ -24,7 +24,6 @@ import org.apache.seatunnel.connectors.seatunnel.hudi.config.HudiTableConfig;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -39,7 +38,6 @@ import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.seatunnel.connectors.seatunnel.hudi.sink.convert.AvroSchemaConverter.convertToSchema;
 import static org.apache.seatunnel.connectors.seatunnel.hudi.sink.convert.RowDataToAvroConverters.createConverter;
 
 public class HudiRecordConverter implements Serializable {
@@ -59,17 +57,11 @@ public class HudiRecordConverter implements Serializable {
             HudiTableConfig hudiTableConfig) {
         GenericRecord rec = new GenericData.Record(schema);
         for (int i = 0; i < seaTunnelRowType.getTotalFields(); i++) {
+            String fieldName = seaTunnelRowType.getFieldNames()[i];
             rec.put(
-                    seaTunnelRowType.getFieldNames()[i],
+                    fieldName,
                     createConverter(seaTunnelRowType.getFieldType(i))
-                            .convert(
-                                    convertToSchema(
-                                            seaTunnelRowType.getFieldType(i),
-                                            AvroSchemaUtils.getAvroRecordQualifiedName(
-                                                            hudiTableConfig.getTableName())
-                                                    + "."
-                                                    + seaTunnelRowType.getFieldNames()[i]),
-                                    element.getField(i)));
+                            .convert(schema.getField(fieldName).schema(), element.getField(i)));
         }
         return new HoodieAvroRecord<>(
                 getHoodieKey(element, seaTunnelRowType, hudiTableConfig),

--- a/seatunnel-connectors-v2/connector-hudi/src/test/java/org/apache/seatunnel/connectors/seatunnel/hudi/HudiTest.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/test/java/org/apache/seatunnel/connectors/seatunnel/hudi/HudiTest.java
@@ -23,10 +23,15 @@ import org.apache.seatunnel.api.table.type.MapType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.hudi.config.HudiTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.hudi.sink.convert.HudiRecordConverter;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.avro.AvroSchemaUtils;
 import org.apache.hudi.client.HoodieJavaWriteClient;
@@ -37,6 +42,7 @@ import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
@@ -53,6 +59,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -125,6 +132,45 @@ public class HudiTest {
         Assertions.assertEquals(
                 "{\"type\":\"record\",\"name\":\"hudi_record\",\"namespace\":\"hoodie.hudi\",\"fields\":[{\"name\":\"bool\",\"type\":[\"null\",\"boolean\"],\"default\":null},{\"name\":\"int\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"longValue\",\"type\":[\"null\",\"long\"],\"default\":null},{\"name\":\"float\",\"type\":[\"null\",\"float\"],\"default\":null},{\"name\":\"name\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"date\",\"type\":[\"null\",{\"type\":\"int\",\"logicalType\":\"date\"}],\"default\":null},{\"name\":\"time\",\"type\":[\"null\",{\"type\":\"int\",\"logicalType\":\"time-millis\"}],\"default\":null},{\"name\":\"timestamp3\",\"type\":[\"null\",{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}],\"default\":null},{\"name\":\"map\",\"type\":[\"null\",{\"type\":\"map\",\"values\":[\"null\",\"long\"]}],\"default\":null},{\"name\":\"decimal\",\"type\":[\"null\",{\"type\":\"fixed\",\"name\":\"fixed\",\"namespace\":\"hoodie.hudi.hudi_record.decimal\",\"size\":5,\"logicalType\":\"decimal\",\"precision\":10,\"scale\":5}],\"default\":null}]}",
                 getSchema());
+    }
+
+    @Test
+    void testConvertNullableStructField() throws IOException {
+        SeaTunnelRowType structType =
+                new SeaTunnelRowType(
+                        new String[] {"field1", "field2"},
+                        new SeaTunnelDataType[] {STRING_TYPE, INT_TYPE});
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"id", "payload"},
+                        new SeaTunnelDataType[] {INT_TYPE, structType});
+        Schema schema =
+                convertToSchema(rowType, AvroSchemaUtils.getAvroRecordQualifiedName(tableName));
+
+        Assertions.assertEquals(Schema.Type.RECORD, schema.getType());
+        Assertions.assertEquals(Schema.Type.UNION, schema.getField("payload").schema().getType());
+
+        SeaTunnelRow nullStructRow = new SeaTunnelRow(2);
+        nullStructRow.setField(0, 1);
+        nullStructRow.setField(1, null);
+
+        GenericRecord nullStructRecord = convertToAvroRecord(schema, rowType, nullStructRow);
+        Assertions.assertNull(nullStructRecord.get("payload"));
+        writeAvroRecord(schema, nullStructRecord);
+
+        SeaTunnelRow struct = new SeaTunnelRow(2);
+        struct.setField(0, "value");
+        struct.setField(1, 100);
+
+        SeaTunnelRow structRow = new SeaTunnelRow(2);
+        structRow.setField(0, 2);
+        structRow.setField(1, struct);
+
+        GenericRecord structRecord = convertToAvroRecord(schema, rowType, structRow);
+        GenericRecord payload = (GenericRecord) structRecord.get("payload");
+        Assertions.assertEquals("value", payload.get("field1").toString());
+        Assertions.assertEquals(100, payload.get("field2"));
+        writeAvroRecord(schema, structRecord);
     }
 
     @Test
@@ -208,6 +254,25 @@ public class HudiTest {
 
         return new HoodieAvroRecord<>(
                 getHoodieKey(element, seaTunnelRowType), new HoodieAvroPayload(Option.of(rec)));
+    }
+
+    private GenericRecord convertToAvroRecord(
+            Schema schema, SeaTunnelRowType rowType, SeaTunnelRow element) throws IOException {
+        HudiTableConfig tableConfig =
+                HudiTableConfig.builder()
+                        .tableName(tableName)
+                        .opType(WriteOperationType.INSERT)
+                        .build();
+        HoodieRecord<HoodieAvroPayload> record =
+                new HudiRecordConverter().convertRow(schema, rowType, element, tableConfig);
+        return (GenericRecord) record.getData().getInsertValue(schema).get();
+    }
+
+    private void writeAvroRecord(Schema schema, GenericRecord record) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        new GenericDatumWriter<GenericRecord>(schema).write(record, encoder);
+        encoder.flush();
     }
 
     private HoodieKey getHoodieKey(SeaTunnelRow element, SeaTunnelRowType seaTunnelRowType) {


### PR DESCRIPTION
### Purpose
Fixes #10584.

This PR fixes Hudi sink conversion when a SeaTunnel ROW/struct field is null.

### Root Cause
Nested ROW fields were converted to a plain Avro record schema even though Hudi fields are written with null defaults. When the struct value was null, Avro rejected the null value/default because the field schema did not allow null. Recomputing per-field schemas during row conversion also bypassed the schema already generated for the top-level Hudi record.

### Changes
- Keep the top-level Hudi Avro schema as a record.
- Generate nullable Avro schemas for nested ROW fields, including ROW values inside arrays/maps.
- Convert Hudi row fields using the field schema from the top-level Avro record.
- Add a regression test covering both null and non-null struct field values.

### Tests
- `./mvnw -pl seatunnel-connectors-v2/connector-hudi -Dtest=HudiTest#testConvertNullableStructField test`
- `./mvnw -pl seatunnel-connectors-v2/connector-hudi -Dtest=HudiTest test`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `./mvnw -pl seatunnel-connectors-v2/connector-hudi test`