### PR TITLE
[Docs][Connector-V2] Improve Aerospike sink example

### DIFF
--- a/docs/en/connectors/sink/Aerospike.md
+++ b/docs/en/connectors/sink/Aerospike.md
@@ -61,35 +61,49 @@ Note:
 | username       | string | No       | -       | Username for authentication                                                |
 | password       | string | No       | -       | Password for authentication                                                |
 | key            | string | Yes      | -       | Field name to use as Aerospike primary key                                 |
-| bin_name       | string | No       | -       | Bin name for storing data                                                  |
+| bin_name       | string | No       | -       | Bin name for storing data. Required when `data_format` is `map` or `string` |
 | data_format    | string | No       | string  | Data storage format: map/string/kv                                         |
 | write_timeout  | int    | No       | 200     | Write operation timeout in milliseconds                                    |
 | schema.field   | map    | No       | {}      | Field type mappings (e.g. {"name":"STRING","age":"INTEGER"})               |
 
 ### data_format Options
-- **map**: Store data as JSON map
-- **string**: Store data as JSON string
-- **kv**: Store each field as separate bin
+
+- **map**: Store all non-key fields as a map in `bin_name`
+- **string**: Store all non-key fields as a JSON string in `bin_name`
+- **kv**: Store each non-key field as a separate bin. `bin_name` is not used
 
 ## Task Example
 
-### Simple Example
+### Write FakeSource Data To Aerospike
 
 ```hocon
 env {
-  parallelism = 2
+  parallelism = 1
   job.mode = "BATCH"
 }
 
 source {
   FakeSource {
-    row.num = 10
+    row.num = 9
+    string.fake.mode = "template"
+    string.template = ["tyrantlucifer", "hailin", "kris", "fanjia", "zongwen", "gaojun"]
+    int.fake.mode = "template"
+    int.template = [20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+    double.fake.mode = "template"
+    double.template = [44.0, 45.0, 46.0, 47.0]
+    timestamp.fake.mode = "template"
+    timestamp.template = [
+      "2022-01-01 00:00:00",
+      "2022-01-01 00:00:01",
+      "2022-01-01 00:00:02",
+      "2022-01-01 00:00:03"
+    ]
     schema = {
       fields {
-        id = "int"
-        name = "string"
-        age = "int"
-        address = "string"
+        c_id = "int"
+        c_name = "string"
+        c_money = "double"
+        c_birth = "timestamp"
       }
     }
   }
@@ -97,18 +111,22 @@ source {
 
 sink {
   Aerospike {
-    host = "localhost"
+    host = "aerospike-host"
     port = 3000
-    namespace = "test_namespace"
-    set = "user_data"
-    key = "id"
-    data_format = "map"
-    write_timeout = 300
-    schema.field = {
-      id = "INTEGER"
-      name = "STRING"
-      age = "INTEGER"
-      address = "STRING"
+    namespace = "test"
+    set = "seatunnel"
+    key = "c_id"
+    bin_name = "data"
+    data_format = "string"
+    username = ""
+    password = ""
+    schema {
+      field {
+        c_id = "INTEGER"
+        c_name = "STRING"
+        c_money = "DOUBLE"
+        c_birth = "LONG"
+      }
     }
   }
 }

--- a/docs/zh/connectors/sink/Aerospike.md
+++ b/docs/zh/connectors/sink/Aerospike.md
@@ -61,35 +61,49 @@ import ChangeLog from '../changelog/connector-aerospike.md';
 | username       | string  | 否   | -       | 认证用户名                                                          |
 | password       | string  | 否   | -       | 认证密码                                                            |
 | key            | string  | 是   | -       | 用作 Aerospike 主键的字段名称                                       |
-| bin_name       | string  | 否   | -       | 数据存储的 bin 名称                                                 |
+| bin_name       | string  | 否   | -       | 数据存储的 bin 名称。`data_format` 为 `map` 或 `string` 时需要配置   |
 | data_format    | string  | 否   | string  | 数据存储格式：map/string/kv                                         |
 | write_timeout  | int     | 否   | 200     | 写入操作超时时间（毫秒）                                            |
 | schema.field   | map     | 否   | {}      | 字段类型映射（示例：{"name":"STRING","age":"INTEGER"}）             |
 
 ### data_format 选项说明
-- **map**: 以JSON对象格式存储
-- **string**: 以JSON字符串格式存储
-- **kv**: 每个字段存储为独立的bin
+
+- **map**: 将所有非主键字段作为一个 map 存到 `bin_name`
+- **string**: 将所有非主键字段作为 JSON 字符串存到 `bin_name`
+- **kv**: 每个非主键字段存储为独立的 bin，此时不使用 `bin_name`
 
 ## 任务示例
 
-### 简单示例
+### 将 FakeSource 数据写入 Aerospike
 
 ```hocon
 env {
-  parallelism = 2
+  parallelism = 1
   job.mode = "BATCH"
 }
 
 source {
   FakeSource {
-    row.num = 10
+    row.num = 9
+    string.fake.mode = "template"
+    string.template = ["tyrantlucifer", "hailin", "kris", "fanjia", "zongwen", "gaojun"]
+    int.fake.mode = "template"
+    int.template = [20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+    double.fake.mode = "template"
+    double.template = [44.0, 45.0, 46.0, 47.0]
+    timestamp.fake.mode = "template"
+    timestamp.template = [
+      "2022-01-01 00:00:00",
+      "2022-01-01 00:00:01",
+      "2022-01-01 00:00:02",
+      "2022-01-01 00:00:03"
+    ]
     schema = {
       fields {
-        id = "int"
-        name = "string"
-        age = "int"
-        address = "string"
+        c_id = "int"
+        c_name = "string"
+        c_money = "double"
+        c_birth = "timestamp"
       }
     }
   }
@@ -97,18 +111,22 @@ source {
 
 sink {
   Aerospike {
-    host = "localhost"
+    host = "aerospike-host"
     port = 3000
-    namespace = "test_namespace"
-    set = "user_data"
-    key = "id"
-    data_format = "map"
-    write_timeout = 300
-    schema.field = {
-      id = "INTEGER"
-      name = "STRING"
-      age = "INTEGER"
-      address = "STRING"
+    namespace = "test"
+    set = "seatunnel"
+    key = "c_id"
+    bin_name = "data"
+    data_format = "string"
+    username = ""
+    password = ""
+    schema {
+      field {
+        c_id = "INTEGER"
+        c_name = "STRING"
+        c_money = "DOUBLE"
+        c_birth = "LONG"
+      }
     }
   }
 }


### PR DESCRIPTION
### Purpose

Improve the Aerospike sink documentation by aligning the task example with the existing e2e job configuration.

### Changes

- Update the English and Chinese Aerospike sink examples to include `bin_name`, `data_format`, and field type mappings used by the e2e FakeSource-to-Aerospike task.
- Clarify how `data_format` stores non-key fields and when `bin_name` is required.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`