### PR TITLE
[Chore] Enable PR branch update suggestions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,8 @@ github:
     squash: true
     merge: false
     rebase: false
+  pull_requests:
+    allow_update_branch: true
   protected_branches:
     dev:
       required_status_checks:


### PR DESCRIPTION
## What changed
- enabled `github.pull_requests.allow_update_branch` in `.asf.yaml`

## Why
- maintainers currently do not get the GitHub `Update branch` action consistently on out-of-date pull requests
- enabling this repository setting lets GitHub offer the branch update action directly on eligible PRs

## Impact
- contributors and maintainers can sync outdated PR branches more easily from the GitHub UI
- no runtime, connector, or engine behavior is changed

## Root cause
- the repository metadata did not enable pull request head branch updates via ASF-managed GitHub settings

## Validation
- ran `./mvnw spotless:apply`
- verified the final diff only changes `.asf.yaml`
