### PR TITLE
[Test][E2E] Retry SQL Server XA setup until login is ready

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/SqlServerSchemaChangeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl/src/test/java/org/apache/seatunnel/connectors/jdbc/SqlServerSchemaChangeIT.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.jdbc;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -44,6 +45,8 @@ public class SqlServerSchemaChangeIT extends AbstractSchemaChangeBaseIT {
     private static final String SQLSERVER_PASSWORD = "paanssy1234$";
     private static final int SQLSERVER_PORT = 1433;
     private static final int SQLSERVER_XA_PORT = 5022;
+    private static final Duration SQLSERVER_SQLCMD_READY_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration SQLSERVER_SQLCMD_RETRY_INTERVAL = Duration.ofSeconds(2);
     private final String SQLSERVER_JDBC_URL =
             "jdbc:sqlserver://%s:%s;databaseName=%s;"
                     + "useBulkCopyForBatchInsert=true;delayLoadingLobs=true;useFmtOnly=false;"
@@ -107,45 +110,24 @@ public class SqlServerSchemaChangeIT extends AbstractSchemaChangeBaseIT {
         try {
             // This set of commands prepares for the subsequent enabling of the external user
             // enabled configuration (for XA transaction support)
-            container.execInContainer(
-                    "/opt/mssql-tools18/bin/sqlcmd",
-                    "-S",
-                    "localhost",
-                    "-U",
-                    SQLSERVER_USER,
-                    "-P",
-                    SQLSERVER_PASSWORD,
-                    "-Q",
-                    "EXEC sp_configure 'show advanced options', 1; RECONFIGURE;",
-                    "-C");
+            execSqlcmdWithRetry(
+                    container,
+                    "configure advanced options",
+                    "EXEC sp_configure 'show advanced options', 1; RECONFIGURE;");
 
             // Enable external user access permissions, which is a requirement for SQL Server to
             // support XA distributed transactions.
-            container.execInContainer(
-                    "/opt/mssql-tools18/bin/sqlcmd",
-                    "-S",
-                    "localhost",
-                    "-U",
-                    SQLSERVER_USER,
-                    "-P",
-                    SQLSERVER_PASSWORD,
-                    "-Q",
-                    "EXEC sp_configure 'external user enabled', 1; RECONFIGURE;",
-                    "-C");
+            execSqlcmdWithRetry(
+                    container,
+                    "enable external user access",
+                    "EXEC sp_configure 'external user enabled', 1; RECONFIGURE;");
 
             log.info("Installing stored procedures sp_sqljdbc_xa_install.");
-            container.execInContainer(
-                    "/opt/mssql-tools18/bin/sqlcmd",
-                    "-S",
-                    "localhost",
-                    "-U",
-                    SQLSERVER_USER,
-                    "-P",
-                    SQLSERVER_PASSWORD,
-                    "-Q",
+            execSqlcmdWithRetry(
+                    container,
+                    "install SQL Server XA stored procedures",
                     "IF NOT EXISTS (SELECT * FROM sys.objects WHERE name = 'xp_sqljdbc_xa_init_ex') "
-                            + "EXEC sp_sqljdbc_xa_install",
-                    "-C");
+                            + "EXEC sp_sqljdbc_xa_install");
         } catch (IOException | InterruptedException e) {
             log.error("XA procedure installation failed: ", e);
             throw new RuntimeException(e);
@@ -156,5 +138,46 @@ public class SqlServerSchemaChangeIT extends AbstractSchemaChangeBaseIT {
     @Override
     protected String sinkDatabaseType() {
         return DATABASE_TYPE;
+    }
+
+    /**
+     * SQL Server 2022 can emit the generic ready log before system database upgrades finish, so
+     * retry sqlcmd setup steps until login and execution both succeed.
+     */
+    private void execSqlcmdWithRetry(GenericContainer<?> container, String description, String sql)
+            throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + SQLSERVER_SQLCMD_READY_TIMEOUT.toNanos();
+        Container.ExecResult lastResult = null;
+        while (System.nanoTime() < deadline) {
+            lastResult =
+                    container.execInContainer(
+                            "/opt/mssql-tools18/bin/sqlcmd",
+                            "-S",
+                            "localhost",
+                            "-U",
+                            SQLSERVER_USER,
+                            "-P",
+                            SQLSERVER_PASSWORD,
+                            "-Q",
+                            sql,
+                            "-C");
+            if (lastResult.getExitCode() == 0) {
+                return;
+            }
+            log.info(
+                    "sqlcmd step [{}] is not ready yet, exitCode={}, stdout={}, stderr={}",
+                    description,
+                    lastResult.getExitCode(),
+                    lastResult.getStdout(),
+                    lastResult.getStderr());
+            Thread.sleep(SQLSERVER_SQLCMD_RETRY_INTERVAL.toMillis());
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "Timed out waiting for sqlcmd step [%s] to succeed, last exitCode=%s, stdout=%s, stderr=%s",
+                        description,
+                        lastResult == null ? null : lastResult.getExitCode(),
+                        lastResult == null ? null : lastResult.getStdout(),
+                        lastResult == null ? null : lastResult.getStderr()));
     }
 }


### PR DESCRIPTION
## What

- Retry each SQL Server XA setup `sqlcmd` step until the command actually succeeds
- Fail fast when `execInContainer` keeps returning non-zero instead of silently continuing

## Why

SQL Server 2022 can print the generic ready log before system database upgrades finish. In that window, the `sa` login returns error `18456`, so the XA setup commands may fail silently — and later schema-change integration tests never reach the expected running state.

## Verification

```bash
./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl \
  -nsu spotless:apply
```

```bash
./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-ddl \
  -nsu -DskipTests test-compile
```

> **Note:** Local Docker is unavailable in this environment, so the full Testcontainers E2E flow was not rerun locally.