### PR TITLE
[Improve][Zeta] Abstract checkpoint id counter state store

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointCoordinatorFailoverIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointCoordinatorFailoverIT.java
@@ -25,13 +25,13 @@ import org.apache.seatunnel.common.utils.FileUtils;
 import org.apache.seatunnel.engine.client.SeaTunnelClient;
 import org.apache.seatunnel.engine.client.job.ClientJobExecutionEnvironment;
 import org.apache.seatunnel.engine.client.job.ClientJobProxy;
-import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.JobConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
-import org.apache.seatunnel.engine.server.checkpoint.IMapCheckpointIDCounter;
+import org.apache.seatunnel.engine.server.checkpoint.StateStoreCheckpointIDCounter;
+import org.apache.seatunnel.engine.server.common.statestore.EngineStateStoreNames;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
@@ -279,7 +279,7 @@ public class CheckpointCoordinatorFailoverIT {
                                             JobStatus.RUNNING, clientJobProxy.getJobStatus()));
 
             // Verify at least one pipeline's checkpoint id strictly grows on the new master.
-            IMap<String, Long> ckIdMap = masterNode2.getMap(Constant.IMAP_CHECKPOINT_ID);
+            IMap<String, Long> ckIdMap = masterNode2.getMap(EngineStateStoreNames.CHECKPOINT_ID);
             Map<Integer, Long> checkpointBefore = new HashMap<>();
             Awaitility.await()
                     .atMost(30, TimeUnit.SECONDS)
@@ -291,7 +291,7 @@ public class CheckpointCoordinatorFailoverIT {
                                         pipelineId <= rowNumPerSource.length;
                                         pipelineId++) {
                                     String ckIdKey =
-                                            IMapCheckpointIDCounter.convertLongIntToBase64(
+                                            StateStoreCheckpointIDCounter.convertLongIntToBase64(
                                                     jobId, pipelineId);
                                     Long value = ckIdMap.get(ckIdKey);
                                     if (value != null) {
@@ -316,7 +316,7 @@ public class CheckpointCoordinatorFailoverIT {
                                     int pid = entry.getKey();
                                     long before = entry.getValue();
                                     String ckIdKey =
-                                            IMapCheckpointIDCounter.convertLongIntToBase64(
+                                            StateStoreCheckpointIDCounter.convertLongIntToBase64(
                                                     jobId, pid);
                                     Long current = ckIdMap.get(ckIdKey);
                                     if (current != null && current > before) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
@@ -55,8 +55,6 @@ public class Constant {
 
     public static final String IMAP_OWNED_SLOT_PROFILES = "engine_ownedSlotProfilesIMap";
 
-    public static final String IMAP_CHECKPOINT_ID = "engine_checkpoint-id-map";
-
     public static final String IMAP_PENDING_PIPELINE_CLEANUP = "engine_pendingPipelineCleanup";
 
     public static final String IMAP_PENDING_JOB_CLEANUP = "engine_pendingJobCleanup";

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
@@ -34,6 +34,8 @@ import org.apache.seatunnel.engine.server.checkpoint.operation.TaskAcknowledgeOp
 import org.apache.seatunnel.engine.server.checkpoint.operation.TaskReportStatusOperation;
 import org.apache.seatunnel.engine.server.checkpoint.operation.TriggerSchemaChangeAfterCheckpointOperation;
 import org.apache.seatunnel.engine.server.checkpoint.operation.TriggerSchemaChangeBeforeCheckpointOperation;
+import org.apache.seatunnel.engine.server.common.SeaTunnelEngineContext;
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
 import org.apache.seatunnel.engine.server.dag.execution.Pipeline;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
@@ -93,6 +95,7 @@ public class CheckpointManager {
             CheckpointStorage checkpointStorage,
             ExecutorService executorService,
             IMap<Object, Object> runningJobStateIMap,
+            SeaTunnelEngineContext engineContext,
             CheckpointMonitorService checkpointMonitorService) {
         this.jobId = jobId;
         this.nodeEngine = nodeEngine;
@@ -100,14 +103,18 @@ public class CheckpointManager {
         this.checkpointStorage = checkpointStorage;
         this.checkpointConfig = checkpointConfig;
         this.checkpointMonitorService = checkpointMonitorService;
+        CounterStateStore<String> checkpointCounterStore =
+                engineContext.getStateStores().checkpointCounterStore();
 
         this.coordinatorMap =
                 MDCTracer.tracing(checkpointPlanMap.values().parallelStream())
                         .map(
                                 plan -> {
-                                    IMapCheckpointIDCounter idCounter =
-                                            new IMapCheckpointIDCounter(
-                                                    jobId, plan.getPipelineId(), nodeEngine);
+                                    StateStoreCheckpointIDCounter idCounter =
+                                            new StateStoreCheckpointIDCounter(
+                                                    jobId,
+                                                    plan.getPipelineId(),
+                                                    checkpointCounterStore);
                                     try {
                                         idCounter.start();
                                         PipelineState pipelineState = null;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/StateStoreCheckpointIDCounter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/StateStoreCheckpointIDCounter.java
@@ -23,30 +23,30 @@ import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.checkpoint.CheckpointIDCounter;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
-
-import com.hazelcast.map.IMap;
-import com.hazelcast.spi.impl.NodeEngine;
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
 
 import java.nio.ByteBuffer;
 import java.util.Base64;
+import java.util.Objects;
 
-import static org.apache.seatunnel.engine.common.Constant.IMAP_CHECKPOINT_ID;
 import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
 
-public class IMapCheckpointIDCounter implements CheckpointIDCounter {
+public class StateStoreCheckpointIDCounter implements CheckpointIDCounter {
 
     private final String key;
-    private final IMap<String, Long> checkpointIdMap;
+    private final CounterStateStore<String> checkpointCounterStore;
 
-    public IMapCheckpointIDCounter(Long jobID, Integer pipelineId, NodeEngine nodeEngine) {
+    public StateStoreCheckpointIDCounter(
+            Long jobID, Integer pipelineId, CounterStateStore<String> checkpointCounterStore) {
         this.key = convertLongIntToBase64(jobID, pipelineId);
-        this.checkpointIdMap = nodeEngine.getHazelcastInstance().getMap(IMAP_CHECKPOINT_ID);
+        this.checkpointCounterStore =
+                Objects.requireNonNull(checkpointCounterStore, "checkpointCounterStore");
     }
 
     @Override
     public void start() throws Exception {
         RetryUtils.retryWithException(
-                () -> checkpointIdMap.putIfAbsent(key, INITIAL_CHECKPOINT_ID),
+                () -> checkpointCounterStore.initializeIfAbsent(key, INITIAL_CHECKPOINT_ID),
                 new RetryUtils.RetryMaterial(
                         Constant.OPERATION_RETRY_TIME,
                         true,
@@ -57,26 +57,26 @@ public class IMapCheckpointIDCounter implements CheckpointIDCounter {
     @Override
     public CompletableFuture<Void> shutdown(PipelineStatus pipelineStatus) {
         if (pipelineStatus.isEndState()) {
-            checkpointIdMap.remove(key);
+            checkpointCounterStore.remove(key);
         }
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public long getAndIncrement() throws Exception {
-        Long nextId = checkpointIdMap.compute(key, (k, v) -> v == null ? null : v + 1);
+        long nextId = checkpointCounterStore.incrementAndGet(key);
         checkNotNull(nextId);
-        return nextId - 1;
+        return nextId - 1L;
     }
 
     @Override
     public long get() {
-        return checkpointIdMap.get(key);
+        return checkpointCounterStore.get(key);
     }
 
     @Override
     public void setCount(long newId) throws Exception {
-        checkpointIdMap.put(key, newId);
+        checkpointCounterStore.set(key, newId);
     }
 
     public static String convertLongIntToBase64(long longValue, int intValue) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/AuthoritativeStateStores.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/AuthoritativeStateStores.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.engine.server.common.statestore;
 
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
+
 /**
  * Bundle of authoritative control state that a new leader must trust during leader handoff.
  *
@@ -25,6 +27,15 @@ package org.apache.seatunnel.engine.server.common.statestore;
  * authoritative belongs more strongly to this group.
  */
 public interface AuthoritativeStateStores extends AutoCloseable {
+
+    /**
+     * Returns the checkpoint ID counter store.
+     *
+     * <p>The current key format is a string composed from {@code jobId + pipelineId}.
+     *
+     * @return checkpoint counter store
+     */
+    CounterStateStore<String> checkpointCounterStore();
 
     /**
      * Releases resources owned by authoritative stores.

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/DefaultAuthoritativeStateStores.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/DefaultAuthoritativeStateStores.java
@@ -17,5 +17,22 @@
 
 package org.apache.seatunnel.engine.server.common.statestore;
 
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
+
+import java.util.Objects;
+
 /** Default immutable implementation of {@link AuthoritativeStateStores}. */
-public class DefaultAuthoritativeStateStores implements AuthoritativeStateStores {}
+public class DefaultAuthoritativeStateStores implements AuthoritativeStateStores {
+
+    private final CounterStateStore<String> checkpointCounterStore;
+
+    public DefaultAuthoritativeStateStores(CounterStateStore<String> checkpointCounterStore) {
+        this.checkpointCounterStore =
+                Objects.requireNonNull(checkpointCounterStore, "checkpointCounterStore");
+    }
+
+    @Override
+    public CounterStateStore<String> checkpointCounterStore() {
+        return checkpointCounterStore;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/EngineStateStoreNames.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/EngineStateStoreNames.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 public class EngineStateStoreNames {
     private EngineStateStoreNames() {}
 
+    public static final String CHECKPOINT_ID = "engine_checkpoint-id-map";
     public static final String RUNNING_JOB_METRICS = "engine_runningJobMetrics";
     public static final String CHECKPOINT_MONITOR = "engine_checkpoint_monitor";
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/EngineStateStores.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/EngineStateStores.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server.common.statestore;
 
 import org.apache.seatunnel.engine.server.common.statestore.checkpoint.CheckpointOverviewStateStore;
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 
 /**
@@ -53,6 +54,17 @@ public interface EngineStateStores extends AutoCloseable {
      */
     default MetricsSnapshotStateStore metricsSnapshotStore() {
         return auxiliary().metricsSnapshotStore();
+    }
+
+    /**
+     * Returns the checkpoint ID counter store.
+     *
+     * <p>The current key format is a string composed from {@code jobId + pipelineId}.
+     *
+     * @return checkpoint counter store
+     */
+    default CounterStateStore<String> checkpointCounterStore() {
+        return authoritative().checkpointCounterStore();
     }
 
     /**

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/counter/CounterStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/counter/CounterStateStore.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.common.statestore.counter;
+
+/**
+ * Store for counter-like state.
+ *
+ * <p>This interface is intended for states with explicit increment semantics, such as checkpoint ID
+ * counters, instead of exposing a generic {@code compute()} operation.
+ *
+ * @param <K> key type
+ */
+public interface CounterStateStore<K> {
+
+    /**
+     * Atomically initializes the counter with the given value if no value is currently stored.
+     *
+     * @param key key to initialize
+     * @param initialValue initial counter value to store when absent
+     * @return {@code true} if the counter was initialized by this call, {@code false} if it already
+     *     existed
+     */
+    boolean initializeIfAbsent(K key, long initialValue);
+
+    /**
+     * Returns the current counter value.
+     *
+     * @param key key to look up
+     * @return stored value, or {@code 0} if absent
+     */
+    long get(K key);
+
+    /**
+     * Increments the counter by one and returns the updated value.
+     *
+     * @param key key to increment
+     * @return updated value
+     */
+    long incrementAndGet(K key);
+
+    /**
+     * Overwrites the counter with a specific value.
+     *
+     * @param key key to store
+     * @param value value to store
+     */
+    void set(K key, long value);
+
+    /**
+     * Removes the counter.
+     *
+     * @param key key to remove
+     */
+    void remove(K key);
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/counter/hazelcast/HazelcastCounterStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/counter/hazelcast/HazelcastCounterStateStore.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.common.statestore.counter.hazelcast;
+
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
+
+import com.hazelcast.map.IMap;
+
+/**
+ * Counter-store implementation backed by Hazelcast {@link IMap}.
+ *
+ * @param <K> key type
+ */
+public class HazelcastCounterStateStore<K> implements CounterStateStore<K> {
+
+    private final IMap<K, Long> iMap;
+
+    public HazelcastCounterStateStore(IMap<K, Long> iMap) {
+        this.iMap = iMap;
+    }
+
+    @Override
+    public boolean initializeIfAbsent(K key, long initialValue) {
+        return iMap.putIfAbsent(key, initialValue) == null;
+    }
+
+    @Override
+    public long get(K key) {
+        Long value = iMap.get(key);
+        return value == null ? 0L : value.longValue();
+    }
+
+    @Override
+    public long incrementAndGet(K key) {
+        Long value =
+                iMap.compute(
+                        key,
+                        (ignored, current) ->
+                                current == null ? 1L : Long.valueOf(current.longValue() + 1L));
+        return value.longValue();
+    }
+
+    @Override
+    public void set(K key, long value) {
+        iMap.put(key, Long.valueOf(value));
+    }
+
+    @Override
+    public void remove(K key) {
+        iMap.remove(key);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/hazelcast/HazelcastEngineStateStores.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/hazelcast/HazelcastEngineStateStores.java
@@ -24,6 +24,8 @@ import org.apache.seatunnel.engine.server.common.statestore.DefaultAuxiliaryStat
 import org.apache.seatunnel.engine.server.common.statestore.EngineStateStores;
 import org.apache.seatunnel.engine.server.common.statestore.checkpoint.CheckpointOverviewStateStore;
 import org.apache.seatunnel.engine.server.common.statestore.checkpoint.hazelcast.HazelcastCheckpointOverviewStateStore;
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
+import org.apache.seatunnel.engine.server.common.statestore.counter.hazelcast.HazelcastCounterStateStore;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.hazelcast.HazelcastMetricsSnapshotStateStore;
 
@@ -31,6 +33,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 
 import java.util.Objects;
 
+import static org.apache.seatunnel.engine.server.common.statestore.EngineStateStoreNames.CHECKPOINT_ID;
 import static org.apache.seatunnel.engine.server.common.statestore.EngineStateStoreNames.CHECKPOINT_MONITOR;
 import static org.apache.seatunnel.engine.server.common.statestore.EngineStateStoreNames.RUNNING_JOB_METRICS;
 
@@ -66,10 +69,14 @@ public class HazelcastEngineStateStores implements EngineStateStores {
                     new HazelcastMetricsSnapshotStateStore(
                             nodeEngine.getHazelcastInstance().getMap(RUNNING_JOB_METRICS),
                             metricsPartitionCount);
+            CounterStateStore<String> checkpointCounterStore =
+                    new HazelcastCounterStateStore<>(
+                            nodeEngine.getHazelcastInstance().getMap(CHECKPOINT_ID));
             CheckpointOverviewStateStore checkpointOverviewStateStore =
                     new HazelcastCheckpointOverviewStateStore(
                             nodeEngine.getHazelcastInstance().getMap(CHECKPOINT_MONITOR));
-            this.authoritativeStateStores = new DefaultAuthoritativeStateStores();
+            this.authoritativeStateStores =
+                    new DefaultAuthoritativeStateStores(checkpointCounterStore);
             this.auxiliaryStateStores =
                     new DefaultAuxiliaryStateStores(
                             metricsSnapshotStore, checkpointOverviewStateStore);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -339,6 +339,7 @@ public class JobMaster {
                         checkpointStorage,
                         executorService,
                         runningJobStateIMap,
+                        seaTunnelServer.getEngineContext(),
                         seaTunnelServer.getCheckpointMonitorService());
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExports.java
@@ -46,7 +46,7 @@ public class EngineStateStoreMetricExports extends AbstractCollector {
                     Constant.IMAP_FINISHED_JOB_VERTEX_INFO,
                     EngineStateStoreNames.CHECKPOINT_MONITOR,
                     Constant.IMAP_CONNECTOR_JAR_REF_COUNTERS,
-                    Constant.IMAP_CHECKPOINT_ID,
+                    EngineStateStoreNames.CHECKPOINT_ID,
                     Constant.IMAP_PENDING_PIPELINE_CLEANUP);
 
     public EngineStateStoreMetricExports(Node node) {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
 import org.apache.seatunnel.engine.server.checkpoint.monitor.CheckpointMonitorService;
 import org.apache.seatunnel.engine.server.checkpoint.operation.TaskAcknowledgeOperation;
+import org.apache.seatunnel.engine.server.common.SeaTunnelEngineContext;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
@@ -86,6 +87,7 @@ public class CheckpointCoordinatorTest
                         server.getCheckpointService().getCheckpointStorage(),
                         instance.getExecutorService("test"),
                         nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                        server.getEngineContext(),
                         null);
         checkpointManager.acknowledgeTask(
                 new TaskAcknowledgeOperation(
@@ -123,6 +125,7 @@ public class CheckpointCoordinatorTest
                             server.getCheckpointService().getCheckpointStorage(),
                             executorService,
                             nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                            server.getEngineContext(),
                             null) {
 
                         @Override
@@ -168,6 +171,7 @@ public class CheckpointCoordinatorTest
                             server.getCheckpointService().getCheckpointStorage(),
                             executorService,
                             nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                            server.getEngineContext(),
                             null) {
                         @Override
                         protected void handleCheckpointError(int pipelineId, boolean neverRestore) {
@@ -242,6 +246,7 @@ public class CheckpointCoordinatorTest
                             server.getCheckpointService().getCheckpointStorage(),
                             executorService,
                             nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                            server.getEngineContext(),
                             null) {
 
                         @Override
@@ -312,6 +317,7 @@ public class CheckpointCoordinatorTest
                         server.getCheckpointService().getCheckpointStorage(),
                         instance.getExecutorService("test"),
                         nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                        server.getEngineContext(),
                         null);
 
         TaskGroupLocation group1 = new TaskGroupLocation(1L, 1, 1);
@@ -1075,6 +1081,7 @@ class TestCheckpointManager extends CheckpointManager {
             CheckpointStorage checkpointStorage,
             ExecutorService executorService,
             IMap<Object, Object> runningJobStateIMap,
+            SeaTunnelEngineContext engineContext,
             CheckpointMonitorService checkpointMonitorService) {
         super(
                 jobId,
@@ -1086,6 +1093,7 @@ class TestCheckpointManager extends CheckpointManager {
                 checkpointStorage,
                 executorService,
                 runningJobStateIMap,
+                engineContext,
                 checkpointMonitorService);
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.common.statestore.counter.CounterStateStore;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -36,13 +37,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import com.hazelcast.map.IMap;
-
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.seatunnel.engine.common.Constant.IMAP_CHECKPOINT_ID;
 import static org.apache.seatunnel.engine.common.Constant.IMAP_RUNNING_JOB_STATE;
 
 @DisabledOnOs(OS.WINDOWS)
@@ -50,7 +48,7 @@ import static org.apache.seatunnel.engine.common.Constant.IMAP_RUNNING_JOB_STATE
 public class CheckpointManagerTest extends AbstractSeaTunnelServerTest {
 
     @Test
-    public void testHAByIMapCheckpointIDCounter() throws CheckpointStorageException {
+    public void testHAByStateStoreCheckpointIDCounter() throws CheckpointStorageException {
         long jobId = (long) (Math.random() * 1000000L);
         CheckpointStorage checkpointStorage =
                 FactoryUtil.discoverFactory(
@@ -75,9 +73,10 @@ public class CheckpointManagerTest extends AbstractSeaTunnelServerTest {
                         .checkpointId(1)
                         .states(new ProtoStuffSerializer().serialize(completedCheckpoint))
                         .build());
-        IMap<Integer, Long> checkpointIdMap =
-                nodeEngine.getHazelcastInstance().getMap(String.format(IMAP_CHECKPOINT_ID, jobId));
-        checkpointIdMap.put(1, 2L);
+        CounterStateStore<String> checkpointCounterStore =
+                server.getEngineContext().getStateStores().checkpointCounterStore();
+        String counterKey = StateStoreCheckpointIDCounter.convertLongIntToBase64(jobId, 1);
+        checkpointCounterStore.set(counterKey, 2L);
         Map<Integer, CheckpointPlan> planMap = new HashMap<>();
         planMap.put(1, CheckpointPlan.builder().pipelineId(1).build());
         CheckpointManager checkpointManager =
@@ -91,10 +90,11 @@ public class CheckpointManagerTest extends AbstractSeaTunnelServerTest {
                         server.getCheckpointService().getCheckpointStorage(),
                         instance.getExecutorService("test"),
                         nodeEngine.getHazelcastInstance().getMap(IMAP_RUNNING_JOB_STATE),
+                        server.getEngineContext(),
                         null);
         Assertions.assertTrue(checkpointManager.isCompletedPipeline(1));
         checkpointManager.listenPipeline(1, PipelineStatus.FINISHED);
-        Assertions.assertNull(checkpointIdMap.get(1));
+        Assertions.assertEquals(0L, checkpointCounterStore.get(counterKey));
         checkpointManager.clearCheckpointIfNeed(JobStatus.FINISHED);
         Assertions.assertTrue(checkpointStorage.getAllCheckpoints(jobId + "").isEmpty());
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreMetricExportsTest.java
@@ -117,7 +117,7 @@ class EngineStateStoreMetricExportsTest {
                                 Constant.IMAP_FINISHED_JOB_VERTEX_INFO,
                                 EngineStateStoreNames.CHECKPOINT_MONITOR,
                                 Constant.IMAP_CONNECTOR_JAR_REF_COUNTERS,
-                                Constant.IMAP_CHECKPOINT_ID,
+                                EngineStateStoreNames.CHECKPOINT_ID,
                                 Constant.IMAP_PENDING_PIPELINE_CLEANUP)),
                 exportedStores);
     }


### PR DESCRIPTION
Related: #10804 

### Purpose of this pull request

Abstract the checkpoint id counter map behind a dedicated `CounterStateStore` interface and wire it through `EngineStateStores`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
