### PR TITLE
[Docs][Connector-V2] Improve Qdrant connector docs

### DIFF
--- a/docs/en/connectors/sink/Qdrant.md
+++ b/docs/en/connectors/sink/Qdrant.md
@@ -14,7 +14,6 @@ This connector can be used to write data into a Qdrant collection.
 
 | SeaTunnel Data Type | Qdrant Data Type |
 |---------------------|------------------|
-| TINYINT             | INTEGER          |
 | SMALLINT            | INTEGER          |
 | INT                 | INTEGER          |
 | BIGINT              | INTEGER          |
@@ -22,34 +21,30 @@ This connector can be used to write data into a Qdrant collection.
 | DOUBLE              | DOUBLE           |
 | BOOLEAN             | BOOL             |
 | STRING              | STRING           |
-| ARRAY               | LIST             |
+| DATE                | STRING           |
 | FLOAT_VECTOR        | DENSE_VECTOR     |
 | BINARY_VECTOR       | DENSE_VECTOR     |
 | FLOAT16_VECTOR      | DENSE_VECTOR     |
 | BFLOAT16_VECTOR     | DENSE_VECTOR     |
-| SPARSE_FLOAT_VECTOR | SPARSE_VECTOR    |
 
-The value of the primary key column will be used as point ID in Qdrant. If no primary key is present, a random UUID will be used.
+The value of the primary key column will be used as point ID in Qdrant. Supported primary key types are `INT` for numeric point IDs and `STRING` for UUID point IDs. If no primary key is present, a random UUID will be used.
+
+Non-vector columns are written into the Qdrant payload with the same field name. Vector columns are written as named vectors with the same field name, so the target collection must already define matching vector names and dimensions.
 
 ## Options
 
 |      name       |  type  | required | default value |
 |-----------------|--------|----------|---------------|
 | collection_name | string | yes      | -             |
-| batch_size      | int    | no       | 64            |
 | host            | string | no       | localhost     |
 | port            | int    | no       | 6334          |
 | api_key         | string | no       | -             |
-| use_tls         | int    | no       | false         |
+| use_tls         | bool   | no       | false         |
 | common-options  |        | no       | -             |
 
 ### collection_name [string]
 
-The name of the Qdrant collection to read data from.
-
-### batch_size [int]
-
-The batch size of each upsert request to Qdrant.
+The name of the Qdrant collection to write data into.
 
 ### host [string]
 
@@ -70,6 +65,50 @@ Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Task Example
+
+The following example writes two payload fields, `file_name` and `file_size`, and one named vector, `my_vector`, into Qdrant.
+
+Before running the job, create the target Qdrant collection and define a vector named `my_vector` with dimension `4`.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    vector.dimension = 4
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## Changelog
 

--- a/docs/en/connectors/source/Qdrant.md
+++ b/docs/en/connectors/source/Qdrant.md
@@ -19,7 +19,7 @@ This connector can be used to read data from a Qdrant collection.
 | host            | string | no       | localhost     |
 | port            | int    | no       | 6334          |
 | api_key         | string | no       | -             |
-| use_tls         | int    | no       | false         |
+| use_tls         | bool   | no       | false         |
 | common-options  |        | no       | -             |
 
 ### collection_name [string]
@@ -34,17 +34,26 @@ Eg:
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    some_vector = float_vector
-  }
+  columns = [
+    {
+      name = age
+      type = int
+    }
+    {
+      name = address
+      type = string
+    }
+    {
+      name = some_vector
+      type = float_vector
+    }
+  ]
 }
 ```
 
 Each entry in Qdrant is called a point.
 
-The `float_vector` type columns are read from the vectors of each point, others are read from the JSON payload associated with the point.
+The `float_vector` type columns are read from the vectors of each point. Other columns are read from the JSON payload associated with the point. Field names in the SeaTunnel schema must match the payload key or vector name in Qdrant.
 
 If a column is marked as primary key, the ID of the Qdrant point is written into it. It can be of type `"string"` or `"int"`. Since Qdrant only [allows](https://qdrant.tech/documentation/concepts/points/#point-ids) positive integers and UUIDs as point IDs.
 
@@ -52,11 +61,20 @@ If the collection was created with a single default/unnamed vector, use `default
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    default_vector = float_vector
-  }
+  columns = [
+    {
+      name = age
+      type = int
+    }
+    {
+      name = address
+      type = string
+    }
+    {
+      name = default_vector
+      type = float_vector
+    }
+  ]
 }
 ```
 
@@ -81,6 +99,47 @@ Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
 ### common options
 
 Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+
+## Task Example
+
+The following example reads payload fields `file_name` and `file_size`, and reads the named vector `my_vector` from a Qdrant collection.
+
+Before running the job, make sure the Qdrant collection exists and contains a vector named `my_vector`.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
 
 ## Changelog
 

--- a/docs/zh/connectors/sink/Qdrant.md
+++ b/docs/zh/connectors/sink/Qdrant.md
@@ -12,7 +12,6 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 |   SeaTunnel 数据类型    |  Qdrant 数据类型  |
 |---------------------|---------------|
-| TINYINT             | INTEGER       |
 | SMALLINT            | INTEGER       |
 | INT                 | INTEGER       |
 | BIGINT              | INTEGER       |
@@ -20,21 +19,21 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 | DOUBLE              | DOUBLE        |
 | BOOLEAN             | BOOL          |
 | STRING              | STRING        |
-| ARRAY               | LIST          |
+| DATE                | STRING        |
 | FLOAT_VECTOR        | DENSE_VECTOR  |
 | BINARY_VECTOR       | DENSE_VECTOR  |
 | FLOAT16_VECTOR      | DENSE_VECTOR  |
 | BFLOAT16_VECTOR     | DENSE_VECTOR  |
-| SPARSE_FLOAT_VECTOR | SPARSE_VECTOR |
 
-主键列的值将用作 Qdrant 中的点 ID。如果没有主键，则将使用随机 UUID。
+主键列的值将用作 Qdrant 中的点 ID。主键支持 `INT` 类型的数字 ID，以及 `STRING` 类型的 UUID ID。如果没有主键，则将使用随机 UUID。
+
+非向量字段会按同名字段写入 Qdrant payload。向量字段会按同名字段写入 Qdrant named vector，所以目标集合中需要提前定义好同名向量，并保证维度一致。
 
 ## 选项
 
 |       名称        |   类型   | 必填 |    默认值    |
 |-----------------|--------|----|-----------|
 | collection_name | string | 是  | -         |
-| batch_size      | int    | 否  | 64        |
 | host            | string | 否  | localhost |
 | port            | int    | 否  | 6334      |
 | api_key         | string | 否  | -         |
@@ -43,11 +42,7 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 ### collection_name [string]
 
-要从中读取数据的 Qdrant 集合的名称。
-
-### batch_size [int]
-
-每个 upsert 请求到 Qdrant 的批量大小。
+要写入数据的 Qdrant 集合的名称。
 
 ### host [string]
 
@@ -68,6 +63,50 @@ Qdrant 实例的 gRPC 端口。
 ### 通用选项
 
 Sink插件通用参数，请参考[Sink通用选项](../common-options/sink-common-options.md)了解详情。
+
+## 任务示例
+
+下面的示例会把 `file_name`、`file_size` 两个 payload 字段和 `my_vector` 这个向量字段写入 Qdrant。
+
+运行任务前，请先创建目标 Qdrant 集合，并定义一个名为 `my_vector`、维度为 `4` 的向量。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    vector.dimension = 4
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Qdrant.md
+++ b/docs/zh/connectors/source/Qdrant.md
@@ -32,17 +32,26 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    some_vector = float_vector
-  }
+  columns = [
+    {
+      name = age
+      type = int
+    }
+    {
+      name = address
+      type = string
+    }
+    {
+      name = some_vector
+      type = float_vector
+    }
+  ]
 }
 ```
 
 Qdrant 中的每个条目称为一个点。
 
-`float_vector` 类型的列从每个点的向量中读取，其他列从与该点关联的 JSON 有效负载中读取。
+`float_vector` 类型的列从每个点的向量中读取，其他列从与该点关联的 JSON payload 中读取。SeaTunnel schema 中的字段名必须和 Qdrant 中的 payload key 或向量名称一致。
 
 如果列被标记为主键，Qdrant 点的 ID 将写入其中。它可以是 `"string"` 或 `"int"` 类型。因为 Qdrant 仅[允许](https://qdrant.tech/documentation/concepts/points/#point-ids)使用正整数和 UUID 作为点 ID。
 
@@ -50,11 +59,20 @@ Qdrant 中的每个条目称为一个点。
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    default_vector = float_vector
-  }
+  columns = [
+    {
+      name = age
+      type = int
+    }
+    {
+      name = address
+      type = string
+    }
+    {
+      name = default_vector
+      type = float_vector
+    }
+  ]
 }
 ```
 
@@ -78,7 +96,48 @@ Qdrant 实例的 gRPC 端口。
 
 ### 通用选项
 
-源插件的通用参数，请参考[源通用选项](../common-options/source-common-options.md)了解详情。****
+源插件的通用参数，请参考[源通用选项](../common-options/source-common-options.md)了解详情。
+
+## 任务示例
+
+下面的示例从 Qdrant 集合中读取 payload 字段 `file_name`、`file_size`，并读取名为 `my_vector` 的向量。
+
+运行任务前，请先确认 Qdrant 集合已经存在，并且集合中有名为 `my_vector` 的向量。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
 
 ## 变更日志
 


### PR DESCRIPTION
## Purpose

Improve the Qdrant connector documentation by aligning the source and sink pages with the current connector behavior and adding complete task examples.

## Changes

- Add runnable Qdrant source and sink task examples in English and Chinese docs.
- Clarify how Qdrant payload fields and named vector fields map to SeaTunnel schema fields.
- Fix the Qdrant sink collection description from read to write.
- Correct the `use_tls` type to boolean.
- Remove the documented `batch_size` sink option because it is not a user-facing Qdrant sink option in the current implementation.
- Adjust the Qdrant sink type mapping table to avoid listing unsupported user-visible mappings.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`