### PR TITLE
[Docs][Connector-V2] Improve ClickHouse Redis and Prometheus docs

### DIFF
--- a/docs/en/connectors/sink/Clickhouse.md
+++ b/docs/en/connectors/sink/Clickhouse.md
@@ -15,7 +15,7 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
 
-> The Clickhouse sink plug-in can achieve accuracy once by implementing idempotent writing, and needs to cooperate with aggregatingmergetree and other engines that support deduplication.
+> The Clickhouse sink can reduce duplicate effects through idempotent writing when the target table engine supports deduplication, such as `AggregatingMergeTree` or `ReplacingMergeTree`. It is not marked as exactly-once because the guarantee depends on the target table design.
 
 - [x] [support multiple table sink](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
@@ -64,10 +64,10 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 | primary_key                           | String  | No       | -       | Primary key column list used to handle INSERT/UPDATE/DELETE changelog rows. Use commas for multiple columns, for example `id,name`.                                                                                                                                                                         |
 | support_upsert                        | Boolean | No       | false   | Whether to query by `primary_key` before writing and perform upsert-style writes.                                                                                                                                                                                                                           |
 | allow_experimental_lightweight_delete | Boolean | No       | false   | Allows DELETE changelog rows to use ClickHouse lightweight delete on `*MergeTree` table engines.                                                                                                                                                                                                            |
-| schema_save_mode               | Enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST | Schema save mode. Please refer to the `schema_save_mode` section below.                                                                                       |
-| data_save_mode                 | Enum    | no       | APPEND_DATA                  | Data save mode. Please refer to the `data_save_mode` section below.                                                                                         |
-| custom_sql                  | String  | no       | -                            | When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL parameter. This parameter usually fills in a SQL that can be executed. SQL will be executed before synchronization tasks.        |
-| save_mode_create_template      | string  | no       | see below                    | See below.                                                                                                                                                  |
+| schema_save_mode                     | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Schema save mode. Please refer to the `schema_save_mode` section below.                                                                                                                                                                                                                  |
+| data_save_mode                       | Enum    | No       | APPEND_DATA                  | Data save mode. Please refer to the `data_save_mode` section below.                                                                                                                                                                                                                      |
+| custom_sql                           | String  | No       | -                            | Required when `data_save_mode = CUSTOM_PROCESSING`. The SQL is executed before the synchronization task starts.                                                                                                                                                                           |
+| save_mode_create_template            | String  | No       | see below                    | Template used to create the ClickHouse table when schema save mode creates a table.                                                                                                                                                                                                      |
 | common-options                        |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                                                                                                                                |
 
 ### schema_save_mode [Enum]
@@ -214,6 +214,9 @@ sink {
 ```
 
 ### CDC(Change data capture) Sink
+
+For changelog rows, configure `primary_key` so the connector can map `UPDATE` and `DELETE` rows to target rows.
+Configure `support_upsert=true` when the sink should query by primary key before writing.
 
 ```hocon
 sink {

--- a/docs/en/connectors/sink/Prometheus.md
+++ b/docs/en/connectors/sink/Prometheus.md
@@ -39,7 +39,7 @@ downloaded from Maven Central.
 
 | Datasource | Supported Versions | Dependency |
 |------------|--------------------|------------|
-| Prometheus | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/seatunnel-connectors-v2/connector-prometheus) |
+| Prometheus | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-prometheus) |
 
 ## Sink Options
 

--- a/docs/en/connectors/sink/Redis.md
+++ b/docs/en/connectors/sink/Redis.md
@@ -12,12 +12,27 @@ Redis Cluster, and can write to `key`/`string`, `hash`, `list`, `set`, and `zset
 The configured `key` can be either a literal Redis key or an upstream field name. When `support_custom_key = true`,
 the connector can build the Redis key from one or more upstream fields, for example `user:${id}`.
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+To use the Redis connector, the following dependency is required. It can be installed by `install-plugin.sh` or
+downloaded from Maven Central.
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| Redis      | 5.x, 7.x           | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## Options
 
@@ -77,6 +92,9 @@ row as the hash value.
 ### multi_table_sink_replica
 
 Replica count for multi-table sink writers. It applies when upstream rows carry table identifiers and the job writes multiple Redis tables in one pipeline.
+
+For multi-table jobs, `key` may include `${table_name}` so rows from different upstream tables are written to separate
+Redis keys, for example `key = "redis-result-${table_name}"`.
 
 ## Examples
 

--- a/docs/en/connectors/sink/Redis.md
+++ b/docs/en/connectors/sink/Redis.md
@@ -30,9 +30,9 @@ the connector can build the Redis key from one or more upstream fields, for exam
 To use the Redis connector, the following dependency is required. It can be installed by `install-plugin.sh` or
 downloaded from Maven Central.
 
-| Datasource | Supported Versions | Dependency |
-|------------|--------------------|------------|
-| Redis      | 5.x, 7.x           | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
+| Datasource | Dependency |
+|------------|------------|
+| Redis      | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## Options
 

--- a/docs/en/connectors/source/Prometheus.md
+++ b/docs/en/connectors/source/Prometheus.md
@@ -13,11 +13,26 @@ Configure `url` as the server base address, such as `http://prometheus:9090` or 
 SeaTunnel automatically uses the Prometheus query endpoint for `Instant` queries and the query range endpoint for
 `Range` queries.
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+To use the Prometheus connector, the following dependency is required. It can be installed by `install-plugin.sh` or
+downloaded from Maven Central.
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| Prometheus | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-prometheus) |
 
 ## Source Options
 

--- a/docs/en/connectors/source/Redis.md
+++ b/docs/en/connectors/source/Redis.md
@@ -8,7 +8,13 @@ import ChangeLog from '../changelog/connector-redis.md';
 
 Used to read data from Redis.
 
-## Key features
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
@@ -17,6 +23,15 @@ Used to read data from Redis.
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+To use the Redis connector, the following dependency is required. It can be installed by `install-plugin.sh` or
+downloaded from Maven Central.
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| Redis      | 5.x, 7.x           | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## Options
 
@@ -31,6 +46,9 @@ Used to read data from Redis.
 | nodes          | list   | yes when mode=cluster   | -             | Redis cluster nodes in format `["host1:port1", "host2:port2"]` |
 | tables_configs | list   | no                      | -             | List of table configurations for multi-table reading |
 | common-options |        | no                      | -             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details |
+
+Use `keys` and `data_type` for a single key pattern. Use `tables_configs` for multiple key patterns; `keys` and
+`tables_configs` cannot be configured at the same time.
 
 ### Table list configuration
 
@@ -448,6 +466,7 @@ source {
         format = JSON
         batch_size = 10
         schema {
+          table = "user_table"
           fields {
             id = int
             name = string
@@ -463,6 +482,7 @@ source {
         read_key_enabled = true
         key_field_name = "session_id"
         schema {
+          table = "session_table"
           fields {
             session_id = string
             user_id = int
@@ -476,17 +496,29 @@ source {
         data_type = LIST
         format = TEXT
         field_delimiter = "|"
+        schema {
+          table = "task_table"
+          fields {
+            content = string
+          }
+        }
       }
     ]
   }
 }
 
 sink {
-  Console {
-    parallelism = 1
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "redis-result-${table_name}"
+    data_type = LIST
   }
 }
 ```
+
+In multi-table mode, the table name comes from `schema.table`. Downstream sinks can use `${table_name}` to route
+different Redis key patterns to different target tables or keys.
 
 **Example 2: Cluster mode with multiple tables**
 

--- a/docs/en/connectors/source/Redis.md
+++ b/docs/en/connectors/source/Redis.md
@@ -29,9 +29,9 @@ Used to read data from Redis.
 To use the Redis connector, the following dependency is required. It can be installed by `install-plugin.sh` or
 downloaded from Maven Central.
 
-| Datasource | Supported Versions | Dependency |
-|------------|--------------------|------------|
-| Redis      | 5.x, 7.x           | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
+| Datasource | Dependency |
+|------------|------------|
+| Redis      | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## Options
 

--- a/docs/zh/connectors/sink/Clickhouse.md
+++ b/docs/zh/connectors/sink/Clickhouse.md
@@ -15,7 +15,7 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 - [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
 
-> Clickhouse sink 插件通过实现幂等写入可以达到精准一次，需要配合 aggregating merge tree 支持重复数据删除的引擎。
+> 当目标表引擎支持去重时，例如 `AggregatingMergeTree` 或 `ReplacingMergeTree`，Clickhouse Sink 可以通过幂等写入减少重复数据影响。这里未标记为精准一次，因为实际保证取决于目标表设计。
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
@@ -51,23 +51,23 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 
 |                  名称                   |   类型    | 是否必须 |  默认值  |                                                                                        描述                                                                                        |
 |---------------------------------------|---------|------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| host                                  | String  | Yes  | -     | `ClickHouse` 集群地址, 格式是`host:port` , 允许多个`hosts`配置. 例如 `"host1:8123,host2:8123"`.                                                                                                 |
-| database                              | String  | Yes  | -     | `ClickHouse` 数据库名称.                                                                                                                                                              |
-| table                                 | String  | Yes  | -     | 表名称.                                                                                                                                                                             |
-| username                              | String  | Yes  | -     | `ClickHouse` 用户账号.                                                                                                                                                               |
-| password                              | String  | Yes  | -     | `ClickHouse` 用户密码.                                                                                                                                                               |
-| clickhouse.config                     | Map     | No   |       | 除了上述必须由 `clickhouse-jdbc` 指定的必填参数外，用户还可以指定多个可选参数，这些参数涵盖了 `clickhouse-jdbc` 提供的所有[参数](https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-client#configuration). |
-| bulk_size                             | int     | No   | 20000 | 每次通过[Clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-jdbc) 写入的行数，即默认是20000.                                                                                            |
-| split_mode                            | Boolean | No   | false | 仅当目标 ClickHouse 表使用 `Distributed` 引擎且 `internal_replication` 为 `true` 时生效。SeaTunnel 会拆分分布式表写入，并直接写入各个分片。 |
-| sharding_key                          | String  | No   | -     | `split_mode=true` 时用于分片算法的字段。不配置时会随机选择目标分片。 |
-| primary_key                           | String  | No   | -     | 用于处理 INSERT/UPDATE/DELETE 变更数据的主键列。多列用英文逗号分隔，例如 `id,name`。 |
-| support_upsert                        | Boolean | No   | false | 是否按 `primary_key` 查询后再写入，从而实现类似 upsert 的写入效果。 |
-| allow_experimental_lightweight_delete | Boolean | No   | false | 允许 DELETE 变更数据在 `*MergeTree` 表引擎上使用 ClickHouse lightweight delete。 |
-| schema_save_mode               | Enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST | schema保存模式，请参考下面的`schema_save_mode`                                                                                                                    |
-| data_save_mode                 | Enum    | no       | APPEND_DATA                  | 数据保存模式，请参考下面的`data_save_mode`。                                                                                                                         |
-| custom_sql                  | String  | no   | -                            | 当data_save_mode设置为CUSTOM_PROCESSING时，必须同时设置CUSTOM_SQL参数。CUSTOM_SQL的值为可执行的SQL语句，在同步任务开启前SQL将会被执行                     |
-| save_mode_create_template      | string  | no       | see below                    | 见下文。                                                                                                                                                   |
-| common-options                        |         | No   | -     | Sink插件查用参数,详见[Sink常用选项](../common-options/sink-common-options.md).                                                                                                                              |
+| host                                  | String  | 是   | -     | `ClickHouse` 集群地址，格式为 `host:port`，支持配置多个 host，例如 `"host1:8123,host2:8123"`。 |
+| database                              | String  | 是   | -     | `ClickHouse` 数据库名称。 |
+| table                                 | String  | 是   | -     | 表名称。 |
+| username                              | String  | 是   | -     | `ClickHouse` 用户账号。 |
+| password                              | String  | 是   | -     | `ClickHouse` 用户密码。 |
+| clickhouse.config                     | Map     | 否   | -     | 除了上述必填参数外，还可以指定 `clickhouse-jdbc` 支持的其他[参数](https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-client#configuration)。 |
+| bulk_size                             | int     | 否   | 20000 | 每次通过 [Clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-jdbc) 写入的行数。 |
+| split_mode                            | Boolean | 否   | false | 仅当目标 ClickHouse 表使用 `Distributed` 引擎且 `internal_replication` 为 `true` 时生效。SeaTunnel 会拆分分布式表写入，并直接写入各个分片。 |
+| sharding_key                          | String  | 否   | -     | `split_mode=true` 时用于分片算法的字段。不配置时会随机选择目标分片。 |
+| primary_key                           | String  | 否   | -     | 用于处理 INSERT/UPDATE/DELETE 变更数据的主键列。多列用英文逗号分隔，例如 `id,name`。 |
+| support_upsert                        | Boolean | 否   | false | 是否按 `primary_key` 查询后再写入，从而实现类似 upsert 的写入效果。 |
+| allow_experimental_lightweight_delete | Boolean | 否   | false | 允许 DELETE 变更数据在 `*MergeTree` 表引擎上使用 ClickHouse lightweight delete。 |
+| schema_save_mode                      | Enum    | 否   | CREATE_SCHEMA_WHEN_NOT_EXIST | 表结构保存模式，请参考下面的 `schema_save_mode`。 |
+| data_save_mode                        | Enum    | 否   | APPEND_DATA | 数据保存模式，请参考下面的 `data_save_mode`。 |
+| custom_sql                            | String  | 否   | -     | 当 `data_save_mode = CUSTOM_PROCESSING` 时必填。该 SQL 会在同步任务开始前执行。 |
+| save_mode_create_template             | String  | 否   | 见下文 | 当表结构保存模式需要创建表时使用的建表模板。 |
+| common-options                        |         | 否   | -     | Sink 插件通用参数，详见 [Sink 常用选项](../common-options/sink-common-options.md)。 |
 
 ### schema_save_mode [Enum]
 
@@ -215,6 +215,8 @@ sink {
 ```
 
 ### CDC(Change data capture) Sink
+
+处理变更数据时，需要配置 `primary_key`，这样连接器才能把 `UPDATE` 和 `DELETE` 数据对应到目标行。需要写入前按主键查询时，再配置 `support_upsert=true`。
 
 ```hocon
 sink {

--- a/docs/zh/connectors/sink/Prometheus.md
+++ b/docs/zh/connectors/sink/Prometheus.md
@@ -36,7 +36,7 @@ Prometheus 数据接收器把上游数据写入 Prometheus remote write API。�
 
 | 数据源     | 支持版本  | 依赖 |
 |------------|-----------|------|
-| Prometheus | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/seatunnel-connectors-v2/connector-prometheus) |
+| Prometheus | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-prometheus) |
 
 ## 接收器选项
 

--- a/docs/zh/connectors/sink/Redis.md
+++ b/docs/zh/connectors/sink/Redis.md
@@ -12,12 +12,26 @@ Redis 接收器连接器可以在批处理或流处理作业中把上游数据�
 `key` 可以是固定的 Redis key，也可以是上游字段名。开启 `support_custom_key = true` 后，还可以用上游字段
 拼出 Redis key，例如 `user:${id}`。
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+## 支持的数据源信息
+
+使用 Redis 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
+
+| 数据源 | 支持版本 | 依赖 |
+|--------|----------|------|
+| Redis  | 5.x、7.x | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## 选项
 
@@ -75,6 +89,9 @@ Redis 接收器连接器可以在批处理或流处理作业中把上游数据�
 ### multi_table_sink_replica
 
 多表写入时的写入器副本数。当上游数据带有表标识，并且一个作业需要写入多张 Redis 表时使用。
+
+多表作业中，`key` 可以包含 `${table_name}`，这样不同上游表的数据会写入不同 Redis key，例如
+`key = "redis-result-${table_name}"`。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/Redis.md
+++ b/docs/zh/connectors/sink/Redis.md
@@ -29,9 +29,9 @@ Redis 接收器连接器可以在批处理或流处理作业中把上游数据�
 
 使用 Redis 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
 
-| 数据源 | 支持版本 | 依赖 |
-|--------|----------|------|
-| Redis  | 5.x、7.x | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
+| 数据源 | 依赖 |
+|--------|------|
+| Redis  | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## 选项
 

--- a/docs/zh/connectors/source/Prometheus.md
+++ b/docs/zh/connectors/source/Prometheus.md
@@ -11,11 +11,25 @@ Prometheus 数据源连接器通过 Prometheus 兼容 HTTP API 读取指标查�
 `url` 只需要填写服务基础地址，例如 `http://prometheus:9090` 或 `http://victoria-metrics:8428`。SeaTunnel 会根据
 `query_type` 自动使用即时查询接口或范围查询接口。
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行处理](../../introduction/concepts/connector-v2-features.md)
+
+## 支持的数据源信息
+
+使用 Prometheus 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
+
+| 数据源     | 支持版本  | 依赖 |
+|------------|-----------|------|
+| Prometheus | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-prometheus) |
 
 ## 源选项
 

--- a/docs/zh/connectors/source/Redis.md
+++ b/docs/zh/connectors/source/Redis.md
@@ -28,9 +28,9 @@ import ChangeLog from '../changelog/connector-redis.md';
 
 使用 Redis 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
 
-| 数据源 | 支持版本 | 依赖 |
-|--------|----------|------|
-| Redis  | 5.x、7.x | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
+| 数据源 | 依赖 |
+|--------|------|
+| Redis  | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## 配置选项
 

--- a/docs/zh/connectors/source/Redis.md
+++ b/docs/zh/connectors/source/Redis.md
@@ -8,6 +8,12 @@ import ChangeLog from '../changelog/connector-redis.md';
 
 用于从 `Redis` 读取数据
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 主要功能
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
@@ -17,6 +23,14 @@ import ChangeLog from '../changelog/connector-redis.md';
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
+
+## 支持的数据源信息
+
+使用 Redis 连接器时，需要安装以下依赖。可以通过 `install-plugin.sh` 安装，也可以从 Maven 中央仓库下载。
+
+| 数据源 | 支持版本 | 依赖 |
+|--------|----------|------|
+| Redis  | 5.x、7.x | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-redis) |
 
 ## 配置选项
 
@@ -31,6 +45,9 @@ import ChangeLog from '../changelog/connector-redis.md';
 | nodes          | list   | `mode=cluster` 时必须 | -     | Redis 集群节点，格式为 `["host1:port1", "host2:port2"]` |
 | tables_configs | list   | 否                  | -     | 多表读取时的表配置列表 |
 | common-options |        | 否                  | -     | 源连接器插件通用参数，详情请参见 [Source Common Options](../common-options/source-common-options.md) |
+
+读取单个 key pattern 时使用 `keys` 和 `data_type`。读取多个 key pattern 时使用 `tables_configs`；`keys` 和
+`tables_configs` 不能同时配置。
 
 ### 表级配置参数
 
@@ -424,6 +441,7 @@ source {
         format = JSON
         batch_size = 50
         schema {
+          table = "user_table"
           fields {
             id = int
             name = string
@@ -439,6 +457,7 @@ source {
         read_key_enabled = true
         key_field_name = "session_id"
         schema {
+          table = "session_table"
           fields {
             session_id = string
             user_id = int
@@ -452,17 +471,28 @@ source {
         data_type = LIST
         format = TEXT
         field_delimiter = "|"
+        schema {
+          table = "task_table"
+          fields {
+            content = string
+          }
+        }
       }
     ]
   }
 }
 
 sink {
-  Console {
-    parallelism = 1
+  Redis {
+    host = "localhost"
+    port = 6379
+    key = "redis-result-${table_name}"
+    data_type = LIST
   }
 }
 ```
+
+多表模式下，表名来自 `schema.table`。下游 Sink 可以使用 `${table_name}`，把不同 Redis key pattern 的数据路由到不同目标表或 key。
 
 **示例 2：集群模式下的多表配置**
 


### PR DESCRIPTION
## Summary

- Improve ClickHouse sink documentation for CDC, upsert, save-mode options, and Chinese option wording.
- Add Redis source/sink engine support, dependency information, and clearer multi-table routing examples.
- Add Prometheus source dependency information and fix Prometheus sink Maven artifact links.

## Validation

- Checked open PRs for overlapping ClickHouse, Redis, and Prometheus documentation work before creating this PR.
- Ran `./mvnw spotless:apply`.
- Ran `./mvnw -q -DskipTests verify`.
