### PR TITLE
[Docs] Improve Redis connector examples

### DIFF
--- a/docs/en/connectors/sink/Redis.md
+++ b/docs/en/connectors/sink/Redis.md
@@ -155,6 +155,11 @@ Set redis expiration time, the unit is second. The default value is -1, keys do 
 
 if true, the key can be customized by the field value in the upstream data.
 
+The field name must be wrapped with `{` and `}`. For example, `key = "order:{id}"` reads the `id`
+field from each upstream row. If the upstream row comes from Redis source and uses
+`read_key_enabled = true`, you can also use the key field emitted by the source, such as
+`key = "redis-key-check:{key}"`.
+
 Upstream data is the following:
 
 | code |      data      | success |
@@ -235,6 +240,52 @@ Redis {
 }
 ```
 
+custom key from a Redis source key:
+
+```hocon
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key_test*"
+    data_type = string
+    read_key_enabled = true
+    key_field_name = key
+    single_field_name = value
+    format = json
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "key"
+          type = "string"
+        },
+        {
+          name = "id"
+          type = "bigint"
+        },
+        {
+          name = "c_string"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "redis-key-check:{key}"
+    support_custom_key = true
+    data_type = key
+  }
+}
+```
+
 custom value:
 
 ```hocon
@@ -263,4 +314,3 @@ Redis {
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/source/Redis.md
+++ b/docs/en/connectors/source/Redis.md
@@ -427,6 +427,58 @@ sink {
 }
 ```
 
+read Redis keys and write them back with custom sink keys
+
+This example is based on the Redis e2e job. `read_key_enabled = true` keeps the matched Redis key in
+the output row, `key_field_name = key` stores it in the `key` column, and the Redis sink then uses
+`{key}` to build a new Redis key.
+
+```hocon
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key_test*"
+    data_type = string
+    batch_size = 33
+    read_key_enabled = true
+    key_field_name = key
+    single_field_name = value
+    format = json
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "key"
+          type = "string"
+        },
+        {
+          name = "id"
+          type = "bigint"
+        },
+        {
+          name = "c_string"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "redis-key-check:{key}"
+    support_custom_key = true
+    data_type = key
+    batch_size = 33
+  }
+}
+```
+
 ### Multiple Table Mode
 
 **Example 1: Reading multiple key patterns with different data types**

--- a/docs/zh/connectors/sink/Redis.md
+++ b/docs/zh/connectors/sink/Redis.md
@@ -91,6 +91,10 @@ Redis 数据类型，支持 `key` `hash` `list` `set` `zset`
 
 > 每个来自上游的数据都会以权重为 1 的方式添加到配置的 zset key 中。因此，zset 中数据的顺序基于数据的消费顺序。
 
+### batch_size [int]
+
+单机模式下控制每批写入 Redis 的数据条数；集群模式下不保证严格按该数量写入。
+
 ### user [string]
 
 Redis 认证用户，连接加密集群时需要
@@ -150,6 +154,10 @@ Redis 节点信息，在集群模式下使用，必须按如下格式：
 ### support_custom_key [boolean]
 
 设置为true，表示启用自定义Key。
+
+字段名需要用 `{` 和 `}` 包起来。比如 `key = "order:{id}"` 会从每一行上游数据里取 `id`
+字段。如果上游是 Redis source，并且配置了 `read_key_enabled = true`，也可以使用 source 输出的
+key 字段，例如 `key = "redis-key-check:{key}"`。
 
 上游数据如下：
 
@@ -226,6 +234,52 @@ Redis {
   key = "name:${name}"
   support_custom_key = true
   data_type = key
+}
+```
+
+使用 Redis source 读出的 key 作为自定义 key：
+
+```hocon
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key_test*"
+    data_type = string
+    read_key_enabled = true
+    key_field_name = key
+    single_field_name = value
+    format = json
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "key"
+          type = "string"
+        },
+        {
+          name = "id"
+          type = "bigint"
+        },
+        {
+          name = "c_string"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "redis-key-check:{key}"
+    support_custom_key = true
+    data_type = key
+  }
 }
 ```
 

--- a/docs/zh/connectors/source/Redis.md
+++ b/docs/zh/connectors/source/Redis.md
@@ -402,6 +402,58 @@ sink {
 }
 ```
 
+读取 Redis key 并用自定义 key 写回 Redis：
+
+这个示例来自 Redis e2e 任务。`read_key_enabled = true` 会把匹配到的 Redis key 一起读出来，
+`key_field_name = key` 表示把 Redis key 放进 `key` 这一列，后面的 Redis sink 再通过 `{key}`
+拼出新的 Redis key。
+
+```hocon
+source {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    keys = "key_test*"
+    data_type = string
+    batch_size = 33
+    read_key_enabled = true
+    key_field_name = key
+    single_field_name = value
+    format = json
+    schema = {
+      table = "RedisDatabase.RedisTable"
+      columns = [
+        {
+          name = "key"
+          type = "string"
+        },
+        {
+          name = "id"
+          type = "bigint"
+        },
+        {
+          name = "c_string"
+          type = "string"
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Redis {
+    host = "redis-e2e"
+    port = 6379
+    auth = "U2VhVHVubmVs"
+    key = "redis-key-check:{key}"
+    support_custom_key = true
+    data_type = key
+    batch_size = 33
+  }
+}
+```
+
 ### 多表模式
 
 **示例 1：读取具有不同数据类型的多个 key pattern**


### PR DESCRIPTION
## Summary
- Improve Redis source and sink documentation using Redis e2e task patterns.
- Add examples for reading Redis keys with `read_key_enabled` and writing them back with custom Redis sink keys.
- Add the missing Chinese `batch_size` sink option description.

## Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

## Connector analyzed
Redis connector e2e resources, especially `scan-redis-to-redis-with-key.conf`.