### PR TITLE
[Fix][API] Preserve extension exception context in conditional validation

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/ConditionEvaluators.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/ConditionEvaluators.java
@@ -46,15 +46,10 @@ public final class ConditionEvaluators {
             throw new OptionValidationException(
                     "Condition for option '%s' has a null operator", condition.getOption().key());
         }
-        try {
-            Object value = config.get(condition.getOption());
-            Evaluator evaluator = REGISTRY.get(operator);
-            return evaluator.evaluate(value, condition, config);
-        } catch (OptionValidationException e) {
-            throw new OptionValidationException(
-                    "Failed to evaluate constraint '%s' on option '%s': %s",
-                    condition.toString(), condition.getOption().key(), e.getRawMessage());
-        }
+
+        Object value = config.get(condition.getOption());
+        Evaluator evaluator = REGISTRY.get(operator);
+        return evaluator.evaluate(value, condition, config);
     }
 
     @SuppressWarnings({"rawtypes"})

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/ConfigValidator.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/util/ConfigValidator.java
@@ -213,8 +213,17 @@ public class ConfigValidator {
         }
 
         for (ConditionRule conditionRule : rule.getConditionRules()) {
-            if (validate(conditionRule.getExpression())) {
-                collectErrors(conditionRule.getOptionRule(), conditionRule.getExpression(), errors);
+            try {
+                if (validate(conditionRule.getExpression())) {
+                    collectErrors(
+                            conditionRule.getOptionRule(), conditionRule.getExpression(), errors);
+                }
+            } catch (OptionValidationException e) {
+                errors.add(
+                        formatError(
+                                conditionRule.getExpression().toString(),
+                                TYPE_CONDITIONAL,
+                                e.getRawMessage()));
             }
         }
 

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/ConfigValidatorTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/util/ConfigValidatorTest.java
@@ -3598,4 +3598,58 @@ public class ConfigValidatorTest {
                 msg.contains("port value -1 is not positive"),
                 "extension exception message should be preserved: " + msg);
     }
+
+    @Test
+    public void testConditionalExpressionExceptionUsesWholeExpressionContext() {
+        ConditionExtension<Integer> throwingExtension =
+                new ConditionExtension<Integer>() {
+                    @Override
+                    public String description() {
+                        return "must be positive";
+                    }
+
+                    @Override
+                    public boolean evaluate(ReadonlyConfig config, Integer value)
+                            throws OptionValidationException {
+                        if (value != null && value <= 0) {
+                            throw new OptionValidationException(
+                                    "port value %d is not positive", value);
+                        }
+                        return true;
+                    }
+                };
+
+        Expression expression =
+                Expression.of(
+                        Condition.of(MODE, "stream")
+                                .and(Conditions.extension(PORT, throwingExtension)));
+        OptionRule rule =
+                new OptionRule(
+                        Arrays.asList(MODE, PORT),
+                        Collections.emptyList(),
+                        Collections.singletonList(
+                                new ConditionRule(
+                                        expression,
+                                        new OptionRule(
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList()))),
+                        Collections.emptyList());
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(MODE.key(), "stream");
+        config.put(PORT.key(), -1);
+
+        OptionValidationException ex =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () -> ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule));
+        String msg = ex.getMessage();
+        Assertions.assertTrue(msg.contains("Option validation failed (1 error):"), msg);
+        Assertions.assertTrue(
+                msg.contains("[1] option: ('mode' == stream && 'port' must be positive)"), msg);
+        Assertions.assertTrue(msg.contains("type: conditional"), msg);
+        Assertions.assertTrue(msg.contains("constraint: port value -1 is not positive"), msg);
+    }
 }


### PR DESCRIPTION
### Purpose of this pull request

This pull request fixes distorted conditional validation errors in `seatunnel-api`.

- Remove the `try/catch` wrapping from `ConditionEvaluators#evaluate`, which was rewriting `OptionValidationException` thrown by the `EXTENSION` operator during conditional evaluation.
- Catch `OptionValidationException` at the `ConditionRule` level in `ConfigValidator` so the aggregated validation error is reported against the full conditional expression context.

### Does this PR introduce _any_ user-facing change?

Yes. When an `EXTENSION` condition throws `OptionValidationException` inside a conditional rule, the original validation message is now preserved and reported against the whole condition expression instead of being rewritten at the per-condition level.

### How was this patch tested?

```bash
./mvnw spotless:apply
./mvnw -q -DskipTests verify
./mvnw -pl seatunnel-api -Dtest=ConfigValidatorTest test
```

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
