### PR TITLE
[Docs][Connector-V2] Improve Redis sink docs

### DIFF
--- a/docs/en/connectors/sink/Redis.md
+++ b/docs/en/connectors/sink/Redis.md
@@ -6,261 +6,156 @@ import ChangeLog from '../changelog/connector-redis.md';
 
 ## Description
 
-Used to write data to Redis.
+The Redis sink connector writes upstream rows to Redis in batch or streaming jobs. It supports single-node Redis and
+Redis Cluster, and can write to `key`/`string`, `hash`, `list`, `set`, and `zset` data types.
 
-## Key features
+The configured `key` can be either a literal Redis key or an upstream field name. When `support_custom_key = true`,
+the connector can build the Redis key from one or more upstream fields, for example `user:${id}`.
+
+## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-| name               | type    |       required        | default value |
-|--------------------|---------|-----------------------|---------------|
-| host               | string  | yes  when mode=single | -             |
-| port               | int     | no                    | 6379          |
-| key                | string  | yes                   | -             |
-| data_type          | string  | yes                   | -             |
-| batch_size         | int     | no                    | 10            |
-| user               | string  | no                    | -             |
-| auth               | string  | no                    | -             |
-| db_num             | int     | no                    | 0             |
-| mode               | string  | no                    | single        |
-| nodes              | list    | yes when mode=cluster | -             |
-| format             | string  | no                    | json          |
-| expire             | long    | no                    | -1            |
-| support_custom_key | boolean | no                    | false         |
-| value_field        | string  | no                    | -             |
-| hash_key_field     | string  | no                    | -             |
-| hash_value_field   | string  | no                    | -             |
-| field_delimiter    | string  | no                    | ','           |
-| common-options     |         | no                    | -             |
-
-### host [string]
-
-Redis host
-
-### port [int]
-
-Redis port
-
-### key [string]
-
-The value of key you want to write to redis.
-
-For example, if you want to use value of a field from upstream data as key, you can assign it to the field name.
-
-Upstream data is the following:
-
-| code |      data      | success |
-|------|----------------|---------|
-| 200  | get success    | true    |
-| 500  | internal error | false   |
-
-If you assign field name to `code` and data_type to `key`, two data will be written to redis:
-1. `200 -> {code: 200, data: get success, success: true}`
-2. `500 -> {code: 500, data: internal error, success: false}`
-
-If you assign field name to `value` and data_type to `key`, only one data will be written to redis because `value` is not existed in upstream data's fields:
-
-1. `value -> {code: 500, data: internal error, success: false}`
-
-Please see the data_type section for specific writing rules.
-
-Of course, the format of the data written here I just take json as an example, the specific or user-configured `format` prevails.
-
-### data_type [string]
-
-Redis data types, support `key` `hash` `list` `set` `zset`
-
-- key
-
-> Each data from upstream will be updated to the configured key, which means the later data will overwrite the earlier data, and only the last data will be stored in the key.
-
-- hash
-
-> Each data from upstream will be split according to the field and written to the hash key, also the data after will overwrite the data before.
-
-- list
-
-> Each data from upstream will be added to the configured list key.
-
-- set
-
-> Each data from upstream will be added to the configured set key.
-
-- zset
-
-> Each data from upstream will be added to the configured zset key with a weight of 1. So the order of data in zset is based on the order of data consumption.
->
-### batch_size [int]
-
-ensure the batch write size in single-machine mode; no guarantees in cluster mode.
-
-### user [string]
-
-redis authentication user, you need it when you connect to an encrypted cluster
-
-### auth [string]
-
-Redis authentication password, you need it when you connect to an encrypted cluster
-
-### db_num [int]
-
-Redis database index ID. It is connected to db 0 by default
-
-### mode [string]
-
-redis mode, `single` or `cluster`, default is `single`
-
-### nodes [list]
-
-redis nodes information, used in cluster mode, must like as the following format:
-
-["host1:port1", "host2:port2"]
-
-### format [string]
-
-The format of upstream data, currently support `json`, `text` format, default `json`.
-
-When you assign format is `json`, for example:
-
-Upstream data is the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-Connector will generate data as the following and write it to redis:
-
-```json
-
-{"code":  200, "data":  "get success", "success":  "true"}
-```
-
-when you assign format is `text`, and set field_delimiter to `#`, connector will generate data as the following and write it to redis:
-```text
-200#get success#true
-```
-
-### field_delimiter [string]
-Field delimiter, used to tell connector how to slice and dice fields.
-
-Currently, only need to be configured when format is `text`. default is ",".
-
-### expire [long]
-
-Set redis expiration time, the unit is second. The default value is -1, keys do not automatically expire by default.
-
-### support_custom_key [boolean]
-
-if true, the key can be customized by the field value in the upstream data.
-
-Upstream data is the following:
-
-| code |      data      | success |
-|------|----------------|---------|
-| 200  | get success    | true    |
-| 500  | internal error | false   |
-
-You can customize the Redis key using '{' and '}', and the field name in '{}' will be parsed and replaced by the field value in the upstream data. For example, If you assign field name to `{code}` and data_type to `key`, two data will be written to redis:
-1. `200 -> {code: 200, data: get success, success: true}`
-2. `500 -> {code: 500, data: internal error, success: false}`
-
-Redis key can be composed of fixed and variable parts, connected by ':'. For example, If you assign field name to `code:{code}` and data_type to `key`, two data will be written to redis:
-1. `code:200 -> {code: 200, data: get success, success: true}`
-2. `code:500 -> {code: 500, data: internal error, success: false}`
-
-### value_field [string]
-
-The field of value you want to write to redis, `data_type` support `key` `list` `set` `zset`.
-
-When you assign field name to `value` and value_field is `data` and data_type to `key`, for example:
-
-Upstream data is the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-The following data will be written to redis:
-1. `value -> get success`
-
-### hash_key_field [string]
-
-The field of hash key you want to write to redis, `data_type` support `hash`
-
-### hash_value_field [string]
-
-The field of hash value you want to write to redis, `data_type` support `hash`
-
-When you assign field name to `value` and hash_key_field is `data` and hash_value_field is `success` and data_type to `hash`, for example:
-
-Upstream data is the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-Connector will generate data as the following and write it to redis:
-
-The following data will be written to redis:
-1. `value -> get success | true`
-
-### common options
-
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
-
-## Example
-
-simple:
+| Name               | Type    | Required                    | Default | Description |
+|--------------------|---------|-----------------------------|---------|-------------|
+| host               | string  | Yes when `mode = SINGLE`    | -       | Redis host for single-node mode. |
+| port               | int     | No                          | 6379    | Redis port for single-node mode. |
+| nodes              | list    | Yes when `mode = CLUSTER`   | -       | Redis Cluster nodes, for example `["redis-0:6379", "redis-1:6379"]`. |
+| mode               | string  | No                          | SINGLE  | Redis deployment mode. Supported values are `SINGLE` and `CLUSTER`. |
+| user               | string  | No                          | -       | Redis ACL username. |
+| auth               | string  | No                          | -       | Redis authentication password. |
+| db_num             | int     | No                          | 0       | Redis database index. This option is used in single-node mode. |
+| key                | string  | Yes                         | -       | Redis key, upstream field name, or key template when `support_custom_key = true`. |
+| data_type          | string  | Yes                         | -       | Redis data type. Supported values are `KEY`, `STRING`, `HASH`, `LIST`, `SET`, and `ZSET`. |
+| format             | string  | No                          | JSON    | Serialization format used when no value field is configured. Supported values are `JSON` and `TEXT`. |
+| field_delimiter    | string  | No                          | `,`     | Field delimiter used when `format = TEXT`. |
+| batch_size         | int     | No                          | 10      | Maximum number of rows buffered before one batch write. |
+| expire             | long    | No                          | -1      | Key expiration time in seconds. Values less than or equal to 0 mean no expiration is set. |
+| support_custom_key | boolean | No                          | false   | Whether to replace placeholders in `key` with upstream field values. |
+| value_field        | string  | No                          | -       | Upstream field used as the Redis value for `KEY`/`STRING`, `LIST`, `SET`, and `ZSET`. |
+| hash_key_field     | string  | No                          | -       | Upstream field used as the Redis hash field when `data_type = HASH`. |
+| hash_value_field   | string  | No                          | -       | Upstream field used as the Redis hash value when `data_type = HASH`. |
+| common-options     | config  | No                          | -       | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md). |
+
+## Write Rules
+
+### key
+
+When `support_custom_key = false`, the connector first checks whether `key` matches an upstream field name:
+
+- If the field exists, the field value is used as the Redis key.
+- If the field does not exist, `key` itself is used as a fixed Redis key.
+
+When `support_custom_key = true`, placeholders in `key` are replaced by upstream field values. Both `${field}` and
+the legacy `{field}` style are supported.
+
+### data_type
+
+- `KEY` and `STRING`: write one Redis string value for each row. Later rows overwrite earlier rows with the same key.
+- `HASH`: write one or more fields into a Redis hash. Configure `hash_key_field` to choose the hash field name.
+- `LIST`: append each row value to a Redis list.
+- `SET`: add each row value to a Redis set.
+- `ZSET`: add each row value to a Redis sorted set with score `1`.
+
+### value_field
+
+For `KEY`/`STRING`, `LIST`, `SET`, and `ZSET`, configure `value_field` when only one upstream field should be written
+as the Redis value. If `value_field` is not configured, the connector serializes the whole upstream row using `format`.
+
+### hash_key_field and hash_value_field
+
+For `HASH`, `hash_key_field` chooses the Redis hash field. If `hash_value_field` is configured, that field value is
+written as the Redis hash value. If `hash_value_field` is not configured, the connector serializes the whole upstream
+row as the hash value.
+
+## Examples
+
+### Write Rows To A Redis List
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = age
-  data_type = list
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        id = int
+        name = string
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "Alice"] },
+      { kind = INSERT, fields = [2, "Bob"] }
+    ]
+  }
+}
+
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person_list"
+    data_type = LIST
+    value_field = "name"
+  }
 }
 ```
 
-custom key:
+### Use A Custom Key Template
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = "name:${name}"
-  support_custom_key = true
-  data_type = key
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person:${id}"
+    support_custom_key = true
+    data_type = KEY
+    format = JSON
+  }
 }
 ```
 
-custom value:
+### Write Hash Fields
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = person
-  value_field = "name"
-  data_type = key
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person_hash"
+    data_type = HASH
+    hash_key_field = "id"
+    hash_value_field = "name"
+  }
 }
 ```
 
-custom HashKey and HashValue:
+### Write To Redis Cluster With Expiration
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = person
-  hash_key_field = "name"
-  hash_value_field = "age"
-  data_type = hash
+sink {
+  Redis {
+    mode = CLUSTER
+    nodes = ["redis-cluster-0:6379", "redis-cluster-1:6379", "redis-cluster-2:6379"]
+    key = "event:${id}"
+    support_custom_key = true
+    data_type = KEY
+    value_field = "name"
+    batch_size = 20
+    expire = 30
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/sink/Redis.md
+++ b/docs/zh/connectors/sink/Redis.md
@@ -2,255 +2,155 @@ import ChangeLog from '../changelog/connector-redis.md';
 
 # Redis
 
-> Redis sink connector
+> Redis 接收器连接器
 
 ## 描述
 
-用于将数据写入 Redis。
+Redis 接收器连接器可以在批处理或流处理作业中把上游数据写入 Redis。它支持单节点 Redis 和 Redis Cluster，
+可以写入 `key`/`string`、`hash`、`list`、`set`、`zset` 这几类 Redis 数据。
 
-## 主要功能
+`key` 可以是固定的 Redis key，也可以是上游字段名。开启 `support_custom_key = true` 后，还可以用上游字段
+拼出 Redis key，例如 `user:${id}`。
 
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+## 主要特性
+
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-| name               | type    |       required        | default value |
-|--------------------|---------|-----------------------|---------------|
-| host               | string  | `mode=single`时必须      | -             |
-| port               | int     | 否                 | 6379          |
-| key                | string  | 是                 | -             |
-| data_type          | string  | 是                 | -             |
-| batch_size         | int     | 否                 | 10            |
-| user               | string  | 否                 | -             |
-| auth               | string  | 否                 | -             |
-| db_num             | int     | 否                 | 0             |
-| mode               | string  | 否                 | single        |
-| nodes              | list    | `mode=cluster`时必须 | -             |
-| format             | string  | 否                 | json          |
-| expire             | long    | 否                 | -1            |
-| support_custom_key | boolean | 否                 | false         |
-| value_field        | string  | 否                 | -             |
-| hash_key_field     | string  | 否                 | -             |
-| hash_value_field   | string  | 否                 | -             |
-| field_delimiter    | string  | 否                 | ","           |
-| common-options     |         | 否                 | -             |
-
-### host [string]
-
-Redis 主机地址
-
-### port [int]
-
-Redis 端口
-
-### key [string]
-
-要写入 Redis 的键值。
-
-例如，如果想使用上游数据中的某个字段值作为键值，可以将该字段名称指定给 key。
-
-上游数据如下：
-
-| code | data | success |
-|------|------|---------|
-| 200  | 获取成功 | true    |
-| 500  | 内部错误 | false   |
-
-如果将字段名称指定为 code 并将 data_type 设置为 key，将有两个数据写入 Redis：
-1. `200 -> {code: 200, data: 获取成功, success: true}`
-2. `500 -> {code: 500, data: 内部错误, success: false}`
-   
-如果将字段名称指定为 value 并将 data_type 设置为 key，则由于上游数据的字段中没有 value 字段，将只有一个数据写入 Redis：
-1. `value -> {code: 500, data: 内部错误, success: false}`
-
-请参见 data_type 部分以了解具体的写入规则。
-
-当然，这里写入的数据格式只是以 json 为例，具体格式以用户配置的 `format` 为准。
-
-### data_type [string]
-
-Redis 数据类型，支持 `key` `hash` `list` `set` `zset`
-
-- key
-
-> 每个来自上游的数据都会更新到配置的 key，这意味着后面的数据会覆盖前面的数据，只有最后的数据会存储在该 key 中。
-
-- hash
-
-> 每个来自上游的数据会根据字段拆分并写入 hash key，后面的数据会覆盖前面的数据。
-
-- list
-
-> 每个来自上游的数据都会被添加到配置的 list key 中。
-
-- set
-
-> 每个来自上游的数据都会被添加到配置的 set key 中。
-
-- zset
-
-> 每个来自上游的数据都会以权重为 1 的方式添加到配置的 zset key 中。因此，zset 中数据的顺序基于数据的消费顺序。
-
-### user [string]
-
-Redis 认证用户，连接加密集群时需要
-
-### auth [string]
-
-Redis 认证密码，连接加密集群时需要
-
-### db_num [int]
-
-Redis 数据库索引 ID，默认连接到 db 0
-
-### mode [string]
-
-Redis 模式，`single` 或 `cluster`，默认是 `single`
-
-### nodes [list]
-
-Redis 节点信息，在集群模式下使用，必须按如下格式：
-
-["host1:port1", "host2:port2"]
-
-### format [string]
-
-上游数据的格式，目前只支持 `json`，`text`，默认 `json`。
-
-当你指定格式为 `json` 时，例如：
-
-上游数据如下：
-
-| code | data | success |
-|------|------|---------|
-| 200  | 获取成功 | true    |
-
-连接器会生成如下数据并写入 Redis：
-
-```json
-{"code":  200, "data":  "获取成功", "success":  "true"}
-```
-
-当你指定format为`text`，并设置field_delimiter为`#`时，连接器将生成如下数据并将其写入redis：
-
-```text
-200#get success#true
-```
-
-### field_delimiter [string]
-字段分隔符，用于告诉连接器如何分割字段。
-
-目前仅当格式为text时需要配置。默认为","。
-
-
-### expire [long]
-
-设置 Redis 的过期时间，单位为秒。默认值为 -1，表示键不会自动过期。
-
-### support_custom_key [boolean]
-
-设置为true，表示启用自定义Key。
-
-上游数据如下：
-
-| code | data | success |
-|------|------|---------|
-| 200  | 获取成功 | true    |
-| 500  | 内部错误 | false   |
-
-可以使用`{`和`}`符号自定义Redis键名，`{}`中的字段名会被解析替换为上游数据中的某个字段值，例如：将字段名称指定为 `{code}` 并将 data_type 设置为 `key`，将有两个数据写入 Redis：
-1. `200 -> {code: 200, data: 获取成功, success: true}`
-2. `500 -> {code: 500, data: 内部错误, success: false}`
-
-Redis键名可以由固定部分和变化部分组成，通过Redis分组符号:连接，例如：将字段名称指定为 `code:{code}` 并将 data_type 设置为 `key`，将有两个数据写入 Redis：
-1. `code:200 -> {code: 200, data: 获取成功, success: true}`
-2. `code:500 -> {code: 500, data: 内部错误, success: false}`
-
-### value_field [string]
-
-要写入Redis的值的字段， `data_type` 支持 `key` `list` `set` `zset`.
-
-当你指定Redis键名字段`key`指定为 `value`，值字段`value_field`指定为`data`，并将`data_type`指定为`key`时,
-
-上游数据如下：
-
-| code | data | success |
-|------|------|---------|
-| 200  | 获取成功 | true    |
-
-如下的数据会被写入Redis:
-1. `value -> 获取成功`
-
-### hash_key_field [string]
-
-要写入Redis的hash键字段, `data_type` 支持 `hash`
-
-### hash_value_field [string]
-
-要写入Redis的hash值字段, `data_type` 支持 `hash`
-
-当你指定Redis键名字段`key`指定为 `value`，hash键字段`hash_key_field`指定为`data`，hash值字段`hash_value_field`指定为`success`，并将`data_type`指定为`hash`时,
-
-上游数据如下：
-
-| code | data | success |
-|------|------|---------|
-| 200  | 获取成功 | true    |
-
-如下的数据会被写入Redis:
-1. `value -> 获取成功 | true`
-
-### common options
-
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 获取详情
+| 名称               | 类型    | 是否必填                    | 默认值 | 描述 |
+|--------------------|---------|-----------------------------|--------|------|
+| host               | string  | `mode = SINGLE` 时必填      | -      | 单节点模式下的 Redis 主机地址。 |
+| port               | int     | 否                          | 6379   | 单节点模式下的 Redis 端口。 |
+| nodes              | list    | `mode = CLUSTER` 时必填     | -      | Redis Cluster 节点，例如 `["redis-0:6379", "redis-1:6379"]`。 |
+| mode               | string  | 否                          | SINGLE | Redis 部署模式，支持 `SINGLE` 和 `CLUSTER`。 |
+| user               | string  | 否                          | -      | Redis ACL 用户名。 |
+| auth               | string  | 否                          | -      | Redis 认证密码。 |
+| db_num             | int     | 否                          | 0      | Redis 数据库编号，主要用于单节点模式。 |
+| key                | string  | 是                          | -      | Redis key、上游字段名，或开启 `support_custom_key` 后的 key 模板。 |
+| data_type          | string  | 是                          | -      | Redis 数据类型，支持 `KEY`、`STRING`、`HASH`、`LIST`、`SET`、`ZSET`。 |
+| format             | string  | 否                          | JSON   | 未配置 value 字段时的序列化格式，支持 `JSON` 和 `TEXT`。 |
+| field_delimiter    | string  | 否                          | `,`    | `format = TEXT` 时使用的字段分隔符。 |
+| batch_size         | int     | 否                          | 10     | 每次批量写入前最多缓存的行数。 |
+| expire             | long    | 否                          | -1     | Redis key 过期时间，单位秒。小于等于 0 表示不设置过期时间。 |
+| support_custom_key | boolean | 否                          | false  | 是否用上游字段值替换 `key` 里的占位符。 |
+| value_field        | string  | 否                          | -      | 写入 `KEY`/`STRING`、`LIST`、`SET`、`ZSET` 时，作为 Redis value 的上游字段。 |
+| hash_key_field     | string  | 否                          | -      | `data_type = HASH` 时，作为 Redis hash field 的上游字段。 |
+| hash_value_field   | string  | 否                          | -      | `data_type = HASH` 时，作为 Redis hash value 的上游字段。 |
+| common-options     | config  | 否                          | -      | 接收器插件通用参数，详情请参考[接收器通用选项](../common-options/sink-common-options.md)。 |
+
+## 写入规则
+
+### key
+
+当 `support_custom_key = false` 时，连接器会先判断 `key` 是否是上游字段名：
+
+- 如果字段存在，就使用该字段的值作为 Redis key。
+- 如果字段不存在，就把 `key` 本身当作固定 Redis key。
+
+当 `support_custom_key = true` 时，连接器会用上游字段值替换 `key` 里的占位符。`${field}` 和旧格式 `{field}` 都支持。
+
+### data_type
+
+- `KEY` 和 `STRING`：每行写入一个 Redis 字符串。同一个 key 下，后写入的数据会覆盖先写入的数据。
+- `HASH`：写入 Redis hash。配置 `hash_key_field` 可以指定 hash field。
+- `LIST`：把每行数据追加到 Redis list。
+- `SET`：把每行数据加入 Redis set。
+- `ZSET`：把每行数据加入 Redis zset，score 固定为 `1`。
+
+### value_field
+
+写入 `KEY`/`STRING`、`LIST`、`SET`、`ZSET` 时，如果只想写入某一个上游字段，可以配置 `value_field`。
+如果不配置，连接器会按 `format` 把整行数据序列化后写入 Redis。
+
+### hash_key_field 和 hash_value_field
+
+写入 `HASH` 时，`hash_key_field` 用来指定 Redis hash field。如果配置了 `hash_value_field`，则把这个字段的值
+作为 Redis hash value；如果不配置，连接器会把整行数据序列化后作为 hash value。
 
 ## 示例
 
-简单示例：
+### 写入 Redis List
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = age
-  data_type = list
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        id = int
+        name = string
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "Alice"] },
+      { kind = INSERT, fields = [2, "Bob"] }
+    ]
+  }
+}
+
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person_list"
+    data_type = LIST
+    value_field = "name"
+  }
 }
 ```
 
-自定义Key示例：
+### 使用自定义 Key 模板
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = "name:${name}"
-  support_custom_key = true
-  data_type = key
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person:${id}"
+    support_custom_key = true
+    data_type = KEY
+    format = JSON
+  }
 }
 ```
 
-自定义Value示例：
+### 写入 Redis Hash
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = person
-  value_field = "name"
-  data_type = key
+sink {
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "person_hash"
+    data_type = HASH
+    hash_key_field = "id"
+    hash_value_field = "name"
+  }
 }
 ```
 
-自定义HashKey和HashValue示例：
+### 写入 Redis Cluster 并设置过期时间
 
 ```hocon
-Redis {
-  host = localhost
-  port = 6379
-  key = person
-  hash_key_field = "name"
-  hash_value_field = "age"
-  data_type = hash
+sink {
+  Redis {
+    mode = CLUSTER
+    nodes = ["redis-cluster-0:6379", "redis-cluster-1:6379", "redis-cluster-2:6379"]
+    key = "event:${id}"
+    support_custom_key = true
+    data_type = KEY
+    value_field = "name"
+    batch_size = 20
+    expire = 30
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Rewrite Redis sink documentation in English and Chinese with complete option descriptions
- Clarify single-node and cluster connection settings, write rules, custom key templates, value fields, hash fields, batch size, and expiration behavior
- Add practical examples for list writes, custom keys, hash writes, and Redis Cluster with expiration

## Verification
- MAVEN_OPTS="-Xmx1200m -XX:MaxMetaspaceSize=512m" ./mvnw spotless:apply
- MAVEN_OPTS="-Xmx1200m -XX:MaxMetaspaceSize=512m" ./mvnw -q -DskipTests verify