### PR TITLE
[Docs][Connector-V2] Improve Qdrant connector docs

### DIFF
--- a/docs/en/connectors/sink/Qdrant.md
+++ b/docs/en/connectors/sink/Qdrant.md
@@ -2,55 +2,39 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 # Qdrant
 
-> Qdrant Sink Connector
+> Qdrant sink connector
 
 ## Description
 
 [Qdrant](https://qdrant.tech/) is a high-performance vector search engine and vector database.
 
-This connector can be used to write data into a Qdrant collection.
+The Qdrant sink writes SeaTunnel rows into one existing Qdrant collection. Normal columns are written to the point payload, vector columns are written as named vectors, and the primary key column is used as the Qdrant point ID when one is present.
 
-The target collection must already exist before the job starts. Vector field names and dimensions in Qdrant must match the vector columns in the SeaTunnel row.
+## Key Features
 
-## Data Type Mapping
-
-| SeaTunnel Data Type | Qdrant Data Type |
-|---------------------|------------------|
-| TINYINT             | INTEGER          |
-| SMALLINT            | INTEGER          |
-| INT                 | INTEGER          |
-| BIGINT              | INTEGER          |
-| FLOAT               | DOUBLE           |
-| DOUBLE              | DOUBLE           |
-| BOOLEAN             | BOOL             |
-| STRING              | STRING           |
-| ARRAY               | LIST             |
-| FLOAT_VECTOR        | DENSE_VECTOR     |
-| BINARY_VECTOR       | DENSE_VECTOR     |
-| FLOAT16_VECTOR      | DENSE_VECTOR     |
-| BFLOAT16_VECTOR     | DENSE_VECTOR     |
-| SPARSE_FLOAT_VECTOR | SPARSE_VECTOR    |
-
-The value of the primary key column will be used as point ID in Qdrant. If no primary key is present, a random UUID will be used.
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [multimodal](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-|      name       |  type  | required | default value |
-|-----------------|--------|----------|---------------|
-| collection_name | string | yes      | -             |
-| host            | string | no       | localhost     |
-| port            | int    | no       | 6334          |
-| api_key         | string | no       | -             |
-| use_tls         | bool   | no       | false         |
-| common-options  |        | no       | -             |
+| name            | type   | required | default value | description |
+|-----------------|--------|----------|---------------|-------------|
+| collection_name | string | yes      | -             | Qdrant collection name to write to. |
+| host            | string | no       | localhost     | Qdrant gRPC host. |
+| port            | int    | no       | 6334          | Qdrant gRPC port. |
+| api_key         | string | no       | -             | Qdrant API key for authenticated deployments. |
+| use_tls         | bool   | no       | false         | Whether to use TLS for the gRPC connection. |
+| common-options  |        | no       | -             | Sink common options. |
 
 ### collection_name [string]
 
-The name of the Qdrant collection to write data to.
+The name of the Qdrant collection to write.
 
 ### host [string]
 
-The host name of the Qdrant instance. Defaults to "localhost".
+The host name of the Qdrant instance.
 
 ### port [int]
 
@@ -58,19 +42,45 @@ The gRPC port of the Qdrant instance.
 
 ### api_key [string]
 
-The API key to use for authentication if set.
+The API key used to connect to authenticated Qdrant deployments.
 
 ### use_tls [bool]
 
-Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
+Whether to use TLS for the gRPC connection. Enable this when connecting to Qdrant Cloud or another HTTPS/TLS endpoint.
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+Sink plugin common parameters, see [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Supported Types
+
+| SeaTunnel type | Qdrant value |
+|----------------|--------------|
+| SMALLINT       | payload integer |
+| INT            | payload integer or numeric point ID |
+| BIGINT         | payload integer |
+| FLOAT          | payload double |
+| DOUBLE         | payload double |
+| STRING         | payload string or UUID point ID |
+| DATE           | payload string |
+| BOOLEAN        | payload bool |
+| FLOAT_VECTOR   | named vector |
+| BINARY_VECTOR  | named vector |
+| FLOAT16_VECTOR | named vector |
+| BFLOAT16_VECTOR | named vector |
+
+The value of the primary key column is used as the Qdrant point ID. Primary key values must be `INT` numeric IDs or `STRING` UUIDs. If no primary key is present, the sink generates a random UUID for each row.
+
+## Notes
+
+- The target collection must already exist before the job starts. The connector does not create collections or vector indexes.
+- Vector column names and dimensions must match the vector configuration of the target Qdrant collection.
+- The sink writes each incoming row as an upsert request. It does not interpret `UPDATE` or `DELETE` row kinds as CDC operations.
+- Each sink block writes to one collection. Use separate sink blocks when different collections need different settings.
 
 ## Task Example
 
-The following example writes records from a Qdrant source collection to another Qdrant collection. Payload fields such as `file_name` and `file_size` are written as point payloads, and `my_vector` is written as a named vector.
+The following example writes records from one Qdrant collection to another. `file_name` and `file_size` are written as point payload fields, and `my_vector` is written as a named vector.
 
 ```hocon
 env {

--- a/docs/en/connectors/source/Qdrant.md
+++ b/docs/en/connectors/source/Qdrant.md
@@ -8,63 +8,69 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 [Qdrant](https://qdrant.tech/) is a high-performance vector search engine and vector database.
 
-This connector can be used to read data from a Qdrant collection.
+The Qdrant source reads points from one existing Qdrant collection. Point payload fields are read as normal SeaTunnel columns, and Qdrant vectors are read as SeaTunnel vector columns.
+
+## Key Features
+
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [multimodal](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-|      name       |  type  | required | default value |
-|-----------------|--------|----------|---------------|
-| collection_name | string | yes      | -             |
-| schema          | config | yes      | -             |
-| host            | string | no       | localhost     |
-| port            | int    | no       | 6334          |
-| api_key         | string | no       | -             |
-| use_tls         | bool   | no       | false         |
-| common-options  |        | no       | -             |
+| name            | type   | required | default value | description |
+|-----------------|--------|----------|---------------|-------------|
+| collection_name | string | yes      | -             | Qdrant collection name to read from. |
+| schema          | config | yes      | -             | SeaTunnel schema used to map Qdrant point IDs, payload fields, and vectors. |
+| host            | string | no       | localhost     | Qdrant gRPC host. |
+| port            | int    | no       | 6334          | Qdrant gRPC port. |
+| api_key         | string | no       | -             | Qdrant API key for authenticated deployments. |
+| use_tls         | bool   | no       | false         | Whether to use TLS for the gRPC connection. |
+| common-options  |        | no       | -             | Source common options. |
 
 ### collection_name [string]
 
-The name of the Qdrant collection to read data from.
+The name of the Qdrant collection to read.
 
 ### schema [config]
 
-The schema of the table to read data into. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
+The schema of the SeaTunnel rows produced by the source. For more details, see [Schema Feature](../../introduction/concepts/schema-feature.md).
 
-Eg:
+Each Qdrant record is a point:
 
-```hocon
-schema = {
-  fields {
-    age = int
-    address = string
-    some_vector = float_vector
-  }
-}
-```
+- A SeaTunnel primary key column is filled from the Qdrant point ID. Qdrant point IDs can be positive integers or UUID strings.
+- Vector columns are read from Qdrant vectors. For named vectors, the SeaTunnel column name must match the Qdrant vector name.
+- Other supported columns are read from the Qdrant point payload.
+- If the collection uses one default unnamed vector, use `default_vector` as the SeaTunnel vector column name.
 
-Each entry in Qdrant is called a point.
-
-Vector columns are read from the vectors of each point. Other columns are read from the JSON payload associated with the point.
-
-If a column is marked as primary key, the ID of the Qdrant point is written into it. It can be of type `"string"` or `"int"`. Since Qdrant only [allows](https://qdrant.tech/documentation/concepts/points/#point-ids) positive integers and UUIDs as point IDs.
-
-If the collection was created with a single default/unnamed vector, use `default_vector` as the vector name.
+Example:
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    default_vector = float_vector
-  }
+  columns = [
+    {
+      name = file_name
+      type = string
+    }
+    {
+      name = file_size
+      type = int
+    }
+    {
+      name = my_vector
+      type = float_vector
+    }
+  ]
 }
 ```
-
-The ID of the point in Qdrant will be written into the column which is marked as the primary key. It can be of type `int` or `string`.
 
 ### host [string]
 
-The host name of the Qdrant instance. Defaults to "localhost".
+The host name of the Qdrant instance.
 
 ### port [int]
 
@@ -72,19 +78,42 @@ The gRPC port of the Qdrant instance.
 
 ### api_key [string]
 
-The API key to use for authentication if set.
+The API key used to connect to authenticated Qdrant deployments.
 
 ### use_tls [bool]
 
-Whether to use TLS(SSL) connection. Required if using Qdrant cloud(https).
+Whether to use TLS for the gRPC connection. Enable this when connecting to Qdrant Cloud or another HTTPS/TLS endpoint.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+Source plugin common parameters, see [Source Common Options](../common-options/source-common-options.md) for details.
+
+## Supported Types
+
+| SeaTunnel type | Qdrant value |
+|----------------|--------------|
+| STRING         | payload string or point UUID |
+| BOOLEAN        | payload bool |
+| TINYINT        | payload integer |
+| SMALLINT       | payload integer |
+| INT            | payload integer or point numeric ID |
+| BIGINT         | payload integer |
+| FLOAT          | payload double |
+| DOUBLE         | payload double |
+| DECIMAL        | payload double |
+| FLOAT_VECTOR   | vector |
+| BINARY_VECTOR  | vector |
+| FLOAT16_VECTOR | vector |
+| BFLOAT16_VECTOR | vector |
+
+## Notes
+
+- The collection must already exist before the job starts.
+- Vector field names and dimensions in Qdrant must match the vector columns in the SeaTunnel schema.
+- The source is bounded and reads with one split, so it is not a parallel source.
+- Qdrant source emits `INSERT` rows only; it does not read CDC changes.
 
 ## Task Example
-
-The Qdrant collection must already exist before the job starts. Vector field names and dimensions in the collection must match the schema used by SeaTunnel.
 
 The following example reads payload fields and a named vector from `source_collection`, then writes the rows to `sink_collection`.
 

--- a/docs/zh/connectors/sink/Qdrant.md
+++ b/docs/zh/connectors/sink/Qdrant.md
@@ -2,53 +2,39 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 # Qdrant
 
-> Qdrant 数据连接器
+> Qdrant 数据写入连接器
+
+## 描述
 
 [Qdrant](https://qdrant.tech/) 是一个高性能的向量搜索引擎和向量数据库。
 
-该连接器可用于将数据写入 Qdrant 集合。
+Qdrant sink 会把 SeaTunnel 行写入一个已经存在的 Qdrant collection。普通列会写入 point payload，向量列会写成命名向量；如果上游 schema 中有主键列，主键值会作为 Qdrant point ID。
 
-目标 collection 必须在作业启动前已经存在。Qdrant 中的向量字段名和维度需要与 SeaTunnel 数据行中的向量列保持一致。
+## 主要特性
 
-## 数据类型映射
-
-|   SeaTunnel 数据类型    |  Qdrant 数据类型  |
-|---------------------|---------------|
-| TINYINT             | INTEGER       |
-| SMALLINT            | INTEGER       |
-| INT                 | INTEGER       |
-| BIGINT              | INTEGER       |
-| FLOAT               | DOUBLE        |
-| DOUBLE              | DOUBLE        |
-| BOOLEAN             | BOOL          |
-| STRING              | STRING        |
-| ARRAY               | LIST          |
-| FLOAT_VECTOR        | DENSE_VECTOR  |
-| BINARY_VECTOR       | DENSE_VECTOR  |
-| FLOAT16_VECTOR      | DENSE_VECTOR  |
-| BFLOAT16_VECTOR     | DENSE_VECTOR  |
-| SPARSE_FLOAT_VECTOR | SPARSE_VECTOR |
-
-主键列的值将用作 Qdrant 中的点 ID。如果没有主键，则将使用随机 UUID。
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] [多模态](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|       名称        |   类型   | 必填 |    默认值    |
-|-----------------|--------|----|-----------|
-| collection_name | string | 是  | -         |
-| host            | string | 否  | localhost |
-| port            | int    | 否  | 6334      |
-| api_key         | string | 否  | -         |
-| use_tls         | bool   | 否  | false     |
-| common-options  |        | 否  | -         |
+| 名称            | 类型   | 必填 | 默认值    | 说明 |
+|-----------------|--------|------|-----------|------|
+| collection_name | string | 是   | -         | 要写入的 Qdrant collection 名称。 |
+| host            | string | 否   | localhost | Qdrant gRPC 主机。 |
+| port            | int    | 否   | 6334      | Qdrant gRPC 端口。 |
+| api_key         | string | 否   | -         | 认证场景下使用的 Qdrant API key。 |
+| use_tls         | bool   | 否   | false     | gRPC 连接是否启用 TLS。 |
+| common-options  |        | 否   | -         | Sink 通用选项。 |
 
 ### collection_name [string]
 
-要写入数据的 Qdrant 集合的名称。
+要写入的 Qdrant collection 名称。
 
 ### host [string]
 
-Qdrant 实例的主机名。默认为 "localhost"。
+Qdrant 实例的主机名。
 
 ### port [int]
 
@@ -56,19 +42,45 @@ Qdrant 实例的 gRPC 端口。
 
 ### api_key [string]
 
-用于身份验证的 API 密钥（如果设置）。
+连接需要认证的 Qdrant 部署时使用的 API key。
 
 ### use_tls [bool]
 
-是否使用 TLS（SSL）连接。如果使用 Qdrant 云（https），则需要。
+gRPC 连接是否启用 TLS。连接 Qdrant Cloud 或其他 HTTPS/TLS 地址时通常需要开启。
 
 ### 通用选项
 
-Sink插件通用参数，请参考[Sink通用选项](../common-options/sink-common-options.md)了解详情。
+Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
+
+## 支持的数据类型
+
+| SeaTunnel 类型 | Qdrant 值 |
+|----------------|-----------|
+| SMALLINT       | payload integer |
+| INT            | payload integer 或数字 point ID |
+| BIGINT         | payload integer |
+| FLOAT          | payload double |
+| DOUBLE         | payload double |
+| STRING         | payload 字符串或 UUID point ID |
+| DATE           | payload 字符串 |
+| BOOLEAN        | payload bool |
+| FLOAT_VECTOR   | 命名向量 |
+| BINARY_VECTOR  | 命名向量 |
+| FLOAT16_VECTOR | 命名向量 |
+| BFLOAT16_VECTOR | 命名向量 |
+
+主键列的值会作为 Qdrant point ID。主键值必须是 `INT` 数字 ID 或 `STRING` UUID。如果没有主键，sink 会为每行生成一个随机 UUID。
+
+## 注意事项
+
+- 目标 collection 必须在作业启动前已经存在。连接器不会自动创建 collection 或向量索引。
+- 向量列名和维度必须与目标 Qdrant collection 的向量配置一致。
+- sink 会把每条输入行作为 upsert 写入，不会按 `UPDATE` 或 `DELETE` 行类型执行 CDC 语义。
+- 每个 sink 配置块写入一个 collection。如果不同 collection 需要不同配置，请使用多个 sink 配置块。
 
 ## 任务示例
 
-下面的示例会把一个 Qdrant source collection 中的记录写入另一个 Qdrant collection。`file_name`、`file_size` 等普通字段会写成 point payload，`my_vector` 会写成命名向量。
+下面的示例会把一个 Qdrant collection 中的记录写入另一个 Qdrant collection。`file_name` 和 `file_size` 会写成 point payload 字段，`my_vector` 会写成命名向量。
 
 ```hocon
 env {

--- a/docs/zh/connectors/source/Qdrant.md
+++ b/docs/zh/connectors/source/Qdrant.md
@@ -4,65 +4,73 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 > Qdrant 数据源连接器
 
+## 描述
+
 [Qdrant](https://qdrant.tech/) 是一个高性能的向量搜索引擎和向量数据库。
 
-该连接器可用于从 Qdrant 集合中读取数据。
+Qdrant source 用来从一个已经存在的 Qdrant collection 读取 point。point 的 payload 字段会读成普通 SeaTunnel 列，Qdrant 向量会读成 SeaTunnel 向量列。
+
+## 主要特性
+
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行读取](../../introduction/concepts/connector-v2-features.md)
+- [x] [多模态](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|       名称        |   类型   | 必填 |    默认值    |
-|-----------------|--------|----|-----------|
-| collection_name | string | 是  | -         |
-| schema          | config | 是  | -         |
-| host            | string | 否  | localhost |
-| port            | int    | 否  | 6334      |
-| api_key         | string | 否  | -         |
-| use_tls         | bool   | 否  | false     |
-| common-options  |        | 否  | -         |
+| 名称            | 类型   | 必填 | 默认值    | 说明 |
+|-----------------|--------|------|-----------|------|
+| collection_name | string | 是   | -         | 要读取的 Qdrant collection 名称。 |
+| schema          | config | 是   | -         | SeaTunnel schema，用来映射 Qdrant point ID、payload 字段和向量。 |
+| host            | string | 否   | localhost | Qdrant gRPC 主机。 |
+| port            | int    | 否   | 6334      | Qdrant gRPC 端口。 |
+| api_key         | string | 否   | -         | 认证场景下使用的 Qdrant API key。 |
+| use_tls         | bool   | 否   | false     | gRPC 连接是否启用 TLS。 |
+| common-options  |        | 否   | -         | Source 通用选项。 |
 
 ### collection_name [string]
 
-要从中读取数据的 Qdrant 集合的名称。
+要读取的 Qdrant collection 名称。
 
 ### schema [config]
 
-要将数据读取到的表的模式。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
+source 输出的 SeaTunnel 行结构。更多说明请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
 
-例如：
+Qdrant 中的每条记录叫作 point：
 
-```hocon
-schema = {
-  fields {
-    age = int
-    address = string
-    some_vector = float_vector
-  }
-}
-```
+- SeaTunnel 主键列会从 Qdrant point ID 中读取。Qdrant point ID 可以是正整数或 UUID 字符串。
+- 向量列会从 Qdrant 向量中读取。读取命名向量时，SeaTunnel 列名必须和 Qdrant 向量名一致。
+- 其他支持的列会从 Qdrant point payload 中读取。
+- 如果 collection 使用默认的未命名向量，请使用 `default_vector` 作为 SeaTunnel 向量列名。
 
-Qdrant 中的每个条目称为一个点。
-
-向量类型的列会从每个点的向量中读取，其他列会从与该点关联的 JSON payload 中读取。
-
-如果列被标记为主键，Qdrant 点的 ID 将写入其中。它可以是 `"string"` 或 `"int"` 类型。因为 Qdrant 仅[允许](https://qdrant.tech/documentation/concepts/points/#point-ids)使用正整数和 UUID 作为点 ID。
-
-如果集合是用单个默认/未命名向量创建的，请使用 `default_vector` 作为向量名称。
+示例：
 
 ```hocon
 schema = {
-  fields {
-    age = int
-    address = string
-    default_vector = float_vector
-  }
+  columns = [
+    {
+      name = file_name
+      type = string
+    }
+    {
+      name = file_size
+      type = int
+    }
+    {
+      name = my_vector
+      type = float_vector
+    }
+  ]
 }
 ```
-
-Qdrant 中点的 ID 将写入标记为主键的列中。它可以是 `int` 或 `string` 类型。
 
 ### host [string]
 
-Qdrant 实例的主机名。默认为 "localhost"。
+Qdrant 实例的主机名。
 
 ### port [int]
 
@@ -70,19 +78,42 @@ Qdrant 实例的 gRPC 端口。
 
 ### api_key [string]
 
-用于身份验证的 API 密钥（如果设置）。
+连接需要认证的 Qdrant 部署时使用的 API key。
 
 ### use_tls [bool]
 
-是否使用 TLS（SSL）连接。如果使用 Qdrant 云（https），则需要。
+gRPC 连接是否启用 TLS。连接 Qdrant Cloud 或其他 HTTPS/TLS 地址时通常需要开启。
 
 ### 通用选项
 
-源插件的通用参数，请参考[源通用选项](../common-options/source-common-options.md)了解详情。
+Source 插件通用参数，请参考 [Source 通用选项](../common-options/source-common-options.md)。
+
+## 支持的数据类型
+
+| SeaTunnel 类型 | Qdrant 值 |
+|----------------|-----------|
+| STRING         | payload 字符串或 point UUID |
+| BOOLEAN        | payload bool |
+| TINYINT        | payload integer |
+| SMALLINT       | payload integer |
+| INT            | payload integer 或 point 数字 ID |
+| BIGINT         | payload integer |
+| FLOAT          | payload double |
+| DOUBLE         | payload double |
+| DECIMAL        | payload double |
+| FLOAT_VECTOR   | vector |
+| BINARY_VECTOR  | vector |
+| FLOAT16_VECTOR | vector |
+| BFLOAT16_VECTOR | vector |
+
+## 注意事项
+
+- 作业启动前，collection 必须已经存在。
+- Qdrant 中的向量字段名和维度必须与 SeaTunnel schema 中的向量列一致。
+- Qdrant source 是有界读取，并且只使用一个 split，不支持并行读取。
+- Qdrant source 只输出 `INSERT` 行，不读取 CDC 变更。
 
 ## 任务示例
-
-作业启动前，Qdrant collection 必须已经存在。Qdrant 中的向量字段名和维度需要与 SeaTunnel schema 中的向量列保持一致。
 
 下面的示例从 `source_collection` 读取 payload 字段和命名向量，然后写入 `sink_collection`。
 


### PR DESCRIPTION
## Summary

This PR improves the Qdrant connector documentation in both English and Chinese.

Changes included:
- Adds source and sink feature lists with current support status.
- Clarifies required and optional Qdrant options with descriptions.
- Documents source schema behavior for point IDs, payload fields, named vectors, and default vectors.
- Corrects the sink/source usage notes around existing collections, vector name/dimension matching, CDC, exactly-once, and single-split batch reads.
- Adds supported type tables and keeps the Qdrant-to-Qdrant task example aligned across EN/ZH docs.

Before opening this PR, I checked existing open PRs for Qdrant documentation and found no duplicate.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `git diff --check`

## Old PR / CI check

Before creating this PR, I checked DanielCarter-stack's open PRs. Failed Build workflows were rerun one by one. They still fail at the website build stage because `apache/seatunnel-website` cannot resolve `@docusaurus/plugin-client-redirects`, which appears unrelated to the connector documentation changes.
