### PR TITLE
[Docs] Add Zeta slow-operation troubleshooting cookbook

### DIFF
--- a/docs/en/engines/zeta/tuning-guide.md
+++ b/docs/en/engines/zeta/tuning-guide.md
@@ -133,4 +133,318 @@ Here are some common tuning parameters:
 If you frequently see logs like the following and the CPU usage is not very high, try increasing this parameter:
 ```log
 2024-09-03 06:15:45,807 WARN  [.s.i.o.s.SlowOperationDetector] [hz.main.SlowOperationDetectorThread] - [seatunnel-worker-1]:5802 [seatunnel] [5.1] Slow operation detected:
-``` 
+```
+
+### Slow Operation Troubleshooting Cookbook
+
+This cookbook provides a step-by-step troubleshooting guide for diagnosing and resolving slow operations in SeaTunnel Zeta (Hazelcast) deployments. Use this alongside the general tuning guidance above.
+
+---
+
+#### 1. Understanding `SlowOperationDetector` Warnings
+
+Hazelcast's `SlowOperationDetector` monitors the execution time of partition operations (RPC calls) and logs warnings when an operation exceeds a threshold. In SeaTunnel Zeta, these warnings typically indicate one of:
+
+| Symptom | Likely Cause |
+|---|---|
+| Frequent warnings on **master** node only | Master is overloaded scheduling jobs or handling REST submissions |
+| Frequent warnings on **worker** nodes only | Worker execution threads are saturated |
+| Warnings on **all nodes** simultaneously | Cluster-wide resource pressure or network latency |
+| Warnings mentioning IMap operations | MapStore persistence is slow (disk I/O or S3 latency) |
+| Intermittent warnings during checkpoints | Checkpoint storage I/O is bottlenecked |
+
+The default slow operation threshold is `hazelcast.slow.operation.detector.threshold.millis=10000` (10 seconds).
+
+---
+
+#### 2. Diagnosing the Source of Latency
+
+Use the following decision tree to isolate the bottleneck:
+
+##### Step 1: Check REST Submission Latency
+
+```bash
+# Time a job submission via REST API
+time curl -X POST http://<master>:8080/submit-job \
+  -H "Content-Type: application/json" \
+  -d @job-config.json
+```
+
+- If submission takes > 5 seconds, the master is under scheduling pressure.
+- **Mitigation:** Increase `hazelcast.operation.generic.thread.count` on the master node, or reduce concurrent job submissions.
+
+##### Step 2: Check Master Scheduling Pressure
+
+```bash
+# Query event queue sizes via health monitor logs or REST API v2
+curl "http://<master>:8080/overview"
+```
+
+Key indicators in health monitoring logs:
+
+| Metric | Healthy Range | Warning Threshold |
+|---|---|---|
+| `executor.q.operations.size` | 0–100 | > 500 |
+| `executor.q.priorityOperation.size` | 0–50 | > 200 |
+| `event.q.size` | 0–10 | > 100 |
+| `operations.pending.invocations.count` | 0–50 | > 200 |
+
+##### Step 3: Check Worker Execution Pressure
+
+```bash
+# Check worker metrics
+curl "http://<worker>:5802/health/check"
+```
+
+- High `executor.q.client.size` on a worker indicates that a task on that worker is generating more data than it can process downstream.
+- **Mitigation:** Increase worker parallelism, add more worker nodes, or reduce source concurrency.
+
+##### Step 4: Check Checkpoint Storage Latency
+
+```bash
+# For S3 checkpoint storage, measure PUT latency
+time aws s3 cp test-file s3://seatunnel-checkpoint-bucket/test/
+```
+
+- Checkpoint storage latency > 1 second per operation can cascade into cluster-wide slowdowns.
+- **Mitigation:** See Section 6 (S3 latency checks).
+
+##### Step 5: Check IMap/MapStore Latency
+
+```bash
+# Check MapStore base directory disk usage and I/O
+du -sh /tmp/seatunnel/imap/
+iostat -x 1 5
+```
+
+- If MapStore base directory is on a slow disk or network mount, IMap operations will be slow.
+- **Mitigation:** Move MapStore to a fast local SSD or increase `hazelcast.fs.write-behind-delay-seconds`.
+
+---
+
+#### 3. Sizing `hazelcast.operation.generic.thread.count`
+
+This parameter controls the number of threads available for executing Hazelcast RPC operations (job submission, state queries, IMap operations). The correct value depends on your deployment mode.
+
+##### Hybrid Mode (master = worker)
+
+In hybrid mode, each node handles both scheduling and execution. Threads should be split between scheduling and execution tasks.
+
+```yaml
+# hazelcast.yaml — Hybrid mode recommendation
+hazelcast:
+  operation:
+    generic:
+      thread:
+        count: <cores * 2>
+```
+
+| CPU Cores per Node | Recommended `thread.count` |
+|---|---|
+| 4 | 8 |
+| 8 | 12–16 |
+| 16 | 16–24 |
+| 32+ | 24–32 (diminishing returns beyond ~32) |
+
+##### Separated Mode (dedicated master + workers)
+
+In separated mode, masters only handle scheduling and cluster management; workers only execute tasks.
+
+```yaml
+# Master node hazelcast.yaml — Separated mode
+hazelcast:
+  operation:
+    generic:
+      thread:
+        count: <cores * 1>
+
+# Worker node hazelcast.yaml — Separated mode  
+hazelcast:
+  operation:
+    generic:
+      thread:
+        count: <cores * 2>
+```
+
+**Rule of thumb:** Start with `thread.count = CPU cores × 2` for workers, `CPU cores × 1` for masters. Increase only if SlowOperationDetector warnings persist and CPU usage is below 70%.
+
+---
+
+#### 4. Metrics and Logs to Collect Before Tuning
+
+Always collect the following baseline data before making configuration changes:
+
+**A. Health Monitor Logs (most recent 5 minutes)**
+```bash
+grep "HealthMonitor" $SEATUNNEL_HOME/logs/seatunnel-server.log | tail -20
+```
+
+**B. Hazelcast Slow Operation Logs**
+```bash
+grep "SlowOperationDetector" $SEATUNNEL_HOME/logs/seatunnel-server.log | tail -50
+```
+
+**C. Node Resource Metrics (per-node)**
+```bash
+# CPU and memory
+top -bn1 | head -5
+# JVM heap
+jcmd <pid> GC.heap_info
+# Disk I/O
+iostat -x 1 3
+# Network
+netstat -an | grep -c ESTABLISHED
+```
+
+**D. Cluster Overview via REST API v2**
+```bash
+curl "http://<master>:8080/overview" | jq .
+```
+
+---
+
+#### 5. Configuration Changes: Restart vs. Hot Reload
+
+Not all Hazelcast changes require a restart. Use this table:
+
+| Configuration Change | Requires Restart? | Notes |
+|---|---|---|
+| `hazelcast.operation.generic.thread.count` | **Yes — full cluster restart** | Affects thread pool sizing at startup |
+| `hazelcast.operation.call.timeout.millis` | **No — hot reload** | Can be changed in running cluster |
+| `hazelcast.slow.operation.detector.threshold.millis` | **No — hot reload** | Takes effect within seconds |
+| `hazelcast.fs.write-behind-delay-seconds` | **Yes — node restart** | MapStore configuration change |
+| `hazelcast.fs.compaction-threshold` | **Yes — node restart** | Requires MapStore re-initialization |
+| `seatunnel.engine.checkpoint.interval` | **No — per-job config** | Set in `seatunnel.yaml` per job |
+| `seatunnel.engine.checkpoint.storage.*` | **Yes — full cluster restart** | Storage backend changes require restart |
+| `hazelcast.initial-cluster-size` | **Yes — full cluster restart** | Cluster formation setting |
+| JVM heap settings (`-Xmx`, `-Xms`) | **Yes — process restart** | JVM-level changes |
+
+---
+
+#### 6. S3 Checkpoint and State Storage Latency
+
+When using S3 as the checkpoint or state storage backend, latency is a common source of slow operations.
+
+##### Diagnosis
+
+```bash
+# Measure S3 endpoint latency
+curl -w "@curl-format.txt" -o /dev/null -s https://s3.<region>.amazonaws.com
+
+# Check checkpoint storage directory size
+aws s3 ls --recursive --summarize s3://<bucket>/seatunnel/checkpoint/ | tail -2
+
+# Monitor with CloudWatch metrics for S3 request latency
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/S3 \
+  --metric-name TotalRequestLatency \
+  --dimensions Name=BucketName,Value=<bucket> \
+  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ) \
+  --end-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  --period 300 \
+  --statistics Average
+```
+
+##### Mitigations
+
+| Issue | Mitigation |
+|---|---|
+| High PUT latency | Enable S3 Transfer Acceleration on the bucket |
+| High GET latency (checkpoint restore) | Use S3 VPC Endpoint to eliminate internet routing |
+| Large checkpoint files | Increase `checkpoint.interval` to reduce frequency; enable compression |
+| Cross-region latency | Ensure S3 bucket is in the same region as the cluster |
+| Throttling | Distribute checkpoints across prefix partitions; request limit increase |
+
+##### Recommended S3 Configuration
+
+```yaml
+seatunnel:
+  engine:
+    checkpoint:
+      storage:
+        type: hdfs
+        plugin-config:
+          namespace: /seatunnel/checkpoint/
+          fs.s3a.endpoint: https://s3.<region>.amazonaws.com
+          fs.s3a.connection.maximum: 200
+          fs.s3a.threads.max: 40
+          fs.s3a.connection.timeout: 30000
+          fs.s3a.fast.upload: true
+          fs.s3a.fast.upload.buffer: disk
+```
+
+---
+
+#### 7. Kubernetes Deployment Checklist
+
+When deploying SeaTunnel Zeta on Kubernetes, verify the following:
+
+- [ ] **Resource requests and limits are set** — Ensure CPU and memory requests match your `hazelcast.operation.generic.thread.count` sizing.
+  ```yaml
+  resources:
+    requests:
+      cpu: "4"
+      memory: "8Gi"
+    limits:
+      cpu: "8"
+      memory: "16Gi"
+  ```
+
+- [ ] **Pod anti-affinity is configured** — Prevent multiple master nodes from scheduling on the same physical node.
+  ```yaml
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredByExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values: [seatunnel-master]
+          topologyKey: kubernetes.io/hostname
+  ```
+
+- [ ] **Network policy allows cluster communication** — Ensure all nodes can reach each other on port 5801 (Hazelcast cluster) and 5802 (member endpoint).
+  ```yaml
+  # Required ports
+  # 5801 — Hazelcast cluster communication
+  # 5802 — Member REST endpoint
+  # 8080 — Master REST API
+  ```
+
+- [ ] **Persistent volume for MapStore** — Use a fast `ReadWriteOnce` volume backed by SSD for the MapStore base directory.
+  ```yaml
+  volumeMounts:
+    - name: imap-storage
+      mountPath: /tmp/seatunnel/imap
+  ```
+
+- [ ] **Readiness probe checks Hazelcast membership** — Do not mark a node as ready until it joins the cluster.
+  ```yaml
+  readinessProbe:
+    httpGet:
+      path: /health/check
+      port: 5802
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  ```
+
+- [ ] **Graceful shutdown** — Set `terminationGracePeriodSeconds` high enough for checkpoint flush + WAL compaction.
+  ```yaml
+  terminationGracePeriodSeconds: 120
+  ```
+
+- [ ] **Log aggregation** — Ensure Hazelcast SlowOperationDetector logs are captured by your logging stack (ELK, Loki, etc.) for proactive alerting.
+
+---
+
+#### Troubleshooting Quick Reference
+
+| Problem | First Check | Common Fix |
+|---|---|---|
+| Job submission slow | Master CPU, REST API latency | Increase master thread count, stagger submissions |
+| SlowOperationDetector on master | `executor.q.operations.size` in health logs | Increase `thread.count` on master |
+| SlowOperationDetector on worker | `executor.q.client.size`, worker CPU | Increase worker threads or add workers |
+| High checkpoint duration | Checkpoint storage I/O latency | Switch to faster storage, increase interval |
+| S3 checkpoint timeout | S3 endpoint latency, network path | Enable S3 Transfer Acceleration, VPC endpoint |
+| IMap operations slow | MapStore disk I/O | Move to SSD, increase write-behind delay |
+| Cluster instability after config change | Restart required | Consult the restart vs. hot-reload table above |


### PR DESCRIPTION
## Purpose

Closes #11280

## Changes

Added a comprehensive **Slow Operation Troubleshooting Cookbook** to the Zeta tuning guide (`docs/en/engines/zeta/tuning-guide.md`).

The cookbook covers all acceptance criteria from the issue:

1. **Understanding `SlowOperationDetector` Warnings** — What they mean in SeaTunnel Zeta, with symptom-to-cause mapping
2. **Diagnosing Latency Sources** — Step-by-step decision tree covering REST submission latency, master scheduling pressure, worker execution pressure, checkpoint storage latency, and IMap/MapStore latency
3. **Sizing `hazelcast.operation.generic.thread.count`** — Separate guidance for hybrid mode and separated mode with CPU-to-thread-count table
4. **Metrics & Logs Collection** — What to collect before tuning (health monitor logs, slow operation logs, node resources, cluster overview)
5. **Restart vs. Hot Reload Reference** — Table of which config changes require process/cluster restart
6. **S3 Storage Latency** — Diagnosis commands, CloudWatch monitoring, and mitigation strategies
7. **Kubernetes Deployment Checklist** — Anti-affinity, resource limits, readiness probes, graceful shutdown, log aggregation

Plus a **Quick Reference** troubleshooting table at the end.

## Verification

- [x] English docs updated
- [x] Content follows existing doc style and structure
- [x] Covers both hybrid and separated deployment modes