### PR TITLE
Add heye1005 in ASF collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,7 @@ github:
     - CosmosNi
     - fcb-xiaobo
     - LeonYoah
-    - silenceland
+    - heye1005
     - SEZ9
     - boy-xiaozhang
     - nzw921rx


### PR DESCRIPTION
## What changed
- replace `silenceland` with `heye1005` in the ASF GitHub collaborators list

## Why
- `heye1005` has recent SeaTunnel contributions and is not already an ASF member-level maintainer
- this updates the lower-level collaborator list to reflect current active contributors

## Validation
- `export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home && ./mvnw -nsu -Dmaven.gitcommitid.skip=true -T 3C -pl '!seatunnel-engine/seatunnel-engine-ui' spotless:apply`
- `ruby -e 'require "yaml"; data = YAML.load_file(".asf.yaml"); abort("missing collaborators") unless data["github"]["collaborators"].include?("heye1005"); abort("still has silenceland") if data["github"]["collaborators"].include?("silenceland"); puts "yaml-ok"'`

## Notes
- `seatunnel-engine-ui` was skipped during Spotless because this change does not touch that module
- no runtime or UI verification is applicable here because the only change is repository metadata in `.asf.yaml`
