### PR TITLE
[Docs][Connector-V2] Improve Email Prometheus and Pulsar docs

### DIFF
--- a/docs/en/connectors/sink/Email.md
+++ b/docs/en/connectors/sink/Email.md
@@ -13,6 +13,7 @@ The tested email version is 1.5.6.
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
@@ -29,6 +30,7 @@ The tested email version is 1.5.6.
 | email_message_content    | string  | yes      | -             |
 | email_attachment_name    | string  | no       | emailsink.csv |
 | email_field_delimiter    | string  | no       | ,             |
+| multi_table_sink_replica | int     | no       | 1             |
 | common-options           |         | no       | -             |
 
 ### email_from_address [string]
@@ -84,6 +86,16 @@ The delimiter used to separate fields in the attachment file. Default is comma `
 The attachment has no header row. Field values are written in the upstream schema order. `null`
 values are written as empty strings.
 
+### multi_table_sink_replica [int]
+
+The replica number of sink writers used for each table in a multi-table sink job. The default value
+is `1`.
+
+### Empty input behavior
+
+The sink sends an email only after at least one row is written. If the upstream table has no rows,
+the email is skipped.
+
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
@@ -92,8 +104,8 @@ Sink plugin common parameters, please refer to [Sink Common Options](../common-o
 
 ### Send one table to multiple recipients
 
-This example uses an SMTP server without authentication and sends one email to each address in
-`email_to_address`.
+This example uses an SMTP server without authentication and sends one email whose recipient list is
+defined by `email_to_address`.
 
 ```hocon
 env {

--- a/docs/en/connectors/sink/Prometheus.md
+++ b/docs/en/connectors/sink/Prometheus.md
@@ -55,12 +55,16 @@ downloaded from Maven Central.
 | retry_backoff_max_ms        | Int    | No       | 10000   | Maximum retry backoff in milliseconds. |
 | batch_size                  | Int    | No       | 1024    | Maximum number of rows buffered before writing to Prometheus. |
 | flush_interval              | Long   | No       | 300000  | Maximum flush interval in milliseconds. |
+| multi_table_sink_replica    | Int    | No       | 1       | Writer replica count for each table in a multi-table sink job. |
 | common-options              | Config | No       | -       | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md). |
 
 ### key_label
 
 The named field should be `map<string, string>`. It is converted to Prometheus labels. Include `__name__` in the map
 to set the metric name.
+
+The sink adds the required remote write headers automatically: `Content-type`,
+`Content-Encoding`, and `X-Prometheus-Remote-Write-Version`.
 
 ### key_timestamp
 
@@ -70,6 +74,11 @@ Supported timestamp field types:
 - `bigint`: treated as epoch milliseconds
 - `double`: treated as Unix seconds and converted to milliseconds
 - `string`: parsed as epoch milliseconds
+
+### multi_table_sink_replica
+
+Replica count for multi-table sink writers. It applies to each table in a multi-table job. Keep the
+default value `1` unless one table needs more writer parallelism.
 
 ## Example
 

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -16,6 +16,7 @@ Source connector for Apache Pulsar.
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
@@ -26,7 +27,7 @@ Source connector for Apache Pulsar.
 | table_path               | String  | No       | -             | Logical table identifier for multi-table mode                                                                    |
 | tables_configs           | Array   | No       | -             | Multi-table configuration. Each item can override global defaults. **Note: only one of `topic`, `topic-pattern`, `tables_configs`** |
 | topic-discovery.interval | Long    | No       | -1            | Interval (ms) to discover new partitions. Non-positive disables discovery. Only works with `topic-pattern`      |
-| subscription.name        | String  | No       | -             | Consumer subscription name. Can be defined globally or per item in multi-table mode                              |
+| subscription.name        | String  | Required for single-table mode or per multi-table item | - | Consumer subscription name. Can be defined globally or per item in multi-table mode                              |
 | client.service-url       | String  | Yes      | -             | Pulsar client service URL, e.g., `pulsar://localhost:6650`                                                      |
 | admin.service-url        | String  | Yes      | -             | Pulsar admin HTTP URL, e.g., `http://localhost:8080`                                                            |
 | auth.plugin-class        | String  | No       | -             | Pulsar client authentication plugin class name                                                                   |
@@ -36,7 +37,7 @@ Source connector for Apache Pulsar.
 | poll.batch.size          | Integer | No       | 500           | Maximum number of messages to poll in a single batch                                                             |
 | cursor.startup.mode      | Enum    | No       | LATEST        | Startup position mode. Options: `EARLIEST`, `LATEST`, `SUBSCRIPTION`, `TIMESTAMP`                                |
 | cursor.startup.timestamp | Long    | No       | -             | Start timestamp (ms) when `cursor.startup.mode=TIMESTAMP`                                                        |
-| cursor.reset.mode        | Enum    | No       | LATEST        | Reset mode when `cursor.startup.mode=SUBSCRIPTION`. Options: `EARLIEST`, `LATEST`                               |
+| cursor.reset.mode        | Enum    | Required when `cursor.startup.mode=SUBSCRIPTION` | - | Reset mode when `cursor.startup.mode=SUBSCRIPTION`. Options: `EARLIEST`, `LATEST`                               |
 | cursor.stop.mode         | Enum    | No       | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch)                         |
 | cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
 | schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
@@ -140,6 +141,7 @@ Start from the specified epoch timestamp (in milliseconds).
 Cursor reset strategy for Pulsar consumer valid values are `'EARLIEST'`, `'LATEST'`.
 
 **Note, This option only works if the "cursor.startup.mode" option used `'SUBSCRIPTION'`.**
+It has no default value and must be configured in that mode.
 
 ### cursor.stop.mode [String]
 

--- a/docs/zh/connectors/sink/Email.md
+++ b/docs/zh/connectors/sink/Email.md
@@ -15,6 +15,7 @@ import ChangeLog from '../changelog/connector-email.md';
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
@@ -32,6 +33,7 @@ import ChangeLog from '../changelog/connector-email.md';
 | email_message_content    | string  | 是    | -             |
 | email_attachment_name    | string  | 否    | emailsink.csv |
 | email_field_delimiter    | string  | 否    | ,             |
+| multi_table_sink_replica | int     | 否    | 1             |
 | common-options           |         | 否    | -             |
 
 ### email_from_address [string]
@@ -84,6 +86,14 @@ import ChangeLog from '../changelog/connector-email.md';
 
 附件不包含表头。字段会按上游 schema 的顺序写入，`null` 值会写成空字符串。
 
+### multi_table_sink_replica [int]
+
+多表写入时，每张表使用的 Sink Writer 副本数。默认值为 `1`。
+
+### 空数据行为
+
+只有上游至少写入一行数据时，Email Sink 才会发送邮件。如果上游表没有数据，则不会发送邮件。
+
 ### common options
 
 Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-common-options.md) 了解详情.
@@ -92,7 +102,7 @@ Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-com
 
 ### 发送单表数据到多个收件人
 
-这个示例使用不需要认证的 SMTP 服务，并给 `email_to_address` 中的每个邮箱各发送一封邮件。
+这个示例使用不需要认证的 SMTP 服务，并发送一封收件人列表由 `email_to_address` 决定的邮件。
 
 ```hocon
 env {

--- a/docs/zh/connectors/sink/Prometheus.md
+++ b/docs/zh/connectors/sink/Prometheus.md
@@ -52,11 +52,15 @@ Prometheus 数据接收器把上游数据写入 Prometheus remote write API。�
 | retry_backoff_max_ms        | Int    | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
 | batch_size                  | Int    | 否       | 1024   | 写入 Prometheus 前最多缓存的行数。 |
 | flush_interval              | Long   | 否       | 300000 | 最大刷新间隔，单位毫秒。 |
+| multi_table_sink_replica    | Int    | 否       | 1      | 多表写入时，每张表使用的写入器副本数。 |
 | common-options              | Config | 否       | -      | 接收器插件通用参数，详情请参考[接收器通用选项](../common-options/sink-common-options.md)。 |
 
 ### key_label
 
 对应字段建议为 `map<string, string>`，会被转换为 Prometheus 标签。建议在 map 中包含 `__name__`，用来表示指标名。
+
+Sink 会自动补充 remote write 需要的请求头：`Content-type`、`Content-Encoding` 和
+`X-Prometheus-Remote-Write-Version`。
 
 ### key_timestamp
 
@@ -66,6 +70,10 @@ Prometheus 数据接收器把上游数据写入 Prometheus remote write API。�
 - `bigint`：按毫秒级时间戳处理
 - `double`：按 Unix 秒级时间戳处理，并转换为毫秒
 - `string`：按毫秒级时间戳解析
+
+### multi_table_sink_replica
+
+多表写入时，每张表使用的 Sink Writer 副本数。默认值为 `1`；只有当单张表需要更高写入并行度时才建议调大。
 
 ## 示例
 

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -16,6 +16,7 @@ Apache Pulsar 的源连接器。
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行读取](../../introduction/concepts/connector-v2-features.md)
 - [ ] [用户自定义 split](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
 
 ## 参数
 
@@ -26,7 +27,7 @@ Apache Pulsar 的源连接器。
 | table_path               | String  | 否    | -      | 多表模式中单个配置项对应的逻辑表标识                                                                        |
 | tables_configs           | Array   | 否    | -      | 多表读取配置。每个 item 可覆盖全局默认值。**注意:只能在 `topic`、`topic-pattern` 和 `tables_configs` 中选择一种**       |
 | topic-discovery.interval | Long    | 否    | -1     | 发现新 topic 分区的间隔(毫秒)。非正值禁用发现。仅在使用 `topic-pattern` 时生效                                      |
-| subscription.name        | String  | 否    | -      | 消费者订阅名。在多表模式下可定义在全局或 item 中                                                               |
+| subscription.name        | String  | 单表模式必填，或在多表 item 中配置 | -      | 消费者订阅名。在多表模式下可定义在全局或 item 中                                                               |
 | client.service-url       | String  | 是    | -      | Pulsar 服务的客户端 URL,例如 `pulsar://localhost:6650`                                            |
 | admin.service-url        | String  | 是    | -      | Pulsar 管理端点的 HTTP URL,例如 `http://localhost:8080`                                          |
 | auth.plugin-class        | String  | 否    | -      | Pulsar 客户端认证插件类名                                                                          |
@@ -36,7 +37,7 @@ Apache Pulsar 的源连接器。
 | poll.batch.size          | Integer | 否    | 500    | 单次拉取的最大消息数                                                                                |
 | cursor.startup.mode      | Enum    | 否    | LATEST | 启动位置模式。可选值:`EARLIEST`、`LATEST`、`SUBSCRIPTION`、`TIMESTAMP`                                 |
 | cursor.startup.timestamp | Long    | 否    | -      | 当 `cursor.startup.mode=TIMESTAMP` 时的起始时间戳(毫秒)                                             |
-| cursor.reset.mode        | Enum    | 否    | LATEST | 当 `cursor.startup.mode=SUBSCRIPTION` 时的重置模式。可选值:`EARLIEST`、`LATEST`                       |
+| cursor.reset.mode        | Enum    | 当 `cursor.startup.mode=SUBSCRIPTION` 时必填 | - | 当 `cursor.startup.mode=SUBSCRIPTION` 时的重置模式。可选值:`EARLIEST`、`LATEST`                       |
 | cursor.stop.mode         | Enum    | 否    | NEVER  | 停止位置模式。可选值:`NEVER`(流式)、`LATEST`(批式)、`TIMESTAMP`(批式)                                       |
 | cursor.stop.timestamp    | Long    | 否    | -      | 当 `cursor.stop.mode=TIMESTAMP` 时的停止时间戳(毫秒)                                                |
 | schema                   | Config  | 否    | -      | 数据结构,包括字段名称和字段类型                                                                          |
@@ -135,6 +136,8 @@ Pulsar 消费者的启动模式，有效值为 `'EARLIEST'`、`'LATEST'`、`'SUB
 ### cursor.reset.mode [Enum]
 
 当 `cursor.startup.mode = SUBSCRIPTION` 时使用的 cursor reset 策略，可选值为 `'EARLIEST'`、`'LATEST'`。
+
+该参数没有默认值。使用 `cursor.startup.mode = SUBSCRIPTION` 时必须显式配置。
 
 ### cursor.stop.mode [Enum]
 


### PR DESCRIPTION
## Purpose

This PR improves the Email, Prometheus, and Pulsar connector documentation based on the current connector behavior and available connector task examples.

## Changes

- Document Email multi-table write support, writer replica option, and empty-input behavior.
- Document Prometheus sink writer replica configuration and automatic remote-write headers.
- Clarify Pulsar source multi-table read support and the required `cursor.reset.mode` behavior for subscription startup.
- Keep the English and Chinese connector pages aligned.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
