### PR TITLE
[Improve][Connector-V2] Add row-level resume for Bigtable source chec…

### DIFF
--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReader.java
@@ -137,6 +137,8 @@ public class BigtableSourceReader implements SourceReader<SeaTunnelRow, Bigtable
                             SeaTunnelRow seaTunnelRow = convertRow(bigtableRow);
                             synchronized (output.getCheckpointLock()) {
                                 output.collect(seaTunnelRow);
+                                // 与 collect 同锁更新进度，保证 triggerBarrier 快照时能看到已 emit 的最后 rowkey
+                                split.setLastReadRowKey(bigtableRow.getKey().toStringUtf8());
                             }
                         });
     }
@@ -144,7 +146,8 @@ public class BigtableSourceReader implements SourceReader<SeaTunnelRow, Bigtable
     private Query buildQuery(BigtableSourceSplit split) {
         Query query = Query.create(parameters.getTable());
 
-        String startKey = split.getStartRowKey();
+        // 恢复场景使用 lastReadRowKey 续读，避免对整个 split 从头重扫
+        String startKey = split.getResumeStartRowKey();
         String endKey = split.getEndRowKey();
         if (!startKey.isEmpty() && !endKey.isEmpty()) {
             query.range(startKey, endKey);

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReader.java
@@ -137,7 +137,8 @@ public class BigtableSourceReader implements SourceReader<SeaTunnelRow, Bigtable
                             SeaTunnelRow seaTunnelRow = convertRow(bigtableRow);
                             synchronized (output.getCheckpointLock()) {
                                 output.collect(seaTunnelRow);
-                                // 与 collect 同锁更新进度，保证 triggerBarrier 快照时能看到已 emit 的最后 rowkey
+                                // Update progress under the same lock as collect for consistent
+                                // snapshots
                                 split.setLastReadRowKey(bigtableRow.getKey().toStringUtf8());
                             }
                         });
@@ -146,7 +147,7 @@ public class BigtableSourceReader implements SourceReader<SeaTunnelRow, Bigtable
     private Query buildQuery(BigtableSourceSplit split) {
         Query query = Query.create(parameters.getTable());
 
-        // 恢复场景使用 lastReadRowKey 续读，避免对整个 split 从头重扫
+        // Resume from lastReadRowKey after checkpoint restore when present
         String startKey = split.getResumeStartRowKey();
         String endKey = split.getEndRowKey();
         if (!startKey.isEmpty() && !endKey.isEmpty()) {

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplit.java
@@ -22,25 +22,28 @@ import org.apache.seatunnel.api.source.SourceSplit;
 import java.io.Serializable;
 
 /**
- * Bigtable Source 分片定义：描述一次范围扫描的边界与可选的片内续读进度。
+ * Describes a bounded Bigtable scan split and optional in-split resume progress.
  *
- * <p>checkpoint 恢复时，若 {@link #lastReadRowKey} 非空，Reader 会从该 rowkey（含）继续扫描， 避免对整个 split 从头重扫。语义为
- * at-least-once，恢复后可能重复读取最后一条已提交行。
+ * <p>When {@link #lastReadRowKey} is present, checkpoint restore resumes from that row key
+ * (inclusive) instead of re-scanning from {@link #startRowKey}. Semantics are at-least-once: the
+ * resume row may be read again after failover.
  */
 public class BigtableSourceSplit implements SourceSplit, Serializable {
 
-    private static final long serialVersionUID = 2L;
+    /** Kept at {@code 1L} so existing checkpoint/savepoint bytes remain deserializable. */
+    private static final long serialVersionUID = 1L;
+
     public static final String SPLIT_PREFIX = "bigtable_source_split_";
 
     private final String splitId;
-    /** 分片起始 rowkey（含）；空串表示表起点。 */
+    /** Inclusive start row key (empty means table start). */
     private final String startRowKey;
-    /** 分片结束 rowkey（不含）；空串表示表终点。 */
+    /** Exclusive end row key (empty means table end). */
     private final String endRowKey;
 
     /**
-     * 已成功 emit 的最后一条 rowkey（UTF-8）。checkpoint 时随 split 持久化；旧 checkpoint 反序列化后为 {@code null}，行为与仅使用
-     * {@link #startRowKey} 一致。
+     * Last successfully emitted row key (UTF-8), persisted in checkpoint state. {@code null} for
+     * legacy checkpoints written before row-level resume was added.
      */
     private volatile String lastReadRowKey;
 
@@ -74,18 +77,19 @@ public class BigtableSourceSplit implements SourceSplit, Serializable {
     }
 
     /**
-     * 在读路径中更新片内进度；与 {@code checkpointLock} 在同一把锁内调用，保证快照能看到已 emit 的最后行。
+     * Updates in-split progress; called under the same lock as {@code collect()} so snapshots see
+     * the last emitted row.
      *
-     * @param rowKeyUtf8 当前行的 rowkey（UTF-8）
+     * @param rowKeyUtf8 current row key (UTF-8)
      */
     void setLastReadRowKey(String rowKeyUtf8) {
         this.lastReadRowKey = rowKeyUtf8;
     }
 
     /**
-     * 构造 {@link com.google.cloud.bigtable.data.v2.models.Query} 时使用的起始 rowkey。
+     * Row key used as the inclusive scan start when building a Bigtable {@code Query}.
      *
-     * <p>有续读进度时返回 {@link #lastReadRowKey}，否则返回 {@link #startRowKey}。
+     * <p>Returns {@link #lastReadRowKey} when set, otherwise {@link #startRowKey}.
      */
     public String getResumeStartRowKey() {
         if (lastReadRowKey != null && !lastReadRowKey.isEmpty()) {

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplit.java
@@ -21,21 +21,39 @@ import org.apache.seatunnel.api.source.SourceSplit;
 
 import java.io.Serializable;
 
+/**
+ * Bigtable Source 分片定义：描述一次范围扫描的边界与可选的片内续读进度。
+ *
+ * <p>checkpoint 恢复时，若 {@link #lastReadRowKey} 非空，Reader 会从该 rowkey（含）继续扫描， 避免对整个 split 从头重扫。语义为
+ * at-least-once，恢复后可能重复读取最后一条已提交行。
+ */
 public class BigtableSourceSplit implements SourceSplit, Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
     public static final String SPLIT_PREFIX = "bigtable_source_split_";
 
     private final String splitId;
-    /** Inclusive start row key (empty means the table start). */
+    /** 分片起始 rowkey（含）；空串表示表起点。 */
     private final String startRowKey;
-    /** Exclusive end row key (empty means the table end). */
+    /** 分片结束 rowkey（不含）；空串表示表终点。 */
     private final String endRowKey;
 
+    /**
+     * 已成功 emit 的最后一条 rowkey（UTF-8）。checkpoint 时随 split 持久化；旧 checkpoint 反序列化后为 {@code null}，行为与仅使用
+     * {@link #startRowKey} 一致。
+     */
+    private volatile String lastReadRowKey;
+
     public BigtableSourceSplit(int splitIndex, String startRowKey, String endRowKey) {
+        this(splitIndex, startRowKey, endRowKey, null);
+    }
+
+    public BigtableSourceSplit(
+            int splitIndex, String startRowKey, String endRowKey, String lastReadRowKey) {
         this.splitId = SPLIT_PREFIX + splitIndex;
         this.startRowKey = startRowKey;
         this.endRowKey = endRowKey;
+        this.lastReadRowKey = lastReadRowKey;
     }
 
     @Override
@@ -51,10 +69,35 @@ public class BigtableSourceSplit implements SourceSplit, Serializable {
         return endRowKey;
     }
 
+    public String getLastReadRowKey() {
+        return lastReadRowKey;
+    }
+
+    /**
+     * 在读路径中更新片内进度；与 {@code checkpointLock} 在同一把锁内调用，保证快照能看到已 emit 的最后行。
+     *
+     * @param rowKeyUtf8 当前行的 rowkey（UTF-8）
+     */
+    void setLastReadRowKey(String rowKeyUtf8) {
+        this.lastReadRowKey = rowKeyUtf8;
+    }
+
+    /**
+     * 构造 {@link com.google.cloud.bigtable.data.v2.models.Query} 时使用的起始 rowkey。
+     *
+     * <p>有续读进度时返回 {@link #lastReadRowKey}，否则返回 {@link #startRowKey}。
+     */
+    public String getResumeStartRowKey() {
+        if (lastReadRowKey != null && !lastReadRowKey.isEmpty()) {
+            return lastReadRowKey;
+        }
+        return startRowKey;
+    }
+
     @Override
     public String toString() {
         return String.format(
-                "{\"split_id\":\"%s\", \"start\":\"%s\", \"end\":\"%s\"}",
-                splitId, startRowKey, endRowKey);
+                "{\"split_id\":\"%s\", \"start\":\"%s\", \"end\":\"%s\", \"last_read\":\"%s\"}",
+                splitId, startRowKey, endRowKey, lastReadRowKey);
     }
 }

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceReaderTest.java
@@ -138,6 +138,77 @@ class BigtableSourceReaderTest {
     }
 
     /**
+     * Checkpoint taken mid-scan must persist the last emitted rowkey so failover can resume inside
+     * the split instead of re-scanning from split start.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSnapshotStateCapturesLastReadRowKeyDuringScan() throws Exception {
+        BigtableSourceSplit split = new BigtableSourceSplit(0, "a", "z");
+        final List<BigtableSourceSplit>[] capturedState = new List[1];
+
+        Row fakeRow = mock(Row.class);
+        RowCell cell = mock(RowCell.class);
+        when(cell.getFamily()).thenReturn("cf");
+        when(cell.getQualifier()).thenReturn(ByteString.copyFromUtf8("name"));
+        when(cell.getValue()).thenReturn(ByteString.copyFromUtf8("bob"));
+        when(fakeRow.getCells()).thenReturn(Collections.singletonList(cell));
+        when(fakeRow.getKey()).thenReturn(ByteString.copyFromUtf8("row-490"));
+
+        BigtableSourceReader reader = createOpenedReader(parameters, rowType);
+        reader.addSplits(Collections.singletonList(split));
+
+        ServerStream<Row> fakeStream = mock(ServerStream.class);
+        Mockito.doAnswer(
+                        invocation -> {
+                            Consumer<Row> action = invocation.getArgument(0);
+                            action.accept(fakeRow);
+                            capturedState[0] = reader.snapshotState(99L);
+                            return null;
+                        })
+                .when(fakeStream)
+                .forEach(any());
+        when(mockDataClient.readRows(any(Query.class))).thenReturn(fakeStream);
+
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+
+        reader.pollNext(collector);
+
+        assertEquals(1, capturedState[0].size());
+        assertEquals("row-490", capturedState[0].get(0).getLastReadRowKey());
+        assertEquals("row-490", capturedState[0].get(0).getResumeStartRowKey());
+    }
+
+    /**
+     * A split restored from checkpoint with {@code lastReadRowKey} must use that key as the scan
+     * start when {@link BigtableSourceReader} issues the read request.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void testRestoredSplitResumesFromLastReadRowKey() throws Exception {
+        BigtableSourceSplit restoredSplit = new BigtableSourceSplit(0, "a", "z", "row-490");
+
+        ServerStream<Row> fakeStream = mock(ServerStream.class);
+        Mockito.doAnswer(invocation -> null).when(fakeStream).forEach(any());
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        when(mockDataClient.readRows(queryCaptor.capture())).thenReturn(fakeStream);
+
+        BigtableSourceReader reader = createOpenedReader(parameters, rowType);
+        reader.addSplits(Collections.singletonList(restoredSplit));
+
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+
+        reader.pollNext(collector);
+
+        assertEquals("row-490", restoredSplit.getResumeStartRowKey());
+        assertTrue(
+                queryCaptor.getValue().toString().contains("row-490"),
+                "Query should scan from restored lastReadRowKey");
+    }
+
+    /**
      * After readSplit() completes, currentSplit is cleared. A snapshot taken after that must NOT
      * re-include the already-finished split.
      */

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitTest.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitTest.java
@@ -19,13 +19,22 @@ package org.apache.seatunnel.connectors.seatunnel.bigtable.source;
 
 import org.apache.seatunnel.common.utils.SerializationUtils;
 
+import org.apache.commons.codec.binary.Base64;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-/** {@link BigtableSourceSplit} 续读进度与序列化兼容性测试。 */
+/** Tests for {@link BigtableSourceSplit} resume progress and checkpoint serialization. */
 class BigtableSourceSplitTest {
+
+    /**
+     * Bytes produced by {@code BigtableSourceSplit(1, "x", "y")} on dev before {@code
+     * lastReadRowKey} existed (serialVersionUID = 1L, three fields only).
+     */
+    private static final String LEGACY_SPLIT_V1_BASE64 =
+            "rO0ABXNyAE1vcmcuYXBhY2hlLnNlYXR1bm5lbC5jb25uZWN0b3JzLnNlYXR1bm5lbC5iaWd0YWJsZS5zb3VyY2UuQmlndGFibGVTb3VyY2VTcGxpdAAAAAAAAAABAgADTAAJZW5kUm93S2V5dAASTGphdmEvbGFuZy9TdHJpbmc7TAAHc3BsaXRJZHEAfgABTAALc3RhcnRSb3dLZXlxAH4AAXhwdAABeXQAF2JpZ3RhYmxlX3NvdXJjZV9zcGxpdF8xdAABeA==";
 
     @Test
     void resumeStartRowKeyFallsBackToSplitStartWhenNoProgress() {
@@ -60,10 +69,12 @@ class BigtableSourceSplitTest {
     }
 
     @Test
-    void legacySplitWithoutProgressDeserializesWithNullLastReadRowKey() {
-        BigtableSourceSplit legacy = new BigtableSourceSplit(1, "x", "y");
-        byte[] bytes = SerializationUtils.serialize(legacy);
-        BigtableSourceSplit restored = SerializationUtils.deserialize(bytes);
+    void deserializesLegacyCheckpointBytesFromDevRelease() {
+        byte[] legacyBytes = Base64.decodeBase64(LEGACY_SPLIT_V1_BASE64);
+        BigtableSourceSplit restored = SerializationUtils.deserialize(legacyBytes);
+        assertEquals("bigtable_source_split_1", restored.splitId());
+        assertEquals("x", restored.getStartRowKey());
+        assertEquals("y", restored.getEndRowKey());
         assertNull(restored.getLastReadRowKey());
         assertEquals("x", restored.getResumeStartRowKey());
     }

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitTest.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.bigtable.source;
+
+import org.apache.seatunnel.common.utils.SerializationUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** {@link BigtableSourceSplit} 续读进度与序列化兼容性测试。 */
+class BigtableSourceSplitTest {
+
+    @Test
+    void resumeStartRowKeyFallsBackToSplitStartWhenNoProgress() {
+        BigtableSourceSplit split = new BigtableSourceSplit(0, "a", "z");
+        assertEquals("a", split.getResumeStartRowKey());
+    }
+
+    @Test
+    void resumeStartRowKeyUsesLastReadRowKeyWhenPresent() {
+        BigtableSourceSplit split = new BigtableSourceSplit(0, "a", "z", "row-490");
+        assertEquals("row-490", split.getResumeStartRowKey());
+    }
+
+    @Test
+    void lastReadRowKeyCanBeUpdatedDuringRead() {
+        BigtableSourceSplit split = new BigtableSourceSplit(0, "", "");
+        split.setLastReadRowKey("key-42");
+        assertEquals("key-42", split.getLastReadRowKey());
+        assertEquals("key-42", split.getResumeStartRowKey());
+    }
+
+    @Test
+    void checkpointRoundTripPreservesLastReadRowKey() {
+        BigtableSourceSplit original = new BigtableSourceSplit(0, "start", "end", "resume-here");
+        byte[] bytes = SerializationUtils.serialize(original);
+        BigtableSourceSplit restored = SerializationUtils.deserialize(bytes);
+        assertEquals(original.splitId(), restored.splitId());
+        assertEquals("start", restored.getStartRowKey());
+        assertEquals("end", restored.getEndRowKey());
+        assertEquals("resume-here", restored.getLastReadRowKey());
+        assertEquals("resume-here", restored.getResumeStartRowKey());
+    }
+
+    @Test
+    void legacySplitWithoutProgressDeserializesWithNullLastReadRowKey() {
+        BigtableSourceSplit legacy = new BigtableSourceSplit(1, "x", "y");
+        byte[] bytes = SerializationUtils.serialize(legacy);
+        BigtableSourceSplit restored = SerializationUtils.deserialize(bytes);
+        assertNull(restored.getLastReadRowKey());
+        assertEquals("x", restored.getResumeStartRowKey());
+    }
+}


### PR DESCRIPTION
…kpoint

Persist lastReadRowKey in split state so failover resumes inside the split instead of re-scanning from split start. Semantics remain at-least-once.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
