### PR TITLE
[Docs][Connector-V2] Improve Elasticsearch Hbase and Milvus docs

### DIFF
--- a/docs/en/connectors/sink/Elasticsearch.md
+++ b/docs/en/connectors/sink/Elasticsearch.md
@@ -47,7 +47,7 @@ Engine Supported
 | tls_truststore_password | string  | no       | -                            |
 | common-options          |         | no       | -                            |
 | vectorization_fields    | array   | no       | -                            |
-| vector_dimensions       | int     | no       | -                            |
+| vector_dimensions       | int     | no       | 0                            |
 | multi_table_sink_replica | int     | no       | 1                            |
 
 ### hosts [array]

--- a/docs/en/connectors/sink/Hbase.md
+++ b/docs/en/connectors/sink/Hbase.md
@@ -14,6 +14,7 @@ how null values, row keys, WAL, timestamps, and existing data are handled.
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
@@ -27,13 +28,13 @@ how null values, row keys, WAL, timestamps, and existing data are handled.
 | version_column     | string  | no       | -               |
 | null_mode          | string  | no       | skip            |
 | wal_write          | boolean | no       | false           |
-| write_buffer_size  | string  | no       | 8 * 1024 * 1024 |
+| write_buffer_size  | int     | no       | 8 * 1024 * 1024 |
 | encoding           | string  | no       | utf8            |
 | schema_save_mode   | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST |
 | data_save_mode     | enum    | no       | APPEND_DATA     |
 | hbase_extra_config | config  | no       | -               |
+| multi_table_sink_replica | int | no     | 1               |
 | common-options     |         | no       | -               |
-| ttl                | long    | no       | -               |
 
 ### zookeeper_quorum [string]
 
@@ -81,7 +82,7 @@ The delimiter of joining multi row keys, default `""`
 
 The version column name, you can use it to assign timestamp for hbase record
 
-### null_mode [double]
+### null_mode [string]
 
 The mode of writing null value, support [`skip`, `empty`], default `skip`
 
@@ -111,6 +112,10 @@ Hbase stores bytes. The connector supports:
 
 The extra configuration of hbase
 
+### multi_table_sink_replica [int]
+
+The replica number of sink writers used for each table in a multi-table sink job. Keep the default value unless one table needs more sink writer parallelism.
+
 ### schema_save_mode [enum]
 
 Controls how the sink handles the target HBase table before writing. Supported values include
@@ -120,10 +125,6 @@ Controls how the sink handles the target HBase table before writing. Supported v
 
 Controls how the sink handles existing target data before writing. Supported values are
 `DROP_DATA`, `APPEND_DATA`, and `ERROR_WHEN_DATA_EXISTS`.
-
-### ttl [long]
-
-Hbase writes data TTL time, the default is based on the TTL set in the table, unit: milliseconds
 
 ### common options
 

--- a/docs/en/connectors/sink/Milvus.md
+++ b/docs/en/connectors/sink/Milvus.md
@@ -23,6 +23,7 @@ Common use cases:
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Data Type Mapping

--- a/docs/en/connectors/source/Elasticsearch.md
+++ b/docs/en/connectors/source/Elasticsearch.md
@@ -16,7 +16,7 @@ support version >= 2.x and <= 8.x.
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
-- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
@@ -36,7 +36,7 @@ support version >= 2.x and <= 8.x.
 | query                   | json    | no       | {"match_all": {}}                                              |
 | search_type             | enum    | no       | Query type, SQL or DSL, default DSL                            |
 | search_api_type         | enum    | no       | Pagination API type, SCROLL or PIT, default SCROLL             |
-| sql_query               | json    | no       | SQL query, required when search_type is SQL                    |
+| sql_query               | string  | no       | SQL query, required when search_type is SQL                    |
 | scroll_time             | string  | no       | 1m                                                             |
 | scroll_size             | int     | no       | 100                                                            |
 | tls_verify_certificate  | boolean | no       | true                                                           |
@@ -267,6 +267,8 @@ Split a single index into multiple slices for parallel reads. Only effective for
 - PIT slicing requires Elasticsearch 7.10 or higher (PIT was introduced in 7.10.0).
 
 **Trade-off:** slicing improves throughput but may reduce snapshot consistency across slices. For strong consistency, prefer PIT with a shared snapshot or set `slice_max = 1`. For append-only or low-write workloads, slicing is usually acceptable.
+
+`slice_max` is ignored when `search_type = "SQL"` because Elasticsearch SQL search does not support slicing.
 
 ### common options
 

--- a/docs/zh/connectors/sink/Elasticsearch.md
+++ b/docs/zh/connectors/sink/Elasticsearch.md
@@ -48,7 +48,7 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 | tls_truststore_password | string  | 否    | -                            |
 | common-options         |         | 否    | -                            |
 | vectorization_fields   | array   | 否    | -                            |
-| vector_dimensions      | int     | 否    | -                            |
+| vector_dimensions      | int     | 否    | 0                            |
 | multi_table_sink_replica | int   | 否    | 1                            |
 
 
@@ -270,7 +270,6 @@ sink {
 }
 ```
 
-```
 变更数据捕获 (Change data capture) 事件多表写入
 
 ```conf

--- a/docs/zh/connectors/sink/Hbase.md
+++ b/docs/zh/connectors/sink/Hbase.md
@@ -26,13 +26,13 @@ import ChangeLog from '../changelog/connector-hbase.md';
 | version_column     | string  | 否       | -      |
 | null_mode          | string  | 否       | skip   |
 | wal_write          | boolean | 否       | false  |
-| write_buffer_size  | string  | 否       | 8 * 1024 * 1024 |
+| write_buffer_size  | int     | 否       | 8 * 1024 * 1024 |
 | encoding           | string  | 否       | utf8   |
 | schema_save_mode   | enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST |
 | data_save_mode     | enum    | 否       | APPEND_DATA |
 | hbase_extra_config | config  | 否       | -      |
+| multi_table_sink_replica | int | 否       | 1      |
 | common-options     |         | 否       | -      |
-| ttl                | long    | 否       | -      |
 
 ### zookeeper_quorum [string]
 
@@ -80,7 +80,7 @@ all_columns = "info"
 
 版本列名称，您可以使用它来分配 hbase 记录的时间戳
 
-### null_mode [double]
+### null_mode [string]
 
 写入 null 值的模式，支持 [ skip , empty], 默认 skip
 
@@ -110,6 +110,10 @@ Hbase 存储字节，连接器支持：
 
 hbase 扩展配置
 
+### multi_table_sink_replica [int]
+
+多表写入时，每张表对应的 Sink Writer 副本数。通常保持默认值即可；只有单表写入压力较大、需要更多写入并行度时再调大。
+
 ### schema_save_mode [enum]
 
 写入前如何处理目标 HBase 表结构。常用值包括 `RECREATE_SCHEMA`、`CREATE_SCHEMA_WHEN_NOT_EXIST` 和
@@ -118,10 +122,6 @@ hbase 扩展配置
 ### data_save_mode [enum]
 
 写入前如何处理目标端已有数据。支持 `DROP_DATA`、`APPEND_DATA` 和 `ERROR_WHEN_DATA_EXISTS`。
-
-### ttl [long]
-
-hbase 写入数据 TTL 时间，默认以表设置的TTL为准，单位毫秒
 
 ### 常见选项
 

--- a/docs/zh/connectors/sink/Milvus.md
+++ b/docs/zh/connectors/sink/Milvus.md
@@ -23,6 +23,7 @@ SeaTunnel 表结构创建目标集合，并支持向量字段、动态字段、�
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 数据类型映射

--- a/docs/zh/connectors/source/Elasticsearch.md
+++ b/docs/zh/connectors/source/Elasticsearch.md
@@ -14,7 +14,7 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义的分片](../../introduction/concepts/connector-v2-features.md)
 
 ## 配置参数选项
@@ -34,7 +34,7 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 | query                   | json    | 否       | {"match_all": {}}                   |
 | search_type             | enum    | 否       | 查询类型，SQL 或 DSL，默认 DSL              |
 | search_api_type         | enum    | 否       | 分页 API 类型，SCROLL 或 PIT，默认 SCROLL    |
-| sql_query               | json    | 否       | SQL 查询语句，当 search_type 为 SQL 时必须    |
+| sql_query               | string  | 否       | SQL 查询语句，当 search_type 为 SQL 时必须    |
 | scroll_time             | string  | 否       | 1m                                  |
 | scroll_size             | int     | 否       | 100                                 |
 | tls_verify_certificate  | boolean | 否       | true                                |
@@ -249,6 +249,8 @@ runtime_fields = [
 - PIT 切片需要 Elasticsearch 7.10 及以上版本（PIT 在 7.10.0 引入）。
 
 **取舍说明：**切片能提升吞吐，但可能降低跨切片的一致性。对一致性要求高时，建议使用 PIT（共享快照）或将 `slice_max = 1`；对追加写或写入较少的场景，开启切片通常可以接受。
+
+当 `search_type = "SQL"` 时，Elasticsearch SQL 查询不支持切片，`slice_max` 会被忽略。
 
 ### common options
 


### PR DESCRIPTION
### Purpose
Improve connector documentation for Elasticsearch, Hbase, and Milvus based on the current connector option contracts and e2e usage patterns.

### Changes
- Clarify Elasticsearch source parallel reads, SQL query option type, slicing limits, and vector dimension default.
- Align Hbase sink option tables with the current sink contract and document multi-table sink replica behavior.
- Mark Milvus sink multi-table writing support in the feature list.
- Fix a malformed Chinese Elasticsearch sink example code block.

### Verification
- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify