### PR TITLE
[Test][E2E] Retry RocketMQ restore offset checks

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
@@ -88,6 +88,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.e2e.connector.rocketmq.RocketMqContainer.NAMESRV_PORT;
@@ -653,9 +654,8 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
                 .atMost(5, TimeUnit.MINUTES)
                 .until(() -> getTopicMaxOffset(sinkTopic) >= expectedSinkAfterFirstRun + 15);
 
-        Thread.sleep(5000);
-        long finalSinkOffset = getTopicMaxOffset(sinkTopic);
         long expectedTotal = expectedSinkAfterFirstRun + 15;
+        long finalSinkOffset = awaitTopicMaxOffset(sinkTopic, expectedTotal, Duration.ofMinutes(1));
         Assertions.assertEquals(
                 expectedTotal,
                 finalSinkOffset,
@@ -722,11 +722,41 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
         return result;
     }
 
+    /**
+     * Waits for RocketMQ admin offset visibility and returns the successful observed offset.
+     *
+     * <p>This keeps the final restore assertion from depending on a single broker metadata read.
+     */
+    private long awaitTopicMaxOffset(String topicName, long expectedOffset, Duration timeout) {
+        AtomicLong observedOffset = new AtomicLong();
+        Awaitility.await()
+                .pollInterval(2, TimeUnit.SECONDS)
+                .atMost(timeout)
+                .until(
+                        () -> {
+                            long current = getTopicMaxOffset(topicName);
+                            observedOffset.set(current);
+                            return current >= expectedOffset;
+                        });
+        return observedOffset.get();
+    }
+
+    /**
+     * Reads topic max offsets with retries because RocketMQ admin queries can temporarily fail
+     * during restore and broker channel transitions.
+     */
     private long getTopicMaxOffset(String topicName) {
         try {
             List<Map<MessageQueue, TopicOffset>> offsetTopics =
-                    RocketMqAdminUtil.offsetTopics(
-                            newConfiguration(), Lists.newArrayList(topicName));
+                    RetryUtils.retryWithException(
+                            () ->
+                                    RocketMqAdminUtil.offsetTopics(
+                                            newConfiguration(), Lists.newArrayList(topicName)),
+                            new RetryUtils.RetryMaterial(
+                                    Constant.OPERATION_RETRY_TIME,
+                                    true,
+                                    exception -> true,
+                                    Constant.OPERATION_RETRY_SLEEP));
             if (offsetTopics.isEmpty()) {
                 return 0;
             }


### PR DESCRIPTION
### Purpose
Fix an unrelated RocketMQ restore E2E CI failure where the final max-offset assertion can read `0` from a transient RocketMQ admin query even after earlier polling observed the sink topic reaching the expected offset.

### Changes
- Replace the fixed post-restore sleep plus one-shot offset read with an Awaitility helper that returns the successful observed offset.
- Retry `RocketMqAdminUtil.offsetTopics` because admin queries can temporarily fail during restore and broker channel transitions.
- Keep the production connector code and dependencies unchanged. No `pom.xml` changes.

### Validation
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e spotless:apply -nsu -Dmaven.gitcommitid.skip=true`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home ./mvnw -B -pl :connector-rocketmq-e2e -DskipTests -DskipITs=true -Dlicense.skipAddThirdParty=true -Dskip.ui=true -Dskip.spotless=true -Dmaven.gitcommitid.skip=true -nsu test-compile`

Full Testcontainers E2E was not run locally because Docker daemon is not available on this machine (`Cannot connect to the Docker daemon`). `seatunnel-engine-ui` was not built because this change only touches a connector E2E Java test.