### PR TITLE
[Docs][Connector-V2] Improve DataHub Firestore and TDengine docs

### DIFF
--- a/docs/en/connectors/sink/Datahub.md
+++ b/docs/en/connectors/sink/Datahub.md
@@ -6,15 +6,20 @@ import ChangeLog from '../changelog/connector-datahub.md';
 
 ## Description
 
-A sink plugin which use send message to DataHub
+The DataHub sink writes SeaTunnel rows to Alibaba Cloud DataHub.
+
+The connector supports single-table writes and multi-table writes. In multi-table
+jobs, use placeholders such as `${table_name}` in `topic` to route records from
+different input tables to different DataHub topics.
 
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-|      name      |  type  | required | default value |
+| name           | type   | required | default value |
 |----------------|--------|----------|---------------|
 | endpoint       | string | yes      | -             |
 | accessId       | string | yes      | -             |
@@ -27,53 +32,125 @@ A sink plugin which use send message to DataHub
 
 ### endpoint [string]
 
-your DataHub endpoint start with http （string）
+The DataHub service endpoint. It usually starts with `http` or `https`.
 
 ### accessId [string]
 
-your DataHub accessId which cloud be access from Alibaba Cloud  (string)
+The Alibaba Cloud access ID used to access DataHub.
 
 ### accessKey [string]
 
-your DataHub accessKey which cloud be access from Alibaba Cloud  (string)
+The Alibaba Cloud access key used to access DataHub.
 
 ### project [string]
 
-your DataHub project which is created in Alibaba Cloud  (string)
+The DataHub project name.
 
 ### topic [string]
 
-your DataHub topic  (string)
+The DataHub topic name. For multi-table writes, this value can contain
+placeholders, for example `${table_name}`.
 
 ### timeout [int]
 
-the max connection timeout (int)
+The maximum client connection timeout in milliseconds.
 
 ### retryTimes [int]
 
-the max retry times when your client put record failed  (int)
+The maximum retry count when writing a record fails.
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
+For multi-table writes, `multi_table_sink_replica` can be used with the common
+sink options.
 
-## Example
+## Examples
+
+### Write one table to one topic
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
 sink {
- DataHub {
-  endpoint="yourendpoint"
-  accessId="xxx"
-  accessKey="xxx"
-  project="projectname"
-  topic="topicname"
-  timeout=3000
-  retryTimes=3
- }
+  DataHub {
+    endpoint = "https://datahub.example.aliyuncs.com"
+    accessId = "your-access-id"
+    accessKey = "your-access-key"
+    project = "demo_project"
+    topic = "user_topic"
+    timeout = 3000
+    retryTimes = 3
+  }
+}
+```
+
+### Write multiple input tables to matching topics
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+
+    tables_configs = [
+      {
+        row.num = 100
+        schema = {
+          table = "users"
+          fields {
+            name = "string"
+            age = "int"
+          }
+        }
+      },
+      {
+        row.num = 200
+        schema = {
+          table = "orders"
+          fields {
+            order_id = "int"
+            amount = "decimal(10, 2)"
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  DataHub {
+    endpoint = "https://datahub.example.aliyuncs.com"
+    accessId = "your-access-id"
+    accessKey = "your-access-key"
+    project = "demo_project"
+    topic = "${table_name}"
+    timeout = 3000
+    retryTimes = 3
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/sink/GoogleFirestore.md
+++ b/docs/en/connectors/sink/GoogleFirestore.md
@@ -6,7 +6,13 @@ import ChangeLog from '../changelog/connector-google-firestore.md';
 
 ## Description
 
-Write data to Google Firestore
+The GoogleFirestore sink writes SeaTunnel rows to a Google Cloud Firestore
+collection.
+
+Each SeaTunnel row is converted to a Firestore document. The connector requires
+the target Google Cloud project and collection. Credentials can be passed as a
+Base64-encoded service account JSON string, or read from Google Application
+Default Credentials when `credentials` is not configured.
 
 ## Key features
 
@@ -14,36 +20,75 @@ Write data to Google Firestore
 
 ## Options
 
-|    name     |  type  | required | default value |
-|-------------|--------|----------|---------------|
-| project_id  | string | yes      | -             |
-| collection  | string | yes      | -             |
-| credentials | string | no       | -             |
+| name           | type   | required | default value |
+|----------------|--------|----------|---------------|
+| project_id     | string | yes      | -             |
+| collection     | string | yes      | -             |
+| credentials    | string | no       | -             |
+| common-options |        | no       | -             |
 
 ### project_id [string]
 
-The unique identifier for a Google Firestore database project.
+The Google Cloud project ID that owns the Firestore database.
 
 ### collection [string]
 
-The collection of Google Firestore.
+The Firestore collection to write to.
 
 ### credentials [string]
 
-The credentials of Google Cloud service account, use base64 codec. If not set, need to check the `GOOGLE APPLICATION CREDENTIALS` environment exists.
+Base64-encoded Google Cloud service account JSON.
+
+If this option is not set, the connector uses Google Application Default
+Credentials. In that case, make sure `GOOGLE_APPLICATION_CREDENTIALS` points to
+the service account JSON file or the runtime environment already provides
+default credentials.
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
 
 ## Example
 
-```bash
-GoogleFirestore {
-  project_id = "dummy-project-id",
-  collection = "dummy-collection",
-  credentials = "dummy-credentials"
-}  
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        c_string = string
+        c_boolean = boolean
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_date = date
+        c_timestamp = timestamp
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["hello", true, 10, 10000000000, 1.23, "123.456", "2023-04-22", "2023-04-22T23:20:58", {"a": "b"}, [1, 2, 3]]
+      }
+    ]
+  }
+}
+
+sink {
+  GoogleFirestore {
+    project_id = "dummy-project"
+    collection = "dummy-collection"
+    credentials = "base64-service-account-json"
+  }
+}
 ```
 
 ## Changelog

--- a/docs/en/connectors/sink/TDengine.md
+++ b/docs/en/connectors/sink/TDengine.md
@@ -6,12 +6,17 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 ## Description
 
-Used to write data to TDengine. You need to create stable before running seatunnel task
+Write data to TDengine.
+
+Create the target database and super table before running the SeaTunnel job. The
+sink can write one input table to one super table, or use placeholders such as
+`${table_name}` in `stable` for multi-table writes.
 
 ## Key features
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
@@ -20,14 +25,15 @@ Used to write data to TDengine. You need to create stable before running seatunn
 | url          | string | yes      | -             |
 | username     | string | yes      | -             |
 | password     | string | yes      | -             |
-| database     | string | yes      |               |
+| database     | string | yes      | -             |
 | stable       | string | yes      | -             |
 | timezone     | string | no       | UTC           |
-| write_columns| list   | no       | -             |
+| write_columns | list   | no       | -             |
+| common-options |       | no       | -             |
 
 ### url [string]
 
-the url of the TDengine when you select the TDengine
+The TDengine REST JDBC URL.
 
 e.g.
 
@@ -37,42 +43,71 @@ jdbc:TAOS-RS://localhost:6041/
 
 ### username [string]
 
-the username of the TDengine when you select
+The username used to connect to TDengine.
 
 ### password [string]
 
-the password of the TDengine when you select
+The password used to connect to TDengine.
 
 ### database [string]
 
-the database of the TDengine when you select
+The TDengine database name.
 
 ### stable [string]
 
-the stable of the TDengine when you select
+The TDengine super table name. For multi-table writes, this value can contain
+placeholders, for example `${table_name}`.
 
 ### timezone [string]
 
-the timeznoe of the TDengine sever, it's important to the ts field
+The TDengine server timezone used for timestamp conversion. The default value is
+`UTC`.
 
 ### write_columns [list]
 The field names to be inserted into TDengine. If not set, all fields will be written. The plugin will automatically append TAGS columns, so please do not include TAGS columns in this option.
 
-## Example
+### common options
 
-### sink
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
+For multi-table writes, `multi_table_sink_replica` can be used with the common
+sink options.
+
+## Examples
+
+### Write to one super table
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+    write_columns = ["ts", "voltage", "current", "power"]
+  }
+}
+```
+
+### Write multiple input tables to matching super tables
 
 ```hocon
 sink {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power2"
-          stable : "meters2"
-          timezone: UTC
-          write_columns: ["ts", "voltage", "current", "power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "${table_name}"
+    timezone = "UTC"
+  }
 }
 ```
 

--- a/docs/en/connectors/source/TDengine.md
+++ b/docs/en/connectors/source/TDengine.md
@@ -6,16 +6,18 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 ## Description
 
-Read external data source data through TDengine.
+Read data from TDengine super tables.
+
+The source reads data in batch mode by querying a time range from one super
+table. You can read all sub tables under the super table, limit the read to
+specific sub tables, and select only part of the columns.
 
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
-
-supports query SQL and can achieve projection effect.
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
@@ -27,16 +29,16 @@ supports query SQL and can achieve projection effect.
 | url          | string | yes      | -             |
 | username     | string | yes      | -             |
 | password     | string | yes      | -             |
-| database     | string | yes      |               |
+| database     | string | yes      | -             |
 | stable       | string | yes      | -             |
 | sub_tables   | list   | no       | -             |
-| lower_bound  | long   | yes      | -             |
-| upper_bound  | long   | yes      | -             |
+| lower_bound  | string | yes      | -             |
+| upper_bound  | string | yes      | -             |
 | read_columns | list   | no       | -             |
 
 ### url [string]
 
-the url of the TDengine when you select the TDengine
+The TDengine REST JDBC URL.
 
 e.g.
 
@@ -46,53 +48,78 @@ jdbc:TAOS-RS://localhost:6041/
 
 ### username [string]
 
-the username of the TDengine when you select
+The username used to connect to TDengine.
 
 ### password [string]
 
-the password of the TDengine when you select
+The password used to connect to TDengine.
 
 ### database [string]
 
-the database of the TDengine when you select
+The TDengine database name.
 
 ### stable [string]
 
-the stable of the TDengine when you select
+The TDengine super table name.
 
 ### sub_tables [list]
-A list of sub_table names. If not specified, all sub-tables will be selected. If specified, only the specified sub-tables will be selected.
+A list of sub table names. If it is not configured, all sub tables under the
+configured super table are read. If it is configured, only the listed sub tables
+are read.
 
-### lower_bound [long]
+### lower_bound [string]
 
-the lower_bound of the migration period
+The inclusive lower bound of the query time range. Use a TDengine-compatible
+timestamp string, for example `2018-10-03 14:38:05.000`.
 
-### upper_bound [long]
+### upper_bound [string]
 
-the upper_bound of the migration period
+The upper bound of the query time range. Use a TDengine-compatible timestamp
+string, for example `2018-10-03 14:38:16.801`.
 
 ### read_columns [list]
-A list of column names to read. If not specified, all columns will be selected. 
-When reading from a super table, please make sure to put the TAGS columns at the end of the list.
+A list of column names to read. If it is not configured, all columns are read.
+When reading from a super table, put TAGS columns at the end of the list.
 
-## Example
+## Examples
 
-### source
+### Read all sub tables in a time range
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+```
+
+### Read selected sub tables and columns
 
 ```hocon
 source {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power"
-          stable : "meters"
-          sub_tables : ["meter_1","meter_2"]
-          lower_bound : "2018-10-03 14:38:05.000"
-          upper_bound : "2018-10-03 14:38:16.800"
-          plugin_output : "tdengine_result"
-          read_columns : ["ts","voltage","current","power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    sub_tables = ["d1001", "d1002"]
+    read_columns = ["ts", "current", "voltage", "phase", "off", "nc", "location", "groupid"]
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/Datahub.md
+++ b/docs/zh/connectors/sink/Datahub.md
@@ -2,74 +2,148 @@ import ChangeLog from '../changelog/connector-datahub.md';
 
 # DataHub
 
-> DataHub 接收器连接器
+> DataHub Sink 连接器
 
 ## 描述
 
-一个使用向 DataHub 发送消息的接收器插件
+DataHub Sink 用于将 SeaTunnel 数据写入阿里云 DataHub。
 
-## 关键特性
+该连接器支持单表写入和多表写入。多表写入时，可以在 `topic` 中使用
+`${table_name}` 这类占位符，将不同输入表的数据写入不同的 DataHub Topic。
+
+## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|      名称           |  类型  | 必需  | 默认值  |
-|----------------|--------|-----|------|
-| endpoint       | string | 是   | -    |
-| accessId       | string | 是   | -    |
-| accessKey      | string | 是   | -    |
-| project        | string | 是   | -    |
-| topic          | string | 是   | -    |
-| timeout        | int    | 否   | 3000 |
-| retryTimes     | int    | 否   | 3    |
-| common-options |        | 否   | -    |
+| 名称           | 类型   | 必填 | 默认值 |
+|----------------|--------|------|--------|
+| endpoint       | string | 是   | -      |
+| accessId       | string | 是   | -      |
+| accessKey      | string | 是   | -      |
+| project        | string | 是   | -      |
+| topic          | string | 是   | -      |
+| timeout        | int    | 否   | 3000   |
+| retryTimes     | int    | 否   | 3      |
+| common-options |        | 否   | -      |
 
 ### endpoint [string]
 
-您的DataHub端点以http开头
+DataHub 服务地址，通常以 `http` 或 `https` 开头。
 
 ### accessId [string]
 
-您的DataHub accessId可以从阿里云访问哪个云
+访问 DataHub 使用的阿里云 Access ID。
 
 ### accessKey [string]
 
-您的DataHub accessKey可以从阿里云访问哪个云
+访问 DataHub 使用的阿里云 Access Key。
 
 ### project [string]
 
-您在阿里云中创建的DataHub项目
+DataHub 项目名称。
 
 ### topic [string]
 
-您的DataHub主题
+DataHub Topic 名称。多表写入时可以使用占位符，例如 `${table_name}`。
 
 ### timeout [int]
 
-最大连接超时
+客户端连接最大超时时间，单位为毫秒。
 
 ### retryTimes [int]
 
-客户端放置记录失败时的最大重试次数
+写入记录失败时的最大重试次数。
 
-### common options
+### 通用选项
 
-接收器插件常用参数，详见 [Sink Common Options](../common-options/sink-common-options.md) 
+Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
+多表写入时，可以配合通用参数中的 `multi_table_sink_replica` 使用。
 
 ## 示例
 
+### 单表写入单个 Topic
+
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
 sink {
- DataHub {
-  endpoint="yourendpoint"
-  accessId="xxx"
-  accessKey="xxx"
-  project="projectname"
-  topic="topicname"
-  timeout=3000
-  retryTimes=3
- }
+  DataHub {
+    endpoint = "https://datahub.example.aliyuncs.com"
+    accessId = "your-access-id"
+    accessKey = "your-access-key"
+    project = "demo_project"
+    topic = "user_topic"
+    timeout = 3000
+    retryTimes = 3
+  }
+}
+```
+
+### 多表写入匹配的 Topic
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+
+    tables_configs = [
+      {
+        row.num = 100
+        schema = {
+          table = "users"
+          fields {
+            name = "string"
+            age = "int"
+          }
+        }
+      },
+      {
+        row.num = 200
+        schema = {
+          table = "orders"
+          fields {
+            order_id = "int"
+            amount = "decimal(10, 2)"
+          }
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  DataHub {
+    endpoint = "https://datahub.example.aliyuncs.com"
+    accessId = "your-access-id"
+    accessKey = "your-access-key"
+    project = "demo_project"
+    topic = "${table_name}"
+    timeout = 3000
+    retryTimes = 3
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/GoogleFirestore.md
+++ b/docs/zh/connectors/sink/GoogleFirestore.md
@@ -6,44 +6,83 @@ import ChangeLog from '../changelog/connector-google-firestore.md';
 
 ## 描述
 
-将数据写入 Google Firestore
+GoogleFirestore Sink 用于将 SeaTunnel 数据写入 Google Cloud Firestore 集合。
+
+每一行 SeaTunnel 数据会转换为一个 Firestore 文档。连接器必须配置目标
+Google Cloud 项目和集合。凭证可以通过 `credentials` 传入 Base64 编码后的
+服务账号 JSON；如果不配置该参数，则会使用 Google 应用默认凭证。
 
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|    名称     |  类型  | 必需 | 默认值 |
-|-------------|--------|------|--------|
-| project_id  | string | 是   | -      |
-| collection  | string | 是   | -      |
-| credentials | string | 否   | -      |
+| 名称           | 类型   | 必填 | 默认值 |
+|----------------|--------|------|--------|
+| project_id     | string | 是   | -      |
+| collection     | string | 是   | -      |
+| credentials    | string | 否   | -      |
+| common-options |        | 否   | -      |
 
 ### project_id [string]
 
-Google Firestore 数据库项目的唯一标识符。
+Firestore 数据库所在的 Google Cloud 项目 ID。
 
 ### collection [string]
 
-Google Firestore 的集合。
+要写入的 Firestore 集合名称。
 
 ### credentials [string]
 
-Google Cloud 服务账户的凭证，使用 base64 编码。如果未设置，需要检查 `GOOGLE_APPLICATION_CREDENTIALS` 环境变量是否存在。
+Base64 编码后的 Google Cloud 服务账号 JSON。
+
+如果不配置该参数，连接器会使用 Google 应用默认凭证。此时需要确保
+`GOOGLE_APPLICATION_CREDENTIALS` 指向服务账号 JSON 文件，或者运行环境已经提供默认凭证。
 
 ### 通用选项
 
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详情。
+Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
 
 ## 示例
 
-```bash
-GoogleFirestore {
-  project_id = "dummy-project-id",
-  collection = "dummy-collection",
-  credentials = "dummy-credentials"
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        c_string = string
+        c_boolean = boolean
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_date = date
+        c_timestamp = timestamp
+        c_map = "map<string, string>"
+        c_array = "array<int>"
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["hello", true, 10, 10000000000, 1.23, "123.456", "2023-04-22", "2023-04-22T23:20:58", {"a": "b"}, [1, 2, 3]]
+      }
+    ]
+  }
+}
+
+sink {
+  GoogleFirestore {
+    project_id = "dummy-project"
+    collection = "dummy-collection"
+    credentials = "base64-service-account-json"
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/TDengine.md
+++ b/docs/zh/connectors/sink/TDengine.md
@@ -6,29 +6,32 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 ## 描述
 
-用于将数据写入TDengine。
+用于将数据写入 TDengine。
+
+运行 SeaTunnel 任务前，需要先创建目标数据库和超级表。该 Sink 支持单表写入，也支持在 `stable` 中使用 `${table_name}` 这类占位符完成多表写入。
 
 ## 主要特性
 
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|   名称   | 类型     | 是否必传 | 默认值 |
-|----------|--------|----------|---------------|
-| url      | string | 是      | -             |
-| username | string | 是      | -             |
-| password | string | 是      | -             |
-| database | string | 是      |               |
-| stable   | string | 是      | -             |
-| timezone | string | 否       | UTC           |
-| write_columns | list   | 否       | -             |
+| 名称           | 类型   | 是否必传 | 默认值 |
+|----------------|--------|----------|--------|
+| url            | string | 是       | -      |
+| username       | string | 是       | -      |
+| password       | string | 是       | -      |
+| database       | string | 是       | -      |
+| stable         | string | 是       | -      |
+| timezone       | string | 否       | UTC    |
+| write_columns  | list   | 否       | -      |
+| common-options |        | 否       | -      |
 
 ### url [string]
 
-TDengine的url
+TDengine REST JDBC 连接地址。
 
 例如
 
@@ -38,46 +41,69 @@ jdbc:TAOS-RS://localhost:6041/
 
 ### username [string]
 
-TDengine的用户名
+连接 TDengine 使用的用户名。
 
 ### password [string]
 
-TDengine的密码
+连接 TDengine 使用的密码。
 
 ### database [string]
 
-TDengine的数据库
+TDengine 数据库名称。
 
 ### stable [string]
 
-TDengine的超级表
+TDengine 超级表名称。多表写入时可以使用占位符，例如 `${table_name}`。
 
 ### timezone [string]
 
-TDengine服务器的时间，对ts字段很重要
+TDengine 服务端时区，用于时间戳转换，默认值为 `UTC`。
 
 ### write_columns [list]
-TDengine的写入列，默认为所有列。无需包含 TAGS 字段，插件会自动处理 TAGS 字段的写入。
+要写入 TDengine 的字段列表。不配置时写入所有字段。无需包含 TAGS 字段，插件会自动处理 TAGS 字段写入。
 
+### 通用选项
+
+Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
+多表写入时，可以配合通用参数中的 `multi_table_sink_replica` 使用。
 
 ## 示例
 
-### sink
+### 写入单个超级表
 
 ```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
 sink {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power2"
-          stable : "meters2"
-          timezone: UTC
-          write_columns: ["ts", "voltage", "current", "power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+    write_columns = ["ts", "voltage", "current", "power"]
+  }
 }
 ```
 
+### 多表写入匹配的超级表
+
+```hocon
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "${table_name}"
+    timezone = "UTC"
+  }
+}
+```
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/TDengine.md
+++ b/docs/zh/connectors/source/TDengine.md
@@ -6,16 +6,16 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 ## 描述
 
-通过 TDengine 读取外部数据源的数据。
+从 TDengine 超级表读取数据。
+
+该 Source 以批处理方式按时间范围读取一个超级表的数据。可以读取该超级表下的所有子表，也可以只读取指定子表；同时支持只读取部分列。
 
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流式](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-
-支持查询 SQL，并可实现投影效果。
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
@@ -27,16 +27,16 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 | url            | string | 是   | -              |
 | username       | string | 是   | -              |
 | password       | string | 是   | -              |
-| database       | string | 是   |                |
+| database       | string | 是   | -              |
 | stable         | string | 是   | -              |
 | sub_tables     | list   | 否   | -              |
-| lower_bound    | long   | 是   | -              |
-| upper_bound    | long   | 是   | -              |
+| lower_bound    | string | 是   | -              |
+| upper_bound    | string | 是   | -              |
 | read_columns   | list   | 否   | -              |
 
 ### url [string]
 
-选择 TDengine 时的连接 URL
+TDengine REST JDBC 连接地址。
 
 例如：
 
@@ -46,54 +46,75 @@ jdbc:TAOS-RS://localhost:6041/
 
 ### username [string]
 
-选择 TDengine 时的用户名
+连接 TDengine 使用的用户名。
 
 ### password [string]
 
-选择 TDengine 时的密码
+连接 TDengine 使用的密码。
 
 ### database [string]
 
-选择 TDengine 时的数据库名
+TDengine 数据库名称。
 
 ### stable [string]
 
-选择 TDengine 时的超级表名
+TDengine 超级表名称。
 
 ### sub_tables [list]
 
-TDengine 的子表名。如果不指定，则会选择所有子表；如果指定，则只选择指定的子表。
+TDengine 子表名称列表。不配置时读取该超级表下的所有子表；配置后只读取指定子表。
 
-### lower_bound [long]
+### lower_bound [string]
 
-迁移时间段的下界
+查询时间范围的下界，使用 TDengine 可识别的时间字符串，例如 `2018-10-03 14:38:05.000`。
 
-### upper_bound [long]
+### upper_bound [string]
 
-迁移时间段的上界
+查询时间范围的上界，使用 TDengine 可识别的时间字符串，例如 `2018-10-03 14:38:16.801`。
 
 ### read_columns [list]
 
-选择 TDengine 时的列名。如果不指定，则选择所有字段；如果指定，则只选择指定的字段。读取超级表时，请包含TAGS 字段，并放在末尾。
+要读取的列名列表。不配置时读取所有列。读取超级表时，请将 TAGS 字段放在列表末尾。
 
 ## 示例
 
-### source 配置示例
+### 按时间范围读取所有子表
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+```
+
+### 读取指定子表和指定列
 
 ```hocon
 source {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power"
-          stable : "meters"
-          sub_tables : ["meter_1","meter_2"]
-          lower_bound : "2018-10-03 14:38:05.000"
-          upper_bound : "2018-10-03 14:38:16.800"
-          plugin_output = "tdengine_result"
-          read_columns : ["ts","voltage","current","power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    sub_tables = ["d1001", "d1002"]
+    read_columns = ["ts", "current", "voltage", "phase", "off", "nc", "location", "groupid"]
+  }
 }
 ```
 


### PR DESCRIPTION
## Purpose

Improve connector documentation for DataHub, GoogleFirestore, and TDengine based on the current connector options and runnable job patterns.

## Changes

- Expand DataHub sink docs with clearer option descriptions, single-table usage, and multi-table topic routing.
- Expand GoogleFirestore sink docs with credential behavior, common options, and a fuller write example.
- Align TDengine source and sink docs with the actual option types, time-range usage, column selection, and multi-table sink placeholders.
- Keep English and Chinese documentation aligned.

## Verification

- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify