### PR TITLE
[Fix][Transform-V2] Parse custom LLM array string response

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/remote/custom/CustomModel.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/nlpmodel/llm/remote/custom/CustomModel.java
@@ -95,13 +95,21 @@ public class CustomModel extends AbstractModel {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new IOException("Failed to get vector from custom, response: " + responseStr);
         }
+        Object parsedResponse = parseResponse(responseStr);
+        if (parsedResponse instanceof String) {
+            String result = (String) parsedResponse;
+            try {
+                return OBJECT_MAPPER.readValue(
+                        convertData(result), new TypeReference<List<String>>() {});
+            } catch (Exception e) {
+                return Collections.singletonList(convertData(result));
+            }
+        }
         try {
-            return OBJECT_MAPPER.convertValue(
-                    parseResponse(responseStr), new TypeReference<List<String>>() {});
+            return OBJECT_MAPPER.convertValue(parsedResponse, new TypeReference<List<String>>() {});
         } catch (Exception e) {
             String result =
-                    OBJECT_MAPPER.convertValue(
-                            parseResponse(responseStr), new TypeReference<String>() {});
+                    OBJECT_MAPPER.convertValue(parsedResponse, new TypeReference<String>() {});
             return Collections.singletonList(result);
         }
     }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/llm/LLMRequestJsonTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/llm/LLMRequestJsonTest.java
@@ -296,4 +296,71 @@ public class LLMRequestJsonTest {
             mockWebServer.shutdown();
         }
     }
+
+    @Test
+    void testCustomOpenAIContentArrayString() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        try {
+            String mockBaseUrl = mockWebServer.url("/v1/chat/completions").toString();
+            String jsonResponse =
+                    "{\n"
+                            + "    \"choices\": [\n"
+                            + "        {\n"
+                            + "            \"message\": {\n"
+                            + "                \"role\": \"assistant\",\n"
+                            + "                \"content\": \"[\\\"sfsfsafasfsfasf\\\"]\"\n"
+                            + "            },\n"
+                            + "            \"finish_reason\": \"stop\",\n"
+                            + "            \"index\": 0\n"
+                            + "        }\n"
+                            + "    ]\n"
+                            + "}";
+
+            mockWebServer.enqueue(
+                    new MockResponse()
+                            .setBody(jsonResponse)
+                            .addHeader("Content-Type", "application/json"));
+
+            SeaTunnelRowType rowType =
+                    new SeaTunnelRowType(
+                            new String[] {"content"},
+                            new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+
+            Map<String, String> header = new HashMap<>();
+            header.put("Content-Type", "application/json");
+
+            Map<String, Object> message = new HashMap<>();
+            message.put("role", "user");
+            message.put("content", "${input}");
+
+            Map<String, Object> resultMap = new HashMap<>();
+            resultMap.put("model", "${model}");
+            resultMap.put("messages", Collections.singletonList(message));
+
+            CustomModel model =
+                    new CustomModel(
+                            rowType,
+                            SqlType.STRING,
+                            Collections.singletonList("content"),
+                            "summary",
+                            "custom-model",
+                            mockBaseUrl,
+                            header,
+                            resultMap,
+                            "$.choices[0].message.content");
+            try {
+                SeaTunnelRow row = new SeaTunnelRow(rowType.getFieldTypes().length);
+                row.setField(0, "test");
+
+                List<String> result = model.inference(Collections.singletonList(row));
+
+                Assertions.assertEquals(Collections.singletonList("sfsfsafasfsfasf"), result);
+            } finally {
+                model.close();
+            }
+        } finally {
+            mockWebServer.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
### Purpose

Fixes #9998. Custom LLM responses can return `choices[0].message.content` as a string that itself contains a JSON array, such as `["value"]`. The transform previously treated that value as a plain string, so users saw the array literal in the output column.

### Changes

- Parse custom LLM string responses as a JSON list when possible.
- Keep plain string responses as a single output value.
- Avoid parsing the same custom response multiple times.
- Add unit coverage for OpenAI-compatible custom responses whose content is a JSON array string.

### Validation

- `./mvnw -pl seatunnel-transforms-v2 -DskipIT -Dskip.spotless=true -Dtest=LLMRequestJsonTest test`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`