### PR TITLE
[Docs][Connector-V2] Improve Qdrant Firestore and IoTDB docs

### DIFF
--- a/docs/en/connectors/sink/GoogleFirestore.md
+++ b/docs/en/connectors/sink/GoogleFirestore.md
@@ -6,26 +6,28 @@ import ChangeLog from '../changelog/connector-google-firestore.md';
 
 ## Description
 
-The GoogleFirestore sink writes SeaTunnel rows to a Google Cloud Firestore
-collection.
+The GoogleFirestore sink writes SeaTunnel rows to a Google Cloud Firestore collection.
 
-Each SeaTunnel row is converted to a Firestore document. The connector requires
-the target Google Cloud project and collection. Credentials can be passed as a
-Base64-encoded service account JSON string, or read from Google Application
-Default Credentials when `credentials` is not configured.
+Each SeaTunnel row is converted to one Firestore document. The connector generates the Firestore document ID automatically by calling Firestore `add`, so it appends documents instead of updating a user-specified document ID.
 
-## Key features
+Credentials can be passed as a Base64-encoded service account JSON string. If `credentials` is not configured, the connector reads Google Application Default Credentials from the runtime environment.
+
+## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-| name           | type   | required | default value |
-|----------------|--------|----------|---------------|
-| project_id     | string | yes      | -             |
-| collection     | string | yes      | -             |
-| credentials    | string | no       | -             |
-| common-options |        | no       | -             |
+| name           | type   | required | default value | description |
+|----------------|--------|----------|---------------|-------------|
+| project_id     | string | yes      | -             | Google Cloud project ID that owns the Firestore database. |
+| collection     | string | yes      | -             | Firestore collection name to write to. |
+| credentials    | string | no       | -             | Base64-encoded Google Cloud service account JSON. |
+| common-options |        | no       | -             | Sink common options. |
 
 ### project_id [string]
 
@@ -33,21 +35,44 @@ The Google Cloud project ID that owns the Firestore database.
 
 ### collection [string]
 
-The Firestore collection to write to.
+The Firestore collection to write to. Each sink block writes to one collection.
 
 ### credentials [string]
 
 Base64-encoded Google Cloud service account JSON.
 
-If this option is not set, the connector uses Google Application Default
-Credentials. In that case, make sure `GOOGLE_APPLICATION_CREDENTIALS` points to
-the service account JSON file or the runtime environment already provides
-default credentials.
+If this option is not set, the connector uses Google Application Default Credentials. In that case, make sure `GOOGLE_APPLICATION_CREDENTIALS` points to the service account JSON file or the runtime environment already provides default credentials.
 
 ### common options
 
-Sink plugin common parameters, please refer to
-[Sink Common Options](../common-options/sink-common-options.md) for details.
+Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Supported Types
+
+| SeaTunnel type | Firestore value |
+|----------------|-----------------|
+| TINYINT        | integer |
+| SMALLINT       | integer |
+| INT            | integer |
+| BIGINT         | integer |
+| FLOAT          | double |
+| DOUBLE         | double |
+| DECIMAL        | decimal value |
+| STRING         | string |
+| BOOLEAN        | boolean |
+| BYTES          | blob |
+| DATE           | date at UTC start of day |
+| TIMESTAMP      | timestamp |
+| ARRAY          | array |
+| MAP            | map |
+| NULL           | null |
+
+## Notes
+
+- The connector currently provides a sink only. There is no GoogleFirestore source connector.
+- Firestore document IDs are generated automatically. Use another connector or transform before this sink if you need deterministic document IDs.
+- The sink does not interpret `UPDATE` or `DELETE` row kinds as CDC operations.
+- Do not put raw service account JSON directly in `credentials`; encode it with Base64 first.
 
 ## Example
 
@@ -61,22 +86,27 @@ source {
   FakeSource {
     schema = {
       fields {
-        c_string = string
-        c_boolean = boolean
-        c_int = int
-        c_bigint = bigint
-        c_double = double
-        c_decimal = "decimal(30, 8)"
-        c_date = date
-        c_timestamp = timestamp
         c_map = "map<string, string>"
         c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_null = "null"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
       }
     }
     rows = [
       {
         kind = INSERT
-        fields = ["hello", true, 10, 10000000000, 1.23, "123.456", "2023-04-22", "2023-04-22T23:20:58", {"a": "b"}, [1, 2, 3]]
+        fields = [{"a": "b"}, [10], "c_string", true, 117, 15987, 56387395, 7084913402530365000, 1.23, 1.23, "2924137191386439303744.39292216", null, "bWlJWmo=", "2023-04-22", "2023-04-22T23:20:58"]
       }
     ]
   }

--- a/docs/en/connectors/sink/IoTDB.md
+++ b/docs/en/connectors/sink/IoTDB.md
@@ -50,7 +50,7 @@ Used to write data to IoTDB.
 | key_device                  | String  | Yes      | -                              | Specify field name of the IoTDB deviceId in SeaTunnelRow                                                                                                          |
 | key_timestamp               | String  | No       | processing time                | Specify field-name of the IoTDB timestamp in SeaTunnelRow. If not specified, use processing-time as timestamp                                                     |
 | key_measurement_fields      | Array   | No       | exclude device and timestamp fields | Specify field names of the IoTDB measurement list in SeaTunnelRow. If not specified, include all fields except `key_device` and `key_timestamp` fields.             |
-| storage_group               | Array   | No       | -                              | Specify device storage group(path prefix) <br/> example: deviceId = \${storage_group} + "." +  \${key_device}                                                     |
+| storage_group               | String  | No       | -                              | Specify device storage group(path prefix) <br/> example: deviceId = \${storage_group} + "." +  \${key_device}                                                     |
 | batch_size                  | Integer | No       | 1024                           | For batch writing, data is flushed into IoTDB when the buffered row count reaches `batch_size`.                                                                    |
 | max_retries                 | Integer | No       | -                              | The number of retries to flush failed                                                                                                                             |
 | retry_backoff_multiplier_ms | Integer | No       | -                              | Using as a multiplier for generating the next delay for backoff                                                                                                   |
@@ -61,6 +61,14 @@ Used to write data to IoTDB.
 | enable_rpc_compression      | Boolean | No       | -                              | Enable rpc compression in IoTDB client                                                                                                                            |
 | connection_timeout_in_ms    | Integer | No       | -                              | The maximum time (in ms) to wait when connecting to IoTDB                                                                                                         |
 | common-options              |         | no       | -                              | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                       |
+
+## Write Rules
+
+- `key_device` must name the SeaTunnel field that contains the IoTDB device path.
+- `storage_group` is a string prefix. When it is set, the final device path is built from `storage_group` and the value of `key_device`.
+- `key_timestamp` can name a `STRING`, `BIGINT`, or `TIMESTAMP` field. If it is not configured, the connector uses the current processing time.
+- If `key_measurement_fields` is not configured, all fields except `key_device` and `key_timestamp` are written as measurements.
+- The sink supports `STRING`, `BOOLEAN`, `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `FLOAT`, and `DOUBLE` measurement fields.
 
 ## Examples
 

--- a/docs/en/connectors/sink/Qdrant.md
+++ b/docs/en/connectors/sink/Qdrant.md
@@ -24,7 +24,7 @@ The Qdrant sink writes SeaTunnel rows into one existing Qdrant collection. Norma
 | collection_name | string | yes      | -             | Qdrant collection name to write to. |
 | host            | string | no       | localhost     | Qdrant gRPC host. |
 | port            | int    | no       | 6334          | Qdrant gRPC port. |
-| api_key         | string | no       | -             | Qdrant API key for authenticated deployments. |
+| api_key         | string | no       | ""            | Qdrant API key for authenticated deployments. |
 | use_tls         | bool   | no       | false         | Whether to use TLS for the gRPC connection. |
 | common-options  |        | no       | -             | Sink common options. |
 
@@ -42,7 +42,7 @@ The gRPC port of the Qdrant instance.
 
 ### api_key [string]
 
-The API key used to connect to authenticated Qdrant deployments.
+The API key used to connect to authenticated Qdrant deployments. Leave it empty when the Qdrant service does not require authentication.
 
 ### use_tls [bool]
 

--- a/docs/en/connectors/source/IoTDB.md
+++ b/docs/en/connectors/source/IoTDB.md
@@ -43,9 +43,8 @@ Used to read data from IoTDB.
 | DOUBLE          | DOUBLE              |
 | TEXT            | STRING              |
 | STRING          | STRING              |
-| TIMESTAMP       | TIMESTAMP           |
-| BLOB            | STRING              |
-| DATE            | DATE                |
+| time column     | BIGINT              |
+| time column     | TIMESTAMP           |
 
 ## Source Options
 
@@ -66,7 +65,11 @@ Used to read data from IoTDB.
 | version                    | string  | no       | -             | SQL semantic version used by the client. The possible values are `V_0_12` and `V_0_13`.                           |
 | common-options             |         | no       | -             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details |
 
-We can use time column as a partition key in SQL queries.
+The first field in `schema.fields` must describe the IoTDB time column. It can be `bigint` when you want epoch milliseconds, or `timestamp` when you want a SeaTunnel timestamp value.
+
+When the SQL uses `align by device`, the second field normally describes the IoTDB device name. The remaining fields must follow the same order as the measurements returned by the SQL query.
+
+You can use the time column as a partition key in SQL queries.
 
 #### num_partitions [int]
 
@@ -134,6 +137,67 @@ sink {
 ```
 
 `lower_bound`, `upper_bound`, and `num_partitions` are optional. They are useful when the query covers a large time range and you want SeaTunnel to split the read into multiple time partitions.
+
+The following example reads from one IoTDB path, replaces the device prefix, and writes the result to another IoTDB path.
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  IoTDB {
+    plugin_output = "iotdb_rows"
+    node_urls = "localhost:6667"
+    username = "root"
+    password = "root"
+    sql = "SELECT c_string, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_float, c_double FROM root.source_group.* WHERE time < 4102329600000 align by device"
+    lower_bound = 1
+    upper_bound = 4102329600000
+    num_partitions = 10
+    schema {
+      fields {
+        ts = timestamp
+        device_name = string
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+      }
+    }
+  }
+}
+
+transform {
+  Replace {
+    plugin_input = "iotdb_rows"
+    plugin_output = "sink_rows"
+    replace_field = "device_name"
+    pattern = "root.source_group"
+    replacement = "root.sink_group"
+    is_regex = false
+    replace_first = true
+  }
+}
+
+sink {
+  IoTDB {
+    plugin_input = "sink_rows"
+    node_urls = ["localhost:6667"]
+    username = "root"
+    password = "root"
+    key_device = "device_name"
+    key_timestamp = "ts"
+    key_measurement_fields = ["c_string", "c_boolean", "c_tinyint", "c_smallint", "c_int", "c_bigint", "c_float", "c_double"]
+    batch_size = 1
+  }
+}
+```
 
 The data format from upstream IoTDB is as follows:
 

--- a/docs/en/connectors/source/Qdrant.md
+++ b/docs/en/connectors/source/Qdrant.md
@@ -28,7 +28,7 @@ The Qdrant source reads points from one existing Qdrant collection. Point payloa
 | schema          | config | yes      | -             | SeaTunnel schema used to map Qdrant point IDs, payload fields, and vectors. |
 | host            | string | no       | localhost     | Qdrant gRPC host. |
 | port            | int    | no       | 6334          | Qdrant gRPC port. |
-| api_key         | string | no       | -             | Qdrant API key for authenticated deployments. |
+| api_key         | string | no       | ""            | Qdrant API key for authenticated deployments. |
 | use_tls         | bool   | no       | false         | Whether to use TLS for the gRPC connection. |
 | common-options  |        | no       | -             | Source common options. |
 
@@ -78,7 +78,7 @@ The gRPC port of the Qdrant instance.
 
 ### api_key [string]
 
-The API key used to connect to authenticated Qdrant deployments.
+The API key used to connect to authenticated Qdrant deployments. Leave it empty when the Qdrant service does not require authentication.
 
 ### use_tls [bool]
 

--- a/docs/zh/connectors/sink/GoogleFirestore.md
+++ b/docs/zh/connectors/sink/GoogleFirestore.md
@@ -8,22 +8,26 @@ import ChangeLog from '../changelog/connector-google-firestore.md';
 
 GoogleFirestore Sink 用于将 SeaTunnel 数据写入 Google Cloud Firestore 集合。
 
-每一行 SeaTunnel 数据会转换为一个 Firestore 文档。连接器必须配置目标
-Google Cloud 项目和集合。凭证可以通过 `credentials` 传入 Base64 编码后的
-服务账号 JSON；如果不配置该参数，则会使用 Google 应用默认凭证。
+每一行 SeaTunnel 数据会转换为一个 Firestore 文档。连接器通过 Firestore `add` 自动生成文档 ID，因此它是追加写入，不会按用户指定的文档 ID 更新已有文档。
+
+凭证可以通过 `credentials` 传入 Base64 编码后的服务账号 JSON；如果不配置该参数，则会从运行环境读取 Google 应用默认凭证。
 
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-| 名称           | 类型   | 必填 | 默认值 |
-|----------------|--------|------|--------|
-| project_id     | string | 是   | -      |
-| collection     | string | 是   | -      |
-| credentials    | string | 否   | -      |
-| common-options |        | 否   | -      |
+| 名称           | 类型   | 必填 | 默认值 | 说明 |
+|----------------|--------|------|--------|------|
+| project_id     | string | 是   | -      | Firestore 数据库所在的 Google Cloud 项目 ID。 |
+| collection     | string | 是   | -      | 要写入的 Firestore 集合名称。 |
+| credentials    | string | 否   | -      | Base64 编码后的 Google Cloud 服务账号 JSON。 |
+| common-options |        | 否   | -      | Sink 通用选项。 |
 
 ### project_id [string]
 
@@ -31,18 +35,44 @@ Firestore 数据库所在的 Google Cloud 项目 ID。
 
 ### collection [string]
 
-要写入的 Firestore 集合名称。
+要写入的 Firestore 集合名称。每个 sink 配置块写入一个集合。
 
 ### credentials [string]
 
 Base64 编码后的 Google Cloud 服务账号 JSON。
 
-如果不配置该参数，连接器会使用 Google 应用默认凭证。此时需要确保
-`GOOGLE_APPLICATION_CREDENTIALS` 指向服务账号 JSON 文件，或者运行环境已经提供默认凭证。
+如果不配置该参数，连接器会使用 Google 应用默认凭证。此时需要确保 `GOOGLE_APPLICATION_CREDENTIALS` 指向服务账号 JSON 文件，或者运行环境已经提供默认凭证。
 
 ### 通用选项
 
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
+Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
+
+## 支持的数据类型
+
+| SeaTunnel 类型 | Firestore 值 |
+|----------------|--------------|
+| TINYINT        | 整数 |
+| SMALLINT       | 整数 |
+| INT            | 整数 |
+| BIGINT         | 整数 |
+| FLOAT          | 双精度浮点数 |
+| DOUBLE         | 双精度浮点数 |
+| DECIMAL        | 十进制数 |
+| STRING         | 字符串 |
+| BOOLEAN        | 布尔值 |
+| BYTES          | 二进制 Blob |
+| DATE           | UTC 当天零点日期 |
+| TIMESTAMP      | 时间戳 |
+| ARRAY          | 数组 |
+| MAP            | Map |
+| NULL           | null |
+
+## 注意事项
+
+- 当前连接器只提供 sink，不提供 GoogleFirestore source。
+- Firestore 文档 ID 会自动生成。如果需要固定文档 ID，请在写入前使用其他连接器或转换处理。
+- sink 不会按 `UPDATE` 或 `DELETE` 行类型执行 CDC 语义。
+- `credentials` 不能直接填写服务账号 JSON 原文，需要先做 Base64 编码。
 
 ## 示例
 
@@ -56,22 +86,27 @@ source {
   FakeSource {
     schema = {
       fields {
-        c_string = string
-        c_boolean = boolean
-        c_int = int
-        c_bigint = bigint
-        c_double = double
-        c_decimal = "decimal(30, 8)"
-        c_date = date
-        c_timestamp = timestamp
         c_map = "map<string, string>"
         c_array = "array<int>"
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+        c_decimal = "decimal(30, 8)"
+        c_null = "null"
+        c_bytes = bytes
+        c_date = date
+        c_timestamp = timestamp
       }
     }
     rows = [
       {
         kind = INSERT
-        fields = ["hello", true, 10, 10000000000, 1.23, "123.456", "2023-04-22", "2023-04-22T23:20:58", {"a": "b"}, [1, 2, 3]]
+        fields = [{"a": "b"}, [10], "c_string", true, 117, 15987, 56387395, 7084913402530365000, 1.23, 1.23, "2924137191386439303744.39292216", null, "bWlJWmo=", "2023-04-22", "2023-04-22T23:20:58"]
       }
     ]
   }

--- a/docs/zh/connectors/sink/IoTDB.md
+++ b/docs/zh/connectors/sink/IoTDB.md
@@ -50,7 +50,7 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 | key_device                  | String  | 是    | -                              | 在SeaTunnelRow中指定 IoTDB 设备ID的字段名                                              |
 | key_timestamp               | String  | 否    | processing time                | 在SeaTunnelRow中指定 IoTDB 时间戳的字段名。如果未指定，则使用处理时间作为时间戳                            |
 | key_measurement_fields      | Array   | 否    | 排除设备和时间字段                       | 在 SeaTunnelRow 中指定 IoTDB 测点字段列表。未配置时，会写入除 `key_device` 和 `key_timestamp` 对应字段外的其他字段 |
-| storage_group               | Array   | 否    | -                              | 指定设备存储组（路径前缀） <br/> 例如: deviceId = \${storage_group} + "." +  \${key_device} |
+| storage_group               | String  | 否    | -                              | 指定设备存储组（路径前缀） <br/> 例如: deviceId = \${storage_group} + "." +  \${key_device} |
 | batch_size                  | Integer | 否    | 1024                           | 批量写入时，当缓存行数达到 `batch_size`，数据会刷新到 IoTDB 中                                      |
 | max_retries                 | Integer | 否    | -                              | 写入失败后的最大重试次数                                                                 |
 | retry_backoff_multiplier_ms | Integer | 否    | -                              | 用作生成下一个退避延迟的乘数                                                               |
@@ -60,7 +60,15 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 | zone_id                     | string  | 否    | -                              | IoTDB 客户端使用的 `java.time.ZoneId`                                                |
 | enable_rpc_compression      | Boolean | 否    | -                              | 在 IoTDB 客户端中启用rpc压缩                                                          |
 | connection_timeout_in_ms    | Integer | 否    | -                              | 连接到 IoTDB 时等待的最长时间（毫秒）                                                       |
-| common-options              |         | 否    | -                              | Sink 插件通用参数，详见 [Sink Common Options](../common-options/sink-common-options.md)              |
+| common-options              |         | 否    | -                              | Sink 插件通用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)              |
+
+## 写入规则
+
+- `key_device` 必须指定 SeaTunnel 中保存 IoTDB 设备路径的字段名。
+- `storage_group` 是字符串前缀。配置后，最终设备路径会由 `storage_group` 和 `key_device` 对应字段值拼接而成。
+- `key_timestamp` 可以指定 `STRING`、`BIGINT` 或 `TIMESTAMP` 类型字段。未配置时，连接器会使用当前处理时间。
+- 未配置 `key_measurement_fields` 时，会把除 `key_device` 和 `key_timestamp` 之外的所有字段写为测点。
+- sink 支持写入 `STRING`、`BOOLEAN`、`TINYINT`、`SMALLINT`、`INT`、`BIGINT`、`FLOAT` 和 `DOUBLE` 类型测点。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/Qdrant.md
+++ b/docs/zh/connectors/sink/Qdrant.md
@@ -24,7 +24,7 @@ Qdrant sink 会把 SeaTunnel 行写入一个已经存在的 Qdrant collection。
 | collection_name | string | 是   | -         | 要写入的 Qdrant collection 名称。 |
 | host            | string | 否   | localhost | Qdrant gRPC 主机。 |
 | port            | int    | 否   | 6334      | Qdrant gRPC 端口。 |
-| api_key         | string | 否   | -         | 认证场景下使用的 Qdrant API key。 |
+| api_key         | string | 否   | ""        | 认证场景下使用的 Qdrant API key。 |
 | use_tls         | bool   | 否   | false     | gRPC 连接是否启用 TLS。 |
 | common-options  |        | 否   | -         | Sink 通用选项。 |
 
@@ -42,7 +42,7 @@ Qdrant 实例的 gRPC 端口。
 
 ### api_key [string]
 
-连接需要认证的 Qdrant 部署时使用的 API key。
+连接需要认证的 Qdrant 部署时使用的 API key。如果 Qdrant 服务不需要认证，可以保持为空。
 
 ### use_tls [bool]
 

--- a/docs/zh/connectors/source/IoTDB.md
+++ b/docs/zh/connectors/source/IoTDB.md
@@ -43,10 +43,8 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 | DOUBLE     | DOUBLE         |
 | TEXT       | STRING         |
 | STRING     | STRING         |
-| TIMESTAMP  | BIGINT         |
-| TIMESTAMP  | TIMESTAMP      |
-| BLOB       | STRING         |
-| DATE       | DATE           |
+| 时间列        | BIGINT         |
+| 时间列        | TIMESTAMP      |
 
 ## Source 选项
 
@@ -65,9 +63,13 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 | thrift_max_frame_size      | int     | 否    | -   | Thrift 最大帧尺寸                                                                     |
 | enable_cache_leader        | boolean | 否    | -   | 是否启用 Leader 节点缓存                                                                 |
 | version                    | string  | 否    | -   | 客户端 SQL 语义版本（`V_0_12` / `V_0_13`）                                                |
-| common-options             |         | 否    | -   | Source 插件通用参数，详见 [Source Common Options](../common-options/source-common-options.md)            |
+| common-options             |         | 否    | -   | Source 插件通用参数，详见 [Source 通用选项](../common-options/source-common-options.md)            |
 
-我们可以使用时间列进行分区查询。
+`schema.fields` 中的第一个字段必须对应 IoTDB 时间列。需要毫秒时间戳时可以配置为 `bigint`，需要 SeaTunnel timestamp 值时可以配置为 `timestamp`。
+
+当 SQL 使用 `align by device` 时，第二个字段通常对应 IoTDB 设备名。后续字段需要和 SQL 返回的测点顺序保持一致。
+
+可以使用时间列进行分区查询。
 
 ### num_partitions [int]
 
@@ -137,6 +139,67 @@ sink {
 ```
 
 `lower_bound`、`upper_bound` 和 `num_partitions` 是可选项。当查询覆盖很大的时间范围时，可以用它们把读取任务按时间范围拆成多个分区。
+
+下面的示例从一个 IoTDB 路径读取数据，替换设备名前缀后，再写入另一个 IoTDB 路径。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  IoTDB {
+    plugin_output = "iotdb_rows"
+    node_urls = "localhost:6667"
+    username = "root"
+    password = "root"
+    sql = "SELECT c_string, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_float, c_double FROM root.source_group.* WHERE time < 4102329600000 align by device"
+    lower_bound = 1
+    upper_bound = 4102329600000
+    num_partitions = 10
+    schema {
+      fields {
+        ts = timestamp
+        device_name = string
+        c_string = string
+        c_boolean = boolean
+        c_tinyint = tinyint
+        c_smallint = smallint
+        c_int = int
+        c_bigint = bigint
+        c_float = float
+        c_double = double
+      }
+    }
+  }
+}
+
+transform {
+  Replace {
+    plugin_input = "iotdb_rows"
+    plugin_output = "sink_rows"
+    replace_field = "device_name"
+    pattern = "root.source_group"
+    replacement = "root.sink_group"
+    is_regex = false
+    replace_first = true
+  }
+}
+
+sink {
+  IoTDB {
+    plugin_input = "sink_rows"
+    node_urls = ["localhost:6667"]
+    username = "root"
+    password = "root"
+    key_device = "device_name"
+    key_timestamp = "ts"
+    key_measurement_fields = ["c_string", "c_boolean", "c_tinyint", "c_smallint", "c_int", "c_bigint", "c_float", "c_double"]
+    batch_size = 1
+  }
+}
+```
 
 上游 IoTDB 的数据格式如下所示:
 

--- a/docs/zh/connectors/source/Qdrant.md
+++ b/docs/zh/connectors/source/Qdrant.md
@@ -28,7 +28,7 @@ Qdrant source 用来从一个已经存在的 Qdrant collection 读取 point。po
 | schema          | config | 是   | -         | SeaTunnel schema，用来映射 Qdrant point ID、payload 字段和向量。 |
 | host            | string | 否   | localhost | Qdrant gRPC 主机。 |
 | port            | int    | 否   | 6334      | Qdrant gRPC 端口。 |
-| api_key         | string | 否   | -         | 认证场景下使用的 Qdrant API key。 |
+| api_key         | string | 否   | ""        | 认证场景下使用的 Qdrant API key。 |
 | use_tls         | bool   | 否   | false     | gRPC 连接是否启用 TLS。 |
 | common-options  |        | 否   | -         | Source 通用选项。 |
 
@@ -78,7 +78,7 @@ Qdrant 实例的 gRPC 端口。
 
 ### api_key [string]
 
-连接需要认证的 Qdrant 部署时使用的 API key。
+连接需要认证的 Qdrant 部署时使用的 API key。如果 Qdrant 服务不需要认证，可以保持为空。
 
 ### use_tls [bool]
 


### PR DESCRIPTION
## Summary

This PR improves the connector documentation for Qdrant, GoogleFirestore, and IoTDB.

Changes include:
- Clarify Qdrant `api_key` default handling in both source and sink docs.
- Expand GoogleFirestore sink docs with clearer feature flags, option descriptions, supported type mapping, write behavior notes, and a fuller batch example.
- Improve IoTDB source and sink docs with more accurate type mapping, schema ordering rules, write rules, corrected `storage_group` type, and a source-to-sink example.
- Keep English and Chinese documentation aligned.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
