### PR TITLE
[Docs][Connector-V2] Improve Amazon DynamoDB connector docs

### DIFF
--- a/docs/en/connectors/sink/AmazonDynamoDB.md
+++ b/docs/en/connectors/sink/AmazonDynamoDB.md
@@ -6,7 +6,9 @@ import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
 ## Description
 
-Write data to Amazon DynamoDB
+The Amazon DynamoDB sink connector writes SeaTunnel rows to a DynamoDB table.
+
+The target table must already exist. The connector writes each row as a DynamoDB item and uses batch write requests. It supports single-table writes and multi-table writes when the upstream row carries a table id.
 
 ## Key Features
 
@@ -16,13 +18,13 @@ Write data to Amazon DynamoDB
 
 ## Options
 
-|       Name        |  Type  | Required | Default value |
-|-------------------|--------|----------|---------------|
-| url               | string | yes      | -             |
-| region            | string | yes      | -             |
-| access_key_id     | string | yes      | -             |
-| secret_access_key | string | yes      | -             |
-| table             | string | yes      | -             |
+| name                | type   | required | default value |
+|---------------------|--------|----------|---------------|
+| url                 | string | yes      | -             |
+| region              | string | yes      | -             |
+| access_key_id       | string | yes      | -             |
+| secret_access_key   | string | yes      | -             |
+| table               | string | yes      | -             |
 | batch_size          | int    | no       | 25            |
 | max_retries         | int    | no       | 10            |
 | retry_base_delay_ms | long   | no       | 100           |
@@ -31,70 +33,126 @@ Write data to Amazon DynamoDB
 
 ### url [string]
 
-The URL to write to Amazon DynamoDB.
+The DynamoDB endpoint URL, for example `https://dynamodb.us-east-1.amazonaws.com`.
+
+When testing with DynamoDB Local, use the local endpoint, for example `http://127.0.0.1:8000`.
 
 ### region [string]
 
-The region of Amazon DynamoDB.
+The AWS region of the DynamoDB service, such as `us-east-1`.
 
 ### access_key_id [string]
 
-The access id of Amazon DynamoDB.
+The AWS access key ID used to connect to DynamoDB.
 
 ### secret_access_key [string]
 
-The access secret of Amazon DynamoDB.
+The AWS secret access key used to connect to DynamoDB.
 
 ### table [string]
 
-The table of Amazon DynamoDB. Supports `${table_name}` placeholder for multi-table sink scenarios.
+The DynamoDB table name to write to.
+
+For a normal single-table job, set this to the target table name. In a multi-table pipeline, the writer uses the table id carried by each row as the target table name and falls back to this configured table when the row has no table id.
 
 ### batch_size [int]
 
-The number of records to batch before writing to Amazon DynamoDB.
+The number of records buffered for one DynamoDB batch write request.
+
+DynamoDB batch write supports up to 25 write requests per call, so the default is `25`.
 
 ### max_retries [int]
 
-Maximum number of retries when DynamoDB returns unprocessed items in a batch write.
+The maximum number of retries when DynamoDB returns unprocessed items from a batch write request.
 
 ### retry_base_delay_ms [long]
 
-Base delay in milliseconds for exponential backoff between retries.
+The base delay, in milliseconds, used by exponential backoff between retries.
 
 ### retry_max_delay_ms [long]
 
-Maximum delay in milliseconds between retries regardless of retry count.
+The maximum delay, in milliseconds, between retries.
 
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
 
-## Example
+## Data Type Mapping
 
-### Single table
-```bash
-AmazonDynamoDB {
-    url = "http://127.0.0.1:8000"
-    region = "us-east-1"
-    access_key_id = "dummy-key"
-    secret_access_key = "dummy-secret"
-    table = "TableName"
+| SeaTunnel Data Type | DynamoDB Attribute Type |
+|---------------------|-------------------------|
+| BOOLEAN             | BOOL                    |
+| TINYINT             | N                       |
+| SMALLINT            | N                       |
+| INT                 | N                       |
+| BIGINT              | N                       |
+| FLOAT               | N                       |
+| DOUBLE              | N                       |
+| DECIMAL             | N                       |
+| STRING              | S                       |
+| TIME                | S                       |
+| DATE                | S                       |
+| TIMESTAMP           | S                       |
+| BYTES               | B                       |
+| MAP                 | M                       |
+| ARRAY               | L                       |
+| NULL                | NULL                    |
+
+## Task Example
+
+The following example reads rows from `source_table` and writes them to `sink_table`.
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
 }
-```
 
-### Multiple table
-```bash
-AmazonDynamoDB {
+source {
+  AmazonDynamoDB {
     url = "http://127.0.0.1:8000"
     region = "us-east-1"
     access_key_id = "dummy-key"
     secret_access_key = "dummy-secret"
-    table = "${table_name}"
+    table = "source_table"
+    parallelism = 2
+    schema = {
+      fields {
+        id = string
+        c_map = "map<string, smallint>"
+        c_array = "array<tinyint>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(2, 1)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
+    }
+  }
+}
+
+sink {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "sink_table"
+    batch_size = 25
+    max_retries = 10
+    retry_base_delay_ms = 100
+    retry_max_delay_ms = 5000
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-
-

--- a/docs/en/connectors/source/AmazonDynamoDB.md
+++ b/docs/en/connectors/source/AmazonDynamoDB.md
@@ -2,13 +2,15 @@ import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
 # AmazonDynamoDB
 
-> AmazonDynamoDB source connector
+> Amazon DynamoDB source connector
 
 ## Description
 
-Read data from Amazon DynamoDB.
+The Amazon DynamoDB source connector reads existing items from an Amazon DynamoDB table by using DynamoDB scan requests.
 
-## Key features
+The connector is a batch source. DynamoDB does not expose field types in the same way as a relational database, so the SeaTunnel schema must be configured explicitly.
+
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
@@ -19,7 +21,7 @@ Read data from Amazon DynamoDB.
 
 ## Options
 
-|         name          |  type  | required | default value |
+| name                  | type   | required | default value |
 |-----------------------|--------|----------|---------------|
 | url                   | string | yes      | -             |
 | region                | string | yes      | -             |
@@ -27,88 +29,145 @@ Read data from Amazon DynamoDB.
 | secret_access_key     | string | yes      | -             |
 | table                 | string | yes      | -             |
 | schema                | config | yes      | -             |
-| common-options        |        | yes      | -             |
-| scan_item_limit       |        | false    | -             |
-| parallel_scan_threads |        | false    | -             |
+| scan_item_limit       | int    | no       | 1             |
+| parallel_scan_threads | int    | no       | 2             |
+| common-options        |        | no       | -             |
 
 ### url [string]
 
-The URL to read to Amazon Dynamodb.
+The DynamoDB endpoint URL, for example `https://dynamodb.us-east-1.amazonaws.com`.
+
+When testing with DynamoDB Local, use the local endpoint, for example `http://127.0.0.1:8000`.
 
 ### region [string]
 
-The region of Amazon Dynamodb.
+The AWS region of the DynamoDB service, such as `us-east-1`.
 
 ### access_key_id [string]
 
-The access id of Amazon DynamoDB.
+The AWS access key ID used to connect to DynamoDB.
 
 ### secret_access_key [string]
 
-The access secret of Amazon DynamoDB.
+The AWS secret access key used to connect to DynamoDB.
 
 ### table [string]
 
-The table of Amazon DynamoDB.
+The DynamoDB table name to scan.
 
-### schema [Config]
+### schema [config]
 
-#### fields [config]
+Defines the SeaTunnel fields to read from DynamoDB items.
 
-Amazon Dynamodb is a NOSQL database service of support keys-value storage and document data structure,there is no way to get the data type.Therefore, we must configure schema.
+DynamoDB is a key-value and document database. The source connector cannot infer a complete SeaTunnel schema from DynamoDB, so every field that should be read must be listed here.
 
-such as:
-
-```
-schema {
+```hocon
+schema = {
   fields {
-    id = int
-    key_aa = string
-    key_bb = string
+    id = string
+    c_map = "map<string, smallint>"
+    c_array = "array<tinyint>"
+    c_string = string
+    c_boolean = boolean
+    c_int = int
+    c_bigint = bigint
+    c_float = float
+    c_double = double
+    c_decimal = "decimal(2, 1)"
+    c_bytes = bytes
+    c_date = date
+    c_timestamp = timestamp
   }
 }
 ```
 
+For more schema syntax, see [Schema Feature](../../introduction/concepts/schema-feature.md).
+
+### scan_item_limit [int]
+
+The maximum number of items returned by each DynamoDB scan request.
+
+### parallel_scan_threads [int]
+
+The number of logical scan segments used for DynamoDB parallel scan.
+
+This value controls how the source splits the table scan. It should usually be aligned with job parallelism and table size.
+
 ### common options
 
-Source Plugin common parameters, refer to [Source Plugin](../common-options/source-common-options.md) for details
+Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
 
-### scan_item_limit
+## Data Type Mapping
 
-number of item each scan request should return
+| SeaTunnel Data Type | DynamoDB Attribute Type |
+|---------------------|-------------------------|
+| BOOLEAN             | BOOL                    |
+| TINYINT             | N                       |
+| SMALLINT            | N                       |
+| INT                 | N                       |
+| BIGINT              | N                       |
+| FLOAT               | N                       |
+| DOUBLE              | N                       |
+| DECIMAL             | N                       |
+| STRING              | S                       |
+| TIME                | S                       |
+| DATE                | S                       |
+| TIMESTAMP           | S                       |
+| BYTES               | B                       |
+| MAP                 | M                       |
+| ARRAY               | L                       |
+| NULL                | NULL                    |
 
-### parallel_scan_threads
+## Task Example
 
-number of logical segments for parallel scan
+The following example reads rows from `source_table` and writes them to `sink_table`.
 
-## Example
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
 
-```bash
-Amazondynamodb {
-  url = "http://127.0.0.1:8000"
-  region = "us-east-1"
-  access_key_id = "dummy-key"
-  secret_access_key = "dummy-secret"
-  table = "TableName"
-  schema = {
-    fields {
-      artist = string
-      c_map = "map<string, array<int>>"
-      c_array = "array<int>"
-      c_string = string
-      c_boolean = boolean
-      c_tinyint = tinyint
-      c_smallint = smallint
-      c_int = int
-      c_bigint = bigint
-      c_float = float
-      c_double = double
-      c_decimal = "decimal(30, 8)"
-      c_null = "null"
-      c_bytes = bytes
-      c_date = date
-      c_timestamp = timestamp
+source {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "source_table"
+    parallelism = 2
+    scan_item_limit = 2
+    parallel_scan_threads = 4
+    schema = {
+      fields {
+        id = string
+        c_map = "map<string, smallint>"
+        c_array = "array<tinyint>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(2, 1)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
     }
+  }
+}
+
+sink {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "sink_table"
+    batch_size = 25
   }
 }
 ```

--- a/docs/zh/connectors/sink/AmazonDynamoDB.md
+++ b/docs/zh/connectors/sink/AmazonDynamoDB.md
@@ -2,93 +2,154 @@ import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
 # AmazonDynamoDB
 
-> Amazon DynamoDB 接收器连接器
+> Amazon DynamoDB Sink 连接器
 
 ## 描述
 
-将数据写入 Amazon DynamoDB
+Amazon DynamoDB Sink 连接器用于将 SeaTunnel 数据行写入 DynamoDB 表。
 
-## 关键特性
+目标表必须提前创建。连接器会把每一行写成一个 DynamoDB item，并使用批量写入请求。它支持单表写入，也支持上游数据行携带表名时的多表写入。
+
+## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|       名称        |  类型  | 必需 | 默认值 |
-|-------------------|--------|----|---------------|
-| url               | string | 是  | -             |
-| region            | string | 是  | -             |
-| access_key_id     | string | 是  | -             |
-| secret_access_key | string | 是  | -             |
-| table             | string | 是  | -             |
-| batch_size          | int    | 否  | 25   |
-| max_retries         | int    | 否  | 10   |
-| retry_base_delay_ms | long   | 否  | 100  |
-| retry_max_delay_ms  | long   | 否  | 5000 |
-| common-options      |        | 否  | -    |
+| 名称                | 类型   | 必填 | 默认值 |
+|---------------------|--------|------|--------|
+| url                 | string | 是   | -      |
+| region              | string | 是   | -      |
+| access_key_id       | string | 是   | -      |
+| secret_access_key   | string | 是   | -      |
+| table               | string | 是   | -      |
+| batch_size          | int    | 否   | 25     |
+| max_retries         | int    | 否   | 10     |
+| retry_base_delay_ms | long   | 否   | 100    |
+| retry_max_delay_ms  | long   | 否   | 5000   |
+| common-options      |        | 否   | -      |
 
 ### url [string]
 
-要写入Amazon DynamoDB的URL.
+DynamoDB 服务地址，例如 `https://dynamodb.us-east-1.amazonaws.com`。
+
+如果使用 DynamoDB Local 测试，可以填写本地地址，例如 `http://127.0.0.1:8000`。
 
 ### region [string]
 
-Amazon DynamoDB 的分区.
+DynamoDB 所在的 AWS 区域，例如 `us-east-1`。
 
 ### access_key_id [string]
 
-Amazon DynamoDB的访问id.
+连接 DynamoDB 使用的 AWS access key ID。
 
 ### secret_access_key [string]
 
-Amazon DynamoDB的访问密钥.
+连接 DynamoDB 使用的 AWS secret access key。
 
 ### table [string]
 
-Amazon DynamoDB 的表名. 支持使用 `${table_name}` 占位符，用于多表写入场景.
+要写入的 DynamoDB 表名。
+
+普通单表任务中，这里填写目标表名。多表任务中，写入器会优先使用每条数据自带的表名作为目标表；如果数据没有携带表名，则回退使用这里配置的表名。
 
 ### batch_size [int]
 
-写入 Amazon DynamoDB 前批量缓存的记录数.
+一次 DynamoDB 批量写入请求缓存的记录数。
+
+DynamoDB batch write 每次最多支持 25 条写请求，所以默认值为 `25`。
 
 ### max_retries [int]
 
-当 DynamoDB 返回未处理数据时，批量写入请求的最大重试次数.
+当 DynamoDB 在批量写入结果中返回未处理 item 时，最多重试的次数。
 
 ### retry_base_delay_ms [long]
 
-重试之间指数退避的基础延迟时间（毫秒）.
+重试之间指数退避的基础等待时间，单位为毫秒。
 
 ### retry_max_delay_ms [long]
 
-重试之间的最大延迟时间（毫秒）.
+重试之间的最大等待时间，单位为毫秒。
 
-### 常见选项
+### 通用选项
 
-Sink插件常用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详细信息.
+Sink 连接器通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
 
-## 示例
+## 数据类型映射
 
-### 单表写入
-```bash
-AmazonDynamoDB {
-    url = "http://127.0.0.1:8000"
-    region = "us-east-1"
-    access_key_id = "dummy-key"
-    secret_access_key = "dummy-secret"
-    table = "TableName"
+| SeaTunnel 数据类型 | DynamoDB 属性类型 |
+|--------------------|-------------------|
+| BOOLEAN            | BOOL              |
+| TINYINT            | N                 |
+| SMALLINT           | N                 |
+| INT                | N                 |
+| BIGINT             | N                 |
+| FLOAT              | N                 |
+| DOUBLE             | N                 |
+| DECIMAL            | N                 |
+| STRING             | S                 |
+| TIME               | S                 |
+| DATE               | S                 |
+| TIMESTAMP          | S                 |
+| BYTES              | B                 |
+| MAP                | M                 |
+| ARRAY              | L                 |
+| NULL               | NULL              |
+
+## 任务示例
+
+下面的示例从 `source_table` 读取数据，并写入 `sink_table`。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
 }
-```
 
-### 多表写入
-```bash
-AmazonDynamoDB {
+source {
+  AmazonDynamoDB {
     url = "http://127.0.0.1:8000"
     region = "us-east-1"
     access_key_id = "dummy-key"
     secret_access_key = "dummy-secret"
-    table = "${table_name}"
+    table = "source_table"
+    parallelism = 2
+    schema = {
+      fields {
+        id = string
+        c_map = "map<string, smallint>"
+        c_array = "array<tinyint>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(2, 1)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
+    }
+  }
+}
+
+sink {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "sink_table"
+    batch_size = 25
+    max_retries = 10
+    retry_base_delay_ms = 100
+    retry_max_delay_ms = 5000
+  }
 }
 ```
 

--- a/docs/zh/connectors/source/AmazonDynamoDB.md
+++ b/docs/zh/connectors/source/AmazonDynamoDB.md
@@ -2,13 +2,15 @@ import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
 # AmazonDynamoDB
 
-> AmazonDynamoDB 源连接器
+> Amazon DynamoDB 源连接器
 
 ## 描述
 
-从 Amazon DynamoDB 读取数据.
+Amazon DynamoDB 源连接器通过 DynamoDB scan 请求读取已有表中的数据。
 
-## 关键特性
+该连接器是批处理源。DynamoDB 不像关系型数据库那样提供完整字段类型信息，所以必须在 SeaTunnel 中显式配置 schema。
+
+## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
@@ -19,96 +21,153 @@ import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
 ## 选项
 
-|         名称        |  类型  | 必需    | 默认值 |
-|-----------------------|--------|-------|---------------|
-| url                   | string | 是     | -             |
-| region                | string | 是     | -             |
-| access_key_id         | string | 是     | -             |
-| secret_access_key     | string | 是     | -             |
-| table                 | string | 是     | -             |
-| schema                | config | 是     | -             |
-| common-options        |        | 是     | -             |
-| scan_item_limit       |        | 否     | -             |
-| parallel_scan_threads |        | 否 | -             |
+| 名称                  | 类型   | 必填 | 默认值 |
+|-----------------------|--------|------|--------|
+| url                   | string | 是   | -      |
+| region                | string | 是   | -      |
+| access_key_id         | string | 是   | -      |
+| secret_access_key     | string | 是   | -      |
+| table                 | string | 是   | -      |
+| schema                | config | 是   | -      |
+| scan_item_limit       | int    | 否   | 1      |
+| parallel_scan_threads | int    | 否   | 2      |
+| common-options        |        | 否   | -      |
 
 ### url [string]
 
-读取Amazon Dynamodb的URL.
+DynamoDB 服务地址，例如 `https://dynamodb.us-east-1.amazonaws.com`。
+
+如果使用 DynamoDB Local 测试，可以填写本地地址，例如 `http://127.0.0.1:8000`。
 
 ### region [string]
 
-Amazon DynamoDB 的分区.
+DynamoDB 所在的 AWS 区域，例如 `us-east-1`。
 
 ### access_key_id [string]
 
-Amazon DynamoDB的访问id.
+连接 DynamoDB 使用的 AWS access key ID。
 
 ### secret_access_key [string]
 
-Amazon DynamoDB的访问密钥.
+连接 DynamoDB 使用的 AWS secret access key。
 
 ### table [string]
 
-Amazon DynamoDB 的表名.
+要扫描的 DynamoDB 表名。
 
-### schema [Config]
+### schema [config]
 
-#### fields [config]
+定义需要从 DynamoDB item 中读取的 SeaTunnel 字段。
 
-Amazon Dynamodb是一个支持键值存储和文档数据结构的NOSQL数据库服务，无法获取数据类型。因此，我们必须配置模式。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
+DynamoDB 是键值和文档数据库，源连接器无法从 DynamoDB 自动推断完整的 SeaTunnel schema，所以需要在这里列出所有要读取的字段。
 
-例如:
-
-```
-schema {
+```hocon
+schema = {
   fields {
-    id = int
-    key_aa = string
-    key_bb = string
+    id = string
+    c_map = "map<string, smallint>"
+    c_array = "array<tinyint>"
+    c_string = string
+    c_boolean = boolean
+    c_int = int
+    c_bigint = bigint
+    c_float = float
+    c_double = double
+    c_decimal = "decimal(2, 1)"
+    c_bytes = bytes
+    c_date = date
+    c_timestamp = timestamp
   }
 }
 ```
 
-### common options
+更多 schema 写法请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
 
-源插件常用参数，详见 [Source Plugin](../common-options/source-common-options.md) 
+### scan_item_limit [int]
 
-### scan_item_limit
+每次 DynamoDB scan 请求最多返回的 item 数量。
 
-每个扫描请求应返回的项目数
+### parallel_scan_threads [int]
 
-### parallel_scan_threads
+DynamoDB parallel scan 使用的逻辑分片数量。
 
-并行扫描的逻辑段数
+这个值会影响源连接器如何拆分表扫描任务，通常需要结合任务并行度和表数据量设置。
 
-## 例子
+### 通用选项
 
-```bash
-Amazondynamodb {
-  url = "http://127.0.0.1:8000"
-  region = "us-east-1"
-  access_key_id = "dummy-key"
-  secret_access_key = "dummy-secret"
-  table = "TableName"
-  schema = {
-    fields {
-      artist = string
-      c_map = "map<string, array<int>>"
-      c_array = "array<int>"
-      c_string = string
-      c_boolean = boolean
-      c_tinyint = tinyint
-      c_smallint = smallint
-      c_int = int
-      c_bigint = bigint
-      c_float = float
-      c_double = double
-      c_decimal = "decimal(30, 8)"
-      c_null = "null"
-      c_bytes = bytes
-      c_date = date
-      c_timestamp = timestamp
+源连接器通用参数，请参考[源通用选项](../common-options/source-common-options.md)。
+
+## 数据类型映射
+
+| SeaTunnel 数据类型 | DynamoDB 属性类型 |
+|--------------------|-------------------|
+| BOOLEAN            | BOOL              |
+| TINYINT            | N                 |
+| SMALLINT           | N                 |
+| INT                | N                 |
+| BIGINT             | N                 |
+| FLOAT              | N                 |
+| DOUBLE             | N                 |
+| DECIMAL            | N                 |
+| STRING             | S                 |
+| TIME               | S                 |
+| DATE               | S                 |
+| TIMESTAMP          | S                 |
+| BYTES              | B                 |
+| MAP                | M                 |
+| ARRAY              | L                 |
+| NULL               | NULL              |
+
+## 任务示例
+
+下面的示例从 `source_table` 读取数据，并写入 `sink_table`。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "source_table"
+    parallelism = 2
+    scan_item_limit = 2
+    parallel_scan_threads = 4
+    schema = {
+      fields {
+        id = string
+        c_map = "map<string, smallint>"
+        c_array = "array<tinyint>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(2, 1)"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
+      }
     }
+  }
+}
+
+sink {
+  AmazonDynamoDB {
+    url = "http://127.0.0.1:8000"
+    region = "us-east-1"
+    access_key_id = "dummy-key"
+    secret_access_key = "dummy-secret"
+    table = "sink_table"
+    batch_size = 25
   }
 }
 ```


### PR DESCRIPTION
### Purpose

Improve the Amazon DynamoDB connector documentation using the connector options, implementation behavior, and runnable job examples as references.

### Changes

- Clarify source and sink descriptions, required options, optional options, and default values.
- Add DynamoDB Local endpoint guidance and explicit schema notes for the source connector.
- Add source and sink data type mapping tables.
- Expand the task examples into complete source-to-sink jobs.
- Align the Chinese documentation wording, feature list, tables, and examples with the English documentation.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `git diff --check`
