### PR TITLE
[Docs][Connector-V2] Improve Maxcompute IoTDB and Fluss docs

### DIFF
--- a/docs/en/connectors/sink/Fluss.md
+++ b/docs/en/connectors/sink/Fluss.md
@@ -25,6 +25,8 @@ The connector opens an upsert writer when the target Fluss table has a primary k
 
 The Fluss database and table must already exist before the job starts. The sink does not create Fluss databases or tables.
 
+The target table schema should match the upstream SeaTunnel row schema by field order and compatible type. The sink writes values by position.
+
 ## Dependency
 
 ```xml
@@ -197,6 +199,8 @@ sink {
 ```
 
 The sink resolves the target table separately for each upstream table. Before running the job, create the matching Fluss databases and tables.
+
+In multi-table mode, the target `database` and `table` values can combine fixed text with placeholders. For example, `database = "fluss_db_${database_name}"` and `table = "fluss_tb_${table_name}"` route upstream table `test2.table1` to `fluss_db_test2.fluss_tb_table1`.
 
 ## Changelog
 

--- a/docs/en/connectors/sink/Maxcompute.md
+++ b/docs/en/connectors/sink/Maxcompute.md
@@ -11,6 +11,9 @@ Used to write data to Maxcompute.
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
@@ -32,6 +35,7 @@ Used to write data to Maxcompute.
 | datetime_format           | string  | no       | yyyy-MM-dd HH:mm:ss |
 | tunnel_endpoint           | string  | no       | -             |
 | insert_strategy           | string  | no       | upload        |
+| multi_table_sink_replica  | int     | no       | 1             |
 | common-options            | string  | no       |               |
 
 ### accessId [string]
@@ -184,6 +188,14 @@ If set to `upsert`, insert operations use an upsert session. Upsert sessions req
 Using upload sessions for insert operations alongside update or delete operations may cause insert records to appear in the table later than expected.
 When a primary key is present, it is recommended to set `insert_strategy` to `upsert` to ensure consistent upsert behavior.
 
+`UPDATE_AFTER` and `DELETE` rows are always written through a MaxCompute upsert session, so the target table must have a primary key when the job contains update or delete rows. `UPDATE_BEFORE` rows are not supported by this sink.
+
+### multi_table_sink_replica [int]
+
+The number of writer replicas in multi-table sink mode. The default value is `1`.
+
+Use this option when upstream data contains multiple table identifiers and `table_name` uses placeholders such as `${table_name}`. For example, `table_name = "${table_name}_sink"` writes upstream table `test_table` to target table `test_table_sink`.
+
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
@@ -202,6 +214,65 @@ sink {
     table_name="<your table name>"
     #partition_spec="<your partition spec>"
     #overwrite = false
+  }
+}
+```
+
+### Multiple Tables
+
+```hocon
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        schema = {
+          table = "test_table"
+          fields {
+            ID = int
+            NAME = string
+            AGE = int
+          }
+          primaryKey {
+            name = "ID"
+            columnNames = [ID]
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "INSERT_TEST1", 20] }
+          { kind = INSERT, fields = [2, "INSERT_TEST2", 30] }
+        ]
+      },
+      {
+        schema = {
+          table = "test_table_2"
+          fields {
+            ID = int
+            NAME = string
+            AGE = int
+          }
+          primaryKey {
+            name = "ID"
+            columnNames = [ID]
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "INSERT_TEST1", 20] }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  Maxcompute {
+    accessId = "ak"
+    accesskey = "sk"
+    endpoint = "http://maxcompute:8080"
+    tunnel_endpoint = "http://maxcompute:8080"
+    project = "mocked_mc"
+    table_name = "${table_name}_sink"
+    insert_strategy = "upsert"
+    multi_table_sink_replica = 1
   }
 }
 ```

--- a/docs/en/connectors/source/IoTDB.md
+++ b/docs/en/connectors/source/IoTDB.md
@@ -14,11 +14,13 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 
 Used to read data from IoTDB.
 
+The current source runs a bounded SQL query. It is suitable for batch reads and does not continuously tail new IoTDB data in streaming mode.
+
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [x] [stream](../../introduction/concepts/connector-v2-features.md)
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
   > IoTDB allows column projection using SQL query.
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
@@ -86,7 +88,7 @@ the lower bound of the time range
 ```
      split the time range into numPartitions parts
      if numPartitions = 1, the whole time range will be used
-     if numPartitions < (upper_bound - lower_bound), will use (upper_bound - lower_bound) as numPartitions
+     if (upper_bound - lower_bound) < numPartitions, will use (upper_bound - lower_bound) as numPartitions
      
      eg: lower_bound = 1, upper_bound = 10, numPartitions = 2
      sql = "select * from test where age > 0 and age < 10"

--- a/docs/en/connectors/source/Maxcompute.md
+++ b/docs/en/connectors/source/Maxcompute.md
@@ -25,7 +25,7 @@ Used to read data from Maxcompute.
 | sts_token      | string | no       | -             |
 | endpoint       | string | yes      | -             |
 | project        | string | yes      | -             |
-| table_name     | string | yes      | -             |
+| table_name     | string | yes when `table_list` is not set | -             |
 | schema_name    | string | no       | -             |
 | partition_spec | string | no       | -             |
 | split_row      | int    | no       | 10000         |
@@ -60,7 +60,9 @@ Used to read data from Maxcompute.
 
 ### table_name [string]
 
-`table_name` Target Maxcompute table name eg: fake.
+`table_name` Target Maxcompute table name, for example `fake`.
+
+`table_name` and `table_list` are mutually exclusive. Use `table_name` for one table and `table_list` for multiple tables.
 
 ### partition_spec [string]
 
@@ -87,6 +89,10 @@ Default: not set (uses the project default schema).
 ### table_list [Array]
 
 The list of tables to be read, you can use this configuration instead of `table_name`.
+
+Each table item must contain `table_name`. It can also override `project`, `schema_name`, `partition_spec`, `split_row`, and `read_columns`. If an item does not set those values, the connector uses the top-level value.
+
+This mode is useful when one job needs to read several MaxCompute tables with the same account, endpoint, and default project.
 
 ### tunnel_endpoint [String]
 Specifies the custom endpoint URL for the MaxCompute Tunnel service.

--- a/docs/zh/connectors/sink/Fluss.md
+++ b/docs/zh/connectors/sink/Fluss.md
@@ -25,6 +25,8 @@ Fluss Sink 用于在批处理或流处理作业中，将 SeaTunnel 数据写入�
 
 运行作业前，目标 Fluss database 和 table 必须已经存在。当前 Sink 不会自动创建 Fluss database 或 table。
 
+目标表结构需要和上游 SeaTunnel 数据按字段顺序匹配，并且字段类型需要兼容。Sink 会按字段位置写入数据。
+
 ## 依赖
 
 ```xml
@@ -197,6 +199,8 @@ sink {
 ```
 
 多表写入时，Sink 会为每个上游表分别解析目标表名。运行作业前，需要先创建对应的 Fluss database 和 table。
+
+多表写入时，`database` 和 `table` 可以同时包含固定文本和占位符。例如 `database = "fluss_db_${database_name}"`、`table = "fluss_tb_${table_name}"` 会把上游表 `test2.table1` 写入 `fluss_db_test2.fluss_tb_table1`。
 
 ## Changelog
 

--- a/docs/zh/connectors/sink/Maxcompute.md
+++ b/docs/zh/connectors/sink/Maxcompute.md
@@ -11,6 +11,9 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持 CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
@@ -32,6 +35,7 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 | datetime_format           | string  | 否   | yyyy-MM-dd HH:mm:ss |
 | tunnel_endpoint           | string  | 否   | -      |
 | insert_strategy           | string  | 否   | upload |
+| multi_table_sink_replica  | int     | 否   | 1      |
 | common-options            | string  | 否   |        |
 
 ### accessId [string]
@@ -182,6 +186,14 @@ CREATE TABLE IF NOT EXISTS `${table}`
 在同时存在更新或删除操作的情况下，使用 upload 会话进行插入操作，可能会导致插入的记录 比预期更晚出现在表中。
 当表中存在主键时，建议将 `insert_strategy` 设置为 `upsert`，以确保一致的 upsert 行为。
 
+`UPDATE_AFTER` 和 `DELETE` 数据都会通过 MaxCompute upsert 会话写入，所以任务包含更新或删除数据时，目标表必须有主键。当前 Sink 不支持 `UPDATE_BEFORE` 数据。
+
+### multi_table_sink_replica [int]
+
+多表写入模式下的 writer 副本数，默认值为 `1`。
+
+当上游数据包含多张表，并且 `table_name` 使用 `${table_name}` 这类占位符时可以配置该参数。例如 `table_name = "${table_name}_sink"` 会把上游表 `test_table` 写入目标表 `test_table_sink`。
+
 ### 通用选项
 
 Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 详见。
@@ -200,6 +212,65 @@ sink {
     table_name="<your table name>"
     #partition_spec="<your partition spec>"
     #overwrite = false
+  }
+}
+```
+
+### 多表写入
+
+```hocon
+source {
+  FakeSource {
+    tables_configs = [
+      {
+        schema = {
+          table = "test_table"
+          fields {
+            ID = int
+            NAME = string
+            AGE = int
+          }
+          primaryKey {
+            name = "ID"
+            columnNames = [ID]
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "INSERT_TEST1", 20] }
+          { kind = INSERT, fields = [2, "INSERT_TEST2", 30] }
+        ]
+      },
+      {
+        schema = {
+          table = "test_table_2"
+          fields {
+            ID = int
+            NAME = string
+            AGE = int
+          }
+          primaryKey {
+            name = "ID"
+            columnNames = [ID]
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "INSERT_TEST1", 20] }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  Maxcompute {
+    accessId = "ak"
+    accesskey = "sk"
+    endpoint = "http://maxcompute:8080"
+    tunnel_endpoint = "http://maxcompute:8080"
+    project = "mocked_mc"
+    table_name = "${table_name}_sink"
+    insert_strategy = "upsert"
+    multi_table_sink_replica = 1
   }
 }
 ```
@@ -252,4 +323,3 @@ sink {
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/IoTDB.md
+++ b/docs/zh/connectors/source/IoTDB.md
@@ -14,11 +14,13 @@ import ChangeLog from '../changelog/connector-iotdb.md';
 
 用于从 IoTDB 中读取数据。
 
+当前 Source 执行的是有界 SQL 查询，适合批量读取；即使任务使用流模式，也不会持续监听 IoTDB 新数据。
+
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
-- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
-- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
   > IoTDB 通过 SQL 查询支持列投影功能。
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
@@ -87,7 +89,7 @@ import ChangeLog from '../changelog/connector-iotdb.md';
      将时间范围分割成 numPartitions 个分区
      
      若 numPartitions = 1，使用完整的时间范围
-     若 numPartitions < (upper_bound - lower_bound)，使用 (upper_bound - lower_bound) 个分区
+     若 (upper_bound - lower_bound) < numPartitions，使用 (upper_bound - lower_bound) 个分区
      
      例：lower_bound = 1, upper_bound = 10, numPartitions = 2
          sql = "select * from test where age > 0 and age < 10"

--- a/docs/zh/connectors/source/Maxcompute.md
+++ b/docs/zh/connectors/source/Maxcompute.md
@@ -25,7 +25,7 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 | sts_token      | string | 否  | -             |
 | endpoint       | string | 是  | -             |
 | project        | string | 是  | -             |
-| table_name     | string | 是  | -             |
+| table_name     | string | 未配置 `table_list` 时必填 | -             |
 | schema_name    | string | 否  | -             |
 | partition_spec | string | 否  | -             |
 | split_row      | int    | 否 | 10000         |
@@ -60,7 +60,9 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ### table_name [string]
 
-`table_name` 目标 Maxcompute 表名，例如：fake。
+`table_name` 目标 Maxcompute 表名，例如：`fake`。
+
+`table_name` 和 `table_list` 不能同时配置。读取单表时使用 `table_name`，读取多表时使用 `table_list`。
 
 ### partition_spec [string]
 
@@ -87,6 +89,10 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 ### table_list [Array]
 
 要读取的表列表，您可以使用此配置代替 `table_name`。
+
+每个表配置项都必须包含 `table_name`，也可以单独覆盖 `project`、`schema_name`、`partition_spec`、`split_row` 和 `read_columns`。如果表配置项没有设置这些值，连接器会使用顶层配置。
+
+当一个任务需要用同一组账号、endpoint 和默认 project 读取多张 MaxCompute 表时，可以使用该模式。
 
 ### tunnel_endpoint [String]
 


### PR DESCRIPTION
## Summary

- Improve Maxcompute source docs with clearer single-table and multi-table configuration guidance.
- Improve Maxcompute sink docs with CDC, multi-table, upsert/delete, and writer replica notes plus a multi-table example.
- Correct IoTDB source feature flags and bounded-query wording.
- Clarify Fluss sink schema matching and multi-table placeholder routing.

## Tests

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
