### PR TITLE
[Docs][Connector-V2] Improve Cassandra HBase and Kudu docs

### DIFF
--- a/docs/en/connectors/sink/Cassandra.md
+++ b/docs/en/connectors/sink/Cassandra.md
@@ -34,6 +34,7 @@ schema before starting the job.
 | batch_size        | int     | No       | 5000        | Maximum number of rows buffered before one flush. |
 | batch_type        | String  | No       | UNLOGGED    | Cassandra batch type. Supported driver values include `LOGGED`, `UNLOGGED`, and `COUNTER`. |
 | async_write       | boolean | No       | true        | Whether to execute writes asynchronously. |
+| common-options    |         | No       | -           | Sink plugin common parameters, such as `plugin_input`. |
 
 ### host [string]
 
@@ -86,6 +87,17 @@ The `Cassandra` batch processing mode, default is `UNLOGGED`.
 ### async_write [boolean]
 
 Whether `cassandra` writes in asynchronous mode, default is `true`.
+
+### common-options
+
+Sink plugin common parameters. For details, see [Sink Common Options](../common-options/sink-common-options.md).
+
+## Notes
+
+- The target keyspace and table must already exist before the job starts.
+- `fields` is useful when the upstream row has extra columns. It is not a schema creation option.
+- `async_write = true` improves throughput, while `batch_size` controls how many rows are grouped
+  before a flush.
 
 ## Examples
 

--- a/docs/en/connectors/sink/Hbase.md
+++ b/docs/en/connectors/sink/Hbase.md
@@ -18,23 +18,23 @@ how null values, row keys, WAL, timestamps, and existing data are handled.
 
 ## Options
 
-|        name        |  type   | required |  default value  |
-|--------------------|---------|----------|-----------------|
-| zookeeper_quorum   | string  | yes      | -               |
-| table              | string  | yes      | -               |
-| rowkey_column      | list    | yes      | -               |
-| family_name        | config  | yes      | -               |
-| rowkey_delimiter   | string  | no       | ""              |
-| version_column     | string  | no       | -               |
-| null_mode          | string  | no       | skip            |
-| wal_write          | boolean | no       | false           |
-| write_buffer_size  | int     | no       | 8 * 1024 * 1024 |
-| encoding           | string  | no       | utf8            |
-| schema_save_mode   | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode     | enum    | no       | APPEND_DATA     |
-| hbase_extra_config | config  | no       | -               |
-| multi_table_sink_replica | int | no     | 1               |
-| common-options     |         | no       | -               |
+| Name                     | Type    | Required | Default                      | Description |
+|--------------------------|---------|----------|------------------------------|-------------|
+| zookeeper_quorum         | string  | yes      | -                            | HBase ZooKeeper quorum, for example `hadoop001:2181,hadoop002:2181`. |
+| table                    | string  | yes      | -                            | Target HBase table. Use placeholders such as `${table_name}` for multi-table writes. |
+| rowkey_column            | list    | yes      | -                            | Upstream field names used to build the HBase row key. |
+| family_name              | config  | yes      | -                            | Mapping from upstream fields to HBase column families, or `all_columns` for one family. |
+| rowkey_delimiter         | string  | no       | ""                           | Delimiter used when multiple fields form the row key. |
+| version_column           | string  | no       | -                            | Upstream field used as the HBase cell timestamp. |
+| null_mode                | string  | no       | skip                         | How null values are written. Supported values are `skip` and `empty`. |
+| wal_write                | boolean | no       | false                        | Whether writes should be recorded in the HBase WAL. |
+| write_buffer_size        | int     | no       | 8 * 1024 * 1024              | HBase client write buffer size in bytes. |
+| encoding                 | string  | no       | utf8                         | Encoding for STRING/DECIMAL/DATE/TIME/TIMESTAMP/ARRAY values. Supported values are `utf8` and `gbk`. |
+| schema_save_mode         | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST | How to handle the target table before writing. |
+| data_save_mode           | enum    | no       | APPEND_DATA                  | How to handle existing data before writing. |
+| hbase_extra_config       | config  | no       | -                            | Extra HBase or Hadoop client configuration. |
+| multi_table_sink_replica | int     | no       | 1                            | Number of sink writer replicas for each table in a multi-table job. |
+| common-options           |         | no       | -                            | Sink plugin common parameters, such as `plugin_input`. |
 
 ### zookeeper_quorum [string]
 
@@ -129,6 +129,15 @@ Controls how the sink handles existing target data before writing. Supported val
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+
+## Notes
+
+- `table = "${table_name}"` routes each upstream table to an HBase table with the same name. You
+  can also combine placeholders with fixed text, such as `ods_${table_name}`.
+- `family_name { all_columns = "info" }` writes every non-rowkey field to one column family. Use
+  per-field mappings when fields should go to different column families.
+- `schema_save_mode` controls table creation or recreation. `data_save_mode` controls whether
+  existing rows are kept, dropped, or treated as an error.
 
 ## Example
 

--- a/docs/en/connectors/sink/Kudu.md
+++ b/docs/en/connectors/sink/Kudu.md
@@ -45,8 +45,8 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Kudu normal operation time out.                                                                                                             |
 | client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Kudu admin operation time out.                                                                                                              |
 | enable_kerberos                           | Bool   | No       | false                                          | Kerberos principal enable.                                                                                                                  |
-| kerberos_principal                        | String | No       | -                                              | Kerberos principal. Note that all zeta nodes require have this file.                                                                        |
-| kerberos_keytab                           | String | No       | -                                              | Kerberos keytab. Note that all zeta nodes require have this file.                                                                           |
+| kerberos_principal                        | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                  |
+| kerberos_keytab                           | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                  |
 | kerberos_krb5conf                         | String | No       | -                                              | Kerberos krb5 conf. Note that all zeta nodes require have this file.                                                                        |
 | save_mode                                 | String | No       | APPEND                                         | Storage mode. Supported values are `append` and `overwrite`. In `overwrite` mode, insert rows are written as Kudu upserts.                                                                                             |
 | session_flush_mode                        | String | No       | AUTO_FLUSH_SYNC                                | Kudu flush mode. Supported values are `AUTO_FLUSH_SYNC`, `AUTO_FLUSH_BACKGROUND`, and `MANUAL_FLUSH`.                                                                                                   |
@@ -54,6 +54,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | buffer_flush_interval                     | Int    | No       | 10000                                          | Required only when `session_flush_mode = AUTO_FLUSH_BACKGROUND`. The asynchronous writer flush interval, in milliseconds.                                                             |
 | ignore_not_found                          | Bool   | No       | false                                          | If true, ignore all not found rows.                                                                                                         |
 | ignore_not_duplicate                      | Bool   | No       | false                                          | If true, ignore all duplicate rows.                                                                                                          |
+| multi_table_sink_replica                  | Int    | No       | 1                                              | Number of sink writer replicas for each table in a multi-table job.                                                                          |
 | common-options                            |        | No       | -                                              | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                            |
 
 ## Option Notes
@@ -61,6 +62,9 @@ import ChangeLog from '../changelog/connector-kudu.md';
 - `table_name` is optional. If it is not set, the sink writes to the table name carried by the upstream row.
 - For multi-table jobs, use placeholders in `table_name` to route rows to different Kudu tables.
 - CDC rows are supported: insert records are appended, update records are written as upserts, and delete records are deleted by key.
+- `batch_size` is required only for `AUTO_FLUSH_BACKGROUND` or `MANUAL_FLUSH`. `buffer_flush_interval`
+  is required only for `AUTO_FLUSH_BACKGROUND`.
+- When `enable_kerberos = true`, both `kerberos_principal` and `kerberos_keytab` are required.
 
 ## Task Example
 

--- a/docs/en/connectors/source/Cassandra.md
+++ b/docs/en/connectors/source/Cassandra.md
@@ -61,6 +61,7 @@ the CQL should return the columns that downstream steps need.
 | password          | String     | No       | -           | Cassandra password. Configure it together with `username`. |
 | datacenter        | String     | No       | datacenter1 | Local datacenter name used by the Cassandra Java driver. |
 | consistency_level | String     | No       | LOCAL_ONE   | Read consistency level, such as `LOCAL_ONE`, `ONE`, `QUORUM`, or `LOCAL_QUORUM`. |
+| common-options    |            | No       | -           | Source plugin common parameters, such as `plugin_output`. |
 
 > \* Exactly one of `cql` or `tables_configs` must be provided.
 
@@ -114,6 +115,10 @@ The `Cassandra` datacenter, default is `datacenter1`.
 
 The `Cassandra` read consistency level, default is `LOCAL_ONE`.
 
+### common-options
+
+Source plugin common parameters. For details, see [Source Common Options](../common-options/source-common-options.md).
+
 ## Notes
 
 - `username` and `password` are a pair. Configure both when authentication is enabled; omit both
@@ -123,6 +128,8 @@ The `Cassandra` read consistency level, default is `LOCAL_ONE`.
 - `cql` and `tables_configs` are mutually exclusive. Use `cql` for one result table and
   `tables_configs` when one source should read multiple Cassandra tables.
 - The source is a batch source. It reads the current query result and then finishes.
+- A single CQL query is read as one source split. Increasing job parallelism does not split one
+  Cassandra table scan automatically.
 
 ## Examples
 

--- a/docs/en/connectors/source/Hbase.md
+++ b/docs/en/connectors/source/Hbase.md
@@ -20,23 +20,23 @@ range scans, binary row keys, custom namespaces, and parallel batch reading.
 
 ## Options
 
-| Name                | Type    | Required | Default |
-|---------------------|---------|----------|---------|
-| zookeeper_quorum    | string  | Yes      | -       |
-| table               | string  | Yes      | -       |
-| schema              | config  | Yes      | -       |
-| hbase_extra_config  | config  | No       | -       |
-| caching             | int     | No       | -1      |
-| batch               | int     | No       | -1      |
-| cache_blocks        | boolean | No       | false   |
-| is_binary_rowkey    | boolean | No       | false   |
-| start_rowkey        | string  | No       | -       |
-| end_rowkey          | string  | No       | -       |
-| start_row_inclusive | boolean | No       | true    |
-| end_row_inclusive   | boolean | No       | false   |
-| start_timestamp     | long    | No       | -       |
-| end_timestamp       | long    | No       | -       |
-| common-options      |         | No       | -       |
+| Name                | Type    | Required | Default | Description |
+|---------------------|---------|----------|---------|-------------|
+| zookeeper_quorum    | string  | Yes      | -       | HBase ZooKeeper quorum, for example `hadoop001:2181,hadoop002:2181`. |
+| table               | string  | Yes      | -       | HBase table to scan. Use `namespace:table` for a custom namespace. |
+| schema              | config  | Yes      | -       | SeaTunnel schema. Use `rowkey` for the row key and `family:qualifier` for cells. |
+| hbase_extra_config  | config  | No       | -       | Extra HBase or Hadoop client configuration. |
+| caching             | int     | No       | -1      | Number of rows fetched per RPC. `-1` keeps the HBase client default. |
+| batch               | int     | No       | -1      | Maximum number of cells returned per RPC. `-1` keeps the HBase client default. |
+| cache_blocks        | boolean | No       | false   | Whether scan results should populate the HBase block cache. |
+| is_binary_rowkey    | boolean | No       | false   | Whether the row key column should be handled as binary bytes. |
+| start_rowkey        | string  | No       | -       | Start row key for range scans. |
+| end_rowkey          | string  | No       | -       | End row key for range scans. |
+| start_row_inclusive | boolean | No       | true    | Whether the scan includes `start_rowkey`. |
+| end_row_inclusive   | boolean | No       | false   | Whether the scan includes `end_rowkey`. |
+| start_timestamp     | long    | No       | -       | Start timestamp for time range scans, inclusive. |
+| end_timestamp       | long    | No       | -       | End timestamp for time range scans, exclusive. |
+| common-options      |         | No       | -       | Source plugin common parameters, such as `plugin_output`. |
 
 ### zookeeper_quorum [string]
 

--- a/docs/en/connectors/source/Kudu.md
+++ b/docs/en/connectors/source/Kudu.md
@@ -52,8 +52,8 @@ The tested kudu version is 1.11.1.
 | client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Kudu normal operation time out.                                                                                                                                                                  |
 | client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Kudu admin operation time out.                                                                                                                                                                   |
 | enable_kerberos                           | Bool   | No       | false                                          | Kerberos principal enable.                                                                                                                                                                       |
-| kerberos_principal                        | String | No       | -                                              | Kerberos principal. Note that all zeta nodes require have this file.                                                                                                                             |
-| kerberos_keytab                           | String | No       | -                                              | Kerberos keytab. Note that all zeta nodes require have this file.                                                                                                                                |
+| kerberos_principal                        | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                                                                       |
+| kerberos_keytab                           | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                                                                       |
 | kerberos_krb5conf                         | String | No       | -                                              | Kerberos krb5 conf. Note that all zeta nodes require have this file.                                                                                                                             |
 | scan_token_query_timeout                  | Long   | No       | 30000                                          | The timeout for connecting scan token. If not set, it will be the same as operationTimeout.                                                                                                      |
 | scan_token_batch_size_bytes               | Int    | No       | 1024 * 1024                                    | Kudu scan bytes. The maximum number of bytes read at a time, the default is 1MB.                                                                                                                 |
@@ -68,6 +68,7 @@ The tested kudu version is 1.11.1.
 - Configure exactly one of `table_name` and `table_list`.
 - `filter` is pushed down to Kudu scans and can use Kudu predicate expressions such as `id >= 1 AND id <= 2`.
 - `use_regex = true` treats `table_name` as a Java regular expression. This can be used either at the top level or inside each `table_list` item.
+- When `enable_kerberos = true`, both `kerberos_principal` and `kerberos_keytab` are required.
 
 ## Task Example
 

--- a/docs/zh/connectors/sink/Cassandra.md
+++ b/docs/zh/connectors/sink/Cassandra.md
@@ -32,6 +32,7 @@ sink 会把数据写入已经存在的 Cassandra 表。如果不配置 `fields`�
 | batch_size        | int     | 否       | 5000        | 每次 flush 前最多缓存的行数。 |
 | batch_type        | String  | 否       | UNLOGGED    | Cassandra batch 类型，常用值包括 `LOGGED`、`UNLOGGED`、`COUNTER`。 |
 | async_write       | boolean | 否       | true        | 是否异步执行写入。 |
+| common-options    |         | 否       | -           | Sink 插件通用参数，例如 `plugin_input`。 |
 
 ### host [string]
 
@@ -82,6 +83,16 @@ sink 会把数据写入已经存在的 Cassandra 表。如果不配置 `fields`�
 ### async_write [boolean]
 
 `cassandra` 是否以异步模式写入, 默认值 `true`.
+
+### common-options
+
+Sink 插件通用参数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。
+
+## 注意事项
+
+- 任务启动前，目标 keyspace 和表必须已经存在。
+- `fields` 适合上游数据有额外字段、只想写入其中一部分字段的场景；它不是建表配置。
+- `async_write = true` 可以提升吞吐，`batch_size` 用来控制每次 flush 前聚合的行数。
 
 ## 示例
 

--- a/docs/zh/connectors/sink/Hbase.md
+++ b/docs/zh/connectors/sink/Hbase.md
@@ -16,23 +16,23 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 ## 选项
 
-| 名称               | 类型    | 是否必须 | 默认值 |
-|--------------------|---------|----------|--------|
-| zookeeper_quorum   | string  | 是       | -      |
-| table              | string  | 是       | -      |
-| rowkey_column      | list    | 是       | -      |
-| family_name        | config  | 是       | -      |
-| rowkey_delimiter   | string  | 否       | ""     |
-| version_column     | string  | 否       | -      |
-| null_mode          | string  | 否       | skip   |
-| wal_write          | boolean | 否       | false  |
-| write_buffer_size  | int     | 否       | 8 * 1024 * 1024 |
-| encoding           | string  | 否       | utf8   |
-| schema_save_mode   | enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode     | enum    | 否       | APPEND_DATA |
-| hbase_extra_config | config  | 否       | -      |
-| multi_table_sink_replica | int | 否       | 1      |
-| common-options     |         | 否       | -      |
+| 名称                     | 类型    | 是否必须 | 默认值                         | 描述 |
+|--------------------------|---------|----------|--------------------------------|------|
+| zookeeper_quorum         | string  | 是       | -                              | HBase ZooKeeper 地址，例如 `hadoop001:2181,hadoop002:2181`。 |
+| table                    | string  | 是       | -                              | 目标 HBase 表。多表写入时可使用 `${table_name}` 等占位符。 |
+| rowkey_column            | list    | 是       | -                              | 用来组成 HBase rowkey 的上游字段名。 |
+| family_name              | config  | 是       | -                              | 上游字段到 HBase 列簇的映射，也可以用 `all_columns` 统一写入一个列簇。 |
+| rowkey_delimiter         | string  | 否       | ""                             | 多个字段组成 rowkey 时使用的连接符。 |
+| version_column           | string  | 否       | -                              | 用作 HBase 单元格时间戳的上游字段。 |
+| null_mode                | string  | 否       | skip                           | null 值写入方式，支持 `skip` 和 `empty`。 |
+| wal_write                | boolean | 否       | false                          | 写入时是否记录 HBase WAL。 |
+| write_buffer_size        | int     | 否       | 8 * 1024 * 1024                | HBase 客户端写入缓冲区大小，单位字节。 |
+| encoding                 | string  | 否       | utf8                           | STRING/DECIMAL/DATE/TIME/TIMESTAMP/ARRAY 的编码，支持 `utf8` 和 `gbk`。 |
+| schema_save_mode         | enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST   | 写入前如何处理目标表结构。 |
+| data_save_mode           | enum    | 否       | APPEND_DATA                    | 写入前如何处理目标端已有数据。 |
+| hbase_extra_config       | config  | 否       | -                              | 额外的 HBase 或 Hadoop 客户端配置。 |
+| multi_table_sink_replica | int     | 否       | 1                              | 多表写入时每张表对应的 Sink Writer 副本数。 |
+| common-options           |         | 否       | -                              | Sink 插件通用参数，例如 `plugin_input`。 |
 
 ### zookeeper_quorum [string]
 
@@ -126,6 +126,12 @@ hbase 扩展配置
 ### 常见选项
 
 Sink 插件常用参数，详见 Sink 常用选项 [Sink Common Options](../common-options/sink-common-options.md)
+
+## 注意事项
+
+- `table = "${table_name}"` 会把每张上游表写入同名 HBase 表，也可以和固定文本组合，例如 `ods_${table_name}`。
+- `family_name { all_columns = "info" }` 会把所有非 rowkey 字段写入同一个列簇。不同字段需要写入不同列簇时，请使用逐字段映射。
+- `schema_save_mode` 控制是否创建或重建表，`data_save_mode` 控制保留、清空已有数据，还是在已有数据存在时报错。
 
 ## 案例
 

--- a/docs/zh/connectors/sink/Kudu.md
+++ b/docs/zh/connectors/sink/Kudu.md
@@ -45,8 +45,8 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | client_default_operation_timeout_ms       | Long   | 否       | 30000                                          | Kudu正常运行超时。                                                                                                             |
 | client_default_admin_operation_timeout_ms | Long   | 否       | 30000                                          | Kudu管理员操作超时。                                                                                                              |
 | enable_kerberos                           | Bool   | 否       | false                                          | 启用Kerberos主体。                                                                                                                  |
-| kerberos_principal                        | String | 否       | -                                              | Kerberos主体。请注意，所有zeta节点都需要此文件。                                                                        |
-| kerberos_keytab                           | String | 否       | -                                              | Kerberos密钥表。请注意，所有zeta节点都需要此文件。                                                                           |
+| kerberos_principal                        | String | 当 `enable_kerberos = true` 时必填 | -                                              | Kudu 客户端使用的 Kerberos principal。keytab 文件必须在每个 worker 节点都可访问。                                                                        |
+| kerberos_keytab                           | String | 当 `enable_kerberos = true` 时必填 | -                                              | Kudu 客户端使用的 Kerberos keytab 路径，文件必须在每个 worker 节点都可访问。                                                                           |
 | kerberos_krb5conf                         | String | 否       | -                                              | Kerberos krb5 conf.请注意，所有zeta节点都需要此文件。                                                                        |
 | save_mode                                 | String | 否       | APPEND                                         | 存储模式。支持 `append` 和 `overwrite`。在 `overwrite` 模式下，插入记录会按 Kudu upsert 写入。                                                                                             |
 | session_flush_mode                        | String | 否       | AUTO_FLUSH_SYNC                                | Kudu 刷新模式。支持 `AUTO_FLUSH_SYNC`、`AUTO_FLUSH_BACKGROUND` 和 `MANUAL_FLUSH`。                                                                                                   |
@@ -54,6 +54,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | buffer_flush_interval                     | Int    | 否       | 10000                                          | 仅当 `session_flush_mode = AUTO_FLUSH_BACKGROUND` 时生效，表示异步写入的刷新间隔，单位毫秒。                                                             |
 | ignore_not_found                          | Bool   | 否       | false                                          | 如果为true，则忽略所有未找到的行。                                                                                                         |
 | ignore_not_duplicate                      | Bool   | 否       | false                                          | 如果为 true，则忽略所有重复行。                                                                                                          |
+| multi_table_sink_replica                  | Int    | 否       | 1                                              | 多表写入时每张表对应的 Sink Writer 副本数。                                                                          |
 | common-options                            |        | 否       | -                                              | Sink插件常用参数，详见[Sink common Options](../common-options/sink-common-options.md)。                           |
 
 ## 参数说明
@@ -61,6 +62,9 @@ import ChangeLog from '../changelog/connector-kudu.md';
 - `table_name` 是可选参数。不配置时，Sink 会写入上游数据行携带的表名。
 - 多表写入时，可以在 `table_name` 中使用占位符，把不同来源表的数据写入不同 Kudu 表。
 - 支持 CDC 数据：插入记录会追加写入，更新记录会按 upsert 写入，删除记录会按主键删除。
+- `batch_size` 只在 `AUTO_FLUSH_BACKGROUND` 或 `MANUAL_FLUSH` 模式下需要配置；`buffer_flush_interval`
+  只在 `AUTO_FLUSH_BACKGROUND` 模式下需要配置。
+- 当 `enable_kerberos = true` 时，必须同时配置 `kerberos_principal` 和 `kerberos_keytab`。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/Cassandra.md
+++ b/docs/zh/connectors/source/Cassandra.md
@@ -60,6 +60,7 @@ Cassandra source 支持两种读取方式：
 | password          | String     | 否       | -           | Cassandra 密码，需要和 `username` 一起配置。 |
 | datacenter        | String     | 否       | datacenter1 | Cassandra Java Driver 使用的本地数据中心名称。 |
 | consistency_level | String     | 否       | LOCAL_ONE   | 读取一致性级别，例如 `LOCAL_ONE`、`ONE`、`QUORUM`、`LOCAL_QUORUM`。 |
+| common-options    |            | 否       | -           | Source 插件通用参数，例如 `plugin_output`。 |
 
 > \* `cql` 与 `tables_configs` 二选一，必须提供其中之一。
 
@@ -109,6 +110,10 @@ Cassandra source 支持两种读取方式：
 
 `Cassandra` 的读取一致性级别, 默认为 `LOCAL_ONE`.
 
+### common-options
+
+Source 插件通用参数，详情请参考 [Source 常用选项](../common-options/source-common-options.md)。
+
 ## 注意事项
 
 - `username` 和 `password` 是一组配置。集群开启认证时两个都要配；未开启认证时两个都可以不配。
@@ -117,6 +122,7 @@ Cassandra source 支持两种读取方式：
 - `cql` 和 `tables_configs` 互斥。读取一个结果表时用 `cql`，需要让一个 source 读取多张 Cassandra 表时用
   `tables_configs`。
 - 这是批处理 source。它读取当前查询结果后就会结束。
+- 一个 CQL 查询会作为一个 source split 读取。调大任务并行度不会自动把单张 Cassandra 表拆成多个扫描任务。
 
 ## 示例
 

--- a/docs/zh/connectors/source/Hbase.md
+++ b/docs/zh/connectors/source/Hbase.md
@@ -19,23 +19,23 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 ## 选项
 
-| 名称                 | 类型    | 必填 | 默认值 |
-|----------------------|---------|------|--------|
-| zookeeper_quorum     | string  | 是   | -      |
-| table                | string  | 是   | -      |
-| schema               | config  | 是   | -      |
-| hbase_extra_config   | config  | 否   | -      |
-| caching              | int     | 否   | -1     |
-| batch                | int     | 否   | -1     |
-| cache_blocks         | boolean | 否   | false  |
-| is_binary_rowkey     | boolean | 否   | false  |
-| start_rowkey         | string  | 否   | -      |
-| end_rowkey           | string  | 否   | -      |
-| start_row_inclusive | boolean | 否   | true   |
-| end_row_inclusive   | boolean | 否   | false  |
-| start_timestamp     | long    | 否   | -      |
-| end_timestamp       | long    | 否   | -      |
-| common-options      |         | 否   | -      |
+| 名称                 | 类型    | 必填 | 默认值 | 描述 |
+|----------------------|---------|------|--------|------|
+| zookeeper_quorum     | string  | 是   | -      | HBase ZooKeeper 地址，例如 `hadoop001:2181,hadoop002:2181`。 |
+| table                | string  | 是   | -      | 要扫描的 HBase 表。自定义 namespace 请使用 `namespace:table`。 |
+| schema               | config  | 是   | -      | SeaTunnel 表结构。行键写作 `rowkey`，普通单元格写作 `列簇:列名`。 |
+| hbase_extra_config   | config  | 否   | -      | 额外的 HBase 或 Hadoop 客户端配置。 |
+| caching              | int     | 否   | -1     | 每次 RPC 获取的行数。`-1` 表示使用 HBase 客户端默认值。 |
+| batch                | int     | 否   | -1     | 每次 RPC 返回的最大单元格数量。`-1` 表示使用 HBase 客户端默认值。 |
+| cache_blocks         | boolean | 否   | false  | 扫描结果是否写入 HBase block cache。 |
+| is_binary_rowkey     | boolean | 否   | false  | 是否把行键字段按二进制字节处理。 |
+| start_rowkey         | string  | 否   | -      | 范围扫描的起始行键。 |
+| end_rowkey           | string  | 否   | -      | 范围扫描的结束行键。 |
+| start_row_inclusive  | boolean | 否   | true   | 扫描结果是否包含 `start_rowkey`。 |
+| end_row_inclusive    | boolean | 否   | false  | 扫描结果是否包含 `end_rowkey`。 |
+| start_timestamp      | long    | 否   | -      | 时间范围扫描的起始时间戳，包含该时间。 |
+| end_timestamp        | long    | 否   | -      | 时间范围扫描的结束时间戳，不包含该时间。 |
+| common-options       |         | 否   | -      | Source 插件通用参数，例如 `plugin_output`。 |
 
 ### zookeeper_quorum [string]
 

--- a/docs/zh/connectors/source/Kudu.md
+++ b/docs/zh/connectors/source/Kudu.md
@@ -52,8 +52,8 @@ import ChangeLog from '../changelog/connector-kudu.md';
 | client_default_operation_timeout_ms       | Long   | 否  | 30000                                          | Kudu 普通操作超时时间。                                                                                                                                                                                   |
 | client_default_admin_operation_timeout_ms | Long   | 否  | 30000                                          | Kudu 管理操作超时时间。                                                                                                                                                                                   |
 | enable_kerberos                           | Bool   | 否  | false                                          | Kerberos principal 启用。                                                                                                                                                                           |
-| kerberos_principal                        | String | 否  | -                                              | Kerberos principal。注意所有 zeta 节点都需要有此文件。                                                                                                                                                          |
-| kerberos_keytab                           | String | 否  | -                                              | Kerberos keytab。注意所有 zeta 节点都需要有此文件。                                                                                                                                                             |
+| kerberos_principal                        | String | 当 `enable_kerberos = true` 时必填 | -                                              | Kudu 客户端使用的 Kerberos principal。keytab 文件必须在每个 worker 节点都可访问。                                                                                                                                                          |
+| kerberos_keytab                           | String | 当 `enable_kerberos = true` 时必填 | -                                              | Kudu 客户端使用的 Kerberos keytab 路径，文件必须在每个 worker 节点都可访问。                                                                                                                                                             |
 | kerberos_krb5conf                         | String | 否  | -                                              | Kerberos krb5 conf。注意所有 zeta 节点都需要有此文件。                                                                                                                                                          |
 | scan_token_query_timeout                  | Long   | 否  | 30000                                          | 连接扫描令牌的超时时间。如果未设置，将与 operationTimeout 相同。                                                                                                                                                        |
 | scan_token_batch_size_bytes               | Int    | 否  | 1024 * 1024                                    | Kudu 扫描字节数。一次读取的最大字节数，默认为 1MB。                                                                                                                                                                   |
@@ -68,6 +68,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 - `table_name` 和 `table_list` 只能配置其中一个。
 - `filter` 会下推到 Kudu 扫描中，可以使用类似 `id >= 1 AND id <= 2` 的 Kudu 过滤表达式。
 - `use_regex = true` 会把 `table_name` 当作 Java 正则表达式处理，可以配置在顶层，也可以配置在 `table_list` 的每个条目中。
+- 当 `enable_kerberos = true` 时，必须同时配置 `kerberos_principal` 和 `kerberos_keytab`。
 
 ## 任务示例
 


### PR DESCRIPTION
## Purpose

Improve the Cassandra, HBase, and Kudu connector documentation so the option tables and usage notes better match the current connector behavior and tested examples.

## Changes

- Add common option rows and clearer operational notes for Cassandra source/sink docs.
- Expand HBase source and sink option tables with descriptions, multi-table routing guidance, and save-mode notes.
- Clarify Kudu Kerberos conditional requirements and document `multi_table_sink_replica` for Kudu sink.
- Keep English and Chinese connector docs aligned.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
