### PR TITLE
[Docs][Connector-V2] Improve InfluxDB Snowflake and Cloudberry docs

### DIFF
--- a/docs/en/connectors/sink/Cloudberry.md
+++ b/docs/en/connectors/sink/Cloudberry.md
@@ -56,12 +56,20 @@ Cloudberry uses PostgreSQL's data type implementation. Please refer to PostgreSQ
 Cloudberry connector uses the same options as PostgreSQL. For detailed configuration options, please refer to the PostgreSQL documentation.
 
 Key options include:
+
 - url (required): The JDBC connection URL
 - driver (required): The driver class name (org.postgresql.Driver)
-- user/password: Authentication credentials
+- username/password: Authentication credentials. `user` is also accepted as a fallback key for `username`.
 - query or database/table combination: What data to write and how
 - is_exactly_once: Enable exactly-once semantics with XA transactions
 - batch_size: Control batch writing behavior
+
+## Notes
+
+- Use the `Jdbc` plugin name for Cloudberry jobs.
+- Cloudberry uses PostgreSQL JDBC behavior; configure `driver = "org.postgresql.Driver"` and a `jdbc:postgresql://...` URL.
+- Use `query` for a hand-written INSERT statement, or use `generate_sink_sql` with `database` and `table` when SeaTunnel should generate SQL.
+- `is_exactly_once=true` also needs a valid XA data source class, for example `org.postgresql.xa.PGXADataSource`.
 
 ## Task Example
 

--- a/docs/en/connectors/sink/InfluxDB.md
+++ b/docs/en/connectors/sink/InfluxDB.md
@@ -15,6 +15,21 @@ fields.
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
+## Data Type Mapping
+
+| SeaTunnel Data Type | InfluxDB Usage |
+|---------------------|----------------|
+| BOOLEAN             | Written as an InfluxDB field. |
+| SMALLINT            | Written as an InfluxDB field. |
+| INT                 | Written as an InfluxDB field. |
+| BIGINT              | Written as an InfluxDB field, or as the timestamp when configured by `key_time`. |
+| FLOAT               | Written as an InfluxDB field. |
+| DOUBLE              | Written as an InfluxDB field. |
+| STRING              | Written as an InfluxDB field, a tag value, or a timestamp string when configured by `key_time`. |
+| TIMESTAMP           | Can be used by `key_time`; converted with UTC zone to epoch milliseconds. |
+
+Other SeaTunnel types are not supported by the current InfluxDB sink serializer.
+
 ## Options
 
 | name                        | type   | required | default value         | description                                                                                   |
@@ -81,6 +96,8 @@ For batch writing, when the number of buffers reaches the number of `batch_size`
 
 The number of retries to flush failed
 
+If this option is not configured, the sink tries the write once and fails immediately if that write fails.
+
 ### retry_backoff_multiplier_ms [int]
 
 Using as a multiplier for generating the next delay for backoff
@@ -88,6 +105,9 @@ Using as a multiplier for generating the next delay for backoff
 ### max_retry_backoff_ms [int]
 
 The amount of time to wait before attempting to retry a request to `influxDB`
+
+When retry options are used, configure both `retry_backoff_multiplier_ms` and
+`max_retry_backoff_ms`; otherwise the retry sleep interval remains `0`.
 
 ### write_timeout [int]
 

--- a/docs/en/connectors/sink/Snowflake.md
+++ b/docs/en/connectors/sink/Snowflake.md
@@ -75,7 +75,14 @@ Write data through jdbc. Support Batch mode and Streaming mode, support concurre
 
 > If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
 >
-  ## Task Example
+## Notes
+
+- Use `query` when you want to fully control the INSERT statement and parameter order.
+- Use `database`, `table`, and `primary_keys` when SeaTunnel should generate sink SQL for insert, update, and delete events.
+- Snowflake sink uses normal JDBC batch writes. The connector does not provide exactly-once guarantees for Snowflake.
+- Keep Snowflake credentials out of shared examples, logs, and screenshots.
+
+## Task Example
 
 ### simple
 

--- a/docs/en/connectors/source/Cloudberry.md
+++ b/docs/en/connectors/source/Cloudberry.md
@@ -55,15 +55,23 @@ Cloudberry uses PostgreSQL's data type implementation. Please refer to PostgreSQ
 Cloudberry connector uses the same options as PostgreSQL. For detailed configuration options, please refer to the PostgreSQL documentation.
 
 Key options include:
+
 - url (required): The JDBC connection URL
 - driver (required): The driver class name (org.postgresql.Driver)
-- user/password: Authentication credentials
+- username/password: Authentication credentials. `user` is also accepted as a fallback key for `username`.
 - query or table_path: What data to read
 - partition options for parallel reading
 
 ## Parallel Reader
 
 Cloudberry supports parallel reading following the same rules as PostgreSQL connector. For detailed information on split strategies and parallel reading options, please refer to the PostgreSQL connector documentation.
+
+## Notes
+
+- Use the `Jdbc` plugin name for Cloudberry jobs.
+- Cloudberry uses the PostgreSQL JDBC driver and PostgreSQL-compatible dialect path, so keep `driver = "org.postgresql.Driver"`.
+- Use a PostgreSQL-style URL such as `jdbc:postgresql://host:5432/database`.
+- Keep database passwords out of shared examples, logs, and screenshots.
 
 ## Task Example
 

--- a/docs/en/connectors/source/InfluxDB.md
+++ b/docs/en/connectors/source/InfluxDB.md
@@ -15,11 +15,22 @@ query and an optional parallel scan mode that splits one query by an integer col
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
-
-supports query SQL and can achieve projection effect.
-
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+
+## Data Type Mapping
+
+| SeaTunnel Data Type | Notes |
+|---------------------|-------|
+| BOOLEAN             | Parsed from the returned InfluxDB value. |
+| SMALLINT            | Parsed from the returned InfluxDB value. |
+| INT                 | Parsed from the returned InfluxDB value. |
+| BIGINT              | Parsed from the returned InfluxDB value. |
+| FLOAT               | InfluxDB returns numbers as double values; the connector converts them to FLOAT. |
+| DOUBLE              | Uses the returned numeric value. |
+| STRING              | Uses the returned value as a string. |
+
+Other SeaTunnel types are not supported by the current InfluxDB source converter.
 
 ## Options
 
@@ -95,6 +106,7 @@ The column used to split one query into multiple range queries.
 > - Currently, `split_column` only supports integer data segmentation, and does not support `float`, `string`, `date` and other types.
 > - `split_column`, `lower_bound`, `upper_bound`, and `partition_num` must be configured together.
 > - If the split query contains a filter, use lowercase `where` in `sql`, for example `select * from test where age > 0`. The current split parser is case-sensitive.
+> - `where` is an option in the validation rule, but the current split logic reads the filter from `sql`. Put the filter in `sql` instead of configuring a separate `where` value.
 
 ### upper_bound [int]
 

--- a/docs/en/connectors/source/Snowflake.md
+++ b/docs/en/connectors/source/Snowflake.md
@@ -10,7 +10,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 >
-  ## Key features
+## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
@@ -21,7 +21,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > supports query SQL and can achieve projection effect.
 >
-  ## Description
+## Description
 
 Read external data source data through JDBC.
 
@@ -36,7 +36,7 @@ Read external data source data through JDBC.
 > Please download the support list corresponding to 'Maven' and copy it to the '$SEATUNNEL_HOME/plugins/jdbc/lib/' working directory<br/>
 > For example Snowflake datasource: cp snowflake-connector-java-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
 >
-  ## Data Type Mapping
+## Data Type Mapping
 
 |                             Snowflake Data type                             | SeaTunnel Data type |
 |-----------------------------------------------------------------------------|---------------------|
@@ -79,6 +79,13 @@ Read external data source data through JDBC.
 > If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
 >
 > JDBC Driver Connection Parameters are supported in JDBC connection string. E.g, you can add `?GEOGRAPHY_OUTPUT_FORMAT='EWKT'` to specify the Geospatial Data Types. For more information about configurable parameters, and geospatial data types please visit Snowflake official [document](https://docs.snowflake.com/en/sql-reference/data-types-geospatial)
+
+## Notes
+
+- Use the `Jdbc` plugin name for Snowflake jobs, and set `driver = "net.snowflake.client.jdbc.SnowflakeDriver"`.
+- Put the Snowflake JDBC driver jar in `$SEATUNNEL_HOME/plugins/jdbc/lib/` before running the job.
+- When reading in parallel, `partition_column`, `partition_lower_bound`, `partition_upper_bound`, and `partition_num` should describe the same numeric column range.
+- Snowflake geospatial columns can be returned as bytes or string depending on Snowflake JDBC output parameters such as `GEOGRAPHY_OUTPUT_FORMAT`.
 
 ## Task Example
 

--- a/docs/zh/connectors/sink/Cloudberry.md
+++ b/docs/zh/connectors/sink/Cloudberry.md
@@ -29,10 +29,10 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 ## 主要特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [CDC](../../introduction/concepts/connector-v2-features.md)
 
 > 使用 `XA 事务` 来确保 `精确一次`。因此，只有支持 `XA 事务` 的数据库才支持 `精确一次`。您可以设置 `is_exactly_once=true` 来启用它。
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 支持的数据源信息
 
@@ -56,10 +56,17 @@ Cloudberry 连接器使用与 PostgreSQL 相同的选项。有关详细的配置
 关键选项包括：
 - url（必需）：JDBC 连接 URL
 - driver（必需）：驱动程序类名（org.postgresql.Driver）
-- user/password：身份验证凭证
+- username/password：身份验证凭证。`user` 也可以作为 `username` 的兼容写法
 - query 或 database/table 组合：要写入的数据和方式
 - is_exactly_once：使用 XA 事务启用精确一次语义
 - batch_size：控制批量写入行为
+
+## 注意事项
+
+- Cloudberry 作业使用 `Jdbc` 插件名。
+- Cloudberry 使用 PostgreSQL JDBC 行为，请配置 `driver = "org.postgresql.Driver"` 和 `jdbc:postgresql://...` URL。
+- 需要手写 INSERT 语句时使用 `query`；希望 SeaTunnel 自动生成 SQL 时，使用 `generate_sink_sql`、`database` 和 `table`。
+- `is_exactly_once=true` 还需要配置可用的 XA 数据源类，例如 `org.postgresql.xa.PGXADataSource`。
 
 ## 任务示例
 

--- a/docs/zh/connectors/sink/InfluxDB.md
+++ b/docs/zh/connectors/sink/InfluxDB.md
@@ -14,6 +14,21 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
+## 数据类型映射
+
+| SeaTunnel 数据类型 | InfluxDB 用法 |
+|--------------------|---------------|
+| BOOLEAN            | 写为 InfluxDB field。 |
+| SMALLINT           | 写为 InfluxDB field。 |
+| INT                | 写为 InfluxDB field。 |
+| BIGINT             | 写为 InfluxDB field；配置为 `key_time` 时也可以作为时间戳。 |
+| FLOAT              | 写为 InfluxDB field。 |
+| DOUBLE             | 写为 InfluxDB field。 |
+| STRING             | 可写为 InfluxDB field、tag 值，或在配置为 `key_time` 时作为时间戳字符串。 |
+| TIMESTAMP          | 可用于 `key_time`，连接器会按 UTC 时区转换成 epoch 毫秒。 |
+
+当前 InfluxDB sink 序列化器不支持其他 SeaTunnel 类型。
+
 ## 选项
 
 | 参数名                         | 类型     | 必须 | 默认值          | 描述                                                       |
@@ -80,6 +95,8 @@ measurement 名称，这在多表写入场景很有用。
 
 刷新失败的重试次数
 
+不配置该选项时，sink 只尝试写入一次，失败后直接报错。
+
 ### retry_backoff_multiplier_ms [int]
 
 用作生成下一个退避延迟的乘数
@@ -87,6 +104,8 @@ measurement 名称，这在多表写入场景很有用。
 ### max_retry_backoff_ms [int]
 
 在尝试重新请求 `influxDB` 之前等待的时间量
+
+使用重试配置时，建议同时配置 `retry_backoff_multiplier_ms` 和 `max_retry_backoff_ms`；否则重试等待时间仍为 `0`。
 
 ### write_timeout [int]
 

--- a/docs/zh/connectors/sink/Snowflake.md
+++ b/docs/zh/connectors/sink/Snowflake.md
@@ -13,8 +13,8 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [（CDC）](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [x] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
@@ -74,6 +74,13 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 ## 提示
 
 > 如果未设置`partition_column`，将以单并发运行，如果设置了`partition_column`，将根据任务的并发度并行执行。
+
+## 注意事项
+
+- 需要完全控制 INSERT 语句和参数顺序时，使用 `query`。
+- 希望 SeaTunnel 为插入、更新、删除事件自动生成写入 SQL 时，使用 `database`、`table` 和 `primary_keys`。
+- Snowflake sink 使用普通 JDBC 批量写入，不提供 Snowflake 的精确一次保证。
+- 不要把真实 Snowflake 密码写进共享示例、日志或截图。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/Cloudberry.md
+++ b/docs/zh/connectors/source/Cloudberry.md
@@ -2,7 +2,7 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 
 # Cloudberry
 
-> JDBC Cludberry源连接器
+> JDBC Cloudberry 源连接器
 
 ## 支持引擎
 
@@ -25,11 +25,11 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [列映射](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持用户自定义拆分](../../introduction/concepts/connector-v2-features.md)
 
-> 支持查询SQL，可以实现映射效果。
+> 支持查询 SQL，可以实现列投影效果。
 
 ## 描述
 
@@ -58,13 +58,20 @@ Cloudberry 连接器使用与 PostgreSQL 相同的配置项。有关详细的配
 
 - url (必需): JDBC 连接 URL。
 - driver (必需): 驱动程序类名 (org.postgresql.Driver)。
-- user/password: 认证凭据。
+- username/password: 认证凭据。`user` 也可以作为 `username` 的兼容写法。
 - query or table_path: 要读取的数据。
 - 用于并行读取的分区选项。
 
 ## 并行读取
 
 Cloudberry 支持与 PostgreSQL 连接器相同的并行读取规则。有关切片策略和并行读取选项的详细信息，请参考 PostgreSQL 连接器文档。
+
+## 注意事项
+
+- Cloudberry 作业使用 `Jdbc` 插件名。
+- Cloudberry 使用 PostgreSQL JDBC 驱动和兼容实现，请配置 `driver = "org.postgresql.Driver"`。
+- URL 使用 PostgreSQL 风格，例如 `jdbc:postgresql://host:5432/database`。
+- 不要把真实数据库密码写进共享示例、日志或截图。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/InfluxDB.md
+++ b/docs/zh/connectors/source/InfluxDB.md
@@ -11,15 +11,26 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义切分](../../introduction/concepts/connector-v2-features.md)
 
-支持查询 SQL 并可以实现投影效果。
+## 数据类型映射
 
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [x] [支持用户自定义 split](../../introduction/concepts/connector-v2-features.md)
+| SeaTunnel 数据类型 | 说明 |
+|--------------------|------|
+| BOOLEAN            | 从 InfluxDB 返回值解析。 |
+| SMALLINT           | 从 InfluxDB 返回值解析。 |
+| INT                | 从 InfluxDB 返回值解析。 |
+| BIGINT             | 从 InfluxDB 返回值解析。 |
+| FLOAT              | InfluxDB 会把数字按 double 返回，连接器再转换成 FLOAT。 |
+| DOUBLE             | 使用返回的数字值。 |
+| STRING             | 使用返回值作为字符串。 |
+
+当前 InfluxDB source 转换器不支持其他 SeaTunnel 类型。
 
 ## 选项
 
@@ -94,6 +105,7 @@ InfluxDB 密码
 > - 目前，`split_column` 仅支持整数数据分割，不支持 `float`、`string`、`date` 等类型。
 > - `split_column`、`lower_bound`、`upper_bound`、`partition_num` 需要一起配置。
 > - 如果切分读取的 SQL 中包含过滤条件，请在 `sql` 里使用小写 `where`，例如 `select * from test where age > 0`。当前切分解析逻辑区分大小写。
+> - `where` 是配置校验中保留的选项，但当前切分逻辑会从 `sql` 里读取过滤条件。请把过滤条件写在 `sql` 中，不要单独配置 `where`。
 
 ### upper_bound [int]
 

--- a/docs/zh/connectors/source/Snowflake.md
+++ b/docs/zh/connectors/source/Snowflake.md
@@ -10,18 +10,18 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 >
-  ## 关键特性
+## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [x] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义切分](../../introduction/concepts/connector-v2-features.md)
 
 > 支持查询 SQL 并可以实现投影效果。
 >
-  ## 描述
+## 描述
 
 通过 JDBC 读取外部数据源数据。
 
@@ -36,7 +36,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 > 请下载对应 'Maven' 的支持列表，并将其复制到 '$SEATUNNEL_HOME/plugins/jdbc/lib/' 工作目录<br/>
 > 例如 Snowflake 数据源：cp snowflake-connector-java-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
 >
-  ## 数据类型映射
+## 数据类型映射
 
 | Snowflake 数据类型 | SeaTunnel 数据类型 |
 |------------------|------------------|
@@ -79,6 +79,13 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 > 如果未设置 partition_column，它将以单并发运行，如果设置了 partition_column，它将根据任务的并发度并行执行。
 >
 > JDBC 驱动程序连接参数在 JDBC 连接字符串中受支持。例如，您可以添加 `?GEOGRAPHY_OUTPUT_FORMAT='EWKT'` 来指定地理空间数据类型。有关可配置参数和地理空间数据类型的更多信息，请访问 Snowflake 官方[文档](https://docs.snowflake.com/en/sql-reference/data-types-geospatial)
+
+## 注意事项
+
+- Snowflake 作业使用 `Jdbc` 插件名，并配置 `driver = "net.snowflake.client.jdbc.SnowflakeDriver"`。
+- 运行任务前，需要把 Snowflake JDBC 驱动 jar 放到 `$SEATUNNEL_HOME/plugins/jdbc/lib/`。
+- 并行读取时，`partition_column`、`partition_lower_bound`、`partition_upper_bound`、`partition_num` 应该描述同一个数值列范围。
+- Snowflake 地理空间字段会按 Snowflake JDBC 参数返回为字节或字符串，例如 `GEOGRAPHY_OUTPUT_FORMAT`。
 
 ## 任务示例
 
@@ -156,4 +163,3 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary
- Document InfluxDB source and sink type support, retry/backoff behavior, and split filter guidance.
- Clarify Snowflake JDBC setup, parallel read partition options, geospatial output notes, and generated SQL versus custom query usage.
- Clarify Cloudberry PostgreSQL driver usage, username fallback behavior, generated SQL usage, and XA configuration notes.

## Duplicate check
- Checked open Apache SeaTunnel PRs for InfluxDB, Snowflake, and Cloudberry before opening this PR.

## Verification
- ./mvnw spotless:apply
- ./mvnw -q -DskipTests verify