### PR TITLE
[Test][E2E] Wait for failover task graph before cancel

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
@@ -28,8 +28,14 @@ import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.ScheduleStrategy;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalVertex;
+import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
+import org.apache.seatunnel.engine.server.execution.ExecutionState;
+import org.apache.seatunnel.engine.server.master.JobMaster;
 
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
@@ -148,6 +154,7 @@ public class SplitClusterPendingJobLifecycleFailoverIT {
                                             3, standbyMaster.getCluster().getMembers().size()));
             assertJobStatusWithTimeout(pendingJobAfterFailover, JobStatus.RUNNING, 180);
             assertPendingQueueNotContainsJob(standbyMaster, pendingJobId);
+            assertRunningJobGraphWithTimeout(standbyMaster, pendingJobId, 120);
 
             pendingJobAfterFailover.cancelJob();
             assertJobStatusWithTimeout(pendingJobAfterFailover, JobStatus.CANCELED, 120);
@@ -287,6 +294,66 @@ public class SplitClusterPendingJobLifecycleFailoverIT {
                         () ->
                                 Assertions.assertEquals(
                                         expectedStatus, clientJobProxy.getJobStatus()));
+    }
+
+    /**
+     * Waits until failover restore has rebuilt the running graph on the active master.
+     *
+     * <p>The top-level job status can turn RUNNING before every restored pipeline and task vertex
+     * has reacquired slots and reported RUNNING. Cancelling earlier makes this test depend on a
+     * restore/cancel race instead of pending-job scheduling.
+     */
+    private static void assertRunningJobGraphWithTimeout(
+            HazelcastInstanceImpl activeMaster, long jobId, long timeoutSeconds) {
+        Awaitility.await()
+                .atMost(timeoutSeconds, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            JobMaster jobMaster = getJobMaster(activeMaster, jobId);
+                            Assertions.assertNotNull(
+                                    jobMaster,
+                                    "Job master should exist before checking restored task states");
+                            PhysicalPlan physicalPlan = jobMaster.getPhysicalPlan();
+                            Assertions.assertEquals(JobStatus.RUNNING, physicalPlan.getJobStatus());
+                            physicalPlan
+                                    .getPipelineList()
+                                    .forEach(
+                                            SplitClusterPendingJobLifecycleFailoverIT
+                                                    ::assertRunningSubPlan);
+                        });
+    }
+
+    /**
+     * Asserts that one restored pipeline and all of its task vertices are fully running.
+     *
+     * <p>This keeps the following cancel assertion focused on the lifecycle transition instead of
+     * racing against delayed task deployment after master failover.
+     */
+    private static void assertRunningSubPlan(SubPlan subPlan) {
+        Assertions.assertEquals(PipelineStatus.RUNNING, subPlan.getPipelineState());
+        subPlan.getCoordinatorVertexList()
+                .forEach(SplitClusterPendingJobLifecycleFailoverIT::assertRunningVertex);
+        subPlan.getPhysicalVertexList()
+                .forEach(SplitClusterPendingJobLifecycleFailoverIT::assertRunningVertex);
+    }
+
+    /**
+     * Asserts that one task vertex has completed deployment and reported RUNNING.
+     *
+     * <p>A restored vertex can lag behind the top-level job status while resources are assigned, so
+     * the test must observe the vertex state directly before cancelling.
+     */
+    private static void assertRunningVertex(PhysicalVertex physicalVertex) {
+        Assertions.assertEquals(ExecutionState.RUNNING, physicalVertex.getExecutionState());
+    }
+
+    /**
+     * Reads the current job master from the active SeaTunnel server embedded in the test cluster.
+     */
+    private static JobMaster getJobMaster(HazelcastInstanceImpl activeMaster, long jobId) {
+        SeaTunnelServer server =
+                activeMaster.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+        return server.getCoordinatorService().getJobMaster(jobId);
     }
 
     private static HazelcastInstanceImpl waitAndFindActiveMaster(


### PR DESCRIPTION
### Purpose
Stabilize SplitClusterPendingJobLifecycleFailoverIT.testPendingJobLifecycleInMasterFailover after CI observed the job remain in CANCELING for two minutes.

### Root cause
After master failover, the top-level job status can become RUNNING before every restored pipeline and task vertex has reacquired slots and reported RUNNING. Cancelling immediately after the top-level state check races with restore and resource scheduling, so the assertion can observe CANCELING instead of the final CANCELED state.

### Changes
- Wait for the active master restored physical plan to have all pipelines and physical or coordinator vertices in RUNNING state before issuing cancelJob.
- Keep the assertion focused on the pending-job lifecycle transition without changing production cancellation logic.

### Validation
- ./mvnw -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base spotless:apply -nsu -Dmaven.gitcommitid.skip=true
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home ./mvnw -B -pl :connector-seatunnel-e2e-base -DskipTests -DskipITs=true -Dlicense.skipAddThirdParty=true -Dskip.ui=true -Dskip.spotless=true -Dmaven.gitcommitid.skip=true -nsu test-compile
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home ./mvnw -B -pl :connector-seatunnel-e2e-base -DskipITs=false -DskipTests=false -Dtest=SplitClusterPendingJobLifecycleFailoverIT#testPendingJobLifecycleInMasterFailover -Dmaven.test.dependency.excludes=org.apache.seatunnel:seatunnel-flink-starter-common,org.apache.seatunnel:seatunnel-flink-13-starter,org.apache.seatunnel:seatunnel-flink-15-starter,org.apache.seatunnel:seatunnel-flink-20-starter,org.apache.seatunnel:seatunnel-spark-starter-common,org.apache.seatunnel:seatunnel-spark-2-starter,org.apache.seatunnel:seatunnel-spark-3-starter -Dlicense.skipAddThirdParty=true -Dskip.ui=true -Dskip.spotless=true -Dmaven.gitcommitid.skip=true -nsu clean test

seatunnel-engine-ui was not modified. It was not revalidated directly beyond the Maven dependency path used by the engine E2E test.