### PR TITLE
[Docs][Connector-V2] Improve ActiveMQ Sls and Typesense docs

### DIFF
--- a/docs/en/connectors/sink/Activemq.md
+++ b/docs/en/connectors/sink/Activemq.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-activemq.md';
 
 ## Description
 
-Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text message.
+Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text message. This is
+a sink-only connector; SeaTunnel does not provide an ActiveMQ source connector.
 
 ## Key features
 
@@ -37,6 +38,7 @@ Write SeaTunnel rows to an ActiveMQ queue. Each row is serialized as a JSON text
 - `username` and `password` are optional, but they must be configured together when the broker requires authentication.
 - The connector writes each SeaTunnel row as one JSON text message to `queue_name`. There is no separate `format` option for this sink.
 - Configure the broker address with `uri`. `host` and `port` are not ActiveMQ sink options.
+- Use any SeaTunnel source before this sink. The ActiveMQ connector only controls how the final rows are sent to the queue.
 
 ## Example
 

--- a/docs/en/connectors/sink/Sls.md
+++ b/docs/en/connectors/sink/Sls.md
@@ -41,7 +41,6 @@ Maven central repository.
 | access_key_secret | String | Yes      | -                  | Alibaba Cloud AccessKey secret.                                                                         |
 | source            | String | No       | `SeaTunnel-Source` | Source tag written to SLS log groups.                                                                   |
 | topic             | String | No       | `SeaTunnel-Topic`  | Topic tag written to SLS log groups.                                                                    |
-| log_group_size    | Int    | No       | 100                | Configured SLS log group write size. The current writer sends one SeaTunnel row in each write request.  |
 
 ## Notes
 
@@ -86,7 +85,6 @@ sink {
     access_key_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     source = "seatunnel-demo"
     topic = "fake-source"
-    log_group_size = 100
   }
 }
 ```

--- a/docs/en/connectors/sink/Typesense.md
+++ b/docs/en/connectors/sink/Typesense.md
@@ -17,18 +17,19 @@ or more primary key fields.
 
 ## Options
 
-|       Name       |  Type  | Required |        Default Value         |
-|------------------|--------|----------|------------------------------|
-| hosts            | array  | Yes      | -                            |
-| collection       | string | Yes      | -                            |
-| schema_save_mode | string | Yes      | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode   | string | Yes      | APPEND_DATA                  |
-| primary_keys     | array  | No       |                              |
-| key_delimiter    | string | No       | `_`                          |
-| api_key          | string | Yes      | -                            |
-| max_retry_count  | int    | No       | 3                            |
-| max_batch_size   | int    | No       | 10                           |
-| common-options   |        | No       | -                            |
+| Name                     | Type   | Required | Default                      | Description                                                                                          |
+|--------------------------|--------|----------|------------------------------|------------------------------------------------------------------------------------------------------|
+| hosts                    | array  | Yes      | -                            | Typesense node addresses in `host:port` format. Multiple hosts are supported.                        |
+| collection               | string | Yes      | -                            | Target collection name.                                                                              |
+| schema_save_mode         | string | Yes      | CREATE_SCHEMA_WHEN_NOT_EXIST | How to handle the target collection schema before writing.                                           |
+| data_save_mode           | string | Yes      | APPEND_DATA                  | How to handle existing documents before writing.                                                     |
+| primary_keys             | array  | No       | -                            | Source fields used to build the Typesense document `id`.                                             |
+| key_delimiter            | string | No       | `_`                          | Delimiter used when `primary_keys` contains more than one field.                                     |
+| api_key                  | string | Yes      | -                            | Typesense API key.                                                                                   |
+| max_retry_count          | int    | No       | 3                            | Maximum retry count for one bulk request.                                                            |
+| max_batch_size           | int    | No       | 10                           | Maximum number of documents sent in one bulk request.                                                |
+| multi_table_sink_replica | int    | No       | -                            | Number of sink replicas used by the common multi-table sink routing mechanism.                       |
+| common-options           |        | No       | -                            | Common sink options.                                                                                 |
 
 ### hosts [array]
 
@@ -59,6 +60,11 @@ The maximum number of retry attempts for one batch request.
 
 The maximum number of documents sent in one batch.
 
+### multi_table_sink_replica [int]
+
+Common multi-table sink option. Configure it when a multi-table job needs more sink replicas for
+the Typesense writer.
+
 ### common options
 
 Common parameters for Sink plugins. Refer to [Common Sink Options](../common-options/sink-common-options.md) for more details.
@@ -69,6 +75,9 @@ Choose how to handle the target-side schema before starting the synchronization 
 - `RECREATE_SCHEMA`: Creates the table if it doesn’t exist, and deletes and recreates it if it does.
 - `CREATE_SCHEMA_WHEN_NOT_EXIST`: Creates the table if it doesn’t exist, skips creation if it does.
 - `ERROR_WHEN_SCHEMA_NOT_EXIST`: Throws an error if the table doesn’t exist.
+
+Typesense collection creation uses the upstream SeaTunnel schema. Configure `primary_keys` when the
+generated document `id` must be stable across repeated writes.
 
 ### data_save_mode
 

--- a/docs/zh/connectors/sink/Activemq.md
+++ b/docs/zh/connectors/sink/Activemq.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-activemq.md';
 
 ## 描述
 
-用于把 SeaTunnel 数据写入 ActiveMQ 队列。每一行数据都会被序列化成一条 JSON 文本消息。
+用于把 SeaTunnel 数据写入 ActiveMQ 队列。每一行数据都会被序列化成一条 JSON 文本消息。这个连接器只支持
+Sink，SeaTunnel 目前没有提供 ActiveMQ Source 连接器。
 
 ## 关键特性
 
@@ -37,6 +38,7 @@ import ChangeLog from '../changelog/connector-activemq.md';
 - `username` 和 `password` 是可选项；如果 Broker 需要认证，这两个配置要一起写。
 - 连接器会把每一行 SeaTunnel 数据作为一条 JSON 文本消息写入 `queue_name`，当前没有单独的 `format` 配置。
 - Broker 地址请使用 `uri` 配置，`host` 和 `port` 不是 ActiveMQ Sink 的配置项。
+- 该 Sink 前面可以接任意 SeaTunnel Source。ActiveMQ 连接器只负责把最终的数据行发送到队列。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/Sls.md
+++ b/docs/zh/connectors/sink/Sls.md
@@ -40,7 +40,6 @@ JSON，然后作为 SLS 日志项写入，日志内容的 key 为 `content`。
 | access_key_secret | String | 是       | -                  | 阿里云 AccessKey Secret。                                                                              |
 | source            | String | 否       | `SeaTunnel-Source` | 写入 SLS log group 的 source 标记。                                                                    |
 | topic             | String | 否       | `SeaTunnel-Topic`  | 写入 SLS log group 的 topic 标记。                                                                     |
-| log_group_size    | Int    | 否       | 100                | 配置的 SLS log group 写入大小。当前 writer 每次写入请求会发送一条 SeaTunnel 数据。                     |
 
 ## 注意事项
 
@@ -85,7 +84,6 @@ sink {
     access_key_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     source = "seatunnel-demo"
     topic = "fake-source"
-    log_group_size = 100
   }
 }
 ```

--- a/docs/zh/connectors/sink/Typesense.md
+++ b/docs/zh/connectors/sink/Typesense.md
@@ -10,24 +10,25 @@ import ChangeLog from '../changelog/connector-typesense.md';
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [CDC](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|        名称        |   类型   | 是否必须 |             默认值              |
-|------------------|--------|------|------------------------------|
-| hosts            | array  | 是    | -                            |
-| collection       | string | 是    | -                            |
-| schema_save_mode | string | 是    | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode   | string | 是    | APPEND_DATA                  |
-| primary_keys     | array  | 否    |                              |
-| key_delimiter    | string | 否    | `_`                          |
-| api_key          | string | 是    | -                            |
-| max_retry_count  | int    | 否    | 3                            |
-| max_batch_size   | int    | 否    | 10                           |
-| common-options   |        | 否    | -                            |
+| 名称                       | 类型     | 是否必须 | 默认值                          | 描述                                                |
+|--------------------------|--------|------|------------------------------|---------------------------------------------------|
+| hosts                    | array  | 是    | -                            | Typesense 节点地址，格式为 `host:port`，支持配置多个地址。        |
+| collection               | string | 是    | -                            | 目标 collection 名。                                 |
+| schema_save_mode         | string | 是    | CREATE_SCHEMA_WHEN_NOT_EXIST | 写入前如何处理目标 collection 结构。                         |
+| data_save_mode           | string | 是    | APPEND_DATA                  | 写入前如何处理目标 collection 中已有文档。                      |
+| primary_keys             | array  | 否    | -                            | 用于生成 Typesense 文档 `id` 的源字段。                     |
+| key_delimiter            | string | 否    | `_`                          | `primary_keys` 配置多个字段时使用的拼接分隔符。                  |
+| api_key                  | string | 是    | -                            | Typesense API Key。                                 |
+| max_retry_count          | int    | 否    | 3                            | 单个批量请求的最大重试次数。                                  |
+| max_batch_size           | int    | 否    | 10                           | 单个批量请求最多写入的文档数量。                                |
+| multi_table_sink_replica | int    | 否    | -                            | 通用多表写入路由机制使用的 Sink 副本数。                         |
+| common-options           |        | 否    | -                            | 通用 Sink 选项。                                      |
 
 ### hosts [array]
 
@@ -57,6 +58,10 @@ Typesense 安全认证的 `api_key`。
 
 每批最多写入的文档数量。
 
+### multi_table_sink_replica [int]
+
+通用多表写入选项。当多表任务需要为 Typesense 写入端配置更多 Sink 副本时使用。
+
 ### common options
 
 Sink 插件常用参数，请参考 [Sink 常用选项](../common-options/sink-common-options.md) 了解详情。
@@ -68,6 +73,9 @@ Sink 插件常用参数，请参考 [Sink 常用选项](../common-options/sink-c
 `RECREATE_SCHEMA` ：当表不存在时会创建，当表已存在时会删除并重建<br/>
 `CREATE_SCHEMA_WHEN_NOT_EXIST` ：当表不存在时会创建，当表已存在时则跳过创建<br/>
 `ERROR_WHEN_SCHEMA_NOT_EXIST` ：当表不存在时将抛出错误<br/>
+
+Typesense collection 创建时会使用上游 SeaTunnel 表结构。如果希望重复写入时文档 `id` 保持稳定，
+请配置 `primary_keys`。
 
 ### data_save_mode
 


### PR DESCRIPTION
## Summary
- Clarify that the ActiveMQ connector is sink-only and can consume rows from any upstream SeaTunnel source.
- Align the SLS sink documentation with the exposed sink option surface by removing the unsupported `log_group_size` setting from EN/ZH docs and examples.
- Expand the Typesense sink option table in EN/ZH docs, including `multi_table_sink_replica`, clearer option descriptions, and Chinese feature wording.

## Verification
- `./mvnw spotless:apply -DskipTests`
- `./mvnw -q -DskipTests -Dskip.spotless=true -pl seatunnel-connectors-v2/connector-activemq,seatunnel-connectors-v2/connector-sls,seatunnel-connectors-v2/connector-typesense -am verify`

Note: a full `./mvnw -q -DskipTests -Dskip.spotless=true verify` run was started but manually interrupted after it stayed running for several minutes after exporting connector metadata.