### PR TITLE
[Test][E2E] Avoid SQLServer CDC driver download in container

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
@@ -45,6 +45,7 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
+import org.testcontainers.utility.MountableFile;
 
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
@@ -195,20 +196,28 @@ public class SqlServerCDCIT extends TestSuiteBase implements TestResource {
                             new Slf4jLogConsumer(
                                     DockerLoggerFactory.getLogger("sqlserver-docker-image")));
 
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/9.4.1.jre8/mssql-jdbc-9.4.1.jre8.jar";
+    private String driverJarPath() {
+        return Paths.get(
+                        System.getProperty("user.home"),
+                        ".m2/repository/com/microsoft/sqlserver/mssql-jdbc/9.4.1.jre8/mssql-jdbc-9.4.1.jre8.jar")
+                .toString();
     }
 
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
+                String driverJarPath = driverJarPath();
+                Assertions.assertTrue(
+                        Files.exists(Paths.get(driverJarPath)),
+                        "SQLServer JDBC driver should be resolved by Maven before E2E runs: "
+                                + driverJarPath);
                 Container.ExecResult extraCommands =
                         container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/SqlServer-CDC/lib && cd /tmp/seatunnel/plugins/SqlServer-CDC/lib && wget "
-                                        + driverUrl());
+                                "bash", "-c", "mkdir -p /tmp/seatunnel/plugins/SqlServer-CDC/lib");
                 Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(driverJarPath),
+                        "/tmp/seatunnel/plugins/SqlServer-CDC/lib/mssql-jdbc-9.4.1.jre8.jar");
             };
 
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
@@ -53,6 +53,7 @@ import io.debezium.relational.TableId;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/sqlserver/SqlServerCDCIT.java
@@ -47,13 +47,14 @@ import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.MountableFile;
 
+import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -196,20 +197,31 @@ public class SqlServerCDCIT extends TestSuiteBase implements TestResource {
                             new Slf4jLogConsumer(
                                     DockerLoggerFactory.getLogger("sqlserver-docker-image")));
 
-    private String driverJarPath() {
-        return Paths.get(
-                        System.getProperty("user.home"),
-                        ".m2/repository/com/microsoft/sqlserver/mssql-jdbc/9.4.1.jre8/mssql-jdbc-9.4.1.jre8.jar")
-                .toString();
+    /**
+     * Resolve the SQLServer JDBC test dependency from the active test classpath instead of
+     * hard-coding a Maven local repository path.
+     */
+    private Path driverJarPath() {
+        try {
+            return Paths.get(
+                    SQLServerDriver.class
+                            .getProtectionDomain()
+                            .getCodeSource()
+                            .getLocation()
+                            .toURI());
+        } catch (Exception e) {
+            throw new SeaTunnelException(
+                    "Failed to resolve SQLServer JDBC driver jar from the test classpath", e);
+        }
     }
 
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                String driverJarPath = driverJarPath();
+                Path driverJarPath = driverJarPath();
                 Assertions.assertTrue(
-                        Files.exists(Paths.get(driverJarPath)),
-                        "SQLServer JDBC driver should be resolved by Maven before E2E runs: "
+                        Files.isRegularFile(driverJarPath),
+                        "SQLServer JDBC driver should be resolved from the test classpath before E2E runs: "
                                 + driverJarPath);
                 Container.ExecResult extraCommands =
                         container.execInContainer(


### PR DESCRIPTION
### Purpose
Fix an unrelated SQLServer CDC E2E CI failure where the test container downloads the SQLServer JDBC driver with `wget` from Maven Central during runtime. That path can fail with transient TLS/network errors such as `Unable to establish SSL connection`, even though Maven has already resolved the same driver for the module.

### Changes
- Reuse the Maven-resolved `mssql-jdbc-9.4.1.jre8.jar` from the local repository.
- Copy the driver into `/tmp/seatunnel/plugins/SqlServer-CDC/lib` via Testcontainers instead of downloading it inside the container.
- Keep the driver version unchanged and do not modify `pom.xml`.

### Validation
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-sqlserver-e2e spotless:apply -nsu -Dmaven.gitcommitid.skip=true`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home ./mvnw -B -pl :connector-cdc-sqlserver-e2e -DskipTests -DskipITs=true -Dlicense.skipAddThirdParty=true -Dskip.ui=true -Dskip.spotless=true -Dmaven.gitcommitid.skip=true -nsu test-compile`

Full Testcontainers E2E was not run locally because Docker daemon is not available on this machine (`Cannot connect to the Docker daemon`). `seatunnel-engine-ui` was not built because this change only touches a connector E2E Java test.