### PR TITLE
[Docs][Connector-V2] Improve InfluxDB connector docs

### DIFF
--- a/docs/en/connectors/sink/InfluxDB.md
+++ b/docs/en/connectors/sink/InfluxDB.md
@@ -6,7 +6,9 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## Description
 
-Write data to InfluxDB.
+Write SeaTunnel rows to InfluxDB 1.x. The sink converts one row into one InfluxDB point, using
+`measurement`, `key_time`, and `key_tags` to decide the target measurement, timestamp, tags, and
+fields.
 
 ## Key features
 
@@ -15,20 +17,26 @@ Write data to InfluxDB.
 
 ## Options
 
-|            name             |  type  | required |        default value         |
-|-----------------------------|--------|----------|------------------------------|
-| url                         | string | yes      | -                            |
-| database                    | string | yes      |                              |
-| measurement                 | string | yes      |                              |
-| username                    | string | no       | -                            |
-| password                    | string | no       | -                            |
-| key_time                    | string | no       | processing time              |
-| key_tags                    | array  | no       | exclude `field` & `key_time` |
-| batch_size                  | int    | no       | 1024                         |
-| max_retries                 | int    | no       | -                            |
-| retry_backoff_multiplier_ms | int    | no       | -                            |
-| connect_timeout_ms          | long   | no       | 15000                        |
-| common-options              | config | no       | -                            |
+| name                        | type   | required | default value         | description                                                                                   |
+|-----------------------------|--------|----------|-----------------------|-----------------------------------------------------------------------------------------------|
+| url                         | string | yes      | -                     | InfluxDB server URL, for example `http://influxdb-host:8086`.                                 |
+| database                    | string | yes      | -                     | InfluxDB database name.                                                                       |
+| measurement                 | string | no       | input table full name | InfluxDB measurement name. If it is not configured, the sink uses the input table name.        |
+| username                    | string | no       | -                     | InfluxDB username. It must be configured together with `password`.                            |
+| password                    | string | no       | -                     | InfluxDB password. It must be configured together with `username`.                            |
+| key_time                    | string | no       | processing time       | Field name used as the InfluxDB point timestamp. If omitted, processing time is used.          |
+| key_tags                    | array  | no       | -                     | Field names written as InfluxDB tags. Other fields are written as point fields.                |
+| batch_size                  | int    | no       | 1024                  | Number of points buffered before flushing to InfluxDB.                                        |
+| max_retries                 | int    | no       | -                     | Maximum retry count when flushing points fails.                                               |
+| write_timeout               | int    | no       | 5                     | Write timeout used by the InfluxDB client.                                                     |
+| retry_backoff_multiplier_ms | int    | no       | -                     | Backoff multiplier used between retry attempts, in milliseconds.                              |
+| max_retry_backoff_ms        | int    | no       | -                     | Maximum backoff between retry attempts, in milliseconds.                                      |
+| rp                          | string | no       | -                     | Retention policy used when writing points.                                                     |
+| epoch                       | string | no       | n                     | Time precision used by the client. Uppercase values `H`, `M`, `S`, `MS`, `U`, and `NS` are recognized for write precision. |
+| connect_timeout_ms          | long   | no       | 15000                 | Timeout for connecting to InfluxDB, in milliseconds.                                          |
+| query_timeout_sec           | int    | no       | 3                     | Read timeout used by the InfluxDB client, in seconds.                                         |
+| multi_table_sink_replica    | int    | no       | -                     | Replica count for multi-table sink writers.                                                   |
+| common-options              | config | no       | -                     | Sink plugin common options.                                                                   |
 
 ### url
 
@@ -44,7 +52,8 @@ The name of `influxDB` database
 
 ### measurement [string]
 
-The name of `influxDB` measurement
+The name of `influxDB` measurement. This option is optional. If it is omitted, the sink uses the
+input table full name as the measurement name, which is useful for multi-table writes.
 
 ### username [string]
 
@@ -79,6 +88,24 @@ Using as a multiplier for generating the next delay for backoff
 
 The amount of time to wait before attempting to retry a request to `influxDB`
 
+### write_timeout [int]
+
+The write timeout used by the InfluxDB client.
+
+### rp [string]
+
+Retention policy used when writing points.
+
+### epoch [string]
+
+Time precision used by the InfluxDB client. For sink write precision, uppercase values `H`, `M`,
+`S`, `MS`, `U`, and `NS` are recognized by the current connector. The default `n` is treated as
+nanosecond precision.
+
+### query_timeout_sec [int]
+
+The read timeout used by the InfluxDB client, in seconds.
+
 ### connect_timeout_ms [long]
 
 the timeout for connecting to InfluxDB, in milliseconds
@@ -88,6 +115,8 @@ the timeout for connecting to InfluxDB, in milliseconds
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
 
 ## Examples
+
+### Write One Measurement
 
 ```hocon
 sink {
@@ -103,9 +132,53 @@ sink {
 
 ```
 
-### Multiple table
+### Write Without Explicit Measurement
 
-#### example1
+When `measurement` is omitted, the sink uses the input table full name as the measurement name.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      table = "influxdb_sink"
+      fields {
+        label = STRING
+        c_string = STRING
+        c_double = DOUBLE
+        c_bigint = BIGINT
+        c_float = FLOAT
+        c_int = INT
+        c_smallint = SMALLINT
+        c_boolean = BOOLEAN
+        time = BIGINT
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
+      }
+    ]
+  }
+}
+
+sink {
+  InfluxDB {
+    url = "http://influxdb-host:8086"
+    database = "test"
+    key_time = "time"
+    key_tags = ["label"]
+    batch_size = 1
+  }
+}
+```
+
+### Multiple Table
 
 ```hocon
 env {
@@ -131,7 +204,8 @@ sink {
   InfluxDB {
     url = "http://influxdb-host:8086"
     database = "test"
-    measurement = "${table_name}_test"
+    key_time = "time"
+    batch_size = 1
   }
 }
 ```

--- a/docs/en/connectors/source/InfluxDB.md
+++ b/docs/en/connectors/source/InfluxDB.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## Description
 
-Read external data source data through InfluxDB.
+Read data from InfluxDB 1.x by using an InfluxQL query. The connector supports a normal single
+query and an optional parallel scan mode that splits one query by an integer column range.
 
 ## Key features
 
@@ -22,22 +23,23 @@ supports query SQL and can achieve projection effect.
 
 ## Options
 
-|        name        |  type  | required | default value |
-|--------------------|--------|----------|---------------|
-| url                | string | yes      | -             |
-| sql                | string | yes      | -             |
-| schema             | config | yes      | -             |
-| database           | string | yes      |               |
-| username           | string | no       | -             |
-| password           | string | no       | -             |
-| lower_bound        | long   | no       | -             |
-| upper_bound        | long   | no       | -             |
-| partition_num      | int    | no       | -             |
-| split_column       | string | no       | -             |
-| epoch              | string | no       | n             |
-| connect_timeout_ms | long   | no       | 15000         |
-| query_timeout_sec  | int    | no       | 3             |
-| common-options     | config | no       | -             |
+| name               | type   | required | default value | description                                                                                      |
+|--------------------|--------|----------|---------------|--------------------------------------------------------------------------------------------------|
+| url                | string | yes      | -             | InfluxDB server URL, for example `http://influxdb-host:8086`.                                    |
+| sql                | string | yes      | -             | InfluxQL query used to read data.                                                                |
+| schema             | config | yes      | -             | Output schema returned by the source.                                                            |
+| database           | string | yes      | -             | InfluxDB database name.                                                                          |
+| username           | string | no       | -             | InfluxDB username. It must be configured together with `password`.                               |
+| password           | string | no       | -             | InfluxDB password. It must be configured together with `username`.                               |
+| lower_bound        | int    | no       | -             | Lower bound of `split_column` when parallel scan is enabled.                                      |
+| upper_bound        | int    | no       | -             | Upper bound of `split_column` when parallel scan is enabled.                                      |
+| partition_num      | int    | no       | 0             | Number of query splits. `0` means the source runs the original `sql` as one split.                |
+| split_column       | string | no       | -             | Integer column used to split the query when parallel scan is enabled.                             |
+| where              | string | no       | -             | Reserved source option. The current split logic reads the `where` keyword from `sql` directly.    |
+| epoch              | string | no       | n             | Time precision returned by InfluxDB. For example: `H`, `m`, `s`, `MS`, `u`, `n`.                 |
+| connect_timeout_ms | long   | no       | 15000         | Timeout for connecting to InfluxDB, in milliseconds.                                             |
+| query_timeout_sec  | int    | no       | 3             | Timeout for querying InfluxDB, in seconds.                                                       |
+| common-options     | config | no       | -             | Source plugin common options.                                                                    |
 
 ### url
 
@@ -85,18 +87,19 @@ the password of the influxDB when you select
 
 ### split_column [string]
 
-the `split_column` of the influxDB when you select
+The column used to split one query into multiple range queries.
 
 > Tips:
 > - influxDB tags is not supported as a segmented primary key because the type of tags can only be a string
 > - influxDB time is not supported as a segmented primary key because the time field cannot participate in mathematical calculation
 > - Currently, `split_column` only supports integer data segmentation, and does not support `float`, `string`, `date` and other types.
+> - `split_column`, `lower_bound`, `upper_bound`, and `partition_num` must be configured together.
 
-### upper_bound [long]
+### upper_bound [int]
 
 upper bound of the `split_column`column
 
-### lower_bound [long]
+### lower_bound [int]
 
 lower bound of the `split_column` column
 
@@ -142,50 +145,113 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
 
 ## Examples
 
-Example of multi parallelism and multi partition scanning
+### Read With Parallel Range Splits
 
 ```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
 source {
 
     InfluxDB {
         url = "http://influxdb-host:8086"
-        sql = "select label, value, rt, time from test"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
         database = "test"
-        upper_bound = 100
-        lower_bound = 1
+        upper_bound = 99
+        lower_bound = 0
         partition_num = 4
-        split_column = "value"
+        split_column = "c_int"
         schema {
             fields {
                 label = STRING
-                value = INT
-                rt = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
                 time = BIGINT
             }
+        }
     }
 
 }
 
+sink {
+    Console {}
+}
 ```
 
-Example of not using partition scan
+### Read Without Parallel Range Splits
 
 ```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
 source {
 
     InfluxDB {
         url = "http://influxdb-host:8086"
-        sql = "select label, value, rt, time from test"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
         database = "test"
         schema {
             fields {
                 label = STRING
-                value = INT
-                rt = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
                 time = BIGINT
             }
+        }
     }
 
+}
+
+sink {
+    Console {}
+}
+```
+
+### Read With InfluxQL Time Zone
+
+```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
+source {
+    InfluxDB {
+        url = "http://influxdb-host:8086"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source tz('Asia/Shanghai')"
+        database = "test"
+        schema {
+            fields {
+                label = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
+                time = BIGINT
+            }
+        }
+    }
+}
+
+sink {
+    Console {}
 }
 ```
 

--- a/docs/zh/connectors/sink/InfluxDB.md
+++ b/docs/zh/connectors/sink/InfluxDB.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## 描述
 
-将数据写入 InfluxDB。
+将 SeaTunnel 行数据写入 InfluxDB 1.x。Sink 会把一行数据转换成一个 InfluxDB point，并通过
+`measurement`、`key_time`、`key_tags` 决定写入的 measurement、时间戳、tag 和 field。
 
 ## 关键特性
 
@@ -15,20 +16,26 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## 选项
 
-|            参数名             |  类型  | 必须 |        默认值         |
-|-----------------------------|--------|------|------------------------------|
-| url                         | string | 是   | -                            |
-| database                    | string | 是   |                              |
-| measurement                 | string | 是   |                              |
-| username                    | string | 否   | -                            |
-| password                    | string | 否   | -                            |
-| key_time                    | string | 否   | processing time              |
-| key_tags                    | array  | 否   | exclude `field` & `key_time` |
-| batch_size                  | int    | 否   | 1024                         |
-| max_retries                 | int    | 否   | -                            |
-| retry_backoff_multiplier_ms | int    | 否   | -                            |
-| connect_timeout_ms          | long   | 否   | 15000                        |
-| common-options              | config | 否   | -                            |
+| 参数名                         | 类型     | 必须 | 默认值          | 描述                                                       |
+|-----------------------------|--------|----|--------------|----------------------------------------------------------|
+| url                         | string | 是  | -            | InfluxDB 连接 URL，例如 `http://influxdb-host:8086`。          |
+| database                    | string | 是  | -            | InfluxDB 数据库名称。                                           |
+| measurement                 | string | 否  | 输入表完整名称      | InfluxDB measurement 名称。不配置时使用输入表名。                     |
+| username                    | string | 否  | -            | InfluxDB 用户名。必须和 `password` 一起配置。                         |
+| password                    | string | 否  | -            | InfluxDB 密码。必须和 `username` 一起配置。                         |
+| key_time                    | string | 否  | processing time | 作为 InfluxDB point 时间戳的字段名。不配置时使用处理时间。                 |
+| key_tags                    | array  | 否  | -            | 写为 InfluxDB tag 的字段名。其他字段会写为 point field。               |
+| batch_size                  | int    | 否  | 1024         | 缓存多少个 point 后写入 InfluxDB。                                |
+| max_retries                 | int    | 否  | -            | 写入失败时的最大重试次数。                                            |
+| write_timeout               | int    | 否  | 5            | InfluxDB 客户端写入超时时间。                                      |
+| retry_backoff_multiplier_ms | int    | 否  | -            | 重试等待时间的倍数，单位毫秒。                                          |
+| max_retry_backoff_ms        | int    | 否  | -            | 两次重试之间的最大等待时间，单位毫秒。                                     |
+| rp                          | string | 否  | -            | 写入时使用的 retention policy。                                  |
+| epoch                       | string | 否  | n            | 客户端使用的时间精度。写入精度识别大写值：`H`、`M`、`S`、`MS`、`U`、`NS`。 |
+| connect_timeout_ms          | long   | 否  | 15000        | 连接 InfluxDB 的超时时间，单位毫秒。                                  |
+| query_timeout_sec           | int    | 否  | 3            | InfluxDB 客户端读超时时间，单位秒。                                   |
+| multi_table_sink_replica    | int    | 否  | -            | 多表写入时的 sink writer 副本数。                                  |
+| common-options              | config | 否  | -            | Sink 插件通用参数。                                             |
 
 ### url
 
@@ -44,7 +51,8 @@ http://influxdb-host:8086
 
 ### measurement [string]
 
-`influxDB` measurement 的名称
+`influxDB` measurement 的名称。这个配置是可选项；不配置时，sink 会使用输入表完整名称作为
+measurement 名称，这在多表写入场景很有用。
 
 ### username [string]
 
@@ -79,6 +87,23 @@ http://influxdb-host:8086
 
 在尝试重新请求 `influxDB` 之前等待的时间量
 
+### write_timeout [int]
+
+InfluxDB 客户端写入超时时间。
+
+### rp [string]
+
+写入 point 时使用的 retention policy。
+
+### epoch [string]
+
+InfluxDB 客户端使用的时间精度。用于 sink 写入精度时，当前连接器识别大写值 `H`、`M`、`S`、`MS`、
+`U`、`NS`。默认值 `n` 会按纳秒精度处理。
+
+### query_timeout_sec [int]
+
+InfluxDB 客户端读超时时间，单位秒。
+
 ### connect_timeout_ms [long]
 
 连接到 InfluxDB 的超时时间，以毫秒为单位
@@ -88,6 +113,8 @@ http://influxdb-host:8086
 Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 详见
 
 ## 示例
+
+### 写入一个 measurement
 
 ```hocon
 sink {
@@ -103,9 +130,53 @@ sink {
 
 ```
 
-### 多表
+### 不显式配置 measurement
 
-#### 示例1
+不配置 `measurement` 时，sink 会使用输入表完整名称作为 measurement 名称。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      table = "influxdb_sink"
+      fields {
+        label = STRING
+        c_string = STRING
+        c_double = DOUBLE
+        c_bigint = BIGINT
+        c_float = FLOAT
+        c_int = INT
+        c_smallint = SMALLINT
+        c_boolean = BOOLEAN
+        time = BIGINT
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
+      }
+    ]
+  }
+}
+
+sink {
+  InfluxDB {
+    url = "http://influxdb-host:8086"
+    database = "test"
+    key_time = "time"
+    key_tags = ["label"]
+    batch_size = 1
+  }
+}
+```
+
+### 多表写入
 
 ```hocon
 env {
@@ -131,7 +202,8 @@ sink {
   InfluxDB {
     url = "http://influxdb-host:8086"
     database = "test"
-    measurement = "${table_name}_test"
+    key_time = "time"
+    batch_size = 1
   }
 }
 ```
@@ -139,5 +211,3 @@ sink {
 ## 变更日志
 
 <ChangeLog />
-
-

--- a/docs/zh/connectors/source/InfluxDB.md
+++ b/docs/zh/connectors/source/InfluxDB.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## 描述
 
-通过 InfluxDB 读取外部数据源数据。
+通过 InfluxQL 查询从 InfluxDB 1.x 读取数据。连接器支持普通单查询，也支持按一个整数列范围切分查询，
+让多个并行任务分别读取不同范围的数据。
 
 ## 关键特性
 
@@ -28,13 +29,14 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 | sql                | string | 是  | -     | 用于搜索数据的查询 SQL                                                                 |
 | schema             | config | 是  | -     | 上游数据的模式信息。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
 | database           | string | 是  | -     | InfluxDB 数据库                                                                  |
-| username           | string | 否  | -     | InfluxDB 用户名                                                                  |
-| password           | string | 否  | -     | InfluxDB 密码                                                                   |
-| lower_bound        | long   | 否  | -     | split_column 的下界                                                              |
-| upper_bound        | long   | 否  | -     | split_column 的上界                                                              |
-| partition_num      | int    | 否  | -     | 分区数量                                                                          |
+| username           | string | 否  | -     | InfluxDB 用户名。必须和 `password` 一起配置。                                                |
+| password           | string | 否  | -     | InfluxDB 密码。必须和 `username` 一起配置。                                                |
+| lower_bound        | int    | 否  | -     | 启用并行范围读取时，`split_column` 的下界。                                                   |
+| upper_bound        | int    | 否  | -     | 启用并行范围读取时，`split_column` 的上界。                                                   |
+| partition_num      | int    | 否  | 0     | 查询切分数量。`0` 表示不切分，直接执行原始 `sql`。                                              |
 | split_column       | string | 否  | -     | 分割列                                                                           |
-| epoch              | string | 否  | n     | 返回的时间精度                                                                       |
+| where              | string | 否  | -     | 预留的 source 配置项。当前切分逻辑直接从 `sql` 中读取 `where` 关键字。                              |
+| epoch              | string | 否  | n     | 返回的时间精度，例如：`H`、`m`、`s`、`MS`、`u`、`n`。                                     |
 | connect_timeout_ms | long   | 否  | 15000 | 连接 InfluxDB 的超时时间（毫秒）                                                         |
 | query_timeout_sec  | int    | 否  | 3     | 查询超时时间（秒）                                                                     |
 | common-options     | config | 否  | -     | 源插件通用参数                                                                       |
@@ -84,18 +86,19 @@ InfluxDB 密码
 
 ### split_column [string]
 
-InfluxDB 的分割列
+用于把一次查询切分成多个范围查询的列。
 
 > 提示：
 > - InfluxDB tags 不支持作为分割主键，因为 tags 的类型只能是字符串
 > - InfluxDB time 不支持作为分割主键，因为 time 字段无法参与数学计算
 > - 目前，`split_column` 仅支持整数数据分割，不支持 `float`、`string`、`date` 等类型。
+> - `split_column`、`lower_bound`、`upper_bound`、`partition_num` 需要一起配置。
 
-### upper_bound [long]
+### upper_bound [int]
 
 `split_column` 列的上界
 
-### lower_bound [long]
+### lower_bound [int]
 
 `split_column` 列的下界
 
@@ -141,24 +144,34 @@ InfluxDB 的查询超时时间（秒）
 
 ## 示例
 
-多并行性和多分区扫描示例
+### 使用并行范围读取
 
 ```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
 source {
 
     InfluxDB {
         url = "http://influxdb-host:8086"
-        sql = "select label, value, rt, time from test"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
         database = "test"
-        upper_bound = 100
-        lower_bound = 1
+        upper_bound = 99
+        lower_bound = 0
         partition_num = 4
-        split_column = "value"
+        split_column = "c_int"
         schema {
             fields {
                 label = STRING
-                value = INT
-                rt = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
                 time = BIGINT
             }
         }
@@ -166,31 +179,81 @@ source {
 
 }
 
+sink {
+    Console {}
+}
 ```
 
-不使用分区扫描的示例
+### 不使用并行范围读取
 
 ```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
 source {
 
     InfluxDB {
         url = "http://influxdb-host:8086"
-        sql = "select label, value, rt, time from test"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
         database = "test"
         schema {
             fields {
                 label = STRING
-                value = INT
-                rt = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
                 time = BIGINT
             }
         }
     }
 
+}
+
+sink {
+    Console {}
+}
+```
+
+### 使用 InfluxQL 时区查询
+
+```hocon
+env {
+    parallelism = 1
+    job.mode = "BATCH"
+}
+
+source {
+    InfluxDB {
+        url = "http://influxdb-host:8086"
+        sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source tz('Asia/Shanghai')"
+        database = "test"
+        schema {
+            fields {
+                label = STRING
+                c_string = STRING
+                c_double = DOUBLE
+                c_bigint = BIGINT
+                c_float = FLOAT
+                c_int = INT
+                c_smallint = SMALLINT
+                c_boolean = BOOLEAN
+                time = BIGINT
+            }
+        }
+    }
+}
+
+sink {
+    Console {}
 }
 ```
 
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary
- Improve InfluxDB source and sink documentation in English and Chinese.
- Align option tables with the current connector option rules and runtime behavior.
- Add clearer examples for range-split source reads, timezone queries, explicit measurement writes, omitted-measurement writes, and multi-table sink writes.

## Analysis
The existing InfluxDB docs were missing or misdescribing several public options. In particular, the sink documented `measurement` as required even though the connector derives it from the input table name when omitted. The sink option table also missed `write_timeout`, `max_retry_backoff_ms`, `rp`, `epoch`, `query_timeout_sec`, and `multi_table_sink_replica`. The source docs missed the public `where` option and did not clearly document the default `partition_num = 0` behavior.

Before opening this PR, I checked DanielCarter-stack's existing open documentation PRs and searched for an existing InfluxDB connector docs PR to avoid duplicating work.

## Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `git diff --check`