### PR TITLE
[Docs][Connector-V2] Improve Druid GraphQL and Hive docs

### DIFF
--- a/docs/en/connectors/sink/Druid.md
+++ b/docs/en/connectors/sink/Druid.md
@@ -57,6 +57,8 @@ The number of rows buffered before SeaTunnel sends one indexing task to Druid. T
 
 SeaTunnel also flushes the remaining buffered rows when the writer closes.
 
+Use a larger value for high-throughput batch jobs to reduce the number of Druid indexing tasks. Use a smaller value when you need data to be submitted to Druid earlier, but note that this can create more indexing tasks.
+
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
@@ -70,6 +72,8 @@ The connector converts each SeaTunnel row into inline CSV data and submits it to
 The connector adds a processing-time column named `timestamp` to satisfy Druid's primary timestamp requirement. This generated timestamp is used by Druid ingestion; source `TIMESTAMP` fields are written as string dimensions according to the mapping above.
 
 Rows are flushed when the buffered row count reaches `batchSize`. Remaining rows are also flushed when the writer closes. There is no time-based periodic flush option.
+
+The sink is designed for append-style batch ingestion. It does not interpret CDC update/delete row kinds as Druid upserts or deletes.
 
 ## Example
 

--- a/docs/en/connectors/sink/GraphQL.md
+++ b/docs/en/connectors/sink/GraphQL.md
@@ -56,6 +56,7 @@ It can be downloaded via install-plugin.sh or from Maven central repository.
 - Field names in the upstream row should match variable names used by the mutation.
 - If `variables` already contains a key and `valueCover = true`, the configured variable value is kept.
 - If `valueCover = false`, row field values replace variables with the same name.
+- The sink sends one mutation request for each input row. If the upstream source contains multiple tables, make sure the same mutation and variable names can handle every table routed to this sink.
 
 ## Task Example
 
@@ -147,6 +148,64 @@ sink {
     query = """
       mutation MyMutation($id: Int!, $val_bool: Boolean!) {
         insert_sink(objects: {id: $id, val_bool: $val_bool}) {
+          affected_rows
+        }
+      }
+    """
+  }
+}
+```
+
+### Write Multiple Upstream Tables
+
+```hocon
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        schema = {
+          table = "graphql_sink_1"
+          fields {
+            id = int
+            val_bool = boolean
+            val_string = string
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = [1, true, "NEW"]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "graphql_sink_2"
+          fields {
+            id = int
+            val_bool = boolean
+            val_string = string
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = [2, true, "READY"]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  GraphQL {
+    plugin_input = "fake"
+    url = "http://graphql:8080/v1/graphql"
+    query = """
+      mutation MyMutation($id: Int!, $val_bool: Boolean!, $val_string: String!) {
+        insert_sink(objects: {id: $id, val_bool: $val_bool, val_string: $val_string}) {
           affected_rows
         }
       }

--- a/docs/en/connectors/sink/Hive.md
+++ b/docs/en/connectors/sink/Hive.md
@@ -46,7 +46,7 @@ By default, we use 2PC commit to ensure `exactly-once`
 | krb5_path                             | string  | no       | /etc/krb5.conf |
 | kerberos_principal                    | string  | no       | -              |
 | kerberos_keytab_path                  | string  | no       | -              |
-| abort_drop_partition_metadata         | boolean | no       | true           |
+| abort_drop_partition_metadata         | boolean | no       | false          |
 | parquet_avro_write_timestamp_as_int96 | boolean | no       | false          |
 | overwrite                             | boolean | no       | false          |
 | data_save_mode                        | enum    | no       | APPEND_DATA    |
@@ -100,6 +100,8 @@ The keytab path of kerberos
 
 Flag to decide whether to drop partition metadata from Hive Metastore during an abort operation. Note: this only affects the metadata in the metastore, the data in the partition will always be deleted(data generated during the synchronization process).
 
+The default value is `false`.
+
 ### parquet_avro_write_timestamp_as_int96 [boolean]
 
 Support writing Parquet INT96 from a timestamp, only valid for parquet files.
@@ -120,6 +122,8 @@ Select how to handle existing data on the target before writing new data.
 - CUSTOM_PROCESSING / ERROR_WHEN_DATA_EXISTS: Currently not recommended for Hive sink unless you have specific requirements.
 
 Note: overwrite=true and data_save_mode=DROP_DATA are equivalent. Use either one; do not set both.
+
+For batch jobs, use either `overwrite = true` or `data_save_mode = "DROP_DATA"` when the target Hive table should be replaced by the current run. For normal append jobs, keep the default `data_save_mode = "APPEND_DATA"`.
 
 ### schema_save_mode [enum]
 

--- a/docs/en/connectors/source/GraphQL.md
+++ b/docs/en/connectors/source/GraphQL.md
@@ -65,6 +65,8 @@ It can be downloaded via install-plugin.sh or from Maven central repository.
 - In subscription mode, set `enable_subscription = true` and use a `ws://` or `wss://` URL.
 - Source queries cannot be GraphQL `mutation` operations.
 - `content_field` is usually needed because GraphQL responses are commonly wrapped under `data`.
+- For streaming query mode over HTTP, configure `poll_interval_millis` to control how often SeaTunnel sends the same query again.
+- For WebSocket subscription mode, `max_retries` and `retry_delay_ms` only control reconnect behavior after a subscription connection fails.
 
 ## Task Example
 

--- a/docs/zh/connectors/sink/Druid.md
+++ b/docs/zh/connectors/sink/Druid.md
@@ -57,6 +57,8 @@ SeaTunnel 缓存多少行之后向 Druid 提交一次索引任务。默认值为
 
 写入器关闭时，SeaTunnel 也会把剩余缓存数据提交到 Druid。
 
+批量写入量较大时，可以适当调大该值，减少提交给 Druid 的索引任务数量。如果希望数据更早提交到 Druid，可以适当调小该值，但这会产生更多索引任务。
+
 ### common options
 
 Sink 插件通用参数，详见 [Sink Common Options](../common-options/sink-common-options.md)。
@@ -70,6 +72,8 @@ Sink 插件通用参数，详见 [Sink Common Options](../common-options/sink-co
 Druid 写入需要主时间列。连接器会自动追加一个名为 `timestamp` 的处理时间列给 Druid 使用；上游的 `TIMESTAMP` 字段会按上面的类型映射写成字符串维度。
 
 当缓存行数达到 `batchSize` 时会触发一次写入；写入器关闭时，也会把剩余缓存数据提交到 Druid。当前没有按时间间隔定期刷新的配置。
+
+该 Sink 适合追加式批量写入，不会把 CDC 的更新/删除行自动转换成 Druid 的 upsert 或 delete 操作。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/GraphQL.md
+++ b/docs/zh/connectors/sink/GraphQL.md
@@ -55,6 +55,7 @@ mutation 一起发送。
 - 上游字段名应和 mutation 里使用的变量名保持一致。
 - 如果 `variables` 已有某个 key，并且设置 `valueCover = true`，会保留配置里的变量值。
 - 如果 `valueCover = false`，同名输入行字段会覆盖配置里的变量值。
+- Sink 会为每一行输入数据发送一次 mutation 请求。如果上游包含多张表，需要确认同一条 mutation 和变量名可以处理所有写入到该 Sink 的表。
 
 ## 任务示例
 
@@ -146,6 +147,64 @@ sink {
     query = """
       mutation MyMutation($id: Int!, $val_bool: Boolean!) {
         insert_sink(objects: {id: $id, val_bool: $val_bool}) {
+          affected_rows
+        }
+      }
+    """
+  }
+}
+```
+
+### 写入多张上游表
+
+```hocon
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        schema = {
+          table = "graphql_sink_1"
+          fields {
+            id = int
+            val_bool = boolean
+            val_string = string
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = [1, true, "NEW"]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "graphql_sink_2"
+          fields {
+            id = int
+            val_bool = boolean
+            val_string = string
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = [2, true, "READY"]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  GraphQL {
+    plugin_input = "fake"
+    url = "http://graphql:8080/v1/graphql"
+    query = """
+      mutation MyMutation($id: Int!, $val_bool: Boolean!, $val_string: String!) {
+        insert_sink(objects: {id: $id, val_bool: $val_bool, val_string: $val_string}) {
           affected_rows
         }
       }

--- a/docs/zh/connectors/sink/Hive.md
+++ b/docs/zh/connectors/sink/Hive.md
@@ -100,6 +100,8 @@ Kerberos 的 keytab 文件路径
 
 在中止操作期间是否从 Hive Metastore 中删除分区元数据的标志。注意：这只影响元存储中的元数据，分区中的数据将始终被删除（同步过程中生成的数据）。
 
+默认值为 `false`。
+
 ### parquet_avro_write_timestamp_as_int96 [boolean]
 
 支持从时间戳写入 Parquet INT96，仅对 parquet 文件有效。
@@ -120,6 +122,8 @@ Kerberos 的 keytab 文件路径
 - CUSTOM_PROCESSING / ERROR_WHEN_DATA_EXISTS：如无特殊需求，不建议在 Hive sink 下使用
 
 注意：overwrite=true 与 data_save_mode=DROP_DATA 行为等价，二者择一配置即可，勿同时设置。
+
+批处理作业中，如果希望本次运行替换目标 Hive 表里的已有数据，可以使用 `overwrite = true` 或 `data_save_mode = "DROP_DATA"`。普通追加写入场景保持默认的 `data_save_mode = "APPEND_DATA"` 即可。
 
 ### schema_save_mode [枚举]
 

--- a/docs/zh/connectors/source/GraphQL.md
+++ b/docs/zh/connectors/source/GraphQL.md
@@ -64,6 +64,8 @@ GraphQL 源连接器用于从 GraphQL 服务读取数据。它支持：
 - 订阅模式下，需要设置 `enable_subscription = true`，并使用 `ws://` 或 `wss://` 地址。
 - Source 不支持 GraphQL `mutation` 操作。
 - GraphQL 响应通常包在 `data` 字段下面，所以一般需要配置 `content_field`。
+- 使用 HTTP 流式轮询读取时，可以通过 `poll_interval_millis` 控制重复发送同一条查询的间隔。
+- 使用 WebSocket 订阅读取时，`max_retries` 和 `retry_delay_ms` 只控制订阅连接失败后的重连行为。
 
 ## 任务示例
 


### PR DESCRIPTION
## Summary
- clarify Druid sink batching behavior and append-style limitations
- document GraphQL source polling and subscription retry behavior
- add a GraphQL sink multi-table example and clarify per-row mutation writes
- correct the Hive sink `abort_drop_partition_metadata` default and clarify overwrite/save-mode usage

## Verification
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`