### PR TITLE
[Fix][Connector-V2] Remove incorrect HTTP entity content encoding

### DIFF
--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProvider.java
@@ -43,7 +43,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.EntityUtils;
@@ -518,7 +517,7 @@ public class HttpClientProvider implements AutoCloseable {
         }
 
         StringEntity entity = new StringEntity(body, ContentType.APPLICATION_JSON);
-        entity.setContentEncoding(new BasicHeader(HTTP.CONTENT_TYPE, APPLICATION_JSON));
+
         request.setEntity(entity);
     }
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/http/client/HttpClientProviderTest.java
@@ -16,13 +16,17 @@
  */
 package org.apache.seatunnel.connectors.seatunnel.http.client;
 
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
+
 import org.apache.http.Header;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicHeader;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,5 +87,39 @@ class HttpClientProviderTest {
         }
         // ensure no manually set content type or encoding
         Assertions.assertNull(post.getEntity().getContentEncoding());
+    }
+
+    @Test
+    void testJsonMapBodyDoesNotSetContentEncodingHeader() throws Exception {
+        HttpPost post = new HttpPost("http://localhost:8080");
+        Map<String, Object> body = new HashMap<>();
+        body.put("key", "value");
+
+        HttpClientProvider.addBody(post, body);
+
+        Assertions.assertEquals("application/json", post.getFirstHeader("Content-Type").getValue());
+        Assertions.assertNull(post.getFirstHeader("Content-Encoding"));
+        Assertions.assertNull(post.getEntity().getContentEncoding());
+        Assertions.assertTrue(
+                post.getEntity().getContentType().getValue().contains("application/json"));
+    }
+
+    @Test
+    void testJsonStringBodyDoesNotSetContentEncodingHeader() throws Exception {
+        HttpPost post = new HttpPost("http://localhost:8080");
+        Method addStringBody =
+                HttpClientProvider.class.getDeclaredMethod(
+                        "addBody", HttpEntityEnclosingRequestBase.class, String.class);
+        addStringBody.setAccessible(true);
+
+        try (HttpClientProvider provider = new HttpClientProvider(new HttpParameter())) {
+            addStringBody.invoke(provider, post, "{\"key\":\"value\"}");
+        }
+
+        Assertions.assertEquals("application/json", post.getFirstHeader("Content-Type").getValue());
+        Assertions.assertNull(post.getFirstHeader("Content-Encoding"));
+        Assertions.assertNull(post.getEntity().getContentEncoding());
+        Assertions.assertTrue(
+                post.getEntity().getContentType().getValue().contains("application/json"));
     }
 }


### PR DESCRIPTION
### Purpose

  Remove an incorrect `StringEntity#setContentEncoding` call in `HttpClientProvider`.

  The request body is already created with `ContentType.APPLICATION_JSON`, so the entity content type is set correctly. Setting content encoding with a `Content-Type: application/json` header is semantically wrong because content
  encoding should describe encodings such as gzip or deflate.

  ### Changes

  - Removed the incorrect entity content encoding assignment for JSON string request bodies.
  - Let `StringEntity(body, ContentType.APPLICATION_JSON)` handle the JSON content type.

  ### Impact

  This avoids sending misleading entity encoding metadata while preserving the existing JSON request body behavior.