### PR TITLE
[Docs] Improve Email connector examples

### DIFF
--- a/docs/en/connectors/sink/Email.md
+++ b/docs/en/connectors/sink/Email.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ## Description
 
-Send the data as a file to email.
+Send the received rows as an attachment file to one or more email addresses.
 
 The tested email version is 1.5.6.
 
@@ -24,7 +24,7 @@ The tested email version is 1.5.6.
 | email_transport_protocol | string  | yes      | -             |
 | email_smtp_auth          | boolean | yes      | -             |
 | email_smtp_port          | int     | no       | 465           |
-| email_authorization_code | string  | no       | -             |
+| email_authorization_code | string  | yes      | -             |
 | email_message_headline   | string  | yes      | -             |
 | email_message_content    | string  | yes      | -             |
 | email_attachment_name    | string  | no       | emailsink.csv |
@@ -38,6 +38,8 @@ Sender Email Address.
 ### email_to_address [string]
 
 Address to receive mail, Support multiple email addresses, separated by commas (,).
+
+Example: `receiver-1@example.com,receiver-2@example.com`.
 
 ### email_host [string]
 
@@ -57,7 +59,10 @@ Select port for authentication.
 
 ### email_authorization_code [string]
 
-authorization code,You can obtain the authorization code from the mailbox Settings.
+Authorization code or password. You can obtain the authorization code from the mailbox settings.
+
+This option is required by the connector configuration. When `email_smtp_auth = false`, it can be
+set to an empty string.
 
 ### email_message_headline [string]
 
@@ -69,11 +74,15 @@ The body of the entire message.
 
 ### email_attachment_name [string]
 
-The name of the email attachment file. Default is `emailsink.csv`.
+The name of the email attachment file. Default is `emailsink.csv`. The connector writes the rows to
+this local file before sending the email.
 
 ### email_field_delimiter [string]
 
 The delimiter used to separate fields in the attachment file. Default is comma `,`.
+
+The attachment has no header row. Field values are written in the upstream schema order. `null`
+values are written as empty strings.
 
 ### common options
 
@@ -81,24 +90,111 @@ Sink plugin common parameters, please refer to [Sink Common Options](../common-o
 
 ## Example
 
-```bash
+### Send one table to multiple recipients
 
- EmailSink {
-      email_from_address = "xxxxxx@qq.com"
-      email_to_address = "xxxxxx@163.com"
-      email_host="smtp.qq.com"
-      email_transport_protocol="smtp"
-      email_smtp_auth="true"
-      email_authorization_code=""
-      email_message_headline=""
-      email_message_content=""
-      email_attachment_name="report.csv"  # Optional, default is emailsink.csv
-      email_field_delimiter="|"           # Optional, default is ,
-   }
+This example follows the Email e2e job. It uses a test SMTP server without authentication and sends
+one email to each address in `email_to_address`.
 
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        row.num = 100
+        schema = {
+          table = "test.table1"
+          columns = [
+            {
+              name = "id"
+              type = "bigint"
+            },
+            {
+              name = "name"
+              type = "string"
+            },
+            {
+              name = "age"
+              type = "int"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  EmailSink {
+    email_from_address = "sender@example.com"
+    email_to_address = "receiver-1@example.com,receiver-2@example.com"
+    email_host = "email-e2e"
+    email_transport_protocol = "smtp"
+    email_smtp_auth = false
+    email_smtp_port = 3025
+    email_authorization_code = ""
+    email_message_headline = "test-title"
+    email_message_content = "test-content"
+    email_attachment_name = "report.csv"
+    email_field_delimiter = "|"
+  }
+}
+```
+
+### Send multiple tables
+
+Email sink supports multi-table input. In the e2e job, two upstream tables create two emails for
+each recipient.
+
+```hocon
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        row.num = 100
+        schema {
+          table = "test.table1"
+          fields {
+            id = bigint
+            name = string
+            age = int
+          }
+        }
+      },
+      {
+        row.num = 100
+        schema {
+          table = "test.table2"
+          fields {
+            id = bigint
+            name = string
+            age = int
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  EmailSink {
+    email_from_address = "sender@example.com"
+    email_to_address = "receiver-3@example.com,receiver-4@example.com"
+    email_host = "email-e2e"
+    email_transport_protocol = "smtp"
+    email_smtp_auth = false
+    email_smtp_port = 3025
+    email_authorization_code = ""
+    email_message_headline = "test-title"
+    email_message_content = "test-content"
+  }
+}
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/sink/Email.md
+++ b/docs/zh/connectors/sink/Email.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ## 描述
 
-将接收的数据作为文件发送到电子邮件
+将接收到的数据写成附件文件，并发送到一个或多个邮箱地址。
 
 ## 支持版本
 
@@ -27,7 +27,7 @@ import ChangeLog from '../changelog/connector-email.md';
 | email_transport_protocol | string  | 是    | -   |
 | email_smtp_auth          | boolean | 是    | -   |
 | email_smtp_port          | int     | 否    | 465           |
-| email_authorization_code | string  | 否    | -             |
+| email_authorization_code | string  | 是    | -             |
 | email_message_headline   | string  | 是    | -             |
 | email_message_content    | string  | 是    | -             |
 | email_attachment_name    | string  | 否    | emailsink.csv |
@@ -41,6 +41,8 @@ import ChangeLog from '../changelog/connector-email.md';
 ### email_to_address [string]
 
 接收邮件的地址，支持多个邮箱地址，以逗号（,）分隔。
+
+示例：`receiver-1@example.com,receiver-2@example.com`。
 
 ### email_host [string]
 
@@ -60,7 +62,9 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ### email_authorization_code [string]
 
-授权码,您可以从邮箱设置中获取授权码
+授权码或密码，可以从邮箱设置中获取。
+
+连接器要求必须配置该项。当 `email_smtp_auth = false` 时，可以配置为空字符串。
 
 ### email_message_headline [string]
 
@@ -72,11 +76,13 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ### email_attachment_name [string]
 
-邮件附件的文件名。默认为 `emailsink.csv`。
+邮件附件的文件名。默认为 `emailsink.csv`。连接器会先把数据写到本地这个文件里，再作为附件发送。
 
 ### email_field_delimiter [string]
 
 附件文件中用于分隔字段的分隔符。默认为逗号 `,`。
+
+附件不包含表头。字段会按上游 schema 的顺序写入，`null` 值会写成空字符串。
 
 ### common options
 
@@ -84,21 +90,108 @@ Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-com
 
 ## 示例
 
-```bash
+### 发送单表数据到多个收件人
 
- EmailSink {
-      email_from_address = "xxxxxx@qq.com"
-      email_to_address = "xxxxxx@163.com"
-      email_host="smtp.qq.com"
-      email_transport_protocol="smtp"
-      email_smtp_auth="true"
-      email_authorization_code=""
-      email_message_headline=""
-      email_message_content=""
-      email_attachment_name="report.csv"  # 可选，默认为 emailsink.csv
-      email_field_delimiter="|"           # 可选，默认为 ,
-   }
+这个示例来自 Email e2e 任务。示例使用不需要认证的测试 SMTP 服务，并给 `email_to_address`
+中的每个邮箱各发送一封邮件。
 
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        row.num = 100
+        schema = {
+          table = "test.table1"
+          columns = [
+            {
+              name = "id"
+              type = "bigint"
+            },
+            {
+              name = "name"
+              type = "string"
+            },
+            {
+              name = "age"
+              type = "int"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  EmailSink {
+    email_from_address = "sender@example.com"
+    email_to_address = "receiver-1@example.com,receiver-2@example.com"
+    email_host = "email-e2e"
+    email_transport_protocol = "smtp"
+    email_smtp_auth = false
+    email_smtp_port = 3025
+    email_authorization_code = ""
+    email_message_headline = "test-title"
+    email_message_content = "test-content"
+    email_attachment_name = "report.csv"
+    email_field_delimiter = "|"
+  }
+}
+```
+
+### 发送多表数据
+
+Email sink 支持多表输入。在 e2e 任务中，两个上游表会让每个收件人收到两封邮件。
+
+```hocon
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        row.num = 100
+        schema {
+          table = "test.table1"
+          fields {
+            id = bigint
+            name = string
+            age = int
+          }
+        }
+      },
+      {
+        row.num = 100
+        schema {
+          table = "test.table2"
+          fields {
+            id = bigint
+            name = string
+            age = int
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  EmailSink {
+    email_from_address = "sender@example.com"
+    email_to_address = "receiver-3@example.com,receiver-4@example.com"
+    email_host = "email-e2e"
+    email_transport_protocol = "smtp"
+    email_smtp_auth = false
+    email_smtp_port = 3025
+    email_authorization_code = ""
+    email_message_headline = "test-title"
+    email_message_content = "test-content"
+  }
+}
 ```
 
 ## 变更日志


### PR DESCRIPTION
## Summary
- Improve Email sink documentation using Email e2e task examples.
- Mark `email_authorization_code` as required to match the connector option rule, while documenting that it may be empty when SMTP auth is disabled.
- Add e2e-style examples for multiple recipients and multi-table input.
- Clarify attachment output details, including delimiter, field order, and null value handling.

## Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

## Connector analyzed
Email sink connector e2e resources: `fake_to_email.conf` and `fake_to_multiemailsink.conf`.