### PR TITLE
[Fix][Core] Extend serialVersionUID checker coverage

### DIFF
--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/SerialVersionUIDCheckerTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/SerialVersionUIDCheckerTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,8 +61,47 @@ public class SerialVersionUIDCheckerTest {
     private static final Logger LOG = LoggerFactory.getLogger(SerialVersionUIDCheckerTest.class);
     private static final String JAVA_FILE_EXTENSION = ".java";
     private static final String CONNECTOR_DIR = "seatunnel-connectors-v2";
+    private static final String CONNECTOR_CDC_DIR =
+            CONNECTOR_DIR + File.separator + "connector-cdc";
     private static final String JAVA_PATH_FRAGMENT =
             "src" + File.separator + "main" + File.separator + "java";
+    private static final List<String> CHECKED_PATHS =
+            Arrays.asList(
+                    CONNECTOR_CDC_DIR,
+                    "seatunnel-engine"
+                            + File.separator
+                            + "seatunnel-engine-core"
+                            + File.separator
+                            + JAVA_PATH_FRAGMENT
+                            + File.separator
+                            + "org"
+                            + File.separator
+                            + "apache"
+                            + File.separator
+                            + "seatunnel"
+                            + File.separator
+                            + "engine"
+                            + File.separator
+                            + "core"
+                            + File.separator
+                            + "job",
+                    "seatunnel-engine"
+                            + File.separator
+                            + "seatunnel-engine-common"
+                            + File.separator
+                            + JAVA_PATH_FRAGMENT
+                            + File.separator
+                            + "org"
+                            + File.separator
+                            + "apache"
+                            + File.separator
+                            + "seatunnel"
+                            + File.separator
+                            + "engine"
+                            + File.separator
+                            + "common"
+                            + File.separator
+                            + "job");
     private static final JavaParser JAVA_PARSER;
     private static final Set<String> checkedClasses = new HashSet<>();
     private static final Map<String, ClassOrInterfaceDeclaration> classDeclarationMap =
@@ -95,21 +135,21 @@ public class SerialVersionUIDCheckerTest {
     @Test
     public void checkSerialVersionUID() {
         List<String> missingSerialVersionUID = new ArrayList<>();
-        List<Path> connectorClassPaths = findConnectorClassPaths();
-        LOG.info("Found {} connector class files to check", connectorClassPaths.size());
+        List<Path> classPaths = findClassPaths();
+        LOG.info("Found {} class files to check", classPaths.size());
 
         // First, populate the classDeclarationMap with all classes
-        for (Path path : connectorClassPaths) {
+        for (Path path : classPaths) {
             populateClassDeclarationMap(path);
         }
         LOG.info("Populated class declaration map with {} classes", classDeclarationMap.size());
 
         // Then check each class path for serialVersionUID
-        for (Path path : connectorClassPaths) {
+        for (Path path : classPaths) {
             checkClassPath(path, missingSerialVersionUID);
         }
 
-        LOG.info("Check completed. Checked {} connector classes.", connectorClassPaths.size());
+        LOG.info("Check completed. Checked {} class files.", classPaths.size());
         if (!missingSerialVersionUID.isEmpty()) {
             String errorMessage = generateErrorMessage(missingSerialVersionUID);
             LOG.error("Test failed: {}", errorMessage);
@@ -118,18 +158,18 @@ public class SerialVersionUIDCheckerTest {
         LOG.info("All checked classes have correct serialVersionUID.");
     }
 
-    private List<Path> findConnectorClassPaths() {
+    private List<Path> findClassPaths() {
         try (Stream<Path> paths = Files.walk(Paths.get(".."), FileVisitOption.FOLLOW_LINKS)) {
             return paths.filter(
                             path -> {
                                 String pathString = path.toString();
                                 return pathString.endsWith(JAVA_FILE_EXTENSION)
-                                        && pathString.contains(CONNECTOR_DIR)
-                                        && pathString.contains(JAVA_PATH_FRAGMENT);
+                                        && pathString.contains(JAVA_PATH_FRAGMENT)
+                                        && CHECKED_PATHS.stream().anyMatch(pathString::contains);
                             })
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            throw new RuntimeException("Failed to walk through connector directories", e);
+            throw new RuntimeException("Failed to walk through class directories", e);
         }
     }
 
@@ -158,8 +198,9 @@ public class SerialVersionUIDCheckerTest {
     }
 
     /**
-     * Check the class path for classes that implement SeaTunnelSource or SeaTunnelSink and verify
-     * they have serialVersionUID.
+     * Check classes that are serialized in job graphs and state restore paths. Source/sink generic
+     * state remains checked, and concrete connector config/config-factory classes plus engine job
+     * graph classes are checked directly.
      */
     private void checkClassPath(Path path, List<String> missingSerialVersionUID) {
         try {
@@ -172,6 +213,10 @@ public class SerialVersionUIDCheckerTest {
                                 List<ClassOrInterfaceDeclaration> classes =
                                         compilationUnit.findAll(ClassOrInterfaceDeclaration.class);
                                 for (ClassOrInterfaceDeclaration classDeclaration : classes) {
+                                    if (shouldCheckClass(path, classDeclaration)) {
+                                        checkClassDeclaration(
+                                                classDeclaration, missingSerialVersionUID);
+                                    }
                                     if (implementsSeaTunnelSourceOrSink(classDeclaration)) {
                                         checkImplementedTypes(
                                                 classDeclaration, missingSerialVersionUID);
@@ -181,6 +226,81 @@ public class SerialVersionUIDCheckerTest {
         } catch (IOException e) {
             LOG.warn("Could not parse file: {}", path, e);
         }
+    }
+
+    private boolean shouldCheckClass(Path path, ClassOrInterfaceDeclaration classDeclaration) {
+        try {
+            if (classDeclaration.isInterface()) {
+                return false;
+            }
+            ResolvedReferenceTypeDeclaration typeDeclaration = classDeclaration.resolve();
+            if (isAbstractClass(typeDeclaration) || !isSerializable(typeDeclaration)) {
+                return false;
+            }
+            if (isEngineJobClass(path)) {
+                return true;
+            }
+            return isConnectorConfigOrFactory(typeDeclaration);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Could not resolve class: {} in file: {}",
+                    classDeclaration.getNameAsString(),
+                    path,
+                    e);
+            return false;
+        }
+    }
+
+    private boolean isEngineJobClass(Path path) {
+        String pathString = path.toString();
+        return pathString.contains(
+                        "seatunnel-engine"
+                                + File.separator
+                                + "seatunnel-engine-core"
+                                + File.separator
+                                + JAVA_PATH_FRAGMENT
+                                + File.separator
+                                + "org"
+                                + File.separator
+                                + "apache"
+                                + File.separator
+                                + "seatunnel"
+                                + File.separator
+                                + "engine"
+                                + File.separator
+                                + "core"
+                                + File.separator
+                                + "job")
+                || pathString.contains(
+                        "seatunnel-engine"
+                                + File.separator
+                                + "seatunnel-engine-common"
+                                + File.separator
+                                + JAVA_PATH_FRAGMENT
+                                + File.separator
+                                + "org"
+                                + File.separator
+                                + "apache"
+                                + File.separator
+                                + "seatunnel"
+                                + File.separator
+                                + "engine"
+                                + File.separator
+                                + "common"
+                                + File.separator
+                                + "job");
+    }
+
+    private boolean isConnectorConfigOrFactory(ResolvedReferenceTypeDeclaration typeDeclaration) {
+        String className = typeDeclaration.getClassName();
+        return className.endsWith("Config")
+                || className.endsWith("ConfigFactory")
+                || hasAncestor(
+                        typeDeclaration,
+                        "org.apache.seatunnel.connectors.cdc.base.config.SourceConfig")
+                || hasAncestor(
+                        typeDeclaration,
+                        "org.apache.seatunnel.connectors.cdc.base.config.SourceConfig.Factory");
     }
 
     private boolean implementsSeaTunnelSourceOrSink(ClassOrInterfaceDeclaration classDeclaration) {
@@ -248,6 +368,24 @@ public class SerialVersionUIDCheckerTest {
         }
     }
 
+    private void checkClassDeclaration(
+            ClassOrInterfaceDeclaration classDeclaration, List<String> missingSerialVersionUID) {
+        try {
+            ResolvedReferenceTypeDeclaration typeDeclaration = classDeclaration.resolve();
+            String className = typeDeclaration.getQualifiedName();
+            if (!checkedClasses.contains(className)) {
+                if (!hasSerialVersionUID(typeDeclaration)) {
+                    missingSerialVersionUID.add(className);
+                    LOG.warn("Class {} is missing serialVersionUID field", className);
+                }
+                checkedClasses.add(className);
+            }
+        } catch (Exception e) {
+            LOG.warn(
+                    "Could not check class declaration: {}", classDeclaration.getNameAsString(), e);
+        }
+    }
+
     private boolean isSerializable(ResolvedReferenceType resolvedType) {
         return resolvedType.getQualifiedName().equals("java.io.Serializable")
                 || resolvedType.getAllAncestors().stream()
@@ -256,9 +394,20 @@ public class SerialVersionUIDCheckerTest {
                                         ancestor.getQualifiedName().equals("java.io.Serializable"));
     }
 
+    private boolean isSerializable(ResolvedReferenceTypeDeclaration typeDeclaration) {
+        return typeDeclaration.getQualifiedName().equals("java.io.Serializable")
+                || hasAncestor(typeDeclaration, "java.io.Serializable");
+    }
+
+    private boolean hasAncestor(
+            ResolvedReferenceTypeDeclaration typeDeclaration, String ancestorClassName) {
+        return typeDeclaration.getAllAncestors().stream()
+                .anyMatch(ancestor -> ancestor.getQualifiedName().equals(ancestorClassName));
+    }
+
     private boolean hasSerialVersionUID(ResolvedReferenceTypeDeclaration typeDeclaration) {
         return typeDeclaration.isInterface()
-                || typeDeclaration.getAllFields().stream()
+                || typeDeclaration.getDeclaredFields().stream()
                         .anyMatch(field -> field.getName().equals("serialVersionUID"));
     }
 

--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/SerialVersionUIDCheckerTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/SerialVersionUIDCheckerTest.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(SerialVersionUIDCheckerTest.TestResultLogger.class)
@@ -61,13 +62,34 @@ public class SerialVersionUIDCheckerTest {
     private static final Logger LOG = LoggerFactory.getLogger(SerialVersionUIDCheckerTest.class);
     private static final String JAVA_FILE_EXTENSION = ".java";
     private static final String CONNECTOR_DIR = "seatunnel-connectors-v2";
-    private static final String CONNECTOR_CDC_DIR =
-            CONNECTOR_DIR + File.separator + "connector-cdc";
     private static final String JAVA_PATH_FRAGMENT =
             "src" + File.separator + "main" + File.separator + "java";
+    private static final String CONNECTOR_CDC_DIR =
+            CONNECTOR_DIR + File.separator + "connector-cdc";
+    private static final String CONNECTOR_JDBC_CONFIG_DIR =
+            CONNECTOR_DIR
+                    + File.separator
+                    + "connector-jdbc"
+                    + File.separator
+                    + JAVA_PATH_FRAGMENT
+                    + File.separator
+                    + "org"
+                    + File.separator
+                    + "apache"
+                    + File.separator
+                    + "seatunnel"
+                    + File.separator
+                    + "connectors"
+                    + File.separator
+                    + "seatunnel"
+                    + File.separator
+                    + "jdbc"
+                    + File.separator
+                    + "config";
     private static final List<String> CHECKED_PATHS =
             Arrays.asList(
                     CONNECTOR_CDC_DIR,
+                    CONNECTOR_JDBC_CONFIG_DIR,
                     "seatunnel-engine"
                             + File.separator
                             + "seatunnel-engine-core"
@@ -156,6 +178,22 @@ public class SerialVersionUIDCheckerTest {
             fail(errorMessage);
         }
         LOG.info("All checked classes have correct serialVersionUID.");
+    }
+
+    @Test
+    public void checkJdbcConfigPathIsCovered() {
+        List<Path> classPaths = findClassPaths();
+
+        assertTrue(
+                classPaths.stream()
+                        .anyMatch(
+                                path ->
+                                        path.endsWith(
+                                                Paths.get(
+                                                        "jdbc",
+                                                        "config",
+                                                        "JdbcConnectionConfig.java"))),
+                "JDBC config classes should be covered by serialVersionUID checker.");
     }
 
     private List<Path> findClassPaths() {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/config/JdbcSourceTableConfig.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 @Data
 public class JdbcSourceTableConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private String table;
     private List<String> primaryKeys;
     private String snapshotSplitColumn;

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbSourceConfigProvider.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mongodb/config/MongodbSourceConfigProvider.java
@@ -40,6 +40,8 @@ public class MongodbSourceConfigProvider {
     }
 
     public static class Builder implements SourceConfig.Factory<MongodbSourceConfig> {
+        private static final long serialVersionUID = 1L;
+
         private String hosts;
         private String username;
         private String password;

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/config/MySqlSourceConfigFactory.java
@@ -30,6 +30,8 @@ import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.ch
 
 /** A factory to initialize {@link MySqlSourceConfig}. */
 public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
+    private static final long serialVersionUID = -6578851046816898665L;
+
     public static final String SCHEMA_CHANGE_KEY = "include.schema.changes";
 
     private ServerIdRange serverIdRange;

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/config/PostgresSourceConfigFactory.java
@@ -32,6 +32,8 @@ import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.ch
 
 public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String DATABASE_SERVER_NAME = "postgres_cdc_source";
 
     private static final String DRIVER_CLASS_NAME = "org.postgresql.Driver";

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/config/SqlServerSourceConfigFactory.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-sqlserver/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/sqlserver/config/SqlServerSourceConfigFactory.java
@@ -31,6 +31,8 @@ import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.ch
 /** Factory for creating {@link SqlServerSourceConfig}. */
 public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String DATABASE_SERVER_NAME = "sqlserver_transaction_log_source";
     private static final String DRIVER_CLASS_NAME = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final String SCHEMA_CHANGE_KEY = "include.schema.changes";

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-tidb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/tidb/source/config/TiDBSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-tidb/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/tidb/source/config/TiDBSourceConfig.java
@@ -35,6 +35,8 @@ import java.io.Serializable;
 @NoArgsConstructor
 @EqualsAndHashCode
 public class TiDBSourceConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private String databaseName;
     private String tableName;
     private StartupMode startupMode;

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceTableConfig.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSourceTableConfig.java
@@ -37,6 +37,8 @@ import java.util.stream.Collectors;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JdbcSourceTableConfig implements Serializable {
+    private static final long serialVersionUID = 2L;
+
     private static final int DEFAULT_PARTITION_NUMBER = 10;
 
     @JsonProperty("table_path")

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobResult.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobResult.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 @Data
 @AllArgsConstructor
 public class JobResult implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @NonNull private JobStatus status;
 

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStateEvent.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStateEvent.java
@@ -28,6 +28,7 @@ import lombok.ToString;
 @Setter
 @ToString
 public class JobStateEvent implements Event {
+    private static final long serialVersionUID = 1L;
 
     private String jobId;
     private String jobName;

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStatusData.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStatusData.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 public final class JobStatusData implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private Long jobId;
     private String jobName;
     private JobStatus jobStatus;

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/ConnectorJarIdentifier.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/ConnectorJarIdentifier.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 @Setter
 @EqualsAndHashCode
 public class ConnectorJarIdentifier implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private byte[] connectorJarID;
 

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/Edge.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/Edge.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 @Data
 @AllArgsConstructor
 public class Edge implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private Long inputVertexId;
 

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/ExecutionAddress.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/ExecutionAddress.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ExecutionAddress implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private String hostname;
     private int port;
 }

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/JobDAGInfo.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/JobDAGInfo.java
@@ -35,6 +35,8 @@ import java.util.Set;
 @NoArgsConstructor
 @Data
 public class JobDAGInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     Long jobId;
     Map<String, Object> envOptions;
     Map<Integer, List<Edge>> pipelineEdges;

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/JobPipelineCheckpointData.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/JobPipelineCheckpointData.java
@@ -38,6 +38,8 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 public class JobPipelineCheckpointData implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private long jobId;
     private int pipelineId;
     private long checkpointId;
@@ -52,6 +54,8 @@ public class JobPipelineCheckpointData implements Serializable {
     @Data
     @AllArgsConstructor
     public static class ActionState implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         private List<byte[]> coordinatorState;
         private List<ActionSubtaskState> subtaskState;
     }
@@ -59,6 +63,8 @@ public class JobPipelineCheckpointData implements Serializable {
     @Data
     @AllArgsConstructor
     public static class ActionSubtaskState implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         private final int index;
         private final List<byte[]> state;
     }

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/PipelineExecutionState.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/PipelineExecutionState.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 
 @Getter
 public class PipelineExecutionState implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final int pipelineId;
 

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/VertexInfo.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/job/VertexInfo.java
@@ -31,6 +31,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class VertexInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private long vertexId;
 


### PR DESCRIPTION
### Purpose

Fixes #11020.

The existing `SerialVersionUIDCheckerTest` only checked the generic state types referenced by `SeaTunnelSource` and `SeaTunnelSink` implementations. It missed other Java-serialized classes that are part of job graph or restore-related paths, such as CDC source config factories/config objects and engine job graph DTOs.

### Changes

- Extend `SerialVersionUIDCheckerTest` to check:
  - CDC connector config/config-factory classes under `connector-cdc`
  - engine job graph classes under `engine/core/job` and `engine/common/job`
  - existing source/sink generic state types
- Require `serialVersionUID` to be declared on the concrete class itself instead of accepting an inherited field.
- Add explicit `serialVersionUID` fields to the currently uncovered CDC config/factory classes and engine job graph DTOs.
- Preserve the existing MySQL CDC factory UID baseline by declaring `-6578851046816898665L`.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-ci-tools -Dtest=SerialVersionUIDCheckerTest test`
- `./mvnw -q -DskipTests verify`
- `./mvnw -pl seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql -Dtest=MySqlSourceConfigFactorySerializationTest test`