### PR TITLE
[Docs][Connector-V2] Improve Aerospike Assert and BigQuery docs

### DIFF
--- a/docs/en/connectors/sink/Aerospike.md
+++ b/docs/en/connectors/sink/Aerospike.md
@@ -12,18 +12,21 @@ import ChangeLog from '../changelog/connector-aerospike.md';
 
 ## License Compatibility Notice
 
-This connector depends on Aerospike Client Library which is licensed under AGPL 3.0.                                                                                                                                                
+This connector depends on Aerospike Client Library which is licensed under AGPL 3.0.
 When using this connector, you need to comply with AGPL 3.0 license terms.
 
 ## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
 
 Sink connector for Aerospike database. The connector writes records to one Aerospike namespace and set. It uses the configured `key` field as the Aerospike record key.
+
+The connector writes to one fixed target set. It does not route records to different Aerospike sets by table name.
 
 ## Supported DataSource Info
 
@@ -55,12 +58,12 @@ Note:
 | Name           | Type   | Required | Default | Description                                                                 |
 |----------------|--------|----------|---------|-----------------------------------------------------------------------------|
 | host           | string | Yes      | -       | Aerospike server hostname or IP address.                                    |
-| port           | int    | No       | 3000    | Aerospike server port.                                                      |
+| port           | int    | Yes      | 3000    | Aerospike server port.                                                      |
 | namespace      | string | Yes      | -       | Aerospike namespace.                                                        |
 | set            | string | Yes      | -       | Aerospike set name.                                                         |
 | username       | string | No       | -       | Username for authentication. Leave unset when authentication is disabled.    |
 | password       | string | No       | -       | Password for authentication. Leave unset when authentication is disabled.    |
-| key            | string | Yes      | -       | SeaTunnel field used as the Aerospike record key.                           |
+| key            | string | Yes      | -       | SeaTunnel field used as the Aerospike record key. The field must exist in the input schema. |
 | bin_name       | string | No       | -       | Aerospike bin used by `map` and `string` formats. Required for those formats. |
 | data_format    | string | No       | string  | Storage format. Supported values are `map`, `string`, and `kv`.             |
 | write_timeout  | int    | No       | 200     | Write operation timeout in milliseconds.                                    |
@@ -76,7 +79,11 @@ When `data_format` is `map` or `string`, configure `bin_name`; otherwise the wri
 
 ### schema.field
 
-`schema.field` is optional. Configure it when you need to control the Aerospike type used for each field. Supported Aerospike type names include `STRING`, `INTEGER`, `LONG`, `DOUBLE`, `BOOLEAN`, `BYTEARRAY`, and `LIST`.
+`schema.field` is optional for `map` and `string` formats. Configure it when you need to control the Aerospike type used for each field.
+
+For `kv` format, configure `schema.field` for the fields you want to write as independent Aerospike bins. The writer iterates over `schema.field`, so fields not listed there are not written in `kv` mode.
+
+Supported Aerospike type names include `STRING`, `INTEGER`, `LONG`, `DOUBLE`, `BOOLEAN`, `BYTEARRAY`, and `LIST`.
 
 ## Task Example
 
@@ -137,6 +144,7 @@ sink {
   }
 }
 ```
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/en/connectors/sink/Assert.md
+++ b/docs/en/connectors/sink/Assert.md
@@ -4,9 +4,15 @@ import ChangeLog from '../changelog/connector-assert.md';
 
 > Assert sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> Seatunnel Zeta<br/>
+
 ## Description
 
-A sink plugin which can assert illegal data by user defined rules
+Assert is a sink connector used to validate pipeline output. It checks row count, field type, field value, and catalog table metadata by user-defined rules. If the actual data does not match the rules, the job fails.
 
 ## Key Features
 
@@ -52,13 +58,15 @@ A sink plugin which can assert illegal data by user defined rules
 | multi_table_sink_replica                                                                       | int                                             | no       | -       |
 | common-options                                                                                 |                                                 | no       | -       |
 
+Only `rules` is required by the connector. The nested rule blocks are optional, but at least one meaningful rule should be configured; otherwise the sink has nothing to validate.
+
 ### rules [ConfigMap]
 
-Rule definition of user's available data.  Each rule represents one field validation or row num validation.
+Rule definition of expected data. Each rule represents a field validation, row count validation, table-name validation, or catalog table validation.
 
 ### field_rules [ConfigList]
 
-field rules for field validation
+Field rules for field validation. Use this block when you need to check field type, nullability, value range, string length, or exact value.
 
 ### field_name [string]
 
@@ -98,15 +106,15 @@ The value related to rule type. When the `rule_type` is `MIN`, `MAX`, `MIN_LENGT
 
 ### catalog_table_rule [ConfigMap]
 
-Used to assert the catalog table is same with the user defined table.
+Used to assert that the actual catalog table metadata is the same as the user-defined table metadata.
 
 ### table-names [ConfigList]
 
-Used to assert the table should be in the data.
+Used to assert that the listed table names exist in the input data.
 
 ### tables_configs [ConfigList]
 
-Used to assert the multiple tables should be in the data.
+Used to define different assertion rules for multiple input tables. Each item should include a `table_path`.
 
 ### table_path [String]
 
@@ -120,10 +128,17 @@ The replica number used by the multi-table sink common option. Configure it only
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
 
+### Rule Matching Notes
+
+- `row_rules` checks the number of rows received by the Assert sink.
+- `field_rules` checks field values in every received row.
+- `tables_configs` is used for multi-table jobs. The `table_path` value must match the table path carried by the upstream source.
+- `equals_to` compares the actual field value with the configured expected value. For complex values such as array, map, and row, use the same HOCON value shape as the source data.
+
 ## Example
 
 ### Simple
-the whole config obey with `hocon` style
+The following example validates that a pipeline outputs between 5 and 100 rows, and that the selected fields follow the expected rules.
 
 ```hocon
 Assert {
@@ -503,9 +518,9 @@ sink{
 }
 ```
 
-### Assert Multiple Tables 
+### Assert Multiple Tables
 
-check multiple tables
+The following example validates two tables in one job. Each table has its own row count and field rules.
 
 ```hocon
 env {

--- a/docs/en/connectors/sink/BigQuery.md
+++ b/docs/en/connectors/sink/BigQuery.md
@@ -14,6 +14,7 @@ import ChangeLog from '../changelog/connector-bigquery.md';
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md) for batch mode only
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
@@ -40,6 +41,7 @@ Sink connector for Google Cloud BigQuery using the Storage Write API for high-pe
 | sequence_number_column      | string  | No       | -       | Column name used as sequence number for CDC deduplication. Only applicable when `write_mode` is `streaming` |
 | batch_size                  | int     | No       | 1000    | Number of rows to batch before sending to BigQuery                                                          |
 | emulator_host               | string  | No       | -       | BigQuery emulator host, such as `localhost:9050`. This option is intended for tests only.                    |
+| multi_table_sink_replica    | int     | No       | -       | Sink common option. It controls sink replica count in multi-table runtime, but this connector still writes to the single configured BigQuery table. |
 | common-options              |         | No       | -       | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md).                    |
 
 ### Authentication Options
@@ -55,7 +57,12 @@ For production BigQuery jobs, provide **one** of the following authentication me
 The target BigQuery table must already exist.
 The connector reads the existing table schema during writer initialization and does not create the table automatically.
 
-The connector writes to one configured table: `project_id.dataset_id.table_id`. For multi-table pipelines, configure separate sink entries or route data before the BigQuery sink.
+The connector writes to one configured table: `project_id.dataset_id.table_id`. It does not create a different BigQuery table for each upstream table. For multi-table pipelines, configure separate sink entries or route data before the BigQuery sink.
+
+### Write Modes
+
+- `batch`: uses BigQuery buffered write streams and commits data during SeaTunnel checkpoint/commit. This is the mode covered by the exactly-once feature mark.
+- `streaming`: uses the default stream and writes CDC records with BigQuery change fields. This mode is suitable for CDC upsert/delete records, but it is not marked as exactly-once by this connector.
 
 #### sequence_number_column
 

--- a/docs/zh/connectors/sink/Aerospike.md
+++ b/docs/zh/connectors/sink/Aerospike.md
@@ -19,11 +19,14 @@ import ChangeLog from '../changelog/connector-aerospike.md';
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
 用于向 Aerospike 数据库写入数据的连接器。该连接器会把数据写入一个指定的 Aerospike 命名空间和集合，并使用 `key` 指定的字段作为 Aerospike 记录主键。
+
+该连接器只写入一个固定的目标集合，不会按表名自动把数据路由到不同的 Aerospike 集合。
 
 ## 支持的数据源
 
@@ -55,12 +58,12 @@ import ChangeLog from '../changelog/connector-aerospike.md';
 | 参数名称        | 类型    | 必填 | 默认值  | 说明                                                                 |
 |----------------|---------|------|---------|---------------------------------------------------------------------|
 | host           | string  | 是   | -       | Aerospike 服务器主机名或 IP 地址。                                  |
-| port           | int     | 否   | 3000    | Aerospike 服务器端口。                                              |
+| port           | int     | 是   | 3000    | Aerospike 服务器端口。                                              |
 | namespace      | string  | 是   | -       | Aerospike 命名空间。                                                |
 | set            | string  | 是   | -       | Aerospike 集合名称。                                                |
 | username       | string  | 否   | -       | 认证用户名。未开启认证时可以不配置。                                |
 | password       | string  | 否   | -       | 认证密码。未开启认证时可以不配置。                                  |
-| key            | string  | 是   | -       | 用作 Aerospike 记录主键的 SeaTunnel 字段名称。                      |
+| key            | string  | 是   | -       | 用作 Aerospike 记录主键的 SeaTunnel 字段名称，该字段必须存在于输入 schema 中。 |
 | bin_name       | string  | 否   | -       | `map` 和 `string` 格式使用的 Aerospike bin 名称，这两种格式下必填。  |
 | data_format    | string  | 否   | string  | 数据存储格式，支持 `map`、`string`、`kv`。                           |
 | write_timeout  | int     | 否   | 200     | 写入操作超时时间，单位毫秒。                                        |
@@ -76,7 +79,11 @@ import ChangeLog from '../changelog/connector-aerospike.md';
 
 ### schema.field 配置说明
 
-`schema.field` 是可选配置。需要明确控制每个字段写入 Aerospike 时的类型时再配置。支持的 Aerospike 类型名称包括 `STRING`、`INTEGER`、`LONG`、`DOUBLE`、`BOOLEAN`、`BYTEARRAY`、`LIST`。
+`schema.field` 对 `map` 和 `string` 格式是可选配置。需要明确控制每个字段写入 Aerospike 时的类型时再配置。
+
+当 `data_format` 为 `kv` 时，请在 `schema.field` 中列出需要写成独立 Aerospike bin 的字段。写入器会遍历 `schema.field`，未列出的字段不会在 `kv` 模式下写入。
+
+支持的 Aerospike 类型名称包括 `STRING`、`INTEGER`、`LONG`、`DOUBLE`、`BOOLEAN`、`BYTEARRAY`、`LIST`。
 
 ## 任务示例
 
@@ -137,6 +144,7 @@ sink {
   }
 }
 ```
-## Changelog
+
+## 更新日志
 
 <ChangeLog />

--- a/docs/zh/connectors/sink/Assert.md
+++ b/docs/zh/connectors/sink/Assert.md
@@ -4,61 +4,69 @@ import ChangeLog from '../changelog/connector-assert.md';
 
 > Assert 数据接收器
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> Seatunnel Zeta<br/>
+
 ## 描述
 
-Assert 数据接收器是一个用于断言数据是否符合用户定义规则的数据接收器。用户可以通过配置规则来断言数据是否符合预期，如果数据不符合规则，将会抛出异常。
+Assert 是一个用于校验任务输出结果的数据接收器。它可以按用户定义的规则检查行数、字段类型、字段值和 Catalog 表元数据。如果实际数据不符合规则，任务会失败。
 
-## 核心特性
+## 主要特性
 
-- [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
 ## 配置
 
-| Name                                                                                           | Type                                            | Required | Default |
+| 参数名称                                                                                       | 类型                                            | 必填 | 默认值 |
 |------------------------------------------------------------------------------------------------|-------------------------------------------------|----------|---------|
-| rules                                                                                          | ConfigMap                                       | yes      | -       |
-| rules.field_rules                                                                              | ConfigList                                      | no       | -       |
-| rules.field_rules.field_name                                                                   | string\|ConfigMap                               | yes      | -       |
-| rules.field_rules.field_type                                                                   | string                                          | no       | -       |
-| rules.field_rules.field_value                                                                  | ConfigList                                      | no       | -       |
-| rules.field_rules.field_value.rule_type                                                        | string                                          | no       | -       |
-| rules.field_rules.field_value.rule_value                                                       | numeric                                         | no       | -       |
-| rules.field_rules.field_value.equals_to                                                        | boolean\|numeric\|string\|ConfigList\|ConfigMap | no       | -       |
-| rules.row_rules                                                                                | ConfigList                                      | no       | -       |
-| rules.row_rules.rule_type                                                                      | string                                          | no       | -       |
-| rules.row_rules.rule_value                                                                     | string                                          | no       | -       |
-| rules.catalog_table_rule                                                                       | ConfigMap                                       | no       | -       |
-| rules.catalog_table_rule.primary_key_rule                                                      | ConfigMap                                       | no       | -       |
-| rules.catalog_table_rule.primary_key_rule.primary_key_name                                     | string                                          | no       | -       |
-| rules.catalog_table_rule.primary_key_rule.primary_key_columns                                  | ConfigList                                      | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule                                                   | ConfigList                                      | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule.constraint_key_name                               | string                                          | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule.constraint_key_type                               | string                                          | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns                            | ConfigList                                      | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns.constraint_key_column_name | string                                          | no       | -       |
-| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns.constraint_key_sort_type   | string                                          | no       | -       |
-| rules.catalog_table_rule.column_rule                                                           | ConfigList                                      | no       | -       |
-| rules.catalog_table_rule.column_rule.name                                                      | string                                          | no       | -       |
-| rules.catalog_table_rule.column_rule.type                                                      | string                                          | no       | -       |
-| rules.catalog_table_rule.column_rule.column_length                                             | int                                             | no       | -       |
-| rules.catalog_table_rule.column_rule.nullable                                                  | boolean                                         | no       | -       |
-| rules.catalog_table_rule.column_rule.default_value                                             | string                                          | no       | -       |
-| rules.catalog_table_rule.column_rule.comment                                                   | comment                                         | no       | -       |
-| rules.table-names                                                                              | ConfigList                                      | no       | -       |
-| rules.tables_configs                                                                           | ConfigList                                      | no       | -       |
-| rules.tables_configs.table_path                                                                | String                                          | no       | -       |
-| multi_table_sink_replica                                                                       | int                                             | no       | -       |
-| common-options                                                                                 |                                                 | no       | -       |
+| rules                                                                                          | ConfigMap                                       | 是       | -       |
+| rules.field_rules                                                                              | ConfigList                                      | 否       | -       |
+| rules.field_rules.field_name                                                                   | string\|ConfigMap                               | 是       | -       |
+| rules.field_rules.field_type                                                                   | string                                          | 否       | -       |
+| rules.field_rules.field_value                                                                  | ConfigList                                      | 否       | -       |
+| rules.field_rules.field_value.rule_type                                                        | string                                          | 否       | -       |
+| rules.field_rules.field_value.rule_value                                                       | numeric                                         | 否       | -       |
+| rules.field_rules.field_value.equals_to                                                        | boolean\|numeric\|string\|ConfigList\|ConfigMap | 否       | -       |
+| rules.row_rules                                                                                | ConfigList                                      | 否       | -       |
+| rules.row_rules.rule_type                                                                      | string                                          | 否       | -       |
+| rules.row_rules.rule_value                                                                     | string                                          | 否       | -       |
+| rules.catalog_table_rule                                                                       | ConfigMap                                       | 否       | -       |
+| rules.catalog_table_rule.primary_key_rule                                                      | ConfigMap                                       | 否       | -       |
+| rules.catalog_table_rule.primary_key_rule.primary_key_name                                     | string                                          | 否       | -       |
+| rules.catalog_table_rule.primary_key_rule.primary_key_columns                                  | ConfigList                                      | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule                                                   | ConfigList                                      | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule.constraint_key_name                               | string                                          | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule.constraint_key_type                               | string                                          | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns                            | ConfigList                                      | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns.constraint_key_column_name | string                                          | 否       | -       |
+| rules.catalog_table_rule.constraint_key_rule.constraint_key_columns.constraint_key_sort_type   | string                                          | 否       | -       |
+| rules.catalog_table_rule.column_rule                                                           | ConfigList                                      | 否       | -       |
+| rules.catalog_table_rule.column_rule.name                                                      | string                                          | 否       | -       |
+| rules.catalog_table_rule.column_rule.type                                                      | string                                          | 否       | -       |
+| rules.catalog_table_rule.column_rule.column_length                                             | int                                             | 否       | -       |
+| rules.catalog_table_rule.column_rule.nullable                                                  | boolean                                         | 否       | -       |
+| rules.catalog_table_rule.column_rule.default_value                                             | string                                          | 否       | -       |
+| rules.catalog_table_rule.column_rule.comment                                                   | comment                                         | 否       | -       |
+| rules.table-names                                                                              | ConfigList                                      | 否       | -       |
+| rules.tables_configs                                                                           | ConfigList                                      | 否       | -       |
+| rules.tables_configs.table_path                                                                | String                                          | 否       | -       |
+| multi_table_sink_replica                                                                       | int                                             | 否       | -       |
+| common-options                                                                                 |                                                 | 否       | -       |
+
+连接器只强制要求配置 `rules`。`rules` 里面的各类规则块是可选的，但至少应配置一条有实际校验意义的规则，否则 Assert sink 没有可校验的内容。
 
 ### rules [ConfigMap]
 
-规则定义用户可用数据的规则。每个规则代表一个字段验证或行数量验证。
+定义期望数据的校验规则。每条规则可以用于字段校验、行数校验、表名校验或 Catalog 表元数据校验。
 
 ### field_rules [ConfigList]
 
-字段规则用于字段验证
+字段规则用于字段校验。需要检查字段类型、是否为空、取值范围、字符串长度或精确值时使用。
 
 ### field_name [string]
 
@@ -99,15 +107,15 @@ Assert 数据接收器是一个用于断言数据是否符合用户定义规则�
 
 ### catalog_table_rule [ConfigMap]
 
-catalog_table_rule用于断言Catalog表是否与用户定义的表相同。
+用于断言实际 Catalog 表元数据是否与用户定义的表元数据一致。
 
 ### table-names [ConfigList]
 
-用于断言表是否在数据中。
+用于断言输入数据中是否包含指定表名。
 
 ### tables_configs [ConfigList]
 
-用于断言多个表是否在数据中。
+用于为多表任务中的不同表配置不同的校验规则。每一项都应包含 `table_path`。
 
 ### table_path [String]
 
@@ -121,10 +129,17 @@ catalog_table_rule用于断言Catalog表是否与用户定义的表相同。
 
 Sink 插件的通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详情
 
+### 规则匹配说明
+
+- `row_rules` 用于检查 Assert sink 收到的行数。
+- `field_rules` 用于检查每一行中的字段值。
+- `tables_configs` 用于多表任务，`table_path` 必须和上游数据携带的表路径一致。
+- `equals_to` 会比较实际字段值和配置的期望值。数组、Map、Row 这类复杂值需要使用和 source 数据一致的 HOCON 写法。
+
 ## 示例
 
 ### 简单
-整个Config遵循`hocon`风格
+下面的示例校验任务输出行数在 5 到 100 之间，并校验选中字段符合预期规则。
 
 ```hocon
 Assert {
@@ -506,7 +521,7 @@ sink{
 
 ### 验证多表
 
-验证多个表
+下面的示例在一个任务中校验两张表，每张表都有独立的行数规则和字段规则。
 
 ```hocon
 env {

--- a/docs/zh/connectors/sink/BigQuery.md
+++ b/docs/zh/connectors/sink/BigQuery.md
@@ -14,6 +14,7 @@ import ChangeLog from '../changelog/connector-bigquery.md';
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md) 仅适用于 batch 模式
 - [x] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
@@ -39,6 +40,7 @@ import ChangeLog from '../changelog/connector-bigquery.md';
 | sequence_number_column      | string  | 否      | -       | 用于 CDC 去重的序列号列名。仅在 `write_mode` 为 `streaming` 时适用                                                |
 | batch_size                  | int     | 否      | 1000    | 发送到 BigQuery 之前批量处理的行数                                                                               |
 | emulator_host               | string  | 否      | -       | BigQuery emulator 地址，例如 `localhost:9050`。该参数仅用于测试。                                                |
+| multi_table_sink_replica    | int     | 否      | -       | Sink 通用参数，用于控制多表运行时每张表的 sink 副本数；但该连接器仍只写入配置中的单个 BigQuery 表。                    |
 | common-options              |         | 否      | -       | Sink 通用参数，详见 [Sink Common Options](../common-options/sink-common-options.md)。                            |
 
 ### 认证参数
@@ -54,7 +56,12 @@ import ChangeLog from '../changelog/connector-bigquery.md';
 目标 BigQuery 表必须已经存在。
 连接器会在 writer 初始化时读取已有的表 schema，并且不会自动创建 BigQuery 表。
 
-该连接器会写入一个固定的目标表：`project_id.dataset_id.table_id`。如果任务里有多张表，请配置多个 BigQuery sink，或者在写入 BigQuery 前先完成表路由。
+该连接器会写入一个固定的目标表：`project_id.dataset_id.table_id`。它不会按上游表自动创建或切换 BigQuery 目标表。如果任务里有多张表，请配置多个 BigQuery sink，或者在写入 BigQuery 前先完成表路由。
+
+### 写入模式
+
+- `batch`：使用 BigQuery buffered write stream，并在 SeaTunnel checkpoint/commit 阶段提交数据。主要特性中的精确一次能力指的是该模式。
+- `streaming`：使用默认 stream，并携带 BigQuery change 字段写入 CDC 记录。该模式适合 CDC 的 upsert/delete 数据，但该连接器没有将它标记为精确一次。
 
 #### sequence_number_column
 


### PR DESCRIPTION
## Purpose

Improve the Aerospike, Assert, and BigQuery connector documentation based on the current connector option contracts and runnable job examples.

## Changes

- Clarify Aerospike sink required options, single-target behavior, data formats, and kv/schema.field behavior.
- Improve Assert sink English and Chinese docs with engine support, clearer rule descriptions, multi-table matching notes, and localized Chinese option table labels.
- Clarify BigQuery sink single-table behavior, write modes, multi_table_sink_replica meaning, and feature flags in both English and Chinese docs.

## Verification

- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify

## Duplicate Check

Checked open Apache SeaTunnel PRs before creating this PR and found no existing PR covering Aerospike, Assert, and BigQuery documentation updates.