### PR TITLE
[Docs][Connector-V2] Improve Qdrant connector docs

### DIFF
--- a/docs/en/connectors/sink/Qdrant.md
+++ b/docs/en/connectors/sink/Qdrant.md
@@ -10,6 +10,8 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 This connector can be used to write data into a Qdrant collection.
 
+The target collection must already exist before the job starts. Vector field names and dimensions in Qdrant must match the vector columns in the SeaTunnel row.
+
 ## Data Type Mapping
 
 | SeaTunnel Data Type | Qdrant Data Type |
@@ -36,20 +38,15 @@ The value of the primary key column will be used as point ID in Qdrant. If no pr
 |      name       |  type  | required | default value |
 |-----------------|--------|----------|---------------|
 | collection_name | string | yes      | -             |
-| batch_size      | int    | no       | 64            |
 | host            | string | no       | localhost     |
 | port            | int    | no       | 6334          |
 | api_key         | string | no       | -             |
-| use_tls         | int    | no       | false         |
+| use_tls         | bool   | no       | false         |
 | common-options  |        | no       | -             |
 
 ### collection_name [string]
 
-The name of the Qdrant collection to read data from.
-
-### batch_size [int]
-
-The batch size of each upsert request to Qdrant.
+The name of the Qdrant collection to write data to.
 
 ### host [string]
 
@@ -70,6 +67,49 @@ Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Task Example
+
+The following example writes records from a Qdrant source collection to another Qdrant collection. Payload fields such as `file_name` and `file_size` are written as point payloads, and `my_vector` is written as a named vector.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## Changelog
 

--- a/docs/en/connectors/source/Qdrant.md
+++ b/docs/en/connectors/source/Qdrant.md
@@ -19,7 +19,7 @@ This connector can be used to read data from a Qdrant collection.
 | host            | string | no       | localhost     |
 | port            | int    | no       | 6334          |
 | api_key         | string | no       | -             |
-| use_tls         | int    | no       | false         |
+| use_tls         | bool   | no       | false         |
 | common-options  |        | no       | -             |
 
 ### collection_name [string]
@@ -44,7 +44,7 @@ schema = {
 
 Each entry in Qdrant is called a point.
 
-The `float_vector` type columns are read from the vectors of each point, others are read from the JSON payload associated with the point.
+Vector columns are read from the vectors of each point. Other columns are read from the JSON payload associated with the point.
 
 If a column is marked as primary key, the ID of the Qdrant point is written into it. It can be of type `"string"` or `"int"`. Since Qdrant only [allows](https://qdrant.tech/documentation/concepts/points/#point-ids) positive integers and UUIDs as point IDs.
 
@@ -81,6 +81,51 @@ Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
 ### common options
 
 Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+
+## Task Example
+
+The Qdrant collection must already exist before the job starts. Vector field names and dimensions in the collection must match the schema used by SeaTunnel.
+
+The following example reads payload fields and a named vector from `source_collection`, then writes the rows to `sink_collection`.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## Changelog
 

--- a/docs/zh/connectors/sink/Qdrant.md
+++ b/docs/zh/connectors/sink/Qdrant.md
@@ -8,6 +8,8 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 该连接器可用于将数据写入 Qdrant 集合。
 
+目标 collection 必须在作业启动前已经存在。Qdrant 中的向量字段名和维度需要与 SeaTunnel 数据行中的向量列保持一致。
+
 ## 数据类型映射
 
 |   SeaTunnel 数据类型    |  Qdrant 数据类型  |
@@ -34,7 +36,6 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 |       名称        |   类型   | 必填 |    默认值    |
 |-----------------|--------|----|-----------|
 | collection_name | string | 是  | -         |
-| batch_size      | int    | 否  | 64        |
 | host            | string | 否  | localhost |
 | port            | int    | 否  | 6334      |
 | api_key         | string | 否  | -         |
@@ -43,11 +44,7 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 ### collection_name [string]
 
-要从中读取数据的 Qdrant 集合的名称。
-
-### batch_size [int]
-
-每个 upsert 请求到 Qdrant 的批量大小。
+要写入数据的 Qdrant 集合的名称。
 
 ### host [string]
 
@@ -68,6 +65,49 @@ Qdrant 实例的 gRPC 端口。
 ### 通用选项
 
 Sink插件通用参数，请参考[Sink通用选项](../common-options/sink-common-options.md)了解详情。
+
+## 任务示例
+
+下面的示例会把一个 Qdrant source collection 中的记录写入另一个 Qdrant collection。`file_name`、`file_size` 等普通字段会写成 point payload，`my_vector` 会写成命名向量。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Qdrant.md
+++ b/docs/zh/connectors/source/Qdrant.md
@@ -42,7 +42,7 @@ schema = {
 
 Qdrant 中的每个条目称为一个点。
 
-`float_vector` 类型的列从每个点的向量中读取，其他列从与该点关联的 JSON 有效负载中读取。
+向量类型的列会从每个点的向量中读取，其他列会从与该点关联的 JSON payload 中读取。
 
 如果列被标记为主键，Qdrant 点的 ID 将写入其中。它可以是 `"string"` 或 `"int"` 类型。因为 Qdrant 仅[允许](https://qdrant.tech/documentation/concepts/points/#point-ids)使用正整数和 UUID 作为点 ID。
 
@@ -78,7 +78,52 @@ Qdrant 实例的 gRPC 端口。
 
 ### 通用选项
 
-源插件的通用参数，请参考[源通用选项](../common-options/source-common-options.md)了解详情。****
+源插件的通用参数，请参考[源通用选项](../common-options/source-common-options.md)了解详情。
+
+## 任务示例
+
+作业启动前，Qdrant collection 必须已经存在。Qdrant 中的向量字段名和维度需要与 SeaTunnel schema 中的向量列保持一致。
+
+下面的示例从 `source_collection` 读取 payload 字段和命名向量，然后写入 `sink_collection`。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Qdrant {
+    collection_name = "source_collection"
+    host = "localhost"
+    port = 6334
+    schema = {
+      columns = [
+        {
+          name = file_name
+          type = string
+        }
+        {
+          name = file_size
+          type = int
+        }
+        {
+          name = my_vector
+          type = float_vector
+        }
+      ]
+    }
+  }
+}
+
+sink {
+  Qdrant {
+    collection_name = "sink_collection"
+    host = "localhost"
+    port = 6334
+  }
+}
+```
 
 ## 变更日志
 


### PR DESCRIPTION
### Purpose

Improve the Qdrant connector documentation so users can configure source and sink jobs more accurately.

### Changes

- Add complete Qdrant source-to-sink task examples to both English and Chinese docs.
- Document that Qdrant collections must exist before the job starts and vector fields must match the collection definition.
- Fix `use_tls` type from `int` to `bool` in English docs.
- Remove the unsupported `batch_size` sink option from the Qdrant sink docs.
- Correct the sink `collection_name` description to say it writes to the target collection.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`