### PR TITLE
[Feature][Flink] Support MetadataProvider SPI in Flink starter

### DIFF
--- a/docs/en/introduction/concepts/metadata-spi.md
+++ b/docs/en/introduction/concepts/metadata-spi.md
@@ -172,13 +172,15 @@ To enable the Metadata Center, add the following configuration to `seatunnel.yam
 ```yaml
 seatunnel:
   engine:
-     metadata:
+    metadata:
       enabled: true
       kind: gravitino
       gravitino:
         uri: http://127.0.0.1:8090
         metalake: test_metalake
 ```
+
+SeaTunnel Zeta and the Flink starter read this configuration from `$SEATUNNEL_HOME/config/seatunnel.yaml`.
 
 ### Configuration Options
 

--- a/docs/zh/introduction/concepts/metadata-spi.md
+++ b/docs/zh/introduction/concepts/metadata-spi.md
@@ -171,13 +171,15 @@ public interface MetadataProvider extends AutoCloseable {
 ```yaml
 seatunnel:
   engine:
-     metadata:
+    metadata:
       enabled: true
       kind: gravitino
       gravitino:
         uri: http://127.0.0.1:8090
         metalake: test_metalake
 ```
+
+SeaTunnel Zeta 和 Flink starter 会从 `$SEATUNNEL_HOME/config/seatunnel.yaml` 读取该配置。
 
 ### 配置选项
 

--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigBuilder.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigBuilder.java
@@ -26,6 +26,8 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigSyntax;
 import org.apache.seatunnel.shade.com.typesafe.config.impl.Parseable;
 
 import org.apache.seatunnel.api.configuration.ConfigAdapter;
+import org.apache.seatunnel.api.metadata.MetadataConfig;
+import org.apache.seatunnel.api.metadata.MetadataOptions;
 import org.apache.seatunnel.api.sink.TablePlaceholder;
 import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.common.utils.ParserException;
@@ -34,9 +36,11 @@ import org.apache.seatunnel.core.starter.exception.ConfigCheckException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,10 +67,15 @@ public class ConfigBuilder {
     }
 
     private static Config ofInner(@NonNull Path filePath, List<String> variables) {
+        Config config = parseConfigFile(filePath);
+        return ConfigShadeUtils.decryptConfig(backfillUserVariables(config, variables));
+    }
+
+    private static Config parseConfigFile(@NonNull Path filePath) {
         Config config =
                 ConfigFactory.parseFile(filePath.toFile())
                         .resolve(ConfigResolveOptions.defaults().setAllowUnresolved(true));
-        return ConfigShadeUtils.decryptConfig(backfillUserVariables(config, variables));
+        return config;
     }
 
     public static Config of(@NonNull String filePath) {
@@ -312,5 +321,174 @@ public class ConfigBuilder {
                                 ConfigFactory.systemProperties(),
                                 ConfigResolveOptions.defaults().setAllowUnresolved(true));
         return config.root().render(CONFIG_RENDER_OPTIONS);
+    }
+
+    /**
+     * Parses MetadataConfig from the default seatunnel.yaml file.
+     *
+     * <p>The default path is $SEATUNNEL_HOME/config/seatunnel.yaml. If the file doesn't exist or
+     * metadata is not configured, returns a default MetadataConfig (disabled).
+     *
+     * @return MetadataConfig parsed from seatunnel.yaml, or default MetadataConfig if not found
+     */
+    public static MetadataConfig parseMetadataConfigFromSeatunnelYaml() {
+        String seatunnelHome = getSeatunnelHome();
+        if (seatunnelHome == null) {
+            log.info("SEATUNNEL_HOME not set, metadata provider disabled");
+            return new MetadataConfig();
+        }
+
+        Path yamlPath = Paths.get(seatunnelHome, "config", "seatunnel.yaml");
+        if (!Files.exists(yamlPath)) {
+            log.info("seatunnel.yaml not found at {}, metadata provider disabled", yamlPath);
+            return new MetadataConfig();
+        }
+
+        try {
+            return parseMetadataConfig(yamlPath);
+        } catch (Exception e) {
+            log.warn("Failed to parse seatunnel.yaml for metadata config: {}", e.getMessage());
+            return new MetadataConfig();
+        }
+    }
+
+    /**
+     * Gets the SEATUNNEL_HOME from environment variables or system properties.
+     *
+     * @return the SEATUNNEL_HOME path, or null if not set
+     */
+    private static String getSeatunnelHome() {
+        String home = System.getenv("SEATUNNEL_HOME");
+        if (home == null) {
+            home = System.getProperty("SEATUNNEL_HOME");
+        }
+        return home;
+    }
+
+    private static MetadataConfig parseMetadataConfig(Path yamlPath) throws Exception {
+        MetadataConfig config = new MetadataConfig();
+        Map<String, String> properties = new HashMap<>();
+        int seatunnelIndent = -1;
+        int engineIndent = -1;
+        int metadataIndent = -1;
+        int providerIndent = -1;
+        String providerKind = MetadataOptions.KIND.defaultValue();
+
+        for (String line : Files.readAllLines(yamlPath)) {
+            String trimmedLine = stripComment(line).trim();
+            if (trimmedLine.isEmpty()) {
+                continue;
+            }
+
+            int indent = countLeadingSpaces(line);
+            if (metadataIndent < 0 && seatunnelIndent >= 0 && indent <= seatunnelIndent) {
+                engineIndent = -1;
+            }
+            if (metadataIndent < 0 && engineIndent >= 0 && indent <= engineIndent) {
+                engineIndent = -1;
+            }
+            if (metadataIndent >= 0 && indent <= metadataIndent) {
+                break;
+            }
+
+            if (metadataIndent < 0) {
+                String section = parseSection(trimmedLine);
+                if ("seatunnel".equals(section)) {
+                    seatunnelIndent = indent;
+                } else if (seatunnelIndent >= 0
+                        && indent == seatunnelIndent + 2
+                        && "engine".equals(section)) {
+                    engineIndent = indent;
+                } else if (engineIndent >= 0
+                        && indent == engineIndent + 2
+                        && "metadata".equals(section)) {
+                    metadataIndent = indent;
+                }
+                continue;
+            }
+
+            if (indent == metadataIndent + 2) {
+                providerIndent = -1;
+                KeyValue keyValue = parseKeyValue(trimmedLine);
+                if (keyValue == null) {
+                    String section = parseSection(trimmedLine);
+                    if (providerKind.equalsIgnoreCase(section)) {
+                        providerIndent = indent;
+                    }
+                    continue;
+                }
+
+                if (MetadataOptions.ENABLED.key().equals(keyValue.key)) {
+                    config.setEnabled(Boolean.parseBoolean(keyValue.value));
+                } else if (MetadataOptions.KIND.key().equals(keyValue.key)) {
+                    providerKind = keyValue.value;
+                    config.setKind(providerKind);
+                }
+                continue;
+            }
+
+            if (providerIndent >= 0 && indent == providerIndent + 2) {
+                KeyValue keyValue = parseKeyValue(trimmedLine);
+                if (keyValue != null) {
+                    properties.put(keyValue.key, keyValue.value);
+                }
+            }
+        }
+
+        config.setProperties(properties);
+
+        return config;
+    }
+
+    private static String stripComment(String line) {
+        int commentIndex = line.indexOf('#');
+        if (commentIndex < 0) {
+            return line;
+        }
+        return line.substring(0, commentIndex);
+    }
+
+    private static int countLeadingSpaces(String line) {
+        int count = 0;
+        while (count < line.length() && line.charAt(count) == ' ') {
+            count++;
+        }
+        return count;
+    }
+
+    private static String parseSection(String line) {
+        if (!line.endsWith(":")) {
+            return null;
+        }
+        return line.substring(0, line.length() - 1).trim();
+    }
+
+    private static KeyValue parseKeyValue(String line) {
+        int separatorIndex = line.indexOf(':');
+        if (separatorIndex <= 0 || separatorIndex == line.length() - 1) {
+            return null;
+        }
+        String key = line.substring(0, separatorIndex).trim();
+        String value = unquote(line.substring(separatorIndex + 1).trim());
+        return new KeyValue(key, value);
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2
+                && ((value.startsWith("\"") && value.endsWith("\""))
+                        || (value.startsWith("'") && value.endsWith("'")))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static class KeyValue {
+        private final String key;
+        private final String value;
+
+        private KeyValue(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
     }
 }

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigBuilderTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigBuilderTest.java
@@ -17,9 +17,15 @@
 
 package org.apache.seatunnel.core.starter.utils;
 
+import org.apache.seatunnel.api.metadata.MetadataConfig;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -43,5 +49,60 @@ public class ConfigBuilderTest {
                         config, ConfigShadeUtils.getSensitiveOptions(null));
         List<String> keys = new ArrayList<>(desensitizationConfig.keySet());
         Assertions.assertIterableEquals(Arrays.asList("a", "b", "c", "d", "e", "f"), keys);
+    }
+
+    @Test
+    @ClearEnvironmentVariable(key = "SEATUNNEL_HOME")
+    public void testParseMetadataConfigFromSeatunnelYaml(@TempDir Path tempDir) throws Exception {
+        Path configDir = tempDir.resolve("config");
+        Files.createDirectories(configDir);
+        Files.write(
+                configDir.resolve("seatunnel.yaml"),
+                Arrays.asList(
+                        "seatunnel:",
+                        "  engine:",
+                        "    metadata:",
+                        "      enabled: true",
+                        "      kind: gravitino",
+                        "      gravitino:",
+                        "        uri: http://localhost:8090",
+                        "        metalake: test_metalake"));
+
+        String originalHome = System.getProperty("SEATUNNEL_HOME");
+        System.setProperty("SEATUNNEL_HOME", tempDir.toString());
+        try {
+            MetadataConfig metadataConfig = ConfigBuilder.parseMetadataConfigFromSeatunnelYaml();
+
+            Assertions.assertTrue(metadataConfig.isEnabled());
+            Assertions.assertEquals("gravitino", metadataConfig.getKind());
+            Assertions.assertEquals(
+                    "http://localhost:8090", metadataConfig.getProperties().get("uri"));
+            Assertions.assertEquals(
+                    "test_metalake", metadataConfig.getProperties().get("metalake"));
+        } finally {
+            if (originalHome == null) {
+                System.clearProperty("SEATUNNEL_HOME");
+            } else {
+                System.setProperty("SEATUNNEL_HOME", originalHome);
+            }
+        }
+    }
+
+    @Test
+    @ClearEnvironmentVariable(key = "SEATUNNEL_HOME")
+    public void testParseMetadataConfigFromMissingSeatunnelYaml(@TempDir Path tempDir) {
+        String originalHome = System.getProperty("SEATUNNEL_HOME");
+        System.setProperty("SEATUNNEL_HOME", tempDir.toString());
+        try {
+            MetadataConfig metadataConfig = ConfigBuilder.parseMetadataConfigFromSeatunnelYaml();
+
+            Assertions.assertFalse(metadataConfig.isEnabled());
+        } finally {
+            if (originalHome == null) {
+                System.clearProperty("SEATUNNEL_HOME");
+            } else {
+                System.setProperty("SEATUNNEL_HOME", originalHome);
+            }
+        }
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/command/FlinkTaskExecuteCommand.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/command/FlinkTaskExecuteCommand.java
@@ -21,6 +21,8 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigUtil;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigValueFactory;
 
+import org.apache.seatunnel.api.metadata.MetadataConfig;
+import org.apache.seatunnel.api.metadata.MetadataProviderManager;
 import org.apache.seatunnel.api.metalake.MetalakeConfigUtils;
 import org.apache.seatunnel.common.Constants;
 import org.apache.seatunnel.core.starter.command.Command;
@@ -49,9 +51,20 @@ public class FlinkTaskExecuteCommand implements Command<FlinkCommandArgs> {
     public void execute() throws CommandExecuteException {
         Path configFile = FileUtils.getConfigPath(flinkCommandArgs);
         checkConfigExist(configFile);
-        Config config =
-                MetalakeConfigUtils.getMetalakeConfig(
-                        ConfigBuilder.of(configFile, flinkCommandArgs.getVariables()));
+
+        // Load MetadataConfig from seatunnel.yaml
+        MetadataConfig metadataConfig = ConfigBuilder.parseMetadataConfigFromSeatunnelYaml();
+
+        // Load job config (already decrypted)
+        Config jobConfig = ConfigBuilder.of(configFile, flinkCommandArgs.getVariables());
+
+        // Resolve datasource configs via MetadataProviderManager
+        Config resolvedConfig =
+                MetadataProviderManager.resolveDataSourceConfigs(jobConfig, metadataConfig);
+
+        // Apply metalake config transformations
+        Config config = MetalakeConfigUtils.getMetalakeConfig(resolvedConfig);
+
         // if user specified job name using command line arguments, override config option
         if (!flinkCommandArgs.getJobName().equals(Constants.LOGO)) {
             config =

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
@@ -23,12 +23,18 @@ import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.e2e.common.container.seatunnel.SeaTunnelContainer;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.ContainerExtendedFactory;
+import org.apache.seatunnel.e2e.common.container.EngineType;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
+import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.ContainerUtil;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
@@ -38,7 +44,6 @@ import org.testcontainers.images.PullPolicy;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -58,12 +63,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+import static org.apache.seatunnel.e2e.common.container.AbstractTestContainer.SEATUNNEL_HOME;
 import static org.awaitility.Awaitility.given;
 
-public class MetalakeIT extends SeaTunnelContainer {
+public class MetalakeIT extends TestSuiteBase {
+
+    private static final String GRAVITINO_BASE_URL = "http://gravitino:8090";
+    private static final String METALAKE_URL =
+            GRAVITINO_BASE_URL + "/api/metalakes/test_metalake/catalogs/";
 
     protected GenericContainer<?> dbServer;
+    protected GenericContainer<?> gravitinoContainer;
 
     protected JdbcCase jdbcCase;
 
@@ -85,7 +95,10 @@ public class MetalakeIT extends SeaTunnelContainer {
     private static final int MYSQL_PORT = 3306;
     private static final String MYSQL_URL = "jdbc:mysql://" + HOST + ":%s/%s?useSSL=false";
 
+    private static final String GRAVITINO_IMAGE = "apache/gravitino:latest";
+    private static final int GRAVITINO_PORT = 8090;
     private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+    private static final String SEATUNNEL_YAML = "/config/seatunnel.yaml";
 
     private static final List<String> CONFIG_FILE =
             Lists.newArrayList("/mysql_to_mysql_with_metalake.conf");
@@ -101,81 +114,28 @@ public class MetalakeIT extends SeaTunnelContainer {
                     + "    UNIQUE (c_bigint_30)\n"
                     + ");";
 
-    @BeforeEach
-    @Override
+    @TestContainerExtension
+    private final ContainerExtendedFactory extendedFactory =
+            container -> {
+                ContainerUtil.copyFileIntoContainers(
+                        SEATUNNEL_YAML,
+                        Paths.get(SEATUNNEL_HOME, "config", "seatunnel.yaml").toString(),
+                        container);
+                Container.ExecResult extraCommands =
+                        container.execInContainer(
+                                "bash",
+                                "-c",
+                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
+                                        + driverUrl()
+                                        + " --no-check-certificate");
+                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+            };
+
+    @BeforeAll
     public void startUp() throws Exception {
-        server =
-                new GenericContainer<>(getDockerImage())
-                        .withNetwork(NETWORK)
-                        .withEnv("TZ", "UTC")
-                        .withEnv("METALAKE_ENABLED", "true")
-                        .withEnv("METALAKE_TYPE", "gravitino")
-                        .withEnv(
-                                "METALAKE_URL",
-                                "http://127.0.0.1:8090/api/metalakes/test_metalake/catalogs/")
-                        .withCommand(buildStartCommand())
-                        .withNetworkAliases("server")
-                        .withExposedPorts()
-                        .withFileSystemBind("/tmp", "/opt/hive")
-                        .withLogConsumer(
-                                new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger(
-                                                "seatunnel-engine:" + JDK_DOCKER_IMAGE)))
-                        .waitingFor(Wait.forLogMessage(".*received new worker register:.*", 1));
-        copySeaTunnelStarterToContainer(server);
-        server.setPortBindings(Arrays.asList("5801:5801", "8080:8080"));
-        server.withCopyFileToContainer(
-                MountableFile.forHostPath(
-                        PROJECT_ROOT_PATH
-                                + "/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/"),
-                Paths.get(SEATUNNEL_HOME, "config").toString());
-
-        // Copy datasource-enabled seatunnel.yaml
-        server.withCopyFileToContainer(
-                MountableFile.forHostPath(
-                        PROJECT_ROOT_PATH
-                                + "/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/config/seatunnel.yaml"),
-                Paths.get(SEATUNNEL_HOME, "config", "seatunnel.yaml").toString());
-
-        server.withCopyFileToContainer(
-                MountableFile.forHostPath(
-                        PROJECT_ROOT_PATH
-                                + "/seatunnel-shade/seatunnel-hadoop3-3.1.4-uber/target/seatunnel-hadoop3-3.1.4-uber.jar"),
-                Paths.get(SEATUNNEL_HOME, "lib/seatunnel-hadoop3-3.1.4-uber.jar").toString());
-        // execute extra commands
-        executeExtraCommands(server);
-        server.start();
-
-        server.execInContainer(
-                "bash",
-                "-c",
-                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                        + driverUrl()
-                        + " --no-check-certificate"
-                        + "&& mkdir -p /tmp/gravitino && cd /tmp/gravitino && curl -C - --retry 5 -L -k -o gravitino-0.9.1-bin.tar.gz https://dlcdn.apache.org/gravitino/0.9.1/gravitino-0.9.1-bin.tar.gz && tar -zxvf gravitino-0.9.1-bin.tar.gz && cd /tmp/gravitino/gravitino-0.9.1-bin && ./bin/gravitino.sh start");
-
-        given().ignoreExceptions()
-                .await()
-                .pollInterval(2, TimeUnit.SECONDS)
-                .atMost(180, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            Container.ExecResult result =
-                                    server.execInContainer(
-                                            "bash",
-                                            "-c",
-                                            "curl -sf 'http://127.0.0.1:8090/api/metalakes' >/dev/null");
-                            Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
-                        });
-        server.execInContainer(
-                "bash",
-                "-c",
-                "curl -L 'http://127.0.0.1:8090/api/metalakes' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_metalake\",\"comment\":\"for metalake test\",\"properties\":{}}'"
-                        + "&& curl -L 'http://127.0.0.1:8090/api/metalakes/test_metalake/catalogs' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_catalog\",\"type\":\"relational\",\"provider\":\"jdbc-mysql\",\"comment\":\"for metalake test\",\"properties\":{\"jdbc-driver\":\"com.mysql.cj.jdbc.Driver\",\"jdbc-url\":\"jdbc:mysql://mysql-e2e:3306/seatunnel?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true\",\"jdbc-user\":\"root\",\"jdbc-password\":\"Abc!@#135_seatunnel\"}}'");
-
         dbServer = initContainer().withImagePullPolicy(PullPolicy.alwaysPull());
-
         Startables.deepStart(Stream.of(dbServer)).join();
+        startGravitinoContainer();
 
         jdbcCase = getJdbcCase();
 
@@ -188,8 +148,7 @@ public class MetalakeIT extends SeaTunnelContainer {
         insertTestData();
     }
 
-    @AfterEach
-    @Override
+    @AfterAll
     public void tearDown() throws Exception {
         if (catalog != null) {
             catalog.close();
@@ -200,25 +159,66 @@ public class MetalakeIT extends SeaTunnelContainer {
         if (dbServer != null) {
             dbServer.close();
         }
-        super.tearDown();
+        if (gravitinoContainer != null) {
+            gravitinoContainer.close();
+        }
     }
 
-    @Test
-    public void testMetalake() throws IOException, InterruptedException {
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason = "Metalake config is currently applied by Zeta starter.")
+    public void testMetalake(TestContainer container) throws IOException, InterruptedException {
         Container.ExecResult execResult =
-                executeJob("/jdbc_mysql_source_to_assert_sink_with_metalake.conf");
+                container.executeJob(
+                        "/jdbc_mysql_source_to_assert_sink_with_metalake.conf",
+                        Arrays.asList(
+                                "env.metalake_enabled=true",
+                                "env.metalake_type=gravitino",
+                                "env.metalake_url=" + METALAKE_URL));
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 
-    @Test
-    public void testDataSource() throws IOException, InterruptedException {
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK},
+            disabledReason = "Spark starter does not support MetadataProvider yet.")
+    public void testDataSource(TestContainer container) throws IOException, InterruptedException {
         Container.ExecResult execResult =
-                executeJob("/jdbc_mysql_source_to_assert_sink_with_datasource_enable.conf");
+                container.executeJob(
+                        "/jdbc_mysql_source_to_assert_sink_with_datasource_enable.conf");
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 
     String driverUrl() {
         return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
+    }
+
+    private void startGravitinoContainer() throws Exception {
+        gravitinoContainer =
+                new GenericContainer<>(GRAVITINO_IMAGE)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases("gravitino")
+                        .withExposedPorts(GRAVITINO_PORT)
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(
+                                                "gravitino:" + GRAVITINO_IMAGE)))
+                        .waitingFor(Wait.forHttp("/api/metalakes").forPort(GRAVITINO_PORT));
+        gravitinoContainer.start();
+        createMetalakeAndCatalog();
+    }
+
+    private void createMetalakeAndCatalog() throws Exception {
+        Container.ExecResult createResult =
+                gravitinoContainer.execInContainer(
+                        "bash",
+                        "-c",
+                        "curl -L 'http://localhost:8090/api/metalakes' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_metalake\",\"comment\":\"for metalake test\",\"properties\":{}}'"
+                                + " && curl -L 'http://localhost:8090/api/metalakes/test_metalake/catalogs' -H 'Content-Type: application/json' -H 'Accept: application/vnd.gravitino.v1+json' -d '{\"name\":\"test_catalog\",\"type\":\"relational\",\"provider\":\"jdbc-mysql\",\"comment\":\"for metalake test\",\"properties\":{\"jdbc-driver\":\"com.mysql.cj.jdbc.Driver\",\"jdbc-url\":\"jdbc:mysql://mysql-e2e:3306/seatunnel?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true\",\"jdbc-user\":\"root\",\"jdbc-password\":\"Abc!@#135_seatunnel\"}}'");
+        Assertions.assertEquals(0, createResult.getExitCode(), createResult.getStderr());
     }
 
     protected GenericContainer<?> initContainer() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
@@ -56,6 +56,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -170,13 +171,13 @@ public class MetalakeIT extends TestSuiteBase {
             type = {EngineType.FLINK, EngineType.SPARK},
             disabledReason = "Metalake config is currently applied by Zeta starter.")
     public void testMetalake(TestContainer container) throws IOException, InterruptedException {
+        Map<String, String> envs = new LinkedHashMap<>();
+        envs.put("METALAKE_ENABLED", "true");
+        envs.put("METALAKE_TYPE", "gravitino");
+        envs.put("METALAKE_URL", METALAKE_URL);
         Container.ExecResult execResult =
-                container.executeJob(
-                        "/jdbc_mysql_source_to_assert_sink_with_metalake.conf",
-                        Arrays.asList(
-                                "env.metalake_enabled=true",
-                                "env.metalake_type=gravitino",
-                                "env.metalake_url=" + METALAKE_URL));
+                container.executeJobWithEnv(
+                        "/jdbc_mysql_source_to_assert_sink_with_metalake.conf", envs);
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 
@@ -186,9 +187,11 @@ public class MetalakeIT extends TestSuiteBase {
             type = {EngineType.SPARK},
             disabledReason = "Spark starter does not support MetadataProvider yet.")
     public void testDataSource(TestContainer container) throws IOException, InterruptedException {
+        Map<String, String> envs = new LinkedHashMap<>();
+        envs.put("SEATUNNEL_HOME", SEATUNNEL_HOME);
         Container.ExecResult execResult =
-                container.executeJob(
-                        "/jdbc_mysql_source_to_assert_sink_with_datasource_enable.conf");
+                container.executeJobWithEnv(
+                        "/jdbc_mysql_source_to_assert_sink_with_datasource_enable.conf", envs);
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/config/seatunnel.yaml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/config/seatunnel.yaml
@@ -44,5 +44,5 @@ seatunnel:
       enabled: true
       kind: gravitino
       gravitino:
-        uri: http://127.0.0.1:8090
+        uri: http://gravitino:8090
         metalake: test_metalake

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/AbstractTestContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/AbstractTestContainer.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
 import static org.apache.seatunnel.e2e.common.util.ContainerUtil.adaptPathForWin;
@@ -144,6 +145,16 @@ public abstract class AbstractTestContainer implements TestContainer {
     protected Container.ExecResult executeJob(
             GenericContainer<?> container, String confFile, String jobId, List<String> variables)
             throws IOException, InterruptedException {
+        return executeJob(container, confFile, jobId, variables, null);
+    }
+
+    protected Container.ExecResult executeJob(
+            GenericContainer<?> container,
+            String confFile,
+            String jobId,
+            List<String> variables,
+            Map<String, String> envs)
+            throws IOException, InterruptedException {
         final String confInContainerPath = copyConfigFileToContainer(container, confFile);
         // copy connectors
         copyConnectorJarToContainer(
@@ -156,6 +167,10 @@ public abstract class AbstractTestContainer implements TestContainer {
         final List<String> command = new ArrayList<>();
         String binPath = Paths.get(SEATUNNEL_HOME, "bin", getStartShellName()).toString();
         // base command
+        if (envs != null && !envs.isEmpty()) {
+            command.add("env");
+            envs.forEach((key, value) -> command.add(key + "=" + value));
+        }
         command.add(adaptPathForWin(binPath));
         command.add("--config");
         command.add(adaptPathForWin(confInContainerPath));

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/TestContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/TestContainer.java
@@ -24,6 +24,7 @@ import org.testcontainers.containers.Network;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface TestContainer extends TestResource {
@@ -43,6 +44,11 @@ public interface TestContainer extends TestResource {
 
     Container.ExecResult executeJob(String confFile, List<String> variables)
             throws IOException, InterruptedException;
+
+    default Container.ExecResult executeJobWithEnv(String confFile, Map<String, String> envs)
+            throws IOException, InterruptedException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 
     default Container.ExecResult executeJob(String confFile, String jobId, String... variables)
             throws IOException, InterruptedException {

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
@@ -42,6 +42,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -183,6 +184,13 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
             throws IOException, InterruptedException {
         log.info("test in container: {}", identifier());
         return executeJob(jobManager, confFile, null, variables);
+    }
+
+    @Override
+    public Container.ExecResult executeJobWithEnv(String confFile, Map<String, String> envs)
+            throws IOException, InterruptedException {
+        log.info("test in container: {}", identifier());
+        return executeJob(jobManager, confFile, null, null, envs);
     }
 
     @Override

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/ConnectorPackageServiceContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/ConnectorPackageServiceContainer.java
@@ -38,6 +38,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
@@ -233,6 +234,13 @@ public class ConnectorPackageServiceContainer extends AbstractTestContainer {
             throws IOException, InterruptedException {
         log.info("test in container: {}", identifier());
         return executeJob(server1, confFile, null, variables);
+    }
+
+    @Override
+    public Container.ExecResult executeJobWithEnv(String confFile, Map<String, String> envs)
+            throws IOException, InterruptedException {
+        log.info("test in container: {}", identifier());
+        return executeJob(server1, confFile, null, null, envs);
     }
 
     @Override

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/seatunnel/SeaTunnelContainer.java
@@ -326,6 +326,13 @@ public class SeaTunnelContainer extends AbstractTestContainer {
     }
 
     @Override
+    public Container.ExecResult executeJobWithEnv(String confFile, Map<String, String> envs)
+            throws IOException, InterruptedException {
+        log.info("test in container: {}", identifier());
+        return executeJob(server, confFile, null, null, envs);
+    }
+
+    @Override
     public Container.ExecResult executeJob(String confFile, String jobId, String... variables)
             throws IOException, InterruptedException {
         return doExecuteJob(confFile, jobId, variables != null ? Arrays.asList(variables) : null);


### PR DESCRIPTION
 ### Purpose

  This PR adds MetadataProvider SPI support for the Flink starter, so Flink jobs can resolve datasource connection options from the metadata center by using `metadata_datasource_id`.

  Before this change, Flink jobs with configs such as:

  ```hocon
  source {
    Jdbc {
      metadata_datasource_id = "test_catalog"
      query = "select * from source"
    }
  }
  ```

  could fail during connector option validation because required JDBC options like url and driver were not resolved before FactoryUtil created the source.

  ### Changes

  - Load metadata center configuration from seatunnel.yaml in the Flink starter.
  - Resolve datasource configs through MetadataProviderManager before applying legacy Metalake config handling.
  - Keep compatibility with existing Metalake placeholder replacement logic.
  - Update JDBC e2e coverage for MetadataProvider SPI on Flink.
  - Ensure the Flink e2e job process has SEATUNNEL_HOME so it can locate config/seatunnel.yaml.
  - Keep Metalake legacy env behavior using METALAKE_ENABLED, METALAKE_TYPE, and METALAKE_URL.

  ### Why

  The MetadataProvider SPI expects metadata settings from:

  ```yaml
  seatunnel:
    engine:
      metadata:
        enabled: true
        kind: gravitino
        gravitino:
          uri: http://gravitino:8090
          metalake: test_metalake
  ```

  Flink starter needs this config before connector validation, otherwise datasource options are not merged into the job config.
