### PR TITLE
[Docs][Connector-V2] Improve DB2 Kingbase and Vertica docs

### DIFF
--- a/docs/en/connectors/sink/DB2.md
+++ b/docs/en/connectors/sink/DB2.md
@@ -32,13 +32,13 @@ semantics (using XA transaction guarantee).
 
 > Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
 > support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Supported DataSource Info
 
 | Datasource |                    Supported Versions                    |             Driver             |                Url                |                                 Maven                                 |
 |------------|----------------------------------------------------------|--------------------------------|-----------------------------------|-----------------------------------------------------------------------|
-| DB2        | Different dependency version has different driver class. | com.ibm.db2.jdbc.app.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [Download](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
+| DB2        | Different dependency version has different driver class. | com.ibm.db2.jcc.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [Download](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
 
 ## Data Type Mapping
 
@@ -63,7 +63,7 @@ semantics (using XA transaction guarantee).
 |                   Name                    |  Type   | Required | Default |                                                                                                                  Description                                                                                                                   |
 |-------------------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                             |
-| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use DB2 the value is `com.ibm.db2.jdbc.app.DB2Driver`.                                                                                                              |
+| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use DB2 the value is `com.ibm.db2.jcc.DB2Driver`.                                                                                                              |
 | username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                  |
 | password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                   |
 | query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
@@ -73,14 +73,16 @@ semantics (using XA transaction guarantee).
 | connection_check_timeout_sec              | Int     | No       | 30      | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                            |
 | max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
 | batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
+| batch_interval_ms                         | Long    | No       | 0       | Write-triggered flush interval in milliseconds. `0` disables interval flushing. When the value is greater than `0`, each write checks elapsed time and flushes synchronously if the interval has passed. |
 | is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`.                                                                                                              |
 | generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
-| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver, for example, DB2 is `com.db2.cj.jdbc.Db2XADataSource`, and<br/>please refer to appendix for other data sources                                                                           |
+| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver, for example, DB2 is `com.ibm.db2.jcc.DB2XADataSource`, and<br/>please refer to appendix for other data sources                                                                           |
 | max_commit_attempts                       | Int     | No       | 3       | The number of retries for transaction commit failures                                                                                                                                                                                          |
 | transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
 | auto_commit                               | Boolean | No       | true    | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
 | properties                                | Map     | No       | -       | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL. |
 | common-options                            |         | no       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                                    |
+| enable_upsert                             | Boolean | No       | true    | Enable upsert when `primary_keys` exists. If the input does not contain duplicate keys, setting this parameter to `false` can speed up data import. |
 
 ### Tips
 
@@ -124,7 +126,7 @@ transform {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         username = "root"
         password = "123456"
         query = "insert into test_table(name,age) values(?,?)"
@@ -142,7 +144,7 @@ sink {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         username = "root"
         password = "123456"
         # Automatically generate sql statements based on database table names
@@ -161,7 +163,7 @@ sink {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
     
         max_retries = 0
         username = "root"
@@ -170,7 +172,27 @@ sink {
     
         is_exactly_once = "true"
     
-        xa_data_source_class_name = "com.db2.cj.jdbc.Db2XADataSource"
+        xa_data_source_class_name = "com.ibm.db2.jcc.DB2XADataSource"
+    }
+}
+```
+
+### Generate Sink SQL With Upsert
+
+> When `generate_sink_sql = true` and `primary_keys` is set, DB2 uses a generated `MERGE` statement for upsert writes. If the input is insert-only and duplicate keys are impossible, set `enable_upsert = false` to use a faster insert path.
+
+```
+sink {
+    Jdbc {
+        url = "jdbc:db2://127.0.0.1:50000/E2E"
+        driver = "com.ibm.db2.jcc.DB2Driver"
+        username = "db2inst1"
+        password = "123456"
+        database = "E2E"
+        table = "SINK"
+        generate_sink_sql = true
+        enable_upsert = true
+        primary_keys = ["C_INT"]
     }
 }
 ```

--- a/docs/en/connectors/sink/Kingbase.md
+++ b/docs/en/connectors/sink/Kingbase.md
@@ -18,7 +18,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
 
@@ -58,9 +58,9 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 |                   Name                    |  Type   | Required | Default |                                                                                                                 Description                                                                                                                  |
 |-------------------------------------------|---------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                           |
-| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use DB2 the value is `com.ibm.db2.jdbc.app.DB2Driver`.                                                                                                            |
-| username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                |
+| url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:kingbase8://localhost:54321/db_test                                                                                                                                                           |
+| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use Kingbase the value is `com.kingbase8.Driver`.                                                                                                            |
+| username                                      | String  | No       | -       | Connection instance user name. The old key `user` is still accepted as a fallback.                                                                                                                                                                                                                |
 | password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                 |
 | query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                       |
 | database                                  | String  | No       | -       | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                     |
@@ -69,6 +69,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | connection_check_timeout_sec              | Int     | No       | 30      | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                          |
 | max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                        |
 | batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                         |
+| batch_interval_ms                         | Long    | No       | 0       | Write-triggered flush interval in milliseconds. `0` disables interval flushing. When the value is greater than `0`, each write checks elapsed time and flushes synchronously if the interval has passed. |
 | is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`. Kingbase currently does not support                                                                        |
 | generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                     |
 | xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver，Kingbase currently does not support                                                                                                                                                     |
@@ -165,6 +166,22 @@ sink {
         database = test
         table = test_table
     }
+}
+```
+
+### Write To A Schema Table
+
+> When writing with a custom `query`, the placeholder count must match the upstream fields. Kingbase schema-qualified tables can be written as `public.table_name`.
+
+```
+sink {
+  Jdbc {
+    driver = "com.kingbase8.Driver"
+    url = "jdbc:kingbase8://localhost:54321/test"
+    user = "SYSTEM"
+    password = "123456"
+    query = "INSERT INTO public.e2e_table_sink (c1, c2, c3) VALUES (?, ?, ?)"
+  }
 }
 ```
 

--- a/docs/en/connectors/sink/Vertica.md
+++ b/docs/en/connectors/sink/Vertica.md
@@ -27,12 +27,11 @@ semantics (using XA transaction guarantee).
 
 ## Key Features
 
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 
-> Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
-> support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+> Vertica is listed without a JDBC XA data source in the shared JDBC appendix, so this connector should be used with the default `is_exactly_once=false`.
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Supported DataSource Info
 
@@ -70,7 +69,7 @@ semantics (using XA transaction guarantee).
 |                   Name                    |  Type   | Required | Default |                                                                                                                  Description                                                                                                                   |
 |-------------------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:vertica://localhost:5433/vertica                                                                                                                                                         |
-| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use Vertical the value is `com.vertica.jdbc.Driver`.                                                                                                                |
+| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use Vertica the value is `com.vertica.jdbc.Driver`.                                                                                                                |
 | username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                  |
 | password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                   |
 | query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
@@ -80,9 +79,10 @@ semantics (using XA transaction guarantee).
 | connection_check_timeout_sec              | Int     | No       | 30      | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                            |
 | max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
 | batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
+| batch_interval_ms                         | Long    | No       | 0       | Write-triggered flush interval in milliseconds. `0` disables interval flushing. When the value is greater than `0`, each write checks elapsed time and flushes synchronously if the interval has passed. |
 | is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`.                                                                                                              |
 | generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
-| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver, for example, vertical is `com.vertical.cj.jdbc.VerticalXADataSource`, and<br/>please refer to appendix for other data sources                                                            |
+| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver. Vertica does not provide a documented value in the shared JDBC appendix, so keep `is_exactly_once=false` unless your driver provides a compatible XA data source.                                                            |
 | max_commit_attempts                       | Int     | No       | 3       | The number of retries for transaction commit failures                                                                                                                                                                                          |
 | transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
 | auto_commit                               | Boolean | No       | true    | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
@@ -161,24 +161,21 @@ sink {
 }
 ```
 
-### Exactly-once
+### Generate Sink SQL With Upsert
 
-> For accurate write scene we guarantee accurate once
+> When `generate_sink_sql = true` and `primary_keys` is set, Vertica uses a generated `MERGE` statement for upsert writes. This is different from XA exactly-once; keep `is_exactly_once=false` unless your Vertica driver provides a compatible XA data source.
 
 ```
 sink {
     jdbc {
         url = "jdbc:vertica://localhost:5433/vertica"
         driver = "com.vertica.jdbc.Driver"
-    
-        max_retries = 0
         username = "root"
         password = "123456"
-        query = "insert into test_table(name,age) values(?,?)"
-    
-        is_exactly_once = "true"
-    
-        xa_data_source_class_name = "com.vertical.cj.jdbc.VerticalXADataSource"
+        generate_sink_sql = true
+        database = "public"
+        table = "test_table"
+        primary_keys = ["id"]
     }
 }
 ```

--- a/docs/en/connectors/source/DB2.md
+++ b/docs/en/connectors/source/DB2.md
@@ -39,7 +39,7 @@ Read external data source data through JDBC.
 
 | Datasource |                    Supported versions                    |             Driver             |                Url                |                                 Maven                                 |
 |------------|----------------------------------------------------------|--------------------------------|-----------------------------------|-----------------------------------------------------------------------|
-| DB2        | Different dependency version has different driver class. | com.ibm.db2.jdbc.app.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [Download](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
+| DB2        | Different dependency version has different driver class. | com.ibm.db2.jcc.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [Download](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
 
 ## Database Dependency
 
@@ -69,7 +69,7 @@ Read external data source data through JDBC.
 |             Name             |    Type    | Required |     Default     |                                                                                                                            Description                                                                                                                            |
 |------------------------------|------------|----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                          | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                                                |
-| driver                       | String     | Yes      | -               | The jdbc class name used to connect to the remote data source,<br/> if you use db2 the value is `com.ibm.db2.jdbc.app.DB2Driver`.                                                                                                                                 |
+| driver                       | String     | Yes      | -               | The jdbc class name used to connect to the remote data source,<br/> if you use db2 the value is `com.ibm.db2.jcc.DB2Driver`.                                                                                                                                 |
 | username                         | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                     |
 | password                     | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                      |
 | query                        | String     | Yes      | -               | Query statement                                                                                                                                                                                                                                                   |
@@ -101,7 +101,7 @@ env {
 source{
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"
@@ -127,7 +127,7 @@ sink {
 source {
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"
@@ -149,7 +149,7 @@ source {
 source {
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"
@@ -168,4 +168,3 @@ source {
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/source/Kingbase.md
+++ b/docs/en/connectors/source/Kingbase.md
@@ -61,7 +61,7 @@ Read external data source data through JDBC.
 |------------------------------|------------|----------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                          | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: jdbc:kingbase8://localhost:54321/test                                                                                                                                                                                |
 | driver                       | String     | Yes      | -               | The jdbc class name used to connect to the remote data source, should be `com.kingbase8.Driver`.                                                                                                                                                                      |
-| username                         | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                         |
+| username                         | String     | No       | -               | Connection instance user name. The old key `user` is still accepted as a fallback.                                                                                                                                                                                                                                         |
 | password                     | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                          |
 | query                        | String     | Yes      | -               | Query statement                                                                                                                                                                                                                                                       |
 | connection_check_timeout_sec | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete                                                                                                                                                                    |
@@ -153,6 +153,22 @@ source {
     partition_lower_bound = 1
     # Read end boundary
     partition_upper_bound = 500
+  }
+}
+```
+
+### Query With Schema Name
+
+> Kingbase table names are usually written as `schema.table`. You can use either `username` or the fallback key `user` for the connection account.
+
+```
+source {
+  Jdbc {
+    driver = "com.kingbase8.Driver"
+    url = "jdbc:kingbase8://localhost:54321/test"
+    user = "SYSTEM"
+    password = "123456"
+    query = "select * from public.e2e_table_source"
   }
 }
 ```

--- a/docs/zh/connectors/sink/DB2.md
+++ b/docs/zh/connectors/sink/DB2.md
@@ -2,7 +2,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 # DB2
 
-> JDBC DB2接收器连接器
+> JDBC DB2Sink 连接器
 
 ## 支持以下引擎
 
@@ -19,25 +19,26 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 适用于 Spark/Flink 引擎
 
-> 1. 您需要确保 [jdbc driver jar package](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) 已放置在目录 `${SEATUNNEL_HOME}/plugins/`.
+> 1. 您需要确保 [JDBC 驱动 JAR 包](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) 已放置在目录 `${SEATUNNEL_HOME}/plugins/`.
 
 ### 适用于 SeaTunnel Zeta 引擎
 
-> 1. 您需要确保 [jdbc driver jar package](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) 已放置在目录 `${SEATUNNEL_HOME}/lib/`.
+> 1. 您需要确保 [JDBC 驱动 JAR 包](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) 已放置在目录 `${SEATUNNEL_HOME}/lib/`.
 
 ## 关键特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-> 使用 `Xa transactions` 来确保 `精确一次`. 因此，数据库只支持 `exactly-once` 即
-> 支持 `Xa transactions`. 您可以设置 `is_exactly_once=true` 来启用它.
+> 使用 `XA 事务` 来确保 `精确一次`. 因此，数据库只支持 `精确一次` 即
+> 支持 `XA 事务`. 您可以设置 `is_exactly_once=true` 来启用它.
 
 ## 支持的数据源信息
 
 | 数据库 |                    支持版本                    |             驱动             |                Url                |                                 Maven                                 |
 |------------|---------------------------------------------------------|--------------------------------|-----------------------------------|-----------------------------------------------------------------------|
-| DB2        | Different dependency version has different driver class. | com.ibm.db2.jdbc.app.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [Download](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
+| DB2        | 不同的依赖版本有不同的驱动程序类。 | com.ibm.db2.jcc.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [下载](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
 
 ## 数据类型映射
 
@@ -55,31 +56,33 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | DATE                                                                                                 | DATE                |
 | TIME                                                                                                 | TIME                |
 | TIMESTAMP                                                                                            | TIMESTAMP           |
-| ROWID<br/>XML                                                                                        | Not supported yet   |
+| ROWID<br/>XML                                                                                        | 暂不支持   |
 
 ## 选项
 
 | 名称                           |  类型   | 必需 | 默认值 | 描述                                                                                                                                                                                                                                             |
 |------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                          | String  | Yes      | -       | JDBC连接的URL。请参考案例 : jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                                                           |
-| driver                       | String  | Yes      | -       | 用于连接到远程数据源的jdbc类名,<br/> 如果使用DB2，则值为 `com.ibm.db2.jdbc.app.DB2Driver`.                                                                                                                                                                          |
-| username                     | String  | No       | -       | 连接实例用户名                                                                                                                                                                                                                                        |
-| password                     | String  | No       | -       | 连接实例密码                                                                                                                                                                                                                                         |
-| query                        | String  | No       | -       | 使用此sql将上游输入数据写入数据库。例如 `INSERT ...`,`query` 具有更高的优先级                                                                                                                                                                                            |
-| database                     | String  | No       | -       | 使用这个 `database` 和 `table-name` 自动生成sql并接收上游输入数据写入数据库.<br/>此选项与 `query` 互斥，具有更高的优先级.                                                                                                                                                            |
-| table                        | String  | No       | -       | 使用数据库和此表名自动生成sql并接收上游输入数据写入数据库.<br/>此选项与 `query` 互斥，具有更高的优先级.                                                                                                                                                                                  |
-| primary_keys                 | Array   | No       | -       | 此选项用于在自动生成sql时支持 `insert`, `delete`, 和 `update` 等操作.                                                                                                                                                                                           |
-| connection_check_timeout_sec | Int     | No       | 30      | 等待用于验证连接的数据库操作完成的时间（秒）.                                                                                                                                                                                                                        |
-| max_retries                  | Int     | No       | 0       | 提交失败的重试次数 (执行批处理)                                                                                                                                                                                                                              |
-| batch_size                   | Int     | No       | 1000    | 对于批量写入，当缓冲记录的数量达到 `batch_size` 的数量或时间达到 `checkpoint.interval` 时<br/>, 数据将被刷新到数据库中                                                                                                                                                              |
-| is_exactly_once              | Boolean | No       | false   | 是否启用精确一次语义，这将使用 Xa 事务. 如果启用，则需要<br/>设置 `xa_data_source_class_name`.                                                                                                                                                                            |
-| generate_sink_sql            | Boolean | No       | false   | 根据要写入的数据库表生成sql语句                                                                                                                                                                                                                              |
-| xa_data_source_class_name    | String  | No       | -       | 数据库Driver的 xa 数据源类名, for example, DB2 是 `com.db2.cj.jdbc.Db2XADataSource`, <br/>其他数据来源请参考附录                                                                                                           |
-| max_commit_attempts          | Int     | No       | 3       | 事务提交失败的重试次数                                                                                                                                                                                          |
-| transaction_timeout_sec      | Int     | No       | -1      | 事务打开后的超时，默认值为-1（永不超时）. 请注意，设置超时可能会影响＜br/＞精确一次语义                                                                                            |
-| auto_commit                  | Boolean | No       | true    | 默认情况下启用自动事务提交                                                                                                                                                                                             |
-| properties                   | Map     | No       | -       | 附加连接配置参数，当属性和URL具有相同的参数时，优先级由驱动程序的特定实现决定. 例如，在MySQL中，属性优先于URL. |
-| common-options               |         | no       | -       | Sink插件常用参数，详见 [Sink Common Options](../common-options/sink-common-options.md)                                                                                                                                     |
+| url                          | String  | 是       | -       | JDBC连接的URL。请参考案例 : jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                                                           |
+| driver                       | String  | 是       | -       | 用于连接到远程数据源的jdbc类名,<br/> 如果使用DB2，则值为 `com.ibm.db2.jcc.DB2Driver`.                                                                                                                                                                          |
+| username                     | String  | 否       | -       | 连接实例用户名                                                                                                                                                                                                                                        |
+| password                     | String  | 否       | -       | 连接实例密码                                                                                                                                                                                                                                         |
+| query                        | String  | 否       | -       | 使用此sql将上游输入数据写入数据库。例如 `INSERT ...`,`query` 具有更高的优先级                                                                                                                                                                                            |
+| database                     | String  | 否       | -       | 使用这个 `database` 和 `table-name` 自动生成sql并接收上游输入数据写入数据库.<br/>此选项与 `query` 互斥，具有更高的优先级.                                                                                                                                                            |
+| table                        | String  | 否       | -       | 使用数据库和此表名自动生成sql并接收上游输入数据写入数据库.<br/>此选项与 `query` 互斥，具有更高的优先级.                                                                                                                                                                                  |
+| primary_keys                 | Array   | 否       | -       | 此选项用于在自动生成sql时支持 `insert`, `delete`, 和 `update` 等操作.                                                                                                                                                                                           |
+| connection_check_timeout_sec | Int     | 否       | 30      | 等待用于验证连接的数据库操作完成的时间（秒）.                                                                                                                                                                                                                        |
+| max_retries                  | Int     | 否       | 0       | 提交失败的重试次数 (执行批处理)                                                                                                                                                                                                                              |
+| batch_size                   | Int     | 否       | 1000    | 对于批量写入，当缓冲记录的数量达到 `batch_size` 的数量或时间达到 `checkpoint.interval` 时<br/>, 数据将被刷新到数据库中                                                                                                                                                              |
+| batch_interval_ms            | Long    | 否       | 0       | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 `0` 时，每次写入会检查距离上次刷新是否已超过该间隔，超过则同步刷新。 |
+| is_exactly_once              | Boolean | 否       | false   | 是否启用精确一次语义，这将使用 Xa 事务. 如果启用，则需要<br/>设置 `xa_data_source_class_name`.                                                                                                                                                                            |
+| generate_sink_sql            | Boolean | 否       | false   | 根据要写入的数据库表生成sql语句                                                                                                                                                                                                                              |
+| xa_data_source_class_name    | String  | 否       | -       | 数据库 Driver 的 XA 数据源类名，例如 DB2 是 `com.ibm.db2.jcc.DB2XADataSource`，<br/>其他数据源请参考附录。                                                                                                           |
+| max_commit_attempts          | Int     | 否       | 3       | 事务提交失败的重试次数                                                                                                                                                                                          |
+| transaction_timeout_sec      | Int     | 否       | -1      | 事务打开后的超时，默认值为-1（永不超时）. 请注意，设置超时可能会影响<br/>精确一次语义                                                                                            |
+| auto_commit                  | Boolean | 否       | true    | 默认情况下启用自动事务提交                                                                                                                                                                                             |
+| properties                   | Map     | 否       | -       | 附加连接配置参数，当属性和URL具有相同的参数时，优先级由驱动程序的特定实现决定. 例如，在MySQL中，属性优先于URL. |
+| common-options               |         | 否       | -       | Sink 插件常用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)                                                                                                                                     |
+| enable_upsert                | Boolean | 否       | true    | 存在 `primary_keys` 时启用 upsert。如果输入数据不会出现重复主键，将此参数设置为 `false` 可以加快写入速度。 |
 
 ### 小贴士
 
@@ -89,7 +92,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 简单
 
-> 此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在DB2中创建数据库测试和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[Install SeaTunnel](../../getting-started/locally/deployment.md)中的说明安装和部署SeaTunnel。然后按照[Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md) 中的说明运行此作业.
+> 此示例定义了一个SeaTunnel同步任务，该任务通过FakeSource自动生成数据并将其发送到JDBC Sink。FakeSource总共生成16行数据（row.num=16），每行有两个字段，name（字符串类型）和age（int类型）。最终的目标表是test_table，表中也将有16行数据。在运行此作业之前，您需要在DB2中创建数据库测试和表test_table。如果您尚未安装和部署SeaTunnel，则需要按照[安装 SeaTunnel](../../getting-started/locally/deployment.md)中的说明安装和部署SeaTunnel。然后按照[使用 SeaTunnel Engine 快速开始](../../getting-started/locally/quick-start-seatunnel-engine.md) 中的说明运行此作业.
 
 ```
 # 定义运行时环境
@@ -123,7 +126,7 @@ transform {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         username = "root"
         password = "123456"
         query = "insert into test_table(name,age) values(?,?)"
@@ -141,7 +144,7 @@ sink {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         username = "root"
         password = "123456"
         # Automatically generate sql statements based on database table names
@@ -160,7 +163,7 @@ sink {
 sink {
     jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
     
         max_retries = 0
         username = "root"
@@ -169,7 +172,27 @@ sink {
     
         is_exactly_once = "true"
     
-        xa_data_source_class_name = "com.db2.cj.jdbc.Db2XADataSource"
+        xa_data_source_class_name = "com.ibm.db2.jcc.DB2XADataSource"
+    }
+}
+```
+
+### 使用自动生成 SQL 进行 Upsert
+
+> 设置 `generate_sink_sql = true` 并配置 `primary_keys` 后，DB2 会生成 `MERGE` 语句进行 upsert 写入。如果输入只包含新增数据且不会出现重复主键，可以设置 `enable_upsert = false` 使用更快的插入路径。
+
+```
+sink {
+    Jdbc {
+        url = "jdbc:db2://127.0.0.1:50000/E2E"
+        driver = "com.ibm.db2.jcc.DB2Driver"
+        username = "db2inst1"
+        password = "123456"
+        database = "E2E"
+        table = "SINK"
+        generate_sink_sql = true
+        enable_upsert = true
+        primary_keys = ["C_INT"]
     }
 }
 ```

--- a/docs/zh/connectors/sink/Kingbase.md
+++ b/docs/zh/connectors/sink/Kingbase.md
@@ -18,16 +18,17 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
-> 使用 `Xa transactions` 来确保 `精确一次`。因此仅支持支持 `Xa transactions` 的数据库的 `精确一次`。您可以设置 `is_exactly_once=true` 来启用它。Kingbase 目前不支持
+> 使用 `XA 事务` 来确保 `精确一次`。因此仅支持支持 `XA 事务` 的数据库的 `精确一次`。您可以设置 `is_exactly_once=true` 来启用它。Kingbase 目前不支持
 
 ## 支持的数据源信息
 
 | 数据源 | 支持的版本 |        驱动        |                   URL                    |                                             Maven                                              |
 |--------|-----------|----------------------|------------------------------------------|------------------------------------------------------------------------------------------------|
-| Kingbase   | 8.6                | com.kingbase8.Driver | jdbc:kingbase8://localhost:54321/db_test | [Download](https://repo1.maven.org/maven2/cn/com/kingbase/kingbase8/8.6.0/kingbase8-8.6.0.jar) |
+| Kingbase   | 8.6                | com.kingbase8.Driver | jdbc:kingbase8://localhost:54321/db_test | [下载](https://repo1.maven.org/maven2/cn/com/kingbase/kingbase8/8.6.0/kingbase8-8.6.0.jar) |
 
 ## 数据库依赖
 
@@ -56,9 +57,9 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 |                   参数名                    |  类型   | 必须 | 默认值 |                                                                                                                 描述                                                                                                                  |
 |-------------------------------------------|---------|------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                       | String  | 是   | -       | JDBC 连接的 URL。参考示例：jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                           |
-| driver                                    | String  | 是   | -       | 用于连接到远程数据源的 jdbc 类名，<br/> 如果使用 DB2，则值为 `com.ibm.db2.jdbc.app.DB2Driver`。                                                                                                            |
-| username                                      | String  | 否   | -       | 连接实例用户名                                                                                                                                                                                                                |
+| url                                       | String  | 是   | -       | JDBC 连接的 URL。参考示例：jdbc:kingbase8://localhost:54321/db_test                                                                                                                                                           |
+| driver                                    | String  | 是   | -       | 用于连接到远程数据源的 jdbc 类名，<br/> 如果使用 Kingbase，则值为 `com.kingbase8.Driver`。                                                                                                            |
+| username                                      | String  | 否   | -       | 连接实例用户名。旧配置名 `user` 仍可作为兼容写法使用。                                                                                                                                                                                                                |
 | password                                  | String  | 否   | -       | 连接实例密码                                                                                                                                                                                                                 |
 | query                                     | String  | 否   | -       | 使用此 sql 将上游输入数据写入数据库。例如 `INSERT ...`，`query` 具有更高的优先级                                                                                                                                       |
 | database                                  | String  | 否   | -       | 使用此 `database` 和 `table-name` 自动生成 sql 并接收上游输入数据写入数据库。<br/>此选项与 `query` 互斥，具有更高的优先级。                                                     |
@@ -67,6 +68,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | connection_check_timeout_sec              | Int     | 否   | 30      | 等待用于验证连接的数据库操作完成的时间（秒）。                                                                                                                                          |
 | max_retries                               | Int     | 否   | 0       | 提交失败的重试次数 (executeBatch)                                                                                                                                                                                        |
 | batch_size                                | Int     | 否   | 1000    | 对于批量写入，当缓冲记录数达到 `batch_size` 数量或时间达到 `checkpoint.interval` 时<br/>，数据将被刷新到数据库                                                         |
+| batch_interval_ms                         | Long    | 否   | 0       | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 `0` 时，每次写入会检查距离上次刷新是否已超过该间隔，超过则同步刷新。 |
 | is_exactly_once                           | Boolean | 否   | false   | 是否启用精确一次语义，这将使用 Xa 事务。如果启用，您需要<br/>设置 `xa_data_source_class_name`。Kingbase 目前不支持                                                                        |
 | generate_sink_sql                         | Boolean | 否   | false   | 根据您要写入的数据库表生成 sql 语句                                                                                                                                                                     |
 | xa_data_source_class_name                 | String  | 否   | -       | 数据库驱动程序的 xa 数据源类名，Kingbase 目前不支持                                                                                                                                                     |
@@ -158,8 +160,23 @@ sink {
 }
 ```
 
+### 写入 Schema 表
+
+> 使用自定义 `query` 写入时，占位符数量必须和上游字段数量一致。Kingbase 带 schema 的表可以写成 `public.table_name`。
+
+```
+sink {
+  Jdbc {
+    driver = "com.kingbase8.Driver"
+    url = "jdbc:kingbase8://localhost:54321/test"
+    user = "SYSTEM"
+    password = "123456"
+    query = "INSERT INTO public.e2e_table_sink (c1, c2, c3) VALUES (?, ?, ?)"
+  }
+}
+```
+
 ## 变更日志
 
 <ChangeLog />
-
 

--- a/docs/zh/connectors/sink/Vertica.md
+++ b/docs/zh/connectors/sink/Vertica.md
@@ -26,11 +26,11 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 主要特性
 
-- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-> 使用 `Xa 事务` 来保证 `精确一次`。因此仅支持支持 `Xa 事务` 的数据库。可以通过设置 `is_exactly_once=true` 来启用。
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+> 共享 JDBC 附录中没有列出 Vertica 的 JDBC XA 数据源，因此建议使用默认的 `is_exactly_once=false`。
 
 ## 支持的数据源信息
 
@@ -78,14 +78,15 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | connection_check_timeout_sec | Int    | 否       | 30      | 用于验证连接完成的数据库操作的等待时间（秒）。                                                                                                                                                       |
 | max_retries                  | Int    | 否       | 0       | 提交失败（executeBatch）的重试次数。                                                                                                                                                                 |
 | batch_size                   | Int    | 否       | 1000    | 对于批量写入，当缓冲的记录数达到 `batch_size` 或时间达到 `checkpoint.interval` 时，数据将被刷新到数据库中。                                                                                           |
+| batch_interval_ms            | Long   | 否       | 0       | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 `0` 时，每次写入会检查距离上次刷新是否已超过该间隔，超过则同步刷新。 |
 | is_exactly_once              | Boolean  | 否       | false   | 是否启用精确一次语义，将使用 Xa 事务。如果启用，需要设置 `xa_data_source_class_name`。                                                                                                               |
 | generate_sink_sql            | Boolean  | 否       | false   | 根据要写入的数据库表生成 SQL 语句。                                                                                                                                                                  |
-| xa_data_source_class_name    | String  | 否       | -       | 数据库驱动的 XA 数据源类名，例如 Vertica 为 `com.vertical.cj.jdbc.VerticalXADataSource`，其他数据源请参考附录。                                                                                      |
+| xa_data_source_class_name    | String  | 否       | -       | 数据库驱动的 XA 数据源类名。共享 JDBC 附录中没有列出 Vertica 的可用值，因此除非所用驱动提供兼容的 XA 数据源，否则保持 `is_exactly_once=false`。                                                                                      |
 | max_commit_attempts          | Int    | 否       | 3       | 事务提交失败的重试次数。                                                                                                                                                                             |
 | transaction_timeout_sec      | Int    | 否       | -1      | 事务打开后的超时时间，默认为 -1（永不超时）。注意：设置超时可能会影响精确一次语义。                                                                                                                  |
 | auto_commit                  | Boolean  | 否       | true    | 默认启用自动事务提交。                                                                                                                                                                               |
 | properties                   | Map    | 否       | -       | 额外的连接配置参数，当 properties 和 URL 中有相同的参数时，优先级由驱动的具体实现决定。例如，在 MySQL 中，properties 优先于 URL。                                                                     |
-| common-options               |         | 否       | -       | 接收器插件通用参数，详情请参考 [Sink Common Options](../common-options/sink-common-options.md)。                                                                                                                    |
+| common-options               |         | 否       | -       | 接收器插件通用参数，详情请参考 [Sink 通用选项](../common-options/sink-common-options.md)。                                                                                                                    |
 | enable_upsert                | Boolean  | 否       | true    | 通过主键存在启用 upsert。如果任务中没有键重复数据，将此参数设置为 `false` 可以加快数据导入速度。                                                                                                     |
 
 ### 提示
@@ -159,21 +160,21 @@ sink {
 }
 ```
 
-### 精确一次
+### 使用自动生成 SQL 进行 Upsert
 
-> 对于精确写入场景，我们保证精确一次语义。
+> 设置 `generate_sink_sql = true` 并配置 `primary_keys` 后，Vertica 会生成 `MERGE` 语句进行 upsert 写入。这不同于 XA 精确一次；除非所用 Vertica 驱动提供兼容的 XA 数据源，否则保持 `is_exactly_once=false`。
 
 ```
 sink {
     jdbc {
         url = "jdbc:vertica://localhost:5433/vertica"
         driver = "com.vertica.jdbc.Driver"
-        max_retries = 0
         username = "root"
         password = "123456"
-        query = "insert into test_table(name,age) values(?,?)"
-        is_exactly_once = "true"
-        xa_data_source_class_name = "com.vertical.cj.jdbc.VerticalXADataSource"
+        generate_sink_sql = true
+        database = "public"
+        table = "test_table"
+        primary_keys = ["id"]
     }
 }
 ```

--- a/docs/zh/connectors/source/DB2.md
+++ b/docs/zh/connectors/source/DB2.md
@@ -2,7 +2,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 # DB2
 
-> JDBC DB2 Source连接器
+> JDBC DB2 Source 连接器
 
 ## 支持引擎
 
@@ -39,7 +39,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 | 数据源 |                    支持版本                    |             驱动             |                Url                |                                 Maven                                 |
 |------------|----------------------------------------------------------|--------------------------------|-----------------------------------|-----------------------------------------------------------------------|
-| DB2        | 不同的依赖版本有不同的驱动程序类。| com.ibm.db2.jdbc.app.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [下载](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
+| DB2        | 不同的依赖版本有不同的驱动程序类。| com.ibm.db2.jcc.DB2Driver | jdbc:db2://127.0.0.1:50000/dbname | [下载](https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc) |
 
 ## 数据库相关性
 
@@ -49,7 +49,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 ## 数据类型映射
 
 |                                            DB2数据类型                                             | SeaTunnel 数据类型 |
-|------------------------------------------------------------------------------------------------------|---------------------|---|
+|------------------------------------------------------------------------------------------------------|---------------------|
 | BOOLEAN                                                                                              | BOOLEAN             |
 | SMALLINT                                                                                             | SHORT               |
 | INT<br/>INTEGER<br/>                                                                                 | INTEGER             |
@@ -62,14 +62,14 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | DATE                                                                                                 | DATE                |
 | TIME                                                                                                 | TIME                |
 | TIMESTAMP                                                                                            | TIMESTAMP           |
-| ROWID<br/>XML                                                                                        | Not supported yet   |
+| ROWID<br/>XML                                                                                        | 暂不支持   |
 
 ## 源选项
 
 | 名称                           |    类型    | 必需 |     默认值     |                                                                                                                            描述                                                                                                                            |
 |------------------------------|------------|----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                          | String     | 是      | -               | JDBC连接的URL。请参考案例：jdbc:db2://127.0.0.1:50000/dbname                                                                                                                                                                                |
-| driver                       | String     | 是      | -               | 用于连接到远程数据源的jdbc类名，<br/>如果使用db2，则值为`com.ibm.db2.jdbc.app.DB2Driver`。                                                                                                                                 |
+| driver                       | String     | 是      | -               | 用于连接到远程数据源的jdbc类名，<br/>如果使用db2，则值为`com.ibm.db2.jcc.DB2Driver`。                                                                                                                                 |
 | username                     | String     | 否       | -               | 连接实例用户名                                                                                                                                                                                                                                     |
 | password                     | String     | 否       | -               | 连接实例密码                                                                                                                                                                                                                                      |
 | query                        | String     | 是      | -               | 查询语句                                                                                                                                                                                                                                                   |
@@ -80,7 +80,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | partition_num                | Int        | 否      | job parallelism | 分区计数的数量，只支持正整数。默认值是作业并行性                                                                                                                                                                    |
 | fetch_size                   | Int        | 否       | 0               | 对于返回大量对象的查询，您可以配置查询中使用的行提取大小，通过减少满足选择条件所需的数据库请求次数来提高性能。0表示使用jdbc默认值。 |
 | properties                   | Map        | 否       | -               | 其他连接配置参数，当属性和URL具有相同的参数时，优先级由驱动程序的特定实现决定。例如，在MySQL中，属性优先于URL。                    |
-| common-options               |            | 否       | -               | source插件常用参数，详见[Source common Options](../common-options/source-common-options.md)                                                                                                                                                 |
+| common-options               |            | 否       | -               | Source 插件常用参数，详见[源通用选项](../common-options/source-common-options.md)                                                                                                                                                 |
 
 ### 小贴士
 
@@ -101,7 +101,7 @@ env {
 source{
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"
@@ -127,7 +127,7 @@ sink {
 source {
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"
@@ -149,7 +149,7 @@ source {
 source {
     Jdbc {
         url = "jdbc:db2://127.0.0.1:50000/dbname"
-        driver = "com.ibm.db2.jdbc.app.DB2Driver"
+        driver = "com.ibm.db2.jcc.DB2Driver"
         connection_check_timeout_sec = 100
         username = "root"
         password = "123456"

--- a/docs/zh/connectors/source/Kingbase.md
+++ b/docs/zh/connectors/source/Kingbase.md
@@ -61,7 +61,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 |--------|------|------|--------|------|
 | url | String | 是 | - | JDBC 连接的 URL。参考示例：jdbc:kingbase8://localhost:54321/test |
 | driver | String | 是 | - | 用于连接到远程数据源的 jdbc 类名，应为 `com.kingbase8.Driver`。 |
-| username | String | 否 | - | 连接实例用户名 |
+| username | String | 否 | - | 连接实例用户名。旧配置名 `user` 仍可作为兼容写法使用。 |
 | password | String | 否 | - | 连接实例密码 |
 | query | String | 是 | - | 查询语句 |
 | connection_check_timeout_sec | Int | 否 | 30 | 等待用于验证连接的数据库操作完成的时间（秒） |
@@ -157,7 +157,22 @@ source {
 }
 ```
 
+### 使用 Schema 表名查询
+
+> Kingbase 表名通常写成 `schema.table`。连接用户名可以使用 `username`，也可以使用兼容写法 `user`。
+
+```
+source {
+  Jdbc {
+    driver = "com.kingbase8.Driver"
+    url = "jdbc:kingbase8://localhost:54321/test"
+    user = "SYSTEM"
+    password = "123456"
+    query = "select * from public.e2e_table_source"
+  }
+}
+```
+
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Purpose

Improve the DB2, Kingbase, and Vertica JDBC connector documentation based on the current connector option surface and integration examples.

## Changes

- Correct DB2 driver and XA data source class names in English and Chinese docs.
- Document JDBC sink timer flush behavior through `batch_interval_ms`.
- Clarify Kingbase `user` fallback usage and schema-qualified table examples.
- Replace the unsupported Vertica XA example with generated SQL/upsert guidance.
- Add DB2 generated SQL upsert examples and align Chinese wording/formatting.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`