### PR TITLE
[Fix][Connector-V2] Support PostgreSQL enum in JDBC source

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeConverter.java
@@ -34,6 +34,8 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseI
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 
+import java.sql.Types;
+
 // reference http://www.postgres.cn/docs/13/datatype.html
 @Slf4j
 @AutoService(TypeConverter.class)
@@ -283,6 +285,11 @@ public class PostgresTypeConverter implements TypeConverter<BasicTypeDefine> {
                 }
                 break;
             default:
+                if (typeDefine.getSqlType() == Types.OTHER) {
+                    builder.dataType(BasicType.STRING_TYPE);
+                    builder.sourceType(typeDefine.getColumnType());
+                    break;
+                }
                 throw CommonError.convertToSeaTunnelTypeError(
                         identifier(), typeDefine.getDataType(), typeDefine.getName());
         }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeMapper.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeMapper.java
@@ -44,6 +44,7 @@ public class PostgresTypeMapper implements JdbcDialectTypeMapper {
                         .name(columnName)
                         .columnType(nativeType)
                         .dataType(nativeType)
+                        .sqlType(metadata.getColumnType(colIndex))
                         .nullable(isNullable == ResultSetMetaData.columnNullable)
                         .length((long) precision)
                         .precision((long) precision)

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresTypeConverterTest.java
@@ -31,6 +31,13 @@ import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class PostgresTypeConverterTest {
     @Test
     public void testConvertUnsupported() {
@@ -264,6 +271,42 @@ public class PostgresTypeConverterTest {
         Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
         Assertions.assertEquals(null, column.getColumnLength());
         Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+    }
+
+    @Test
+    public void testConvertCustomEnumAsString() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("status")
+                        .columnType("JobStatus")
+                        .dataType("JobStatus")
+                        .sqlType(Types.OTHER)
+                        .nullable(true)
+                        .build();
+
+        Column column = PostgresTypeConverter.INSTANCE.convert(typeDefine);
+
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+        Assertions.assertTrue(column.isNullable());
+    }
+
+    @Test
+    public void testTypeMapperPassesJdbcTypeForCustomEnum() throws SQLException {
+        ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+        when(metadata.getColumnLabel(1)).thenReturn("status");
+        when(metadata.getColumnTypeName(1)).thenReturn("JobStatus");
+        when(metadata.getColumnType(1)).thenReturn(Types.OTHER);
+        when(metadata.isNullable(1)).thenReturn(ResultSetMetaData.columnNullable);
+        when(metadata.getPrecision(1)).thenReturn(0);
+        when(metadata.getScale(1)).thenReturn(0);
+
+        Column column = new PostgresTypeMapper().mappingColumn(metadata, 1);
+
+        Assertions.assertEquals("status", column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals("JobStatus", column.getSourceType());
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Fixes #9835. PostgreSQL custom ENUM columns are reported by the JDBC driver as `Types.OTHER` with the enum type name, such as `JobStatus`. SeaTunnel treated that type name as unsupported and failed JDBC source initialization.

### Changes

- Map PostgreSQL `Types.OTHER` columns to SeaTunnel string columns while preserving the original source type name.
- Pass the JDBC type code through `PostgresTypeMapper` when building column metadata from `ResultSetMetaData`.
- Add unit coverage for PostgreSQL custom enum metadata.

### Validation

- `./mvnw -pl seatunnel-connectors-v2/connector-jdbc -DskipIT -Dskip.spotless=true -Dtest=PostgresTypeConverterTest test`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`