### PR TITLE
[Docs][Connector-V2] Improve Hive Doris and Elasticsearch docs

### DIFF
--- a/docs/en/connectors/sink/Elasticsearch.md
+++ b/docs/en/connectors/sink/Elasticsearch.md
@@ -11,6 +11,7 @@ Output data to `Elasticsearch`.
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 

--- a/docs/en/connectors/source/Doris.md
+++ b/docs/en/connectors/source/Doris.md
@@ -77,6 +77,8 @@ Base configuration:
 | doris.request.retriesdoris.deserialize.queue.size | int | no | 64 | Queue size used by asynchronous Arrow deserialization.                                               |
 | table_list                       | Array  | no       | -          | List of Doris tables to read.                                                                        |
 
+The `doris.request.retriesdoris.deserialize.queue.size` key is the current runtime option name. Use this exact key when tuning the asynchronous Arrow deserialization queue.
+
 Table list configuration:
 
 |               Name               |  Type  | Required |  Default   |                                             Description                                             |

--- a/docs/en/connectors/source/Hive.md
+++ b/docs/en/connectors/source/Hive.md
@@ -211,7 +211,7 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
 
 ```
 
-### Example 3: Regex matching (whole database / subset)
+### Example 4: Regex matching (whole database / subset)
 
 ```bash
   Hive {
@@ -244,7 +244,7 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
   }
 ```
 
-### Example 4 : Kerberos
+### Example 5: Kerberos
 
 ```bash
 source {

--- a/docs/zh/connectors/sink/Doris.md
+++ b/docs/zh/connectors/sink/Doris.md
@@ -6,9 +6,9 @@ import ChangeLog from '../changelog/connector-doris.md';
 
 ## 支持的doris版本
 
-- exactly-once & cdc 支持  `Doris version is >= 1.1.x`
-- 支持数组数据类型 `Doris version is >= 1.2.x`
-- 将支持Map数据类型 `Doris version is 2.x`
+- 精确一次与变更数据捕获支持：`Doris version is >= 1.1.x`
+- 数组类型支持：`Doris version is >= 1.2.x`
+- Map 类型支持：`Doris version is 2.x`
 
 ## 引擎支持
 
@@ -19,7 +19,7 @@ import ChangeLog from '../changelog/connector-doris.md';
 ## 主要特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 

--- a/docs/zh/connectors/sink/Elasticsearch.md
+++ b/docs/zh/connectors/sink/Elasticsearch.md
@@ -11,6 +11,7 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 
@@ -19,7 +20,6 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 * 支持  `ElasticSearch 版本 >= 2.x 并且 <= 8.x`
 
 :::
-- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 

--- a/docs/zh/connectors/source/Doris.md
+++ b/docs/zh/connectors/source/Doris.md
@@ -77,6 +77,8 @@ import ChangeLog from '../changelog/connector-doris.md';
 | doris.request.retriesdoris.deserialize.queue.size | int | no | 64 | 异步反序列化 Arrow 数据时使用的队列大小。                                                                |
 | table_list                       | Array  | no       | -           | 要读取的 Doris 表清单。                                                                                |
 
+`doris.request.retriesdoris.deserialize.queue.size` 是当前运行时实际使用的配置名。调整异步 Arrow 反序列化队列大小时，请按这个完整名称配置。
+
 表清单配置:
 
 |               名称                |  类型   | 是否必须  |  默认值     |                                             描述                                                     |

--- a/docs/zh/connectors/source/Hive.md
+++ b/docs/zh/connectors/source/Hive.md
@@ -205,7 +205,7 @@ Kerberos 认证的 keytab 文件路径
   }
 ```
 
-### 示例 3：正则匹配多表（整库/整库子集）
+### 示例 4：正则匹配多表（整库/整库子集）
 
 ```bash
   Hive {
@@ -238,7 +238,7 @@ Kerberos 认证的 keytab 文件路径
   }
 ```
 
-### 示例 4：Kerberos
+### 示例 5：Kerberos
 
 ```bash
 source {


### PR DESCRIPTION
### Purpose

Improve connector documentation for Hive, Doris, and Elasticsearch based on the current connector behavior and available connector usage examples.

### Changes

- Fix Hive source example numbering in English and Chinese docs.
- Clarify the Doris source asynchronous Arrow queue option by documenting the exact current runtime key.
- Localize Doris sink Chinese feature/version wording for CDC and exactly-once support.
- Align Elasticsearch sink feature lists by including timer flush status in both English and Chinese docs.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`