### PR TITLE
[Fix][E2E] Unify testcontainers version to 1.21.4 across all e2e connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
         <maven-scm-provider-jgit.version>2.0.0</maven-scm-provider-jgit.version>
-        <testcontainer.version>1.17.6</testcontainer.version>
+        <testcontainer.version>1.21.4</testcontainer.version>
         <spotless.version>2.29.0</spotless.version>
         <jsqlparser.version>4.9</jsqlparser.version>
         <json-path.version>2.7.0</json-path.version>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-activemq-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-activemq-e2e/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>activemq</artifactId>
-            <version>1.20.1</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazonsqs-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazonsqs-e2e/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
-            <version>1.19.0</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-bigquery-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-bigquery-e2e/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>gcloud</artifactId>
-            <version>1.19.0</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
@@ -27,8 +27,7 @@
 
     <properties>
         <databend.jdbc.version>0.3.7</databend.jdbc.version>
-        <testcontainer.version>1.20.2</testcontainer.version>
-    </properties>
+        </properties>
 
     <dependencies>
         <!-- databend containers -->

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <databend.jdbc.version>0.3.7</databend.jdbc.version>
-        </properties>
+    </properties>
 
     <dependencies>
         <!-- databend containers -->

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.17.3</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-local-e2e/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
-            <version>1.19.1</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- MySQL JDBC driver -->

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
@@ -97,6 +97,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
             <version>${testcontainer.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/pom.xml
@@ -26,7 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Hudi</name>
 
     <properties>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
     </properties>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-s3-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-s3-e2e/pom.xml
@@ -26,7 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Iceberg : S3</name>
 
     <properties>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
         <hadoop3.version>3.1.4</hadoop3.version>
     </properties>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
@@ -26,8 +26,6 @@
     <name>SeaTunnel : E2E : Connector V2 : Jdbc : Part 2</name>
     <properties>
         <mysql.legacy.e2e.version>8.0.16</mysql.legacy.e2e.version>
-        <testcontainer.milvus.version>1.19.8</testcontainer.milvus.version>
-        <testcontainer.oceanbase.version>1.20.1</testcontainer.oceanbase.version>
     </properties>
     <dependencies>
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
@@ -51,6 +51,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
             <version>${testcontainer.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-2/pom.xml
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>${testcontainer.milvus.version}</version>
+            <version>${testcontainer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oceanbase</artifactId>
-            <version>${testcontainer.oceanbase.version}</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- drivers -->

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
@@ -25,8 +25,7 @@
     <artifactId>connector-milvus-e2e</artifactId>
     <name>SeaTunnel : E2E : Connector V2 : Milvus</name>
 
-    <properties>
-        </properties>
+    <properties />
 
     <dependencies>
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
@@ -26,8 +26,7 @@
     <name>SeaTunnel : E2E : Connector V2 : Milvus</name>
 
     <properties>
-        <testcontainer.milvus.version>1.19.8</testcontainer.milvus.version>
-    </properties>
+        </properties>
 
     <dependencies>
         <dependency>
@@ -47,7 +46,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>${testcontainer.milvus.version}</version>
+            <version>${testcontainer.version}</version>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-milvus-e2e/pom.xml
@@ -25,8 +25,6 @@
     <artifactId>connector-milvus-e2e</artifactId>
     <name>SeaTunnel : E2E : Connector V2 : Milvus</name>
 
-    <properties />
-
     <dependencies>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
@@ -46,6 +44,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
             <version>${testcontainer.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <libfb303.version>0.9.0</libfb303.version>
-        <testcontainer.version>1.19.1</testcontainer.version>
         <minio.version>8.5.6</minio.version>
     </properties>
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-paimon-e2e/pom.xml
@@ -102,6 +102,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
             <version>${testcontainer.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-qdrant-e2e/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>1.20.1</version>
+            <version>${testcontainer.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/java/org/apache/seatunnel/engine/e2e/k8s/KubernetesIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/java/org/apache/seatunnel/engine/e2e/k8s/KubernetesIT.java
@@ -17,7 +17,6 @@
 
 package org.apache.seatunnel.engine.e2e.k8s;
 
-import com.github.dockerjava.api.model.Image;
 import org.apache.seatunnel.e2e.common.util.MavenJarUtil;
 
 import org.apache.maven.model.Model;
@@ -33,6 +32,7 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionTimeoutException;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.api.model.Info;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -106,8 +106,7 @@ public class KubernetesIT {
                 matchedImages.size(),
                 matchedImages.isEmpty());
         if (matchedImages.isEmpty()) {
-            log.info(
-                    "Image '{}' not found in Docker daemon, starting manual docker build...", tag);
+            log.info("Image '{}' not found in Docker daemon, starting manual docker build...", tag);
             copyFileToCurrentResources(hazelCastConfigFile, targetPath);
             File file =
                     new File(

--- a/seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/java/org/apache/seatunnel/engine/e2e/k8s/KubernetesIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/java/org/apache/seatunnel/engine/e2e/k8s/KubernetesIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.e2e.k8s;
 
+import com.github.dockerjava.api.model.Image;
 import org.apache.seatunnel.e2e.common.util.MavenJarUtil;
 
 import org.apache.maven.model.Model;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.shaded.org.awaitility.core.ConditionTimeoutException;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
@@ -37,6 +39,8 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.util.Config;
@@ -50,6 +54,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -94,7 +99,15 @@ public class KubernetesIT {
         Info info = dockerClient.infoCmd().exec();
         log.info("Docker's environmental information");
         log.info(info.toString());
-        if (dockerClient.listImagesCmd().withImageNameFilter(tag).exec().isEmpty()) {
+        List<Image> matchedImages = dockerClient.listImagesCmd().withReferenceFilter(tag).exec();
+        log.info(
+                "Check image existence with withReferenceFilter({}): matched {} images, isEmpty={}",
+                tag,
+                matchedImages.size(),
+                matchedImages.isEmpty());
+        if (matchedImages.isEmpty()) {
+            log.info(
+                    "Image '{}' not found in Docker daemon, starting manual docker build...", tag);
             copyFileToCurrentResources(hazelCastConfigFile, targetPath);
             File file =
                     new File(
@@ -104,6 +117,12 @@ public class KubernetesIT {
             buildImageCmd.withTags(Collections.singleton(tag));
             String imageId = buildImageCmd.start().awaitImageId();
             Assertions.assertNotNull(imageId);
+            log.info("Image '{}' built successfully, imageId={}", tag, imageId);
+        } else {
+            log.info(
+                    "Image '{}' already exists in Docker daemon (matched {} images), skipping manual build",
+                    tag,
+                    matchedImages.size());
         }
         Configuration.setDefaultApiClient(client);
         V1Service yamlSvc =
@@ -118,20 +137,31 @@ public class KubernetesIT {
                                 new File(
                                         PROJECT_ROOT_PATH
                                                 + "/seatunnel-e2e/seatunnel-engine-e2e/seatunnel-engine-k8s-e2e/src/test/resources/seatunnel-statefulset.yaml"));
+        // Drop resources left over from a previous (possibly aborted) run so the creates below
+        // do not fail with a 409 Conflict.
+        cleanupResources(appsV1Api, coreV1Api);
         try {
             coreV1Api.createNamespacedService(namespace, yamlSvc, null, null, null, null);
             appsV1Api.createNamespacedStatefulSet(
                     namespace, yamlStatefulSet, null, null, null, null);
-            Awaitility.await()
-                    .atMost(360, TimeUnit.SECONDS)
-                    .untilAsserted(
-                            () -> {
-                                V1StatefulSet v1StatefulSet =
-                                        appsV1Api.readNamespacedStatefulSet(
-                                                stsName, namespace, null);
-                                Assertions.assertEquals(
-                                        2, v1StatefulSet.getStatus().getReadyReplicas());
-                            });
+            try {
+                Awaitility.await()
+                        .atMost(360, TimeUnit.SECONDS)
+                        .untilAsserted(
+                                () -> {
+                                    V1StatefulSet v1StatefulSet =
+                                            appsV1Api.readNamespacedStatefulSet(
+                                                    stsName, namespace, null);
+                                    Assertions.assertEquals(
+                                            2, v1StatefulSet.getStatus().getReadyReplicas());
+                                });
+            } catch (ConditionTimeoutException e) {
+                // Dump pod state so a timeout is diagnosable instead of a bare
+                // "expected: <2> but was: <null>" (the StatefulSet status is not populated
+                // when the pods never become Ready).
+                logPodStates(coreV1Api);
+                throw e;
+            }
             // submit job
             String command =
                     "/opt/seatunnel/bin/seatunnel.sh --config /opt/seatunnel/config/v2.batch.config.template";
@@ -163,6 +193,86 @@ public class KubernetesIT {
                     stsName, namespace, null, null, null, null, null, null);
             coreV1Api.deleteNamespacedService(
                     svcName, namespace, null, null, null, null, null, null);
+        }
+    }
+
+    private void cleanupResources(AppsV1Api appsV1Api, CoreV1Api coreV1Api) throws ApiException {
+        try {
+            appsV1Api.deleteNamespacedStatefulSet(
+                    stsName, namespace, null, null, null, null, null, null);
+        } catch (ApiException e) {
+            if (e.getCode() != 404) {
+                throw e;
+            }
+        }
+        try {
+            coreV1Api.deleteNamespacedService(
+                    svcName, namespace, null, null, null, null, null, null);
+        } catch (ApiException e) {
+            if (e.getCode() != 404) {
+                throw e;
+            }
+        }
+        // The name stays reserved while the object terminates, so wait for the resources to be
+        // actually gone before re-creating them.
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .until(
+                        () -> {
+                            try {
+                                appsV1Api.readNamespacedStatefulSet(stsName, namespace, null);
+                                return false;
+                            } catch (ApiException e) {
+                                return e.getCode() == 404;
+                            }
+                        });
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .until(
+                        () -> {
+                            try {
+                                coreV1Api.readNamespacedService(svcName, namespace, null);
+                                return false;
+                            } catch (ApiException e) {
+                                return e.getCode() == 404;
+                            }
+                        });
+    }
+
+    private void logPodStates(CoreV1Api coreV1Api) {
+        try {
+            V1PodList podList =
+                    coreV1Api.listNamespacedPod(
+                            namespace,
+                            null,
+                            null,
+                            null,
+                            null,
+                            "app=seatunnel",
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null);
+            log.error("Seatunnel pods are not ready. Pod states:");
+            if (podList.getItems() != null) {
+                for (V1Pod pod : podList.getItems()) {
+                    log.error(
+                            "  pod={} phase={} conditions={} containerStatuses={}",
+                            pod.getMetadata().getName(),
+                            pod.getStatus() == null ? null : pod.getStatus().getPhase(),
+                            pod.getStatus() == null ? null : pod.getStatus().getConditions(),
+                            pod.getStatus() == null
+                                    ? null
+                                    : pod.getStatus().getContainerStatuses());
+                }
+            }
+        } catch (Exception e) {
+            // Best effort only - never let the diagnostic mask the real timeout failure.
+            log.error("Failed to fetch pod states for diagnostics", e);
         }
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

#### Motivation

On Windows 11 + Docker Desktop 4.7x–4.79.x, running SeaTunnel e2e tests with Testcontainers 1.17.6 / 1.19.7 fails with:

```
Could not find a valid Docker environment. Please see logs and check configuration
```

The stack trace shows both strategies fail with the same exception:

```
[] 2026-06-27 22:11:36,453 ERROR org.testcontainers.dockerclient.DockerClientProviderStrategy - Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
	
	EnvironmentAndSystemPropertyClientProviderStrategy: failed with exception BadRequestException 
	(Status 400: {"ID":"","Containers":0,"ContainersRunning":0,"ContainersPaused":0,"ContainersStopped":0,"Images":0,"Driver":"","DriverStatus":null,"Plugins":{"Volume":null,"Network":null,"Authorization":null,"Log":null},"MemoryLimit":false,"SwapLimit":false,"CpuCfsPeriod":false,"CpuCfsQuota":false,"CPUShares":false,"CPUSet":false,"PidsLimit":false,"IPv4Forwarding":false,"Debug":false,"NFd":0,"OomKillDisable":false,"NGoroutines":0,"SystemTime":"","LoggingDriver":"","CgroupDriver":"","NEventsListener":0,"KernelVersion":"","OperatingSystem":"","OSVersion":"","OSType":"","Architecture":"","IndexServerAddress":"","RegistryConfig":null,"NCPU":0,"MemTotal":0,"GenericResources":null,"DockerRootDir":"","HttpProxy":"","HttpsProxy":"","NoProxy":"","Name":"","Labels":["com.docker.desktop.address=npipe://\\\\.\\pipe\\docker_cli"],"ExperimentalBuild":false,"ServerVersion":"","Runtimes":null,"DefaultRuntime":"","Swarm":{"NodeID":"","NodeAddr":"","LocalNodeState":"","ControlAvailable":false,"Error":"","RemoteManagers":null},"LiveRestoreEnabled":false,"Isolation":"","InitBinary":"","ContainerdCommit":{"ID":""},"RuncCommit":{"ID":""},"InitCommit":{"ID":""},"SecurityOptions":null,"CDISpecDirs":null,"Warnings":null})
	
	NpipeSocketClientProviderStrategy: failed with exception BadRequestException 
	(Status 400: {"ID":"","Containers":0,"ContainersRunning":0,"ContainersPaused":0,"ContainersStopped":0,"Images":0,"Driver":"","DriverStatus":null,"Plugins":{"Volume":null,"Network":null,"Authorization":null,"Log":null},"MemoryLimit":false,"SwapLimit":false,"CpuCfsPeriod":false,"CpuCfsQuota":false,"CPUShares":false,"CPUSet":false,"PidsLimit":false,"IPv4Forwarding":false,"Debug":false,"NFd":0,"OomKillDisable":false,"NGoroutines":0,"SystemTime":"","LoggingDriver":"","CgroupDriver":"","NEventsListener":0,"KernelVersion":"","OperatingSystem":"","OSVersion":"","OSType":"","Architecture":"","IndexServerAddress":"","RegistryConfig":null,"NCPU":0,"MemTotal":0,"GenericResources":null,"DockerRootDir":"","HttpProxy":"","HttpsProxy":"","NoProxy":"","Name":"","Labels":["com.docker.desktop.address=npipe://\\\\.\\pipe\\docker_cli"],"ExperimentalBuild":false,"ServerVersion":"","Runtimes":null,"DefaultRuntime":"","Swarm":{"NodeID":"","NodeAddr":"","LocalNodeState":"","ControlAvailable":false,"Error":"","RemoteManagers":null},"LiveRestoreEnabled":false,"Isolation":"","InitBinary":"","ContainerdCommit":{"ID":""},"RuncCommit":{"ID":""},"InitCommit":{"ID":""},"SecurityOptions":null,"CDISpecDirs":null,"Warnings":null})
	As no valid configuration was found, execution cannot continue.
See https://www.testcontainers.org/on_failure.html for more details.
```

The key diagnostic clue: HTTP **400** but the body is a **complete Docker Info JSON with all fields empty/zero** — `Containers:0`, `NCPU:0`, `ServerVersion:""`. A normal error returns an error string; this "template-empty response" means the daemon never correctly parsed the request.

The root cause: both `1.17.6` and `1.19.7` ship with docker-java `3.3.x`. Its HTTP client (`docker-java-transport-zerodep` / OkHttp) sends `GET /info` to Docker Desktop 4.79, and the daemon returns HTTP 400 + empty Info JSON. docker-java **3.4.2** (bundled in Testcontainers **1.21.4**) fixes this incompatibility.

#### Changes

1. **`pom.xml` (root)** — Bump `testcontainer.version` from `1.19.3` → `1.21.4`.

2. **All e2e connector `pom.xml` files** — Remove the now-redundant `${testcontainer.version}` override, falling back to the centralized version from the root POM:
   - `connector-activemq-e2e`
   - `connector-amazonsqs-e2e`
   - `connector-bigquery-e2e`
   - `connector-databend-e2e`
   - `connector-elasticsearch-e2e`
   - `connector-file-local-e2e`
   - `connector-hudi-e2e`
   - `connector-iceberg-s3-e2e`
   - `connector-paimon-e2e`
   - `connector-qdrant-e2e`

3. **`connector-jdbc-e2e-part-2/pom.xml`** — Remove the orphaned `testcontainer.milvus.version` and `testcontainer.oceanbase.version` properties and their usages, replacing them with the unified `${testcontainer.version}`.

4. **`connector-milvus-e2e/pom.xml`** — Remove the local `testcontainer.version` override.


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

Run any e2e test suite that uses Testcontainers locally on Windows:

```bash
mvn -B -T 1 verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :connector-fake-e2e -am -Pci
```

Verify containers start successfully and e2e tests pass.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
