### PR TITLE
[Docs][Connector-V2] Improve Cassandra DataHub and Easysearch docs

### DIFF
--- a/docs/en/connectors/sink/Cassandra.md
+++ b/docs/en/connectors/sink/Cassandra.md
@@ -12,6 +12,9 @@ The sink writes rows to an existing Cassandra table. If `fields` is not configur
 uses all columns from the target Cassandra table schema. If `fields` is configured, only those
 columns are written, and every configured field must exist in the target table.
 
+The connector does not create keyspaces, tables, or missing columns. Prepare the target Cassandra
+schema before starting the job.
+
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
@@ -68,6 +71,8 @@ connector reads the target table schema and writes all columns from that table.
 
 When this option is configured, the field names must exist in the target Cassandra table and must
 also exist in the upstream SeaTunnel row.
+
+Use this option when the upstream row has extra fields that should not be written to Cassandra.
 
 ### batch_size [number]
 

--- a/docs/en/connectors/sink/Datahub.md
+++ b/docs/en/connectors/sink/Datahub.md
@@ -19,16 +19,16 @@ different input tables to different DataHub topics.
 
 ## Options
 
-| name           | type   | required | default value |
-|----------------|--------|----------|---------------|
-| endpoint       | string | yes      | -             |
-| accessId       | string | yes      | -             |
-| accessKey      | string | yes      | -             |
-| project        | string | yes      | -             |
-| topic          | string | yes      | -             |
-| timeout        | int    | no       | 3000          |
-| retryTimes     | int    | no       | 3             |
-| common-options |        | no       | -             |
+| name           | type   | required | default value | description |
+|----------------|--------|----------|---------------|-------------|
+| endpoint       | string | yes      | -             | DataHub service endpoint. |
+| accessId       | string | yes      | -             | Alibaba Cloud access ID used to access DataHub. |
+| accessKey      | string | yes      | -             | Alibaba Cloud access key used to access DataHub. |
+| project        | string | yes      | -             | DataHub project name. |
+| topic          | string | yes      | -             | DataHub topic name. Supports placeholders in multi-table jobs. |
+| timeout        | int    | no       | 3000          | Maximum client connection timeout in milliseconds. |
+| retryTimes     | int    | no       | 3             | Maximum retry count when writing a record fails. |
+| common-options | config | no       | -             | Sink plugin common options. |
 
 ### endpoint [string]
 
@@ -50,6 +50,9 @@ The DataHub project name.
 
 The DataHub topic name. For multi-table writes, this value can contain
 placeholders, for example `${table_name}`.
+
+The SeaTunnel field names must match the DataHub topic fields, because the sink writes fields by
+name according to the topic schema.
 
 ### timeout [int]
 

--- a/docs/en/connectors/sink/Easysearch.md
+++ b/docs/en/connectors/sink/Easysearch.md
@@ -230,6 +230,7 @@ sink {
         username = "admin"
         password = "admin"
 
+        index = "seatunnel_index"
         schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
         data_save_mode = "APPEND_DATA"
     }

--- a/docs/en/connectors/source/Easysearch.md
+++ b/docs/en/connectors/source/Easysearch.md
@@ -88,9 +88,14 @@ Easysearch index name, support * fuzzy matching.
 
 ### source [array]
 
-The fields of index.
-You can get the document id by specifying the field `_id`.If sink _id to other index,you need specify an alias for _id due to the Easysearch limit.
-If `source` is not configured, `schema` must be configured.
+The fields to read from the index.
+
+You can get the document id by specifying the field `_id`. If you need to write `_id` to another
+Easysearch index, specify an alias for `_id` because Easysearch does not allow `_id` to be written
+as a normal field.
+
+`source` and `schema` are mutually exclusive. If both are omitted, the connector reads the field
+mapping from Easysearch and uses all mapped fields in the index.
 
 ### query [json]
 
@@ -107,8 +112,12 @@ Maximum number of hits to be returned with each Easysearch scroll request.
 
 ### schema
 
-The structure of the data, including field names and field types. For more details, see [Schema Feature](../../introduction/concepts/schema-feature.md).
-If `schema` is not configured, `source` must be configured.
+The structure of the data, including field names and field types. For more details, see
+[Schema Feature](../../introduction/concepts/schema-feature.md).
+
+`schema` and `source` are mutually exclusive. Use `schema` when you want SeaTunnel to convert the
+selected fields with an explicit SeaTunnel type definition. If both are omitted, the connector reads
+the field mapping from Easysearch and uses all mapped fields in the index.
 
 ### tls_verify_certificate [boolean]
 
@@ -156,6 +165,11 @@ source {
 ### Read With Schema And Query
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Easysearch {
     hosts = ["https://e2e_easysearch:9200"]
@@ -184,6 +198,18 @@ source {
         c_timestamp = timestamp
       }
     }
+  }
+}
+
+sink {
+  Easysearch {
+    hosts = ["https://e2e_easysearch:9200"]
+    username = "admin"
+    password = "admin"
+    tls_verify_certificate = false
+    tls_verify_hostname = false
+
+    index = "st_index2"
   }
 }
 ```

--- a/docs/zh/connectors/sink/Cassandra.md
+++ b/docs/zh/connectors/sink/Cassandra.md
@@ -11,6 +11,8 @@ import ChangeLog from '../changelog/connector-cassandra.md';
 sink 会把数据写入已经存在的 Cassandra 表。如果不配置 `fields`，连接器会使用目标 Cassandra 表里的全部字段。
 如果配置了 `fields`，则只写这些字段，并且每个字段都必须存在于目标表中。
 
+连接器不会自动创建 keyspace、表或缺失字段。启动任务前请先准备好目标 Cassandra 表结构。
+
 ## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
@@ -65,6 +67,8 @@ sink 会把数据写入已经存在的 Cassandra 表。如果不配置 `fields`�
 需要写入到 `Cassandra` 的字段。如果不配置，连接器会读取目标表结构，并写入目标表中的全部字段。
 
 如果配置了该选项，字段名必须存在于目标 Cassandra 表中，也必须存在于上游 SeaTunnel 数据中。
+
+当上游数据中有不需要写入 Cassandra 的额外字段时，可以使用该选项只选择目标字段。
 
 ### batch_size [number]
 

--- a/docs/zh/connectors/sink/Datahub.md
+++ b/docs/zh/connectors/sink/Datahub.md
@@ -18,16 +18,16 @@ DataHub Sink 用于将 SeaTunnel 数据写入阿里云 DataHub。
 
 ## 选项
 
-| 名称           | 类型   | 必填 | 默认值 |
-|----------------|--------|------|--------|
-| endpoint       | string | 是   | -      |
-| accessId       | string | 是   | -      |
-| accessKey      | string | 是   | -      |
-| project        | string | 是   | -      |
-| topic          | string | 是   | -      |
-| timeout        | int    | 否   | 3000   |
-| retryTimes     | int    | 否   | 3      |
-| common-options |        | 否   | -      |
+| 名称           | 类型   | 必填 | 默认值 | 描述 |
+|----------------|--------|------|--------|------|
+| endpoint       | string | 是   | -      | DataHub 服务地址。 |
+| accessId       | string | 是   | -      | 访问 DataHub 使用的阿里云 Access ID。 |
+| accessKey      | string | 是   | -      | 访问 DataHub 使用的阿里云 Access Key。 |
+| project        | string | 是   | -      | DataHub 项目名称。 |
+| topic          | string | 是   | -      | DataHub Topic 名称，多表写入时支持占位符。 |
+| timeout        | int    | 否   | 3000   | 客户端连接最大超时时间，单位为毫秒。 |
+| retryTimes     | int    | 否   | 3      | 写入记录失败时的最大重试次数。 |
+| common-options | config | 否   | -      | Sink 插件通用参数。 |
 
 ### endpoint [string]
 
@@ -48,6 +48,8 @@ DataHub 项目名称。
 ### topic [string]
 
 DataHub Topic 名称。多表写入时可以使用占位符，例如 `${table_name}`。
+
+SeaTunnel 字段名需要和 DataHub Topic 中的字段名一致，因为 sink 会按照 Topic 结构里的字段名写入数据。
 
 ### timeout [int]
 

--- a/docs/zh/connectors/sink/Easysearch.md
+++ b/docs/zh/connectors/sink/Easysearch.md
@@ -229,6 +229,7 @@ sink {
         username = "admin"
         password = "admin"
 
+        index = "seatunnel_index"
         schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
         data_save_mode = "APPEND_DATA"
     }

--- a/docs/zh/connectors/source/Easysearch.md
+++ b/docs/zh/connectors/source/Easysearch.md
@@ -89,9 +89,12 @@ Easysearch 索引名称，支持 `*` 通配符匹配。
 
 ### source [array]
 
-索引字段。
-可以通过指定字段 `_id` 来获取文档 id。如果要把 `_id` 写入其他索引，由于 Easysearch 限制，需要为 `_id` 指定别名。
-如果不配置 `source`，则必须配置 `schema`。
+要从索引中读取的字段。
+
+可以通过指定字段 `_id` 来获取文档 id。如果要把 `_id` 写入其他 Easysearch 索引，由于 Easysearch 不允许把
+`_id` 当作普通字段写入，需要为 `_id` 指定别名。
+
+`source` 和 `schema` 互斥。如果两者都不配置，连接器会从 Easysearch 读取字段映射，并使用索引中的全部映射字段。
 
 ### query [json]
 
@@ -108,7 +111,9 @@ Easysearch 为 scroll 请求保留查询上下文的时间。
 ### schema
 
 数据结构，包括字段名和字段类型。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-如果不配置 `schema`，则必须配置 `source`。
+
+`schema` 和 `source` 互斥。需要用明确的 SeaTunnel 类型定义转换字段时使用 `schema`。如果两者都不配置，连接器会从
+Easysearch 读取字段映射，并使用索引中的全部映射字段。
 
 ### tls_verify_certificate [boolean]
 
@@ -156,6 +161,11 @@ source {
 ### 使用 Schema 和 Query 读取
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Easysearch {
     hosts = ["https://e2e_easysearch:9200"]
@@ -184,6 +194,18 @@ source {
         c_timestamp = timestamp
       }
     }
+  }
+}
+
+sink {
+  Easysearch {
+    hosts = ["https://e2e_easysearch:9200"]
+    username = "admin"
+    password = "admin"
+    tls_verify_certificate = false
+    tls_verify_hostname = false
+
+    index = "st_index2"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Clarify Cassandra sink behavior for existing target schemas and selected fields.
- Improve DataHub sink option tables and document the field-name contract with DataHub topic schemas.
- Align Easysearch source docs with the actual `source` / `schema` behavior and complete save-mode examples.

## Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

## Notes
- Checked existing open PRs from DanielCarter-stack before creating this PR.
- Existing open PR CI was green; draft PR #11313 was marked ready for review.
- No open duplicate PR was found for the Cassandra, DataHub, and Easysearch documentation update.