### PR TITLE
[Fix][Connector-V2] Fix Doris stream load waitForContinue timeout when FE redirect is slow

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
@@ -85,6 +85,10 @@ public class DorisStreamLoad implements Serializable {
     private final RecordStream recordStream;
     @Getter private Future<CloseableHttpResponse> pendingLoadFuture;
     private final CloseableHttpClient httpClient;
+    // Dedicated client for the stream-load upload path. Unlike the control requests that share
+    // httpClient, the upload sends a non-repeatable body and needs HttpUtil's longer
+    // waitForContinue window so a slow FE 307 redirect does not force the body to FE first.
+    private final CloseableHttpClient streamLoadHttpClient;
     private final ExecutorService executorService;
     private volatile boolean loadBatchFirstRecord;
     private volatile boolean loading = false;
@@ -113,6 +117,7 @@ public class DorisStreamLoad implements Serializable {
         this.streamLoadProp = dorisSinkConfig.getStreamLoadProps();
         this.enableDelete = dorisSinkConfig.getEnableDelete();
         this.httpClient = httpClient;
+        this.streamLoadHttpClient = new HttpUtil().getStreamLoadHttpClient();
         this.executorService =
                 new ThreadPoolExecutor(
                         1,
@@ -297,7 +302,7 @@ public class DorisStreamLoad implements Serializable {
                             () -> {
                                 log.info("start execute load");
                                 return HttpUtil.executeWithRedirectTracking(
-                                        httpClient,
+                                        streamLoadHttpClient,
                                         putBuilder.build(),
                                         loadUrlStr,
                                         directToBe,
@@ -356,6 +361,13 @@ public class DorisStreamLoad implements Serializable {
     }
 
     public void close() throws IOException {
+        if (null != streamLoadHttpClient) {
+            try {
+                streamLoadHttpClient.close();
+            } catch (IOException e) {
+                throw new IOException("Closing streamLoadHttpClient failed.", e);
+            }
+        }
         if (null != httpClient) {
             try {
                 httpClient.close();

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/util/HttpUtil.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/util/HttpUtil.java
@@ -27,6 +27,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpRequestExecutor;
 import org.apache.http.protocol.RequestContent;
 
 import java.io.IOException;
@@ -35,8 +36,16 @@ import java.util.List;
 
 /** util to build http client. */
 public class HttpUtil {
+    // Stream load sends "Expect: 100-continue" and relies on FE's 307 redirect to reach BE.
+    // The default waitForContinue timeout of HttpRequestExecutor is only 3s: when FE is busy
+    // (heavy load / FullGC), the client stops waiting, sends the non-repeatable request body
+    // to FE, and can no longer follow the late 307 redirect. Wait 60s instead, aligned with
+    // doris-flink-connector.
+    private static final int WAIT_FOR_CONTINUE_TIMEOUT_MS = 60 * 1000;
+
     private final HttpClientBuilder httpClientBuilder =
             HttpClients.custom()
+                    .setRequestExecutor(new HttpRequestExecutor(WAIT_FOR_CONTINUE_TIMEOUT_MS))
                     .setRedirectStrategy(
                             new DefaultRedirectStrategy() {
                                 @Override

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/util/HttpUtil.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/util/HttpUtil.java
@@ -36,27 +36,47 @@ import java.util.List;
 
 /** util to build http client. */
 public class HttpUtil {
-    // Stream load sends "Expect: 100-continue" and relies on FE's 307 redirect to reach BE.
-    // The default waitForContinue timeout of HttpRequestExecutor is only 3s: when FE is busy
-    // (heavy load / FullGC), the client stops waiting, sends the non-repeatable request body
-    // to FE, and can no longer follow the late 307 redirect. Wait 60s instead, aligned with
-    // doris-flink-connector.
+    // Stream load upload sends "Expect: 100-continue" and relies on FE's 307 redirect to reach
+    // BE. The default waitForContinue timeout of HttpRequestExecutor is only 3s: when FE is busy
+    // (heavy load / FullGC), the client stops waiting, sends the non-repeatable request body to
+    // FE, and can no longer follow the late 307 redirect. Wait 60s for upload traffic instead,
+    // aligned with doris-flink-connector. Only the stream-load upload client needs this - the
+    // empty-entity control requests (commit / abort / pre-commit) keep the default, so a slow FE
+    // does not stretch checkpoint completion / transaction cleanup.
     private static final int WAIT_FOR_CONTINUE_TIMEOUT_MS = 60 * 1000;
+
+    private static final DefaultRedirectStrategy REDIRECT_STRATEGY =
+            new DefaultRedirectStrategy() {
+                @Override
+                protected boolean isRedirectable(String method) {
+                    return true;
+                }
+            };
 
     private final HttpClientBuilder httpClientBuilder =
             HttpClients.custom()
+                    .setRedirectStrategy(REDIRECT_STRATEGY)
+                    .addInterceptorLast(new RequestContent(true));
+
+    // Separate builder for the stream-load upload path, which sends a non-repeatable body and
+    // needs a longer waitForContinue window than the default 3s.
+    private final HttpClientBuilder streamLoadHttpClientBuilder =
+            HttpClients.custom()
                     .setRequestExecutor(new HttpRequestExecutor(WAIT_FOR_CONTINUE_TIMEOUT_MS))
-                    .setRedirectStrategy(
-                            new DefaultRedirectStrategy() {
-                                @Override
-                                protected boolean isRedirectable(String method) {
-                                    return true;
-                                }
-                            })
+                    .setRedirectStrategy(REDIRECT_STRATEGY)
                     .addInterceptorLast(new RequestContent(true));
 
     public CloseableHttpClient getHttpClient() {
         return httpClientBuilder.build();
+    }
+
+    /**
+     * Client for the stream-load upload path. Raises the waitForContinue timeout so a slow FE 307
+     * redirect does not force the non-repeatable request body to be sent to FE before the redirect
+     * arrives.
+     */
+    public CloseableHttpClient getStreamLoadHttpClient() {
+        return streamLoadHttpClientBuilder.build();
     }
 
     public static CloseableHttpResponse executeWithRedirectTracking(

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/HttpUtilTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/HttpUtilTest.java
@@ -74,7 +74,7 @@ public class HttpUtilTest {
                                             new ByteArrayInputStream(
                                                     payload.getBytes(StandardCharsets.UTF_8))))
                             .build();
-            try (CloseableHttpClient httpClient = new HttpUtil().getHttpClient();
+            try (CloseableHttpClient httpClient = new HttpUtil().getStreamLoadHttpClient();
                     CloseableHttpResponse response = httpClient.execute(put)) {
                 Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
                 EntityUtils.consume(response.getEntity());

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/HttpUtilTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/util/HttpUtilTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.doris.util;
+
+import org.apache.seatunnel.connectors.doris.sink.HttpPutBuilder;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class HttpUtilTest {
+
+    private static final String LOAD_PATH = "/api/test_db/test_table/_stream_load";
+
+    /**
+     * A busy FE may return the 307 redirect later than the default 3s waitForContinue timeout of
+     * HttpRequestExecutor. The stream load client must keep waiting for the redirect instead of
+     * sending the non-repeatable request body to FE: once the body is consumed, RedirectExec
+     * refuses to follow the redirect and returns the raw 307 response to the caller.
+     */
+    @Test
+    @Timeout(30)
+    void testStreamLoadClientWaitsForSlowFeRedirect() throws Exception {
+        String payload = "{\"k1\":1}";
+        AtomicReference<String> bodyReceivedByBe = new AtomicReference<>();
+        HttpServer beServer = createBeServer(bodyReceivedByBe);
+        String location =
+                String.format("http://127.0.0.1:%s%s", beServer.getAddress().getPort(), LOAD_PATH);
+        try (SlowRedirectFeServer feServer = new SlowRedirectFeServer(4000, location)) {
+            HttpPut put =
+                    new HttpPutBuilder()
+                            .setUrl(
+                                    String.format(
+                                            "http://127.0.0.1:%s%s", feServer.getPort(), LOAD_PATH))
+                            .addCommonHeader()
+                            .setEntity(
+                                    new InputStreamEntity(
+                                            new ByteArrayInputStream(
+                                                    payload.getBytes(StandardCharsets.UTF_8))))
+                            .build();
+            try (CloseableHttpClient httpClient = new HttpUtil().getHttpClient();
+                    CloseableHttpResponse response = httpClient.execute(put)) {
+                Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+                EntityUtils.consume(response.getEntity());
+            }
+            Assertions.assertEquals(payload, bodyReceivedByBe.get());
+        } finally {
+            beServer.stop(0);
+        }
+    }
+
+    private HttpServer createBeServer(AtomicReference<String> bodyHolder) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                LOAD_PATH,
+                exchange -> {
+                    bodyHolder.set(
+                            new String(readAll(exchange.getRequestBody()), StandardCharsets.UTF_8));
+                    byte[] result = "{\"Status\":\"Success\"}".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, result.length);
+                    try (OutputStream outputStream = exchange.getResponseBody()) {
+                        outputStream.write(result);
+                    }
+                });
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        return server;
+    }
+
+    private static byte[] readAll(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[1024];
+        int read;
+        while ((read = inputStream.read(chunk)) != -1) {
+            buffer.write(chunk, 0, read);
+        }
+        return buffer.toByteArray();
+    }
+
+    /**
+     * Raw-socket FE stub which reads the request headers and then delays the 307 redirect without
+     * sending "100 Continue". A com.sun HttpServer cannot simulate this: it automatically replies
+     * "100 Continue" before the handler runs, so the client would never wait.
+     */
+    private static final class SlowRedirectFeServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+
+        SlowRedirectFeServer(long redirectDelayMs, String location) throws IOException {
+            this.serverSocket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            Thread thread =
+                    new Thread(
+                            () -> {
+                                try (Socket socket = serverSocket.accept()) {
+                                    readRequestHeaders(socket.getInputStream());
+                                    Thread.sleep(redirectDelayMs);
+                                    String response =
+                                            "HTTP/1.1 307 Temporary Redirect\r\n"
+                                                    + "Location: "
+                                                    + location
+                                                    + "\r\n"
+                                                    + "Content-Length: 0\r\n"
+                                                    + "Connection: close\r\n"
+                                                    + "\r\n";
+                                    OutputStream outputStream = socket.getOutputStream();
+                                    outputStream.write(response.getBytes(StandardCharsets.UTF_8));
+                                    outputStream.flush();
+                                } catch (Exception ignored) {
+                                    // client-side assertions fail the test
+                                }
+                            },
+                            "slow-redirect-fe");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        private static void readRequestHeaders(InputStream inputStream) throws IOException {
+            int state = 0;
+            int b;
+            while (state < 4 && (b = inputStream.read()) != -1) {
+                if (b == '\r' && (state == 0 || state == 2)) {
+                    state++;
+                } else if (b == '\n' && (state == 1 || state == 3)) {
+                    state++;
+                } else {
+                    state = 0;
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fix a Doris sink stream load failure that occurs when FE is slow to return the 307 redirect.

The stream load client sends `Expect: 100-continue` and relies on FE's 307 redirect to reach BE. `HttpUtil` builds the HttpClient without a custom `HttpRequestExecutor`, so the default `waitForContinue` timeout of **3s** applies. When FE is busy (heavy load / FullGC / network jitter) and the 307 arrives later than 3s:

1. The client stops waiting and sends the non-repeatable `InputStreamEntity` body to FE;
2. When the 307 finally arrives, `RedirectExec` detects the consumed entity (`RequestEntityProxy.isRepeatable == false`), silently refuses to follow the redirect, and returns the raw 307 response to the caller;
3. The load fails with `STREAM_LOAD_FAILED ... HTTP/1.1 307 Temporary Redirect`.

This PR raises the `waitForContinue` timeout to **60s** by setting `.setRequestExecutor(new HttpRequestExecutor(60_000))`, aligned with the same fix in doris-flink-connector (apache/doris-flink-connector#522).

The longer timeout is scoped to the **stream-load upload path only** - the request that sends a non-repeatable `InputStreamEntity` body and actually needs the longer window. `HttpUtil` now exposes two clients: `getHttpClient()` (default timeout) for the empty-entity control requests - `DorisStreamLoad` pre-commit / abort and `DorisCommitter` 2PC commit / abort - and `getStreamLoadHttpClient()` (60s) used only by `DorisStreamLoad.startStreamLoad`. This keeps a slow FE from stretching checkpoint completion and transaction cleanup; only the upload waits longer for the redirect.

**Relationship to #10715**: that PR added an opt-in direct-to-BE write path (`direct_to_be=true` + `benodes`), which avoids the FE redirect entirely and is one way to work around this problem. However, direct BE access is not always feasible — e.g. in cloud / Kubernetes / cross-network deployments only FE is exposed to the client while BE addresses are internal and unreachable, or BE topology changes dynamically so a static `benodes` list is hard to maintain. For those cases the default FE-redirect path is still the only option, and this fix makes it reliable when FE is slow to return the 307.

### Does this PR introduce _any_ user-facing change?

No. No config option, public API, or dependency changes — only the stream-load upload path wait-for-continue timeout is raised from 3s to 60s, matching doris-flink-connector's default behavior.

### How was this patch tested?

Added `HttpUtilTest#testStreamLoadClientWaitsForSlowFeRedirect`, which reproduces the scenario end-to-end:

- A raw-socket FE stub reads the request headers, delays the 307 redirect by 4s (longer than the old 3s default, far shorter than the new 60s) without sending `100 Continue`. (A JDK `HttpServer` cannot simulate this — it auto-replies `100 Continue` before the handler runs.)
- A JDK `HttpServer` BE stub receives the redirected request and returns 200.
- The client sends an `HttpPut` built by `HttpPutBuilder` with a non-repeatable `InputStreamEntity`.
- Asserts the request follows the 307 to BE, returns 200, and BE receives the full body.

Before the fix this test fails with `expected: <200> but was: <307>` (instrumentation confirmed the body was prematurely sent to FE and BE was never hit); after the fix it passes.

Also ran the full connector-doris unit test suite (111 tests, all passing), including the existing `DorisStreamLoadTest` / `DorisCommitterTest` 307-handling regressions, plus `./mvnw spotless:apply` and `./mvnw -DskipTests verify`.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — N/A, no new dependency
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — N/A, no user-facing change
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR. — N/A, no incompatible change
* [ ] If you are contributing the connector code, please check that the following files are updated: — N/A, bug fix in existing connector

