### PR TITLE
[Test][E2E] Reduce Databend CDC parallelism for CI stability

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/resources/databend/fake_to_databend_cdc.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/resources/databend/fake_to_databend_cdc.conf
@@ -16,7 +16,9 @@
 #
 
 env {
-  execution.parallelism = 2
+  # Keep this CDC E2E single-parallel to avoid slot starvation on the
+  # tight Flink CI matrix while still covering CDC row-kind merge semantics.
+  execution.parallelism = 1
   job.mode = "BATCH"
   checkpoint.interval  = 1000
 }


### PR DESCRIPTION
## Summary
- reduce `fake_to_databend_cdc.conf` parallelism from `2` to `1`
- keep the CDC row-kind merge assertions unchanged while lowering slot demand on the tight Flink CI lane

## Root cause
`DatabendCDCSinkIT` still fails in shared CI with `NoResourceAvailableException` on one matrix lane.
This test only validates CDC row-kind merge semantics from a small fake source and already waits for the final merged sink rows, so `execution.parallelism = 2` does not add coverage here.
It only increases slot pressure compared with the other Databend E2E configs, which already run with `execution.parallelism = 1`.

## Validation
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e -am spotless:apply -T 3C`
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -f seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/pom.xml -am -DskipTests verify -Dspotless.skip=true -T 3C`

## Notes
- Docker is not available in this environment, so the container-backed Databend E2E path was not rerun locally.
