### PR TITLE
[Docs][Connector-V2] Improve ActiveMQ sink docs

### DIFF
--- a/docs/en/connectors/sink/Activemq.md
+++ b/docs/en/connectors/sink/Activemq.md
@@ -1,12 +1,12 @@
 import ChangeLog from '../changelog/connector-activemq.md';
 
-# Activemq
+# ActiveMQ
 
-> Activemq sink connector
+> ActiveMQ sink connector
 
 ## Description
 
-Used to write data to Activemq.
+Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text message.
 
 ## Key features
 
@@ -14,110 +14,62 @@ Used to write data to Activemq.
 
 ## Options
 
-|                name                 |  type   | required | default value |
-|-------------------------------------|---------|----------|---------------|
-| host                                | string  | no       | -             |
-| port                                | int     | no       | -             |
-| virtual_host                        | string  | no       | -             |
-| username                            | string  | no       | -             |
-| password                            | string  | no       | -             |
-| queue_name                          | string  | yes      | -             |
-| uri                                 | string  | yes      | -             |
-| check_for_duplicate                 | boolean | no       | -             |
-| client_id                           | boolean | no       | -             |
-| copy_message_on_send                | boolean | no       | -             |
-| disable_timeStamps_by_default       | boolean | no       | -             |
-| use_compression                     | boolean | no       | -             |
-| always_session_async                | boolean | no       | -             |
-| dispatch_async                      | boolean | no       | -             |
-| nested_map_and_list_enabled         | boolean | no       | -             |
-| warnAboutUnstartedConnectionTimeout | boolean | no       | -             |
-| closeTimeout                        | int     | no       | -             |
+| name                                    | type    | required | default value | description                                                                                                                                                           |
+|-----------------------------------------|---------|----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| uri                                     | string  | yes      | -             | ActiveMQ broker URL, such as `tcp://localhost:61616`.                                                                                                                 |
+| queue_name                              | string  | yes      | -             | Queue name to write messages to.                                                                                                                                      |
+| username                                | string  | no       | -             | Username used to create the ActiveMQ connection. If this option is set, `password` must also be set.                                                                  |
+| password                                | string  | no       | -             | Password used to create the ActiveMQ connection. If this option is set, `username` must also be set.                                                                  |
+| client_id                               | string  | no       | -             | JMS client ID used by the connection factory.                                                                                                                         |
+| check_for_duplicate                     | boolean | no       | -             | Whether the ActiveMQ client checks duplicate messages.                                                                                                                |
+| always_session_async                    | boolean | no       | -             | Whether the ActiveMQ client always uses a separate thread to dispatch messages for each session.                                                                       |
+| always_sync_send                        | boolean | no       | -             | Whether the ActiveMQ producer always uses synchronous sends.                                                                                                          |
+| close_timeout                           | int     | no       | -             | Timeout in milliseconds before closing the connection is considered failed.                                                                                           |
+| dispatch_async                          | boolean | no       | -             | Whether the broker dispatches messages asynchronously.                                                                                                                |
+| nested_map_and_list_enabled             | boolean | no       | -             | Whether structured message properties and `MapMessage` entries can contain nested `Map` and `List` objects.                                                           |
+| warn_about_unstarted_connection_timeout | int     | no       | -             | Timeout in milliseconds before ActiveMQ warns that a connection was not started correctly. Set a value less than `0` to disable the warning in the ActiveMQ client. |
 
-### host [string]
+## Notes
 
-the default host to use for connections
-
-### port [int]
-
-the default port to use for connections
-
-### username [string]
-
-the AMQP user name to use when connecting to the broker
-
-### password [string]
-
-the password to use when connecting to the broker
-
-### uri [string]
-
-convenience method for setting the fields in an AMQP URI: host, port, username, password and virtual host
-
-### queue_name [string]
-
-the queue to write the message to
-
-### check_for_duplicate [boolean]
-
-will check for duplucate messages
-
-### client_id [string]
-
-client id
-
-### copy_message_on_send [boolean]
-
-if true, enables new JMS Message object as part of the send method
-
-### disable_timeStamps_by_default [boolean]
-
-disables timestamp for slight performance boost
-
-### use_compression [boolean]
-
-Enables the use of compression on the message’s body.
-
-### always_session_async [boolean]
-
-When true a separate thread is used for dispatching messages for each Session in the Connection.
-
-### always_sync_send [boolean]
-
-When true a MessageProducer will always use Sync sends when sending a Message
-
-### close_timeout [boolean]
-
-Sets the timeout, in milliseconds, before a close is considered complete.
-
-### dispatch_async [boolean]
-
-Should the broker dispatch messages asynchronously to the consumer
-
-### nested_map_and_list_enabled [boolean]
-
-Controls whether Structured Message Properties and MapMessages are supported
-
-### warn_about_unstarted_connection_timeout [int]
-
-The timeout, in milliseconds, from the time of connection creation to when a warning is generated
+- `uri` is the connection entry point. Put the broker host and port in this value, for example `tcp://activemq-host:61616`.
+- `username` and `password` are optional, but they must be configured together when the broker requires authentication.
+- The connector writes each SeaTunnel row as one JSON text message to `queue_name`.
 
 ## Example
 
-simple:
+Write fake data to an ActiveMQ queue:
 
 ```hocon
-sink {
-      ActiveMQ {
-          uri="tcp://localhost:61616"
-          username = "admin"
-          password = "admin"
-          queue_name = "test1"
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        id = int
+        name = string
       }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "Alice"] }
+      { kind = INSERT, fields = [2, "Bob"] }
+    ]
+  }
+}
+
+sink {
+  ActiveMQ {
+    uri = "tcp://localhost:61616"
+    username = "admin"
+    password = "admin"
+    queue_name = "testQueue"
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/sink/Activemq.md
+++ b/docs/zh/connectors/sink/Activemq.md
@@ -1,12 +1,12 @@
 import ChangeLog from '../changelog/connector-activemq.md';
 
-# Activemq
+# ActiveMQ
 
-> Activemq 接收器连接器
+> ActiveMQ Sink 连接器
 
 ## 描述
 
-用于将数据写入 Activemq.
+用于把 SeaTunnel 数据写入 ActiveMQ 队列。每一行数据都会被序列化成一条 JSON 文本消息。
 
 ## 关键特性
 
@@ -14,110 +14,62 @@ import ChangeLog from '../changelog/connector-activemq.md';
 
 ## 选项
 
-|                名称                 |  类型   | 必需  | 默认值 |
-|-------------------------------------|---------|-----|--------------|
-| host                                | string  | 否   | -            |
-| port                                | int     | 否   | -            |
-| virtual_host                        | string  | 否   | -            |
-| username                            | string  | 否   | -            |
-| password                            | string  | 否   | -            |
-| queue_name                          | string  | 是   | -            |
-| uri                                 | string  | 是 | -            |
-| check_for_duplicate                 | boolean | 否  | -            |
-| client_id                           | boolean | 否  | -            |
-| copy_message_on_send                | boolean | 否  | -            |
-| disable_timeStamps_by_default       | boolean | 否  | -            |
-| use_compression                     | boolean | 否  | -            |
-| always_session_async                | boolean | 否  | -            |
-| dispatch_async                      | boolean | 否  | -            |
-| nested_map_and_list_enabled         | boolean | 否  | -            |
-| warnAboutUnstartedConnectionTimeout | boolean | 否  | -            |
-| closeTimeout                        | int     | 否  | -            |
+| 名称                                    | 类型      | 是否必传 | 默认值 | 描述                                                                                                      |
+|---------------------------------------|---------|------|-----|---------------------------------------------------------------------------------------------------------|
+| uri                                   | string  | 是    | -   | ActiveMQ Broker 地址，例如 `tcp://localhost:61616`。                                                           |
+| queue_name                            | string  | 是    | -   | 要写入的队列名称。                                                                                              |
+| username                              | string  | 否    | -   | 创建 ActiveMQ 连接时使用的用户名。配置该项时必须同时配置 `password`。                                                      |
+| password                              | string  | 否    | -   | 创建 ActiveMQ 连接时使用的密码。配置该项时必须同时配置 `username`。                                                      |
+| client_id                             | string  | 否    | -   | 连接工厂使用的 JMS 客户端 ID。                                                                                   |
+| check_for_duplicate                   | boolean | 否    | -   | 是否让 ActiveMQ 客户端检查重复消息。                                                                               |
+| always_session_async                  | boolean | 否    | -   | 是否始终为每个 Session 使用独立线程分发消息。                                                                          |
+| always_sync_send                      | boolean | 否    | -   | 是否始终使用同步方式发送消息。                                                                                       |
+| close_timeout                         | int     | 否    | -   | 关闭连接的超时时间，单位毫秒。                                                                                        |
+| dispatch_async                        | boolean | 否    | -   | Broker 是否异步分发消息。                                                                                       |
+| nested_map_and_list_enabled           | boolean | 否    | -   | 是否允许结构化消息属性和 `MapMessage` 条目中包含嵌套的 `Map`、`List` 对象。                                               |
+| warn_about_unstarted_connection_timeout | int   | 否    | -   | 连接没有正确启动时，ActiveMQ 客户端发出警告前等待的毫秒数。设置为小于 `0` 的值可以关闭这个警告。                              |
 
-### host [string]
+## 注意事项
 
-用于连接的默认主机.
-
-### port [int]
-
-用于连接的默认端口
-
-### username [string]
-
-用于连接的默认端口
-
-### password [string]
-
-连接到代理时使用的密码
-
-### uri [string]
-
-用于设置 AMQP URI 中字段（主机、端口、用户名、密码和虚拟主机）的便捷方法
-
-### queue_name [string]
-
-写入消息的队列
-
-### check_for_duplicate [boolean]
-
-将检查重复消息
-
-### client_id [string]
-
-客户端ID
-
-### copy_message_on_send [boolean]
-
-如果为true，则启用新的JMS消息对象作为发送方法的一部分
-
-### disable_timeStamps_by_default [boolean]
-
-禁用时间戳以获得轻微的性能提升.
-
-### use_compression [boolean]
-
-允许对消息正文使用压缩.
-
-### always_session_async [boolean]
-
-当为true时，将使用单独的线程为连接中的每个会话分派消息.
-
-### always_sync_send [boolean]
-
-当为true时，MessageProducer在发送消息时将始终使用同步发送
-
-### close_timeout [boolean]
-
-设置关闭完成前的超时时间（以毫秒为单位）.
-
-### dispatch_async [boolean]
-
-代理是否应该异步地向消费者发送消息
-
-### nested_map_and_list_enabled [boolean]
-
-控制是否支持结构化消息属性和MapMessages
-
-### warn_about_unstarted_connection_timeout [int]
-
-从创建连接到生成警告的超时时间（毫秒）
+- `uri` 是连接入口，Broker 的主机和端口都写在这里，例如 `tcp://activemq-host:61616`。
+- `username` 和 `password` 是可选项；如果 Broker 需要认证，这两个配置要一起写。
+- 连接器会把每一行 SeaTunnel 数据作为一条 JSON 文本消息写入 `queue_name`。
 
 ## 示例
 
-简单:
+把 FakeSource 数据写入 ActiveMQ 队列：
 
 ```hocon
-sink {
-      ActiveMQ {
-          uri="tcp://localhost:61616"
-          username = "admin"
-          password = "admin"
-          queue_name = "test1"
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        id = int
+        name = string
       }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "Alice"] }
+      { kind = INSERT, fields = [2, "Bob"] }
+    ]
+  }
+}
+
+sink {
+  ActiveMQ {
+    uri = "tcp://localhost:61616"
+    username = "admin"
+    password = "admin"
+    queue_name = "testQueue"
+  }
 }
 ```
 
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary
- align the ActiveMQ sink option table with the current connector option rule
- remove options that are not part of the supported sink contract
- document the JSON text-message write behavior and add a complete FakeSource-to-ActiveMQ example

## Verification
- ./mvnw spotless:apply
- ./mvnw -pl seatunnel-connectors-v2/connector-activemq -DskipTests -Dskip.spotless=true verify
- ./mvnw -q -DskipTests verify

## Notes
- Checked existing pull requests for ActiveMQ documentation changes and did not find a duplicate open PR.
- Re-ran failed website jobs on existing Daniel docs PRs; they still fail on the external Docusaurus plugin resolution issue, not on those connector docs.