### PR TITLE
[Test][E2E] Wait for Doris multi-read sink visibility

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisMultiReadIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisMultiReadIT.java
@@ -52,12 +52,21 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.awaitility.Awaitility.await;
+
 @Slf4j
 public class DorisMultiReadIT extends AbstractDorisIT {
+    /**
+     * Multi-source Doris writes can become visible slightly after the SeaTunnel job exits, so the
+     * sink assertions must wait for the final row count instead of querying immediately.
+     */
+    private static final long SINK_ASSERT_TIMEOUT_MILLIS = 60_000L;
+
     private static final String UNIQUE_TABLE_0 = "doris_e2e_unique_table_0";
     private static final String UNIQUE_TABLE_1 = "doris_e2e_unique_table_1";
     private static final String SOURCE_DB_0 = "e2e_source_0";
@@ -149,7 +158,14 @@ public class DorisMultiReadIT extends AbstractDorisIT {
 
     protected void checkSinkData(String database, String tableName, String sqlCondition) {
         try {
+            String sourceSql =
+                    String.format(
+                            "select * from %s.%s %s order by F_ID ",
+                            database, tableName, sqlCondition);
+            String sinkSql = String.format("select * from %s.%s order by F_ID", sinkDB, tableName);
+
             assertHasData(database, tableName);
+            awaitSinkTableReady(sourceSql, sinkSql);
             assertHasData(sinkDB, tableName);
 
             PreparedStatement sourcePre =
@@ -216,16 +232,21 @@ public class DorisMultiReadIT extends AbstractDorisIT {
                             sinkColumnType.toUpperCase(Locale.ROOT));
                 }
             }
-
-            String sourceSql =
-                    String.format(
-                            "select * from %s.%s %s order by F_ID ",
-                            database, tableName, sqlCondition);
-            String sinkSql = String.format("select * from %s.%s order by F_ID", sinkDB, tableName);
             checkSourceAndSinkTableDate(sourceSql, sinkSql, UNIQUE_TABLE_COLUMN_STRING);
         } catch (Exception e) {
             throw new RuntimeException("Doris connection error", e);
         }
+    }
+
+    /**
+     * Wait until the Doris sink exposes the same number of rows as the filtered source query before
+     * running schema and row-by-row assertions.
+     */
+    private void awaitSinkTableReady(String sourceSql, String sinkSql) {
+        int expectedRowCount = queryRowCount(sourceSql);
+        await().atMost(SINK_ASSERT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> Assertions.assertEquals(expectedRowCount, queryRowCount(sinkSql)));
     }
 
     private void checkSourceAndSinkTableDate(String sourceSql, String sinkSql, String columnsString)
@@ -276,6 +297,18 @@ public class DorisMultiReadIT extends AbstractDorisIT {
             throw new RuntimeException("Failed to check data in Doris server", e);
         }
         return -1;
+    }
+
+    private int queryRowCount(String sql) {
+        try (Statement statement =
+                        conn.createStatement(
+                                ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.last();
+            return resultSet.getRow();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to query Doris table rows", e);
+        }
     }
 
     private void assertHasData(String db, String table) {


### PR DESCRIPTION
## What
- wait for the Doris sink row count to match the filtered source result before asserting sink data
- avoid querying the multi-read Doris sink immediately after `executeJob(...)` returns

## Why
`DorisMultiReadIT` currently checks the sink table as soon as the SeaTunnel job exits. In CI, the Doris sink data can become visible slightly later, which makes the test intermittently fail at `assertHasData(sinkDB, table)` even though the job itself succeeds.

## Validation
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e spotless:apply -DskipTests`
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e -DskipTests -DfailIfNoTests=false test-compile -Dspotless.check.skip=true -Dcheckstyle.skip=true`
- attempted `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e -Dtest=DorisMultiReadIT -DfailIfNoTests=false -DskipITs=false test -Dspotless.check.skip=true -Dcheckstyle.skip=true`, but local Testcontainers execution is blocked because this machine currently has no Docker socket (`/var/run/docker.sock` missing)
