### PR TITLE
[Docs][Connector-V2] Improve ActiveMQ AmazonDynamoDB and AmazonSqs docs

### DIFF
--- a/docs/en/connectors/sink/Activemq.md
+++ b/docs/en/connectors/sink/Activemq.md
@@ -10,6 +10,8 @@ Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text
 
 ## Key features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
@@ -33,7 +35,8 @@ Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text
 
 - `uri` is the connection entry point. Put the broker host and port in this value, for example `tcp://activemq-host:61616`.
 - `username` and `password` are optional, but they must be configured together when the broker requires authentication.
-- The connector writes each SeaTunnel row as one JSON text message to `queue_name`.
+- The connector writes each SeaTunnel row as one JSON text message to `queue_name`. There is no separate `format` option for this sink.
+- Configure the broker address with `uri`. `host` and `port` are not ActiveMQ sink options.
 
 ## Example
 

--- a/docs/en/connectors/sink/AmazonDynamoDB.md
+++ b/docs/en/connectors/sink/AmazonDynamoDB.md
@@ -26,6 +26,7 @@ The target table must already exist. The connector writes each row as a DynamoDB
 | secret_access_key   | string | yes      | -             |
 | table               | string | yes      | -             |
 | batch_size          | int    | no       | 25            |
+| multi_table_sink_replica | int | no       | -             |
 | max_retries         | int    | no       | 10            |
 | retry_base_delay_ms | long   | no       | 100           |
 | retry_max_delay_ms  | long   | no       | 5000          |
@@ -60,6 +61,10 @@ For a normal single-table job, set this to the target table name. In a multi-tab
 The number of records buffered for one DynamoDB batch write request.
 
 DynamoDB batch write supports up to 25 write requests per call, so the default is `25`.
+
+### multi_table_sink_replica [int]
+
+Optional common sink option used by multi-table sink jobs. For details, see [Sink Common Options](../common-options/sink-common-options.md).
 
 ### max_retries [int]
 

--- a/docs/en/connectors/sink/AmazonSqs.md
+++ b/docs/en/connectors/sink/AmazonSqs.md
@@ -43,6 +43,7 @@ is serialized by the configured `format`, and the serialized value is sent as th
 - `canal_json` writes Canal JSON messages. For details, see [Canal JSON](../formats/canal-json.md).
 - `debezium_json` writes Debezium JSON messages. For details, see [Debezium JSON](../formats/debezium-json.md).
 - The sink sends only the message body. It does not expose SQS message attributes, delay seconds, deduplication ID, or message group ID options.
+- `access_key_id` and `secret_access_key` are optional, but they must be configured together when static AWS credentials are used.
 
 ## Task Examples
 

--- a/docs/en/connectors/source/AmazonDynamoDB.md
+++ b/docs/en/connectors/source/AmazonDynamoDB.md
@@ -10,6 +10,8 @@ The Amazon DynamoDB source connector reads existing items from an Amazon DynamoD
 
 The connector is a batch source. DynamoDB does not expose field types in the same way as a relational database, so the SeaTunnel schema must be configured explicitly.
 
+This source reads the current table data with scan requests. It does not read DynamoDB Streams or CDC change events.
+
 ## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
@@ -92,6 +94,8 @@ The maximum number of items returned by each DynamoDB scan request.
 The number of logical scan segments used for DynamoDB parallel scan.
 
 This value controls how the source splits the table scan. It should usually be aligned with job parallelism and table size.
+
+For small tables, keep the default value. For large tables, increase it together with `env.parallelism` and the source `parallelism` option so that multiple readers can scan different segments.
 
 ### common options
 

--- a/docs/en/connectors/source/AmazonSqs.md
+++ b/docs/en/connectors/source/AmazonSqs.md
@@ -12,6 +12,8 @@ deserialized by the configured `format` and `schema`, then emitted as SeaTunnel 
 The connector uses a single reader and finishes the job after the current receive request is
 processed. It is suitable for bounded reads from a queue.
 
+Each receive request asks SQS for up to 10 messages. If more messages are waiting in the queue, run another job or use a streaming-style upstream design that repeatedly starts bounded reads.
+
 ## Support Those Engines
 
 > Spark<br/>
@@ -50,6 +52,7 @@ processed. It is suitable for bounded reads from a queue.
 - `canal_json` reads Canal JSON messages. For details, see [Canal JSON](../formats/canal-json.md).
 - `debezium_json` reads Debezium JSON messages. For details, see [Debezium JSON](../formats/debezium-json.md).
 - `delete_message = true` removes consumed messages from SQS. Keep the default `false` when you only want to inspect or copy messages without deleting them.
+- `access_key_id` and `secret_access_key` are optional, but they must be configured together when static AWS credentials are used.
 
 ## Task Examples
 

--- a/docs/zh/connectors/sink/Activemq.md
+++ b/docs/zh/connectors/sink/Activemq.md
@@ -10,6 +10,8 @@ import ChangeLog from '../changelog/connector-activemq.md';
 
 ## 关键特性
 
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
@@ -33,7 +35,8 @@ import ChangeLog from '../changelog/connector-activemq.md';
 
 - `uri` 是连接入口，Broker 的主机和端口都写在这里，例如 `tcp://activemq-host:61616`。
 - `username` 和 `password` 是可选项；如果 Broker 需要认证，这两个配置要一起写。
-- 连接器会把每一行 SeaTunnel 数据作为一条 JSON 文本消息写入 `queue_name`。
+- 连接器会把每一行 SeaTunnel 数据作为一条 JSON 文本消息写入 `queue_name`，当前没有单独的 `format` 配置。
+- Broker 地址请使用 `uri` 配置，`host` 和 `port` 不是 ActiveMQ Sink 的配置项。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/AmazonDynamoDB.md
+++ b/docs/zh/connectors/sink/AmazonDynamoDB.md
@@ -26,6 +26,7 @@ Amazon DynamoDB Sink 连接器用于将 SeaTunnel 数据行写入 DynamoDB 表�
 | secret_access_key   | string | 是   | -      |
 | table               | string | 是   | -      |
 | batch_size          | int    | 否   | 25     |
+| multi_table_sink_replica | int | 否   | -      |
 | max_retries         | int    | 否   | 10     |
 | retry_base_delay_ms | long   | 否   | 100    |
 | retry_max_delay_ms  | long   | 否   | 5000   |
@@ -60,6 +61,10 @@ DynamoDB 所在的 AWS 区域，例如 `us-east-1`。
 一次 DynamoDB 批量写入请求缓存的记录数。
 
 DynamoDB batch write 每次最多支持 25 条写请求，所以默认值为 `25`。
+
+### multi_table_sink_replica [int]
+
+多表写入任务可使用的 Sink 通用选项。更多说明请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
 
 ### max_retries [int]
 

--- a/docs/zh/connectors/sink/AmazonSqs.md
+++ b/docs/zh/connectors/sink/AmazonSqs.md
@@ -43,6 +43,7 @@ Amazon SQS Sink 连接器用于把每条输入的 SeaTunnel 行数据写入一�
 - `canal_json`：写出 Canal JSON 消息，详见 [Canal JSON](../formats/canal-json.md)。
 - `debezium_json`：写出 Debezium JSON 消息，详见 [Debezium JSON](../formats/debezium-json.md)。
 - 当前 sink 只发送消息体，不提供 SQS message attributes、delay seconds、deduplication ID 或 message group ID 等配置。
+- `access_key_id` 和 `secret_access_key` 是可选项；如果使用静态 AWS 凭证，需要两个一起配置。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/AmazonDynamoDB.md
+++ b/docs/zh/connectors/source/AmazonDynamoDB.md
@@ -10,6 +10,8 @@ Amazon DynamoDB 源连接器通过 DynamoDB scan 请求读取已有表中的数�
 
 该连接器是批处理源。DynamoDB 不像关系型数据库那样提供完整字段类型信息，所以必须在 SeaTunnel 中显式配置 schema。
 
+该 Source 使用 scan 请求读取表中当前已有的数据，不读取 DynamoDB Streams 或 CDC 变更事件。
+
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
@@ -92,6 +94,8 @@ schema = {
 DynamoDB parallel scan 使用的逻辑分片数量。
 
 这个值会影响源连接器如何拆分表扫描任务，通常需要结合任务并行度和表数据量设置。
+
+小表通常保留默认值即可。大表可以结合 `env.parallelism` 和 Source 的 `parallelism` 一起调大，让多个 reader 扫描不同分片。
 
 ### 通用选项
 

--- a/docs/zh/connectors/source/AmazonSqs.md
+++ b/docs/zh/connectors/source/AmazonSqs.md
@@ -11,6 +11,8 @@ Amazon SQS 源连接器用于从一个 Amazon SQS 队列 URL 读取消息。连�
 
 该连接器使用单个 reader，处理完本次接收到的消息后任务会结束，适合从队列中做有界读取。
 
+每次 receive 请求最多从 SQS 拉取 10 条消息。如果队列里还有更多消息，需要再次运行任务，或者使用上游调度方式重复触发这种有界读取。
+
 ## 支持的引擎
 
 > Spark<br/>
@@ -49,6 +51,7 @@ Amazon SQS 源连接器用于从一个 Amazon SQS 队列 URL 读取消息。连�
 - `canal_json`：读取 Canal JSON 消息，详见 [Canal JSON](../formats/canal-json.md)。
 - `debezium_json`：读取 Debezium JSON 消息，详见 [Debezium JSON](../formats/debezium-json.md)。
 - `delete_message = true` 会删除已经消费的 SQS 消息。如果只是检查或复制消息，建议保留默认值 `false`。
+- `access_key_id` 和 `secret_access_key` 是可选项；如果使用静态 AWS 凭证，需要两个一起配置。
 
 ## 任务示例
 


### PR DESCRIPTION
## Summary
- Improve ActiveMQ sink documentation with batch/stream capability notes and clearer broker URI guidance.
- Clarify Amazon DynamoDB source scan behavior, parallel scan tuning, and multi-table sink common option usage.
- Clarify Amazon SQS bounded receive behavior and static credential pairing for source and sink docs.

## Validation
- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify

## Compatibility
- Documentation-only change. No runtime behavior changed.