### PR TITLE
[Fix][Connector-V2] Support Dameng NVARCHAR2 type mapping

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
@@ -49,6 +49,7 @@ import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_LONG;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_LONGVARCHAR;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_NVARCHAR;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_NVARCHAR2;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_TEXT;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_VARCHAR;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dm.DmdbTypeConverter.DM_VARCHAR2;
@@ -338,6 +339,7 @@ public class DmdbDialect implements JdbcDialect {
             case DM_VARCHAR:
             case DM_VARCHAR2:
             case DM_NVARCHAR:
+            case DM_NVARCHAR2:
             case DM_LONGVARCHAR:
             case DM_CLOB:
             case DM_TEXT:

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -67,6 +67,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
+    public static final String DM_NVARCHAR2 = "NVARCHAR2";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
     public static final String DM_TEXT = "TEXT";
@@ -204,7 +205,8 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case DM_NVARCHAR:
-                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
+            case DM_NVARCHAR2:
+                builder.sourceType(String.format("%s(%s)", dmType, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
@@ -360,6 +360,19 @@ public class DmdbTypeConverterTest {
         Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
         Assertions.assertEquals(8, column.getColumnLength());
         Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
+
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("nvarchar2(2)")
+                        .dataType("nvarchar2")
+                        .length(2L)
+                        .build();
+        column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(8, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Fixes #10635.

Dameng supports `NVARCHAR2` as an Oracle-compatible character type, but the JDBC Dameng type converter only handled `NVARCHAR`. As a result, reading a Dameng table with `NVARCHAR2` columns failed while building the catalog table with an unsupported type error.

### Changes

- Add `NVARCHAR2` support to `DmdbTypeConverter` and map it to SeaTunnel `STRING`.
- Treat `NVARCHAR2` as a string type when deciding whether Dameng default values need quotes.
- Add a regression test covering Dameng `nvarchar2` conversion.

### Tests

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-jdbc -DskipIT -Dskip.spotless=true -Dtest=DmdbTypeConverterTest#testNvarchar test`
- `./mvnw -q -DskipTests verify`

Note: `./mvnw -pl seatunnel-connectors-v2/connector-jdbc -DskipIT -Dskip.spotless=true test` was also run. The changed `DmdbTypeConverterTest` passed, but the full module run failed on existing Testcontainers-based Oracle/Kingbase tests because Docker is not available in this local environment.
