### PR TITLE
[Docs][Connector-V2] Improve CosFile LocalFile and ObsFile docs

### DIFF
--- a/docs/en/connectors/sink/CosFile.md
+++ b/docs/en/connectors/sink/CosFile.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 
 ## Description
 
-Output data to cos file system.
+Output data to Tencent Cloud COS file system.
 
 :::tip
 
@@ -351,5 +351,4 @@ LocalFile {
 ## Changelog
 
 <ChangeLog />
-
 

--- a/docs/en/connectors/sink/LocalFile.md
+++ b/docs/en/connectors/sink/LocalFile.md
@@ -129,7 +129,7 @@ The separator between columns in a row of data. Only needed by `text` and `csv` 
 
 ### row_delimiter [string]
 
-The separator between rows in a file. Only needed by `text`, `json` and `json` file format.
+The separator between rows in a file. Only needed by `text`, `csv` and `json` file format.
 
 ### have_partition [boolean]
 

--- a/docs/en/connectors/source/CosFile.md
+++ b/docs/en/connectors/source/CosFile.md
@@ -38,7 +38,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 
 ## Description
 
-Read data from aliyun Cos file system.
+Read data from Tencent Cloud COS file system.
 
 :::tip
 
@@ -60,7 +60,7 @@ To use this connector you need put hadoop-cos-{hadoop.version}-{version}.jar and
 | secret_id                  | string  | yes      | -                           |
 | secret_key                 | string  | yes      | -                           |
 | region                     | string  | yes      | -                           |
-| read_columns               | list    | yes      | -                           |
+| read_columns               | list    | no       | -                           |
 | delimiter/field_delimiter  | string  | no       | \001 for text and , for csv |
 | row_delimiter              | string  | no       | \n                          |
 | parse_partition_from_path  | boolean | no       | true                        |
@@ -210,7 +210,7 @@ Note: Markdown format only supports reading, not writing.
 
 ### bucket [string]
 
-The bucket address of Cos file system, for example: `Cos://tyrantlucifer-image-bed`
+The bucket address of COS file system, for example: `cosn://seatunnel-test`
 
 ### secret_id [string]
 

--- a/docs/en/connectors/source/LocalFile.md
+++ b/docs/en/connectors/source/LocalFile.md
@@ -22,7 +22,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
 
   Read all the data in a split in a pollNext call. What splits are read will be saved in snapshot.
 
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 - [x] file format type
@@ -95,6 +95,7 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 | metalake_type              | string  | no       | gravitino                            |
 | recursive_file_scan        | boolean | no       | true                                 |
 | sort_files_by_modification_time | boolean | no       | false                                |
+
 ### path [string]
 
 The source file path.

--- a/docs/en/connectors/source/ObsFile.md
+++ b/docs/en/connectors/source/ObsFile.md
@@ -70,7 +70,7 @@ It only supports hadoop version **2.9.X+**.
 | access_key                 | string  | yes      | -                   | The access key of obs file system                                                                                                                                                    |
 | access_secret              | string  | yes      | -                   | The access secret of obs file system                                                                                                                                                 |
 | endpoint                   | string  | yes      | -                   | The endpoint of obs file system                                                                                                                                                      |
-| read_columns               | list    | yes      | -                   | The read column list of the data source, user can use it to implement field projection.[Tips](#read_columns)                                                                         |
+| read_columns               | list    | no       | -                   | The read column list of the data source, user can use it to implement field projection.[Tips](#read_columns)                                                                         |
 | delimiter                  | string  | no       | \001                | Field delimiter, used to tell connector how to slice and dice fields when reading text files                                                                                         |
 | row_delimiter              | string  | no       | \n                  | Row delimiter, used to tell connector how to slice and dice rows when reading text files. Default is `\n` for text files.                                                            |
 | parse_partition_from_path  | boolean | no       | true                | Control whether parse the partition keys and values from file path. [Tips](#parse_partition_from_path)                                                                               |
@@ -147,15 +147,11 @@ It only supports hadoop version **2.9.X+**.
 >
 > If you assign file type to `json`, you should also assign schema option to tell the connector how to parse data to the row you want.
 >
-> For example,upstream data is the following:
+> For example, upstream data is the following:
 >
 > ```json
->
+> {"code": 200, "data": "get success", "success": true}
 > ```
-
-{"code":  200, "data":  "get success", "success":  true}
-
-```
 
 > You can also save multiple pieces of data in one file and split them by one newline:
 

--- a/docs/zh/connectors/sink/CosFile.md
+++ b/docs/zh/connectors/sink/CosFile.md
@@ -6,15 +6,15 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 
 ## 描述
 
-将数据输出到cos文件系统.
+将数据输出到腾讯云 COS 文件系统。
 
 :::提示
 
-如果你使用spark/flink，为了使用这个连接器，你必须确保你的spark/flilk集群已经集成了hadoop。测试的hadoop版本是2.x
+如果你使用 Spark/Flink，为了使用这个连接器，你必须确保 Spark/Flink 集群已经集成了 Hadoop。测试的 Hadoop 版本是 2.x。
 
-如果你使用SeaTunnel Engine，当你下载并安装SeaTunnel引擎时，它会自动集成hadoop jar。您可以在${SEATUNNEL_HOME}/lib下检查jar包以确认这一点.
+如果你使用 SeaTunnel Engine，当你下载并安装 SeaTunnel Engine 时，它会自动集成 Hadoop jar。你可以在 `${SEATUNNEL_HOME}/lib` 下检查 jar 包以确认这一点。
 
-要使用此连接器，您需要将hadoop cos-{hadoop.version}-{version}.jar和cos_api-bundle-{version}.jar位于${SEATUNNEL_HOME}/lib目录中，下载：[Hoop cos发布](https://github.com/tencentyun/hadoop-cos/releases). 它只支持hadoop 2.6.5+和8.0.2版本+.
+要使用此连接器，你需要将 `hadoop-cos-{hadoop.version}-{version}.jar` 和 `cos_api-bundle-{version}.jar` 放在 `${SEATUNNEL_HOME}/lib` 目录中，下载地址：[Hadoop COS release](https://github.com/tencentyun/hadoop-cos/releases)。它仅支持 Hadoop 2.6.5+ 和 hadoop-cos 8.0.2+。
 
 :::
 

--- a/docs/zh/connectors/sink/LocalFile.md
+++ b/docs/zh/connectors/sink/LocalFile.md
@@ -38,7 +38,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
   - [x] canal_json
   - [x] debezium_json
   - [x] maxwell_json
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
   
 ## 选项
 

--- a/docs/zh/connectors/sink/ObsFile.md
+++ b/docs/zh/connectors/sink/ObsFile.md
@@ -32,7 +32,7 @@ import ChangeLog from '../changelog/connector-file-obs.md';
   - [x] canal_json
   - [x] debezium_json
   - [x] maxwell_json
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 

--- a/docs/zh/connectors/source/CosFile.md
+++ b/docs/zh/connectors/source/CosFile.md
@@ -22,7 +22,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 
   在pollNext调用中读取拆分的所有数据。读取的拆分内容将保存在快照中。
 
-- [x] [列映射](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义拆分](../../introduction/concepts/connector-v2-features.md)
 - [x] 文件格式类型
@@ -38,15 +38,15 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 
 ## 描述
 
-从阿里云Cos文件系统读取数据。
+从腾讯云 COS 文件系统读取数据。
 
 :::提示
 
-如果你使用spark/flink，为了使用这个连接器，你必须确保你的spark/flilk集群已经集成了hadoop。测试的hadoop版本是2.x
+如果你使用 Spark/Flink，为了使用这个连接器，你必须确保 Spark/Flink 集群已经集成了 Hadoop。测试的 Hadoop 版本是 2.x。
 
-如果你使用SeaTunnel Engine，当你下载并安装SeaTunnel引擎时，它会自动集成hadoop jar。您可以在${SEATUNNEL_HOME}/lib下检查jar包以确认这一点.
+如果你使用 SeaTunnel Engine，当你下载并安装 SeaTunnel Engine 时，它会自动集成 Hadoop jar。你可以在 `${SEATUNNEL_HOME}/lib` 下检查 jar 包以确认这一点。
 
-要使用此连接器，您需要将hadoop-cos-{hadoop.version}-{version}.jar和cos_api-bundle-{version}.jar位于${SEATUNNEL_HOME}/lib目录中，下载：[Hadoop-Cos-release](https://github.com/tencentyun/hadoop-cos/releases). 它只支持hadoop 2.6.5+和8.0.2版本+.
+要使用此连接器，你需要将 `hadoop-cos-{hadoop.version}-{version}.jar` 和 `cos_api-bundle-{version}.jar` 放在 `${SEATUNNEL_HOME}/lib` 目录中，下载地址：[Hadoop COS release](https://github.com/tencentyun/hadoop-cos/releases)。它仅支持 Hadoop 2.6.5+ 和 hadoop-cos 8.0.2+。
 
 :::
 
@@ -60,7 +60,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 | secret_id                  | string  | 是  | -                   |
 | secret_key                 | string  | 是  | -                   |
 | region                     | string  | 是  | -                   |
-| read_columns               | list    | 是  | -                   |
+| read_columns               | list    | 否  | -                   |
 | delimiter/field_delimiter  | string  | 否  | \001                |
 | row_delimiter              | string  | 否  | \n                  |
 | parse_partition_from_path  | boolean | 否  | true                |

--- a/docs/zh/connectors/source/LocalFile.md
+++ b/docs/zh/connectors/source/LocalFile.md
@@ -22,7 +22,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
 
   在 pollNext 调用中读取分片中的所有数据。读取的分片将保存在快照中。
 
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
 - [x] 文件格式类型
@@ -90,7 +90,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
 | file_filter_modified_end   | string  | 否    | -                   |
 | enable_file_split          | boolean | 否    | false               | 
 | file_split_size            | long    | 否    | 134217728           | 
-| quote_char                 | string  | 否    | -                   | 
+| quote_char                 | string  | 否    | "                   |
 | escape_char                | string  | 否    | -                   |
 | metalake_type              | string  | 否    | gravitino          | Metalake 服务类型，目前支持 `gravitino`。             |
 | recursive_file_scan        | boolean | 否    | true                |

--- a/docs/zh/connectors/source/ObsFile.md
+++ b/docs/zh/connectors/source/ObsFile.md
@@ -14,9 +14,9 @@ import ChangeLog from '../changelog/connector-file-obs.md';
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
-- [x] [多模态](../../introduction/concepts/connector-v2-features.md#multimodal)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [多模态](../../introduction/concepts/connector-v2-features.md#多模态multimodal)
 
   使用二进制文件格式读写任何格式的文件，例如视频、图片等。简而言之，任何文件都可以同步到目标位置。
 
@@ -25,8 +25,8 @@ import ChangeLog from '../changelog/connector-file-obs.md';
   在一次 pollNext 调用中读取分割中的所有数据。读取哪些分割将保存在快照中。
 
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 - [x] 文件格式类型
   - [x] text
   - [x] csv
@@ -70,7 +70,7 @@ import ChangeLog from '../changelog/connector-file-obs.md';
 | access_key                | string  | 是  | -                   | OBS 文件系统的访问密钥                           |
 | access_secret             | string  | 是  | -                   | OBS 文件系统的访问密钥                           |
 | endpoint                  | string  | 是  | -                   | OBS 文件系统的端点                             |
-| read_columns              | list    | 是  | -                   | 数据源的读取列列表                               |
+| read_columns              | list    | 否  | -                   | 数据源的读取列列表                               |
 | delimiter                 | string  | 否  | \001                | 字段分隔符                                   |
 | row_delimiter             | string  | 否  | \n                  | 行分隔符                                    |
 | parse_partition_from_path | boolean | 否  | true                | 控制是否从文件路径解析分区键和值                        |


### PR DESCRIPTION
### Purpose

Improve the CosFile, LocalFile, and ObsFile connector documents based on the current connector behavior and e2e coverage.

### Changes

- Correct COS wording to Tencent Cloud COS and align bucket examples with `cosn://...`.
- Mark optional projection options correctly for CosFile and ObsFile sources.
- Fix LocalFile source feature status and source option defaults.
- Clean up Chinese feature names for LocalFile and ObsFile docs.
- Fix a malformed ObsFile JSON example code block and a LocalFile sink row delimiter description.

### Validation

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`