### PR TITLE
[Docs][Connector-V2] Improve Prometheus connector docs

### DIFF
--- a/docs/en/connectors/sink/Prometheus.md
+++ b/docs/en/connectors/sink/Prometheus.md
@@ -19,16 +19,23 @@ import ChangeLog from '../changelog/connector-prometheus.md';
 
 ## Description
 
-Writes metric samples to a Prometheus-compatible remote write endpoint.
+The Prometheus sink connector writes rows to the Prometheus remote write API. It builds a remote write sample from
+three upstream fields:
 
-The sink converts each SeaTunnel row into one Prometheus sample, serializes the data as a remote write request, compresses it with Snappy, and sends it by HTTP POST. Use a remote write endpoint such as `http://prometheus:9090/api/v1/write` or `http://victoria-metrics:8428/api/v1/write`.
+- `key_label`: the field that contains Prometheus labels, usually a `map<string, string>`.
+- `key_value`: the numeric sample value field.
+- `key_timestamp`: the optional timestamp field.
 
-Prometheus may reject samples that are too old for the target server's retention and remote write rules.
+The sink serializes rows as Prometheus remote write samples, compresses the request with Snappy, and sends data by
+HTTP `POST` to a Prometheus-compatible remote write endpoint such as `http://prometheus:9090/api/v1/write` or
+`http://victoria-metrics:8428/api/v1/write`.
+
+Prometheus-compatible servers may reject samples that are too old for their retention or remote write rules.
 
 ## Supported DataSource Info
 
-In order to use the Prometheus connector, the following dependency is required.
-It can be downloaded via `install-plugin.sh` or from the Maven central repository.
+To use the Prometheus connector, the following dependency is required. It can be installed by `install-plugin.sh` or
+downloaded from Maven Central.
 
 | Datasource | Supported Versions | Dependency |
 |------------|--------------------|------------|
@@ -36,48 +43,35 @@ It can be downloaded via `install-plugin.sh` or from the Maven central repositor
 
 ## Sink Options
 
-| name                        | type   | required | default value | description |
-|-----------------------------|--------|----------|---------------|-------------|
-| url                         | String | Yes      | -             | Prometheus-compatible remote write URL. |
-| headers                     | Map    | No       | -             | HTTP request headers. |
-| retry                       | Int    | No       | -             | Maximum retry times when the HTTP request fails with `IOException`. |
-| retry_backoff_multiplier_ms | Int    | No       | 100           | Retry backoff multiplier, in milliseconds. |
-| retry_backoff_max_ms        | Int    | No       | 10000         | Maximum retry backoff, in milliseconds. |
-| key_label                   | String | Yes      | -             | Field name whose value is used as Prometheus labels. The field value must be a map. |
-| key_value                   | String | Yes      | -             | Field name whose value is used as the Prometheus sample value. |
-| key_timestamp               | String | No       | -             | Field name whose value is used as the sample timestamp. If omitted, the current system time is used. |
-| batch_size                  | Int    | No       | 1024          | Maximum number of samples written in one request. Must be greater than 0. |
-| flush_interval              | Long   | No       | 300000        | Scheduled flush interval in milliseconds. |
-| common-options              | config | No       | -             | Sink common options. |
+| Name                        | Type   | Required | Default | Description |
+|-----------------------------|--------|----------|---------|-------------|
+| url                         | String | Yes      | -       | Prometheus-compatible remote write API URL, for example `http://prometheus:9090/api/v1/write`. |
+| key_label                   | String | Yes      | -       | Name of the upstream field that contains Prometheus labels. The field value should be a map. |
+| key_value                   | String | Yes      | -       | Name of the upstream field that contains the Prometheus sample value. A `double` field is recommended. |
+| key_timestamp               | String | No       | -       | Name of the upstream field that contains the Prometheus sample timestamp. If omitted, the sink uses the current system time. |
+| headers                     | Map    | No       | -       | HTTP request headers. |
+| retry                       | Int    | No       | -       | Maximum retry times when the HTTP request throws an `IOException`. |
+| retry_backoff_multiplier_ms | Int    | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | Int    | No       | 10000   | Maximum retry backoff in milliseconds. |
+| batch_size                  | Int    | No       | 1024    | Maximum number of rows buffered before writing to Prometheus. |
+| flush_interval              | Long   | No       | 300000  | Maximum flush interval in milliseconds. |
+| common-options              | Config | No       | -       | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md). |
 
-### key_label [String]
+### key_label
 
-The named field must be `map<string, string>`. It is converted into Prometheus labels. Include `__name__` in the map to set the metric name.
+The named field should be `map<string, string>`. It is converted to Prometheus labels. Include `__name__` in the map
+to set the metric name.
 
-### key_value [String]
+### key_timestamp
 
-The named field is converted into the Prometheus sample value. A `double` field is recommended.
-
-### key_timestamp [String]
-
-Optional timestamp field.
-
-Supported field types:
+Supported timestamp field types:
 
 - `timestamp`: converted to epoch milliseconds with the local time zone
 - `bigint`: treated as epoch milliseconds
 - `double`: treated as Unix seconds and converted to milliseconds
 - `string`: parsed as epoch milliseconds
 
-When this option is not configured, the sink uses the current system time.
-
-### common options
-
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
-
 ## Example
-
-### Write to Prometheus remote write
 
 ```hocon
 env {
@@ -120,7 +114,7 @@ sink {
 }
 ```
 
-### Write to a Prometheus-compatible remote write API
+## Prometheus-Compatible Remote Write Example
 
 ```hocon
 sink {

--- a/docs/en/connectors/source/Prometheus.md
+++ b/docs/en/connectors/source/Prometheus.md
@@ -6,60 +6,45 @@ import ChangeLog from '../changelog/connector-prometheus.md';
 
 ## Description
 
-Reads metric samples from Prometheus-compatible HTTP APIs.
+The Prometheus source connector reads metric query results from Prometheus-compatible HTTP APIs. It supports instant
+queries and range queries, and returns each metric sample as a SeaTunnel row.
 
-The connector uses the Prometheus query API. Configure `url` as the base address, such as `http://prometheus:9090` or `http://victoria-metrics:8428`. SeaTunnel appends `/api/v1/query` for `Instant` queries and `/api/v1/query_range` for `Range` queries.
+Configure `url` as the server base address, such as `http://prometheus:9090` or `http://victoria-metrics:8428`.
+SeaTunnel automatically uses the Prometheus query endpoint for `Instant` queries and the query range endpoint for
+`Range` queries.
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-| name                        | type    | required | default value | description |
-|-----------------------------|---------|----------|---------------|-------------|
-| url                         | String  | Yes      | -             | Prometheus-compatible server base URL. |
-| query                       | String  | Yes      | -             | PromQL expression. |
-| query_type                  | String  | No       | Instant       | Query type. Valid values are `Instant` and `Range`. |
-| start                       | String  | Required when `query_type = Range` | - | Range query start time. |
-| end                         | String  | Required when `query_type = Range` | - | Range query end time. |
-| step                        | String  | Required when `query_type = Range` | - | Range query resolution step, for example `15s`. |
-| time                        | Long    | No       | -             | Instant query evaluation time, as a Unix timestamp. |
-| timeout                     | Long    | No       | -             | Query timeout passed to Prometheus. |
-| headers                     | Map     | No       | -             | HTTP request headers. |
-| params                      | Map     | No       | -             | Extra HTTP request parameters. SeaTunnel adds `query` and query time parameters automatically. |
-| content_field               | String  | No       | -             | JSONPath used to extract the sample list. For Prometheus responses, use `$.data.result.*`. |
-| schema.fields               | Config  | Required when `format = json` | - | Output schema. |
-| format                      | String  | No       | text          | Response format. Use `json` for Prometheus metric samples. |
-| poll_interval_millis        | int     | No       | -             | Request interval in stream mode, in milliseconds. |
-| retry                       | int     | No       | -             | Maximum retry times when the HTTP request fails with `IOException`. |
-| retry_backoff_multiplier_ms | int     | No       | 100           | Retry backoff multiplier, in milliseconds. |
-| retry_backoff_max_ms        | int     | No       | 10000         | Maximum retry backoff, in milliseconds. |
-| common-options              | config  | No       | -             | Source common options. |
+| Name                        | Type   | Required | Default | Description |
+|-----------------------------|--------|----------|---------|-------------|
+| url                         | String | Yes      | -       | Prometheus-compatible server base URL, for example `http://prometheus:9090`. |
+| query                       | String | Yes      | -       | Prometheus expression query. |
+| query_type                  | String | No       | Instant | Query type. Supported values are `Instant` and `Range`. |
+| start                       | String | Required when `query_type = Range` | - | Start timestamp for a range query. Supports RFC3339 timestamps, Unix timestamps, and `CURRENT_TIMESTAMP`. |
+| end                         | String | Required when `query_type = Range` | - | End timestamp for a range query. Supports RFC3339 timestamps, Unix timestamps, and `CURRENT_TIMESTAMP`. |
+| step                        | String | Required when `query_type = Range` | - | Query resolution step width, such as `15s`, `1m`, or a float number of seconds. |
+| time                        | Long   | No       | -       | Evaluation timestamp for an instant query, as a Unix timestamp. |
+| timeout                     | Long   | No       | -       | Evaluation timeout passed to the Prometheus query API. |
+| content_field               | String | No       | -       | JSONPath used to extract the array of metric results. For Prometheus responses, usually `$.data.result.*`. |
+| format                      | String | No       | text    | Response format. Use `json` when reading Prometheus query results with a schema. |
+| schema                      | Config | Required when `format = json` | - | Output schema. |
+| headers                     | Map    | No       | -       | HTTP request headers. |
+| params                      | Map    | No       | -       | Extra HTTP request parameters. SeaTunnel adds the Prometheus query parameters automatically. |
+| retry                       | Int    | No       | -       | Maximum retry times when the HTTP request throws an `IOException`. |
+| retry_backoff_multiplier_ms | Int    | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | Int    | No       | 10000   | Maximum retry backoff in milliseconds. |
+| poll_interval_millis        | Int    | No       | -       | HTTP request interval in milliseconds when the job runs in stream mode. |
+| common-options              | Config | No       | -       | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md). |
 
-### query_type [String]
+## Output Schema
 
-`Instant` evaluates the query at a single time. `Range` evaluates the query over a time range.
-
-### start / end [String]
-
-Used only when `query_type = Range`.
-
-Supported values:
-
-- `CURRENT_TIMESTAMP`
-- ISO-8601 timestamp, for example `2025-05-13T02:25:23Z`
-- Unix timestamp in seconds, for example `1747103123.083`
-
-### step [String]
-
-Used only when `query_type = Range`. It is the query resolution step accepted by Prometheus, such as `15s`, `1m`, or a number of seconds.
-
-### schema [Config]
-
-Prometheus source returns three fields in this order:
+For Prometheus query results, use the following schema:
 
 ```hocon
 schema = {
@@ -71,15 +56,15 @@ schema = {
 }
 ```
 
-The `metric` field contains labels, including `__name__`. The `value` field is the metric value. The `time` field is the sample timestamp in milliseconds.
+The connector converts a Prometheus sample into these fields:
 
-### common options
+| Field  | Type                | Description |
+|--------|---------------------|-------------|
+| metric | map<string, string> | Prometheus metric labels, including labels such as `__name__`. |
+| value  | double              | Sample value. |
+| time   | long                | Sample timestamp. |
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
-
-## Example
-
-### Instant query
+## Instant Query Example
 
 ```hocon
 env {
@@ -89,9 +74,9 @@ env {
 
 source {
   Prometheus {
-    plugin_output = "prometheus_metrics"
+    plugin_output = "prometheus"
     url = "http://prometheus:9090"
-    query = "metric_1"
+    query = "up"
     query_type = "Instant"
     content_field = "$.data.result.*"
     format = "json"
@@ -106,7 +91,7 @@ source {
 }
 ```
 
-### Range query
+## Range Query Example
 
 ```hocon
 env {
@@ -116,12 +101,12 @@ env {
 
 source {
   Prometheus {
-    plugin_output = "prometheus_metrics"
+    plugin_output = "prometheus"
     url = "http://prometheus:9090"
-    query = "metric_1"
+    query = "up"
     query_type = "Range"
-    start = "CURRENT_TIMESTAMP"
-    end = "CURRENT_TIMESTAMP"
+    start = CURRENT_TIMESTAMP
+    end = CURRENT_TIMESTAMP
     step = "15s"
     content_field = "$.data.result.*"
     format = "json"
@@ -136,14 +121,14 @@ source {
 }
 ```
 
-### Read from a Prometheus-compatible API
+## Prometheus-Compatible API Example
 
 ```hocon
 source {
   Prometheus {
     plugin_output = "metrics"
     url = "http://victoria-metrics:8428"
-    query = "metric_1"
+    query = "up"
     query_type = "Instant"
     content_field = "$.data.result.*"
     format = "json"

--- a/docs/zh/connectors/sink/Prometheus.md
+++ b/docs/zh/connectors/sink/Prometheus.md
@@ -12,54 +12,53 @@ import ChangeLog from '../changelog/connector-prometheus.md';
 
 ## 主要特性
 
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
-向 Prometheus 兼容的 remote write 接口写入指标样本。
+Prometheus 数据接收器把上游数据写入 Prometheus remote write API。它会从上游数据中取出 3 个字段来组成 Prometheus 采样点：
 
-这个 sink 会把每一行 SeaTunnel 数据转换成一个 Prometheus 样本，再按 remote write 协议序列化，用 Snappy 压缩后通过 HTTP POST 发出。常见地址类似 `http://prometheus:9090/api/v1/write` 或 `http://victoria-metrics:8428/api/v1/write`。
+- `key_label`：Prometheus 标签字段，通常是 `map<string, string>`。
+- `key_value`：指标数值字段。
+- `key_timestamp`：可选的时间戳字段。
+
+接收器会按 Prometheus remote write 协议序列化数据，用 Snappy 压缩后，通过 HTTP `POST` 请求写入 Prometheus
+兼容 remote write 地址，例如 `http://prometheus:9090/api/v1/write` 或 `http://victoria-metrics:8428/api/v1/write`。
 
 如果样本时间太早，目标服务可能会按自己的保留策略或 remote write 规则拒绝写入。
 
 ## 支持的数据源信息
 
-想使用 Prometheus 连接器，需要安装以下依赖。可以通过 `install-plugin.sh` 脚本安装，也可以从 Maven 中央仓库下载。
+使用 Prometheus 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
 
-| 数据源 | 支持版本 | 依赖 |
-|--------|----------|------|
-| Prometheus | universal | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/seatunnel-connectors-v2/connector-prometheus) |
+| 数据源     | 支持版本  | 依赖 |
+|------------|-----------|------|
+| Prometheus | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/seatunnel-connectors-v2/connector-prometheus) |
 
 ## 接收器选项
 
 | 名称                        | 类型   | 是否必填 | 默认值 | 描述 |
 |-----------------------------|--------|----------|--------|------|
-| url                         | String | 是       | -      | Prometheus 兼容 remote write 地址。 |
+| url                         | String | 是       | -      | Prometheus 兼容 remote write API 地址，例如 `http://prometheus:9090/api/v1/write`。 |
+| key_label                   | String | 是       | -      | 上游数据中保存 Prometheus 标签的字段名。字段值建议为 map。 |
+| key_value                   | String | 是       | -      | 上游数据中保存 Prometheus 指标值的字段名。推荐使用 `double` 类型字段。 |
+| key_timestamp               | String | 否       | -      | 上游数据中保存 Prometheus 指标时间戳的字段名。不配置时使用当前系统时间。 |
 | headers                     | Map    | 否       | -      | HTTP 请求头。 |
 | retry                       | Int    | 否       | -      | HTTP 请求出现 `IOException` 时的最大重试次数。 |
-| retry_backoff_multiplier_ms | Int    | 否       | 100    | 重试退避时间乘数，单位毫秒。 |
+| retry_backoff_multiplier_ms | Int    | 否       | 100    | 重试退避时间倍数，单位毫秒。 |
 | retry_backoff_max_ms        | Int    | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
-| key_label                   | String | 是       | -      | 作为 Prometheus 标签的字段名。字段值必须是 map。 |
-| key_value                   | String | 是       | -      | 作为 Prometheus 样本值的字段名。 |
-| key_timestamp               | String | 否       | -      | 作为样本时间戳的字段名。不配置时使用当前系统时间。 |
-| batch_size                  | Int    | 否       | 1024   | 单次请求最多写入的样本数，必须大于 0。 |
-| flush_interval              | Long   | 否       | 300000 | 定时刷新间隔，单位毫秒。 |
-| common-options              | config | 否       | -      | Sink 通用选项。 |
+| batch_size                  | Int    | 否       | 1024   | 写入 Prometheus 前最多缓存的行数。 |
+| flush_interval              | Long   | 否       | 300000 | 最大刷新间隔，单位毫秒。 |
+| common-options              | Config | 否       | -      | 接收器插件通用参数，详情请参考[接收器通用选项](../common-options/sink-common-options.md)。 |
 
-### key_label [String]
+### key_label
 
-对应字段必须是 `map<string, string>`，会被转换为 Prometheus 标签。建议在 map 中包含 `__name__`，用来表示指标名。
+对应字段建议为 `map<string, string>`，会被转换为 Prometheus 标签。建议在 map 中包含 `__name__`，用来表示指标名。
 
-### key_value [String]
-
-对应字段会被转换为 Prometheus 样本值。推荐使用 `double` 类型字段。
-
-### key_timestamp [String]
-
-可选的时间戳字段。
+### key_timestamp
 
 支持以下字段类型：
 
@@ -68,15 +67,7 @@ import ChangeLog from '../changelog/connector-prometheus.md';
 - `double`：按 Unix 秒级时间戳处理，并转换为毫秒
 - `string`：按毫秒级时间戳解析
 
-不配置这个选项时，sink 会使用当前系统时间。
-
-### common options
-
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
-
 ## 示例
-
-### 写入 Prometheus remote write
 
 ```hocon
 env {
@@ -119,7 +110,7 @@ sink {
 }
 ```
 
-### 写入 Prometheus 兼容 remote write 接口
+## Prometheus 兼容 Remote Write 示例
 
 ```hocon
 sink {

--- a/docs/zh/connectors/source/Prometheus.md
+++ b/docs/zh/connectors/source/Prometheus.md
@@ -6,60 +6,43 @@ import ChangeLog from '../changelog/connector-prometheus.md';
 
 ## 描述
 
-从 Prometheus 兼容的 HTTP API 读取指标样本。
+Prometheus 数据源连接器通过 Prometheus 兼容 HTTP API 读取指标查询结果。它支持即时查询和范围查询，并把每个指标采样点转换为一行 SeaTunnel 数据。
 
-连接器使用 Prometheus 查询 API。`url` 只需要填写基础地址，例如 `http://prometheus:9090` 或 `http://victoria-metrics:8428`。SeaTunnel 会按查询类型自动追加 `/api/v1/query` 或 `/api/v1/query_range`。
+`url` 只需要填写服务基础地址，例如 `http://prometheus:9090` 或 `http://victoria-metrics:8428`。SeaTunnel 会根据
+`query_type` 自动使用即时查询接口或范围查询接口。
 
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行处理](../../introduction/concepts/connector-v2-features.md)
 
 ## 源选项
 
-| 名称                        | 类型      | 是否必填 | 默认值 | 描述 |
-|-----------------------------|---------|----------|--------|------|
-| url                         | String  | 是       | -      | Prometheus 兼容服务的基础地址。 |
-| query                       | String  | 是       | -      | PromQL 查询表达式。 |
-| query_type                  | String  | 否       | Instant | 查询类型，可选值为 `Instant` 和 `Range`。 |
-| start                       | String  | `query_type = Range` 时必填 | - | 范围查询开始时间。 |
-| end                         | String  | `query_type = Range` 时必填 | - | 范围查询结束时间。 |
-| step                        | String  | `query_type = Range` 时必填 | - | 范围查询步长，例如 `15s`。 |
-| time                        | Long    | 否       | -      | 即时查询的评估时间，使用 Unix 时间戳。 |
-| timeout                     | Long    | 否       | -      | 传给 Prometheus 的查询超时时间。 |
-| headers                     | Map     | 否       | -      | HTTP 请求头。 |
-| params                      | Map     | 否       | -      | 额外的 HTTP 请求参数。SeaTunnel 会自动加入 `query` 和查询时间参数。 |
-| content_field               | String  | 否       | -      | 用来提取样本列表的 JSONPath。Prometheus 响应通常填写 `$.data.result.*`。 |
-| schema.fields               | Config  | `format = json` 时必填 | - | 输出字段结构。 |
-| format                      | String  | 否       | text   | 响应格式。读取 Prometheus 指标样本时请设置为 `json`。 |
-| poll_interval_millis        | int     | 否       | -      | 流模式下请求间隔，单位毫秒。 |
-| retry                       | int     | 否       | -      | HTTP 请求出现 `IOException` 时的最大重试次数。 |
-| retry_backoff_multiplier_ms | int     | 否       | 100    | 重试退避时间乘数，单位毫秒。 |
-| retry_backoff_max_ms        | int     | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
-| common-options              | config  | 否       | -      | Source 通用选项。 |
+| 名称                        | 类型   | 是否必填 | 默认值  | 描述 |
+|-----------------------------|--------|----------|---------|------|
+| url                         | String | 是       | -       | Prometheus 兼容服务基础地址，例如 `http://prometheus:9090`。 |
+| query                       | String | 是       | -       | Prometheus 查询表达式。 |
+| query_type                  | String | 否       | Instant | 查询类型，支持 `Instant` 和 `Range`。 |
+| start                       | String | 当 `query_type = Range` 时必填 | - | 范围查询的开始时间，支持 RFC3339 时间、Unix 时间戳和 `CURRENT_TIMESTAMP`。 |
+| end                         | String | 当 `query_type = Range` 时必填 | - | 范围查询的结束时间，支持 RFC3339 时间、Unix 时间戳和 `CURRENT_TIMESTAMP`。 |
+| step                        | String | 当 `query_type = Range` 时必填 | - | 查询步长，例如 `15s`、`1m`，也可以填写秒数。 |
+| time                        | Long   | 否       | -       | 即时查询的评估时间，使用 Unix 时间戳。 |
+| timeout                     | Long   | 否       | -       | 传给 Prometheus 查询 API 的超时时间。 |
+| content_field               | String | 否       | -       | 用于提取指标结果数组的 JSONPath。读取 Prometheus 结果时通常填写 `$.data.result.*`。 |
+| format                      | String | 否       | text    | 响应格式。读取 Prometheus 查询结果并配置 schema 时请使用 `json`。 |
+| schema                      | Config | 当 `format = json` 时必填 | - | 输出数据结构。 |
+| headers                     | Map    | 否       | -       | HTTP 请求头。 |
+| params                      | Map    | 否       | -       | 额外的 HTTP 请求参数。SeaTunnel 会自动加入 Prometheus 查询参数。 |
+| retry                       | Int    | 否       | -       | HTTP 请求出现 `IOException` 时的最大重试次数。 |
+| retry_backoff_multiplier_ms | Int    | 否       | 100     | 重试退避时间倍数，单位毫秒。 |
+| retry_backoff_max_ms        | Int    | 否       | 10000   | 最大重试退避时间，单位毫秒。 |
+| poll_interval_millis        | Int    | 否       | -       | 作业以流模式运行时，两次 HTTP 请求之间的间隔，单位毫秒。 |
+| common-options              | Config | 否       | -       | 数据源插件通用参数，详情请参考[数据源通用选项](../common-options/source-common-options.md)。 |
 
-### query_type [String]
+## 输出结构
 
-`Instant` 表示查询某一个时间点的指标值。`Range` 表示查询一段时间范围内的指标值。
-
-### start / end [String]
-
-仅在 `query_type = Range` 时使用。
-
-支持以下写法：
-
-- `CURRENT_TIMESTAMP`
-- ISO-8601 时间，例如 `2025-05-13T02:25:23Z`
-- Unix 秒级时间戳，例如 `1747103123.083`
-
-### step [String]
-
-仅在 `query_type = Range` 时使用。它表示 Prometheus 接受的查询步长，例如 `15s`、`1m`，也可以是秒数。
-
-### schema [Config]
-
-Prometheus source 固定输出下面三个字段，顺序也固定：
+读取 Prometheus 查询结果时，推荐使用下面的固定结构：
 
 ```hocon
 schema = {
@@ -71,15 +54,15 @@ schema = {
 }
 ```
 
-`metric` 字段保存指标标签，包括 `__name__`。`value` 字段是指标值。`time` 字段是毫秒级样本时间戳。
+连接器会把 Prometheus 采样点转换为这些字段：
 
-### common options
+| 字段   | 类型                | 描述 |
+|--------|---------------------|------|
+| metric | map<string, string> | Prometheus 指标标签，包括 `__name__` 等标签。 |
+| value  | double              | 指标采样值。 |
+| time   | long                | 指标采样时间戳。 |
 
-源插件通用参数，请参考 [Source Common Options](../common-options/source-common-options.md)。
-
-## 示例
-
-### 即时查询
+## 即时查询示例
 
 ```hocon
 env {
@@ -89,9 +72,9 @@ env {
 
 source {
   Prometheus {
-    plugin_output = "prometheus_metrics"
+    plugin_output = "prometheus"
     url = "http://prometheus:9090"
-    query = "metric_1"
+    query = "up"
     query_type = "Instant"
     content_field = "$.data.result.*"
     format = "json"
@@ -106,7 +89,7 @@ source {
 }
 ```
 
-### 范围查询
+## 范围查询示例
 
 ```hocon
 env {
@@ -116,12 +99,12 @@ env {
 
 source {
   Prometheus {
-    plugin_output = "prometheus_metrics"
+    plugin_output = "prometheus"
     url = "http://prometheus:9090"
-    query = "metric_1"
+    query = "up"
     query_type = "Range"
-    start = "CURRENT_TIMESTAMP"
-    end = "CURRENT_TIMESTAMP"
+    start = CURRENT_TIMESTAMP
+    end = CURRENT_TIMESTAMP
     step = "15s"
     content_field = "$.data.result.*"
     format = "json"
@@ -136,14 +119,14 @@ source {
 }
 ```
 
-### 读取 Prometheus 兼容接口
+## Prometheus 兼容接口示例
 
 ```hocon
 source {
   Prometheus {
     plugin_output = "metrics"
     url = "http://victoria-metrics:8428"
-    query = "metric_1"
+    query = "up"
     query_type = "Instant"
     content_field = "$.data.result.*"
     format = "json"


### PR DESCRIPTION
### Purpose

Improve the Prometheus connector documentation so users can configure source and sink jobs without cross-checking connector code or E2E examples.

### Changes

- Clarify Prometheus source instant and range query options, including range-only `start`, `end`, and `step` settings.
- Document the expected source output schema and Prometheus-compatible API usage.
- Clarify Prometheus sink remote write behavior, required field mapping options, timer flush, and timestamp handling.
- Align English and Chinese source/sink pages and normalize option tables and examples.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `git diff --check`