### PR TITLE
[Docs][Connector-V2] Improve Greenplum connector docs

### DIFF
--- a/docs/en/connectors/sink/Greenplum.md
+++ b/docs/en/connectors/sink/Greenplum.md
@@ -4,38 +4,150 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > Greenplum sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Write data to Greenplum using [Jdbc connector](Jdbc.md).
+Write data to Greenplum using the [Jdbc connector](Jdbc.md). Greenplum uses the PostgreSQL protocol, so you can usually use the PostgreSQL JDBC driver. If you use the Greenplum native JDBC driver, provide the driver jar yourself.
+
+## Using Dependency
+
+### For Spark/Flink Engine
+
+> 1. When using `org.postgresql.Driver`, ensure the [PostgreSQL JDBC driver](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in `${SEATUNNEL_HOME}/plugins/`.
+> 2. When using `com.pivotal.jdbc.GreenplumDriver`, download the Greenplum JDBC driver by yourself and place it in `${SEATUNNEL_HOME}/plugins/`.
+
+### For SeaTunnel Zeta Engine
+
+> 1. When using `org.postgresql.Driver`, ensure the [PostgreSQL JDBC driver](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in `${SEATUNNEL_HOME}/lib/`.
+> 2. When using `com.pivotal.jdbc.GreenplumDriver`, download the Greenplum JDBC driver by yourself and place it in `${SEATUNNEL_HOME}/lib/`.
 
 ## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 
-Not support exactly-once semantics (XA transaction is not yet supported in Greenplum database).
+Greenplum sink does not support exactly-once semantics because XA transaction is not supported by Greenplum.
 
 :::
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+| Datasource | Driver | Url | Maven |
+|------------|--------|-----|-------|
+| Greenplum by PostgreSQL driver | `org.postgresql.Driver` | `jdbc:postgresql://localhost:5432/testdb` | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| Greenplum native driver | `com.pivotal.jdbc.GreenplumDriver` | `jdbc:pivotal:greenplum://localhost:5432;DatabaseName=testdb` | Download from Greenplum |
 
 ## Options
 
-### driver [string]
+Only Greenplum-specific commonly used options are listed here. Other JDBC sink options, such as `batch_size`, `max_retries`, `generate_sink_sql`, `database`, `table`, `primary_keys`, and `properties`, are inherited from [Jdbc Sink](Jdbc.md).
 
-Optional jdbc drivers:
-- `org.postgresql.Driver`
-- `com.pivotal.jdbc.GreenplumDriver`
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| url | String | Yes | - | JDBC connection URL. Use `jdbc:postgresql://host:port/database` with PostgreSQL driver, or `jdbc:pivotal:greenplum://host:port;DatabaseName=database` with Greenplum native driver. |
+| driver | String | Yes | - | JDBC driver class name, usually `org.postgresql.Driver` or `com.pivotal.jdbc.GreenplumDriver`. |
+| username | String | No | - | Greenplum username. |
+| password | String | No | - | Greenplum password. |
+| query | String | No | - | SQL used to write upstream rows, for example `insert into sink(age, name) values(?, ?)`. `query` has higher priority than generated sink SQL. |
+| batch_size | Int | No | 1000 | Maximum records buffered before flushing to Greenplum. |
+| max_retries | Int | No | 0 | Retry times after `executeBatch` fails. |
+| generate_sink_sql | Boolean | No | false | Generate insert SQL automatically from `database` and `table`. |
+| database | String | No | - | Database name used when `generate_sink_sql = true`. |
+| table | String | No | - | Target table name used when `generate_sink_sql = true`. |
+| common-options | | No | - | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details. |
 
-Warn: for license compliance, if you use `GreenplumDriver` the have to provide Greenplum JDBC driver yourself, e.g. copy greenplum-xxx.jar to $SEATUNNEL_HOME/lib for Standalone.
+:::tip
 
-### url [string]
+For license compliance, SeaTunnel does not ship the Greenplum native JDBC driver. If you use `com.pivotal.jdbc.GreenplumDriver`, copy `greenplum-xxx.jar` to the engine dependency directory before running the job.
 
-The URL of the JDBC connection. if you use postgresql driver the value is `jdbc:postgresql://${yous_host}:${yous_port}/${yous_database}`, or you use greenplum driver the value is `jdbc:pivotal:greenplum://${yous_host}:${yous_port};DatabaseName=${yous_database}`
+:::
 
-### common options
+## Task Example
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+### Write To Greenplum
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 16
+    schema = {
+      fields {
+        age = "int"
+        name = "string"
+      }
+    }
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
+
+### Read And Write Greenplum
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
+
+### Generate Sink SQL
+
+```hocon
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    generate_sink_sql = true
+    database = "testdb"
+    table = "sink"
+  }
+}
+```
 
 ## Changelog
 

--- a/docs/en/connectors/source/Greenplum.md
+++ b/docs/en/connectors/source/Greenplum.md
@@ -6,7 +6,25 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Description
 
-Read Greenplum data through [Jdbc connector](Jdbc.md).
+Read Greenplum data through the [Jdbc connector](Jdbc.md). Greenplum uses the PostgreSQL protocol, so you can usually use the PostgreSQL JDBC driver. If you use the Greenplum native JDBC driver, provide the driver jar yourself.
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Using Dependency
+
+### For Spark/Flink Engine
+
+> 1. When using `org.postgresql.Driver`, ensure the [PostgreSQL JDBC driver](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in `${SEATUNNEL_HOME}/plugins/`.
+> 2. When using `com.pivotal.jdbc.GreenplumDriver`, download the Greenplum JDBC driver by yourself and place it in `${SEATUNNEL_HOME}/plugins/`.
+
+### For SeaTunnel Zeta Engine
+
+> 1. When using `org.postgresql.Driver`, ensure the [PostgreSQL JDBC driver](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in `${SEATUNNEL_HOME}/lib/`.
+> 2. When using `com.pivotal.jdbc.GreenplumDriver`, download the Greenplum JDBC driver by yourself and place it in `${SEATUNNEL_HOME}/lib/`.
 
 ## Key features
 
@@ -14,29 +32,118 @@ Read Greenplum data through [Jdbc connector](Jdbc.md).
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
-
-supports query SQL and can achieve projection effect.
-
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
-- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+
+> Supports query SQL and can achieve column projection.
+
+## Supported DataSource Info
+
+| Datasource | Driver | Url | Maven |
+|------------|--------|-----|-------|
+| Greenplum by PostgreSQL driver | `org.postgresql.Driver` | `jdbc:postgresql://localhost:5432/testdb` | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| Greenplum native driver | `com.pivotal.jdbc.GreenplumDriver` | `jdbc:pivotal:greenplum://localhost:5432;DatabaseName=testdb` | Download from Greenplum |
 
 :::tip
 
-Optional jdbc drivers:
-- `org.postgresql.Driver`
-- `com.pivotal.jdbc.GreenplumDriver`
-
-Warn: for license compliance, if you use `GreenplumDriver` the have to provide Greenplum JDBC driver yourself, e.g. copy greenplum-xxx.jar to $SEATUNNEL_HOME/lib for Standalone.
+For license compliance, SeaTunnel does not ship the Greenplum native JDBC driver. If you use `com.pivotal.jdbc.GreenplumDriver`, copy `greenplum-xxx.jar` to the engine dependency directory before running the job.
 
 :::
 
 ## Options
 
-### common options
+Only Greenplum-specific commonly used options are listed here. Other JDBC source options, such as `fetch_size`, `connection_check_timeout_sec`, `properties`, `table_path`, and multi-table reading, are inherited from [Jdbc Source](Jdbc.md).
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| url | String | Yes | - | JDBC connection URL. Use `jdbc:postgresql://host:port/database` with PostgreSQL driver, or `jdbc:pivotal:greenplum://host:port;DatabaseName=database` with Greenplum native driver. |
+| driver | String | Yes | - | JDBC driver class name, usually `org.postgresql.Driver` or `com.pivotal.jdbc.GreenplumDriver`. |
+| username | String | No | - | Greenplum username. |
+| password | String | No | - | Greenplum password. |
+| query | String | Yes | - | SQL used to read data. You can select only the columns you need. |
+| partition_column | String | No | - | Column used to split data for parallel reading. |
+| partition_lower_bound | Long | No | - | Lower bound of `partition_column`. If not set, SeaTunnel queries the minimum value. |
+| partition_upper_bound | Long | No | - | Upper bound of `partition_column`. If not set, SeaTunnel queries the maximum value. |
+| partition_num | Int | No | job parallelism | Number of source splits. |
+| split.string_split_mode | String | No | sample | String split algorithm. Use `charset_based` when the split column contains printable ASCII strings and you want deterministic range-like splitting. |
+| common-options | | No | - | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details. |
+
+### Tips
+
+> If `partition_column` is not set, the source reads with one split. If it is set, SeaTunnel reads data in parallel according to `partition_num` or job parallelism.
+
+## Task Example
+
+### Read Greenplum Data
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Parallel Read By String Column
+
+```hocon
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+```
+
+### Read And Write Greenplum
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/sink/Greenplum.md
+++ b/docs/zh/connectors/sink/Greenplum.md
@@ -4,39 +4,151 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > Greenplum Sink 连接器
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
-使用 [JDBC 连接器](Jdbc.md) 将数据写入 Greenplum。
+使用 [Jdbc 连接器](Jdbc.md) 将数据写入 Greenplum。Greenplum 使用 PostgreSQL 协议，通常可以直接使用 PostgreSQL JDBC 驱动；如果使用 Greenplum 原生 JDBC 驱动，需要用户自行提供驱动 jar。
+
+## 使用依赖
+
+### Spark/Flink 引擎
+
+> 1. 使用 `org.postgresql.Driver` 时，请确保 [PostgreSQL JDBC 驱动](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放到 `${SEATUNNEL_HOME}/plugins/`。
+> 2. 使用 `com.pivotal.jdbc.GreenplumDriver` 时，请自行下载 Greenplum JDBC 驱动，并放到 `${SEATUNNEL_HOME}/plugins/`。
+
+### SeaTunnel Zeta 引擎
+
+> 1. 使用 `org.postgresql.Driver` 时，请确保 [PostgreSQL JDBC 驱动](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放到 `${SEATUNNEL_HOME}/lib/`。
+> 2. 使用 `com.pivotal.jdbc.GreenplumDriver` 时，请自行下载 Greenplum JDBC 驱动，并放到 `${SEATUNNEL_HOME}/lib/`。
 
 ## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 
-不支持精确一次语义（Greenplum 数据库尚不支持 XA 事务）。
+Greenplum Sink 不支持精确一次语义，因为 Greenplum 不支持 XA 事务。
 
 :::
 
+## 支持的数据源信息
+
+| 数据源 | 驱动 | URL | Maven |
+|--------|------|-----|-------|
+| 使用 PostgreSQL 驱动连接 Greenplum | `org.postgresql.Driver` | `jdbc:postgresql://localhost:5432/testdb` | [下载](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| 使用 Greenplum 原生驱动连接 Greenplum | `com.pivotal.jdbc.GreenplumDriver` | `jdbc:pivotal:greenplum://localhost:5432;DatabaseName=testdb` | 从 Greenplum 获取 |
+
 ## 选项
 
-### driver [string]
+这里只列出 Greenplum 常用配置。其他 JDBC Sink 配置，例如 `batch_size`、`max_retries`、`generate_sink_sql`、`database`、`table`、`primary_keys` 和 `properties`，继承自 [Jdbc Sink](Jdbc.md)。
 
-可选的 JDBC 驱动程序：
-- `org.postgresql.Driver`
-- `com.pivotal.jdbc.GreenplumDriver`
+| 名称 | 类型 | 是否必填 | 默认值 | 描述 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | JDBC 连接 URL。使用 PostgreSQL 驱动时格式为 `jdbc:postgresql://host:port/database`；使用 Greenplum 原生驱动时格式为 `jdbc:pivotal:greenplum://host:port;DatabaseName=database`。 |
+| driver | String | 是 | - | JDBC 驱动类名，通常为 `org.postgresql.Driver` 或 `com.pivotal.jdbc.GreenplumDriver`。 |
+| username | String | 否 | - | Greenplum 用户名。 |
+| password | String | 否 | - | Greenplum 密码。 |
+| query | String | 否 | - | 写入上游数据的 SQL，例如 `insert into sink(age, name) values(?, ?)`。`query` 优先级高于自动生成的写入 SQL。 |
+| batch_size | Int | 否 | 1000 | 写入 Greenplum 前最多缓存的记录数。 |
+| max_retries | Int | 否 | 0 | `executeBatch` 失败后的重试次数。 |
+| generate_sink_sql | Boolean | 否 | false | 是否根据 `database` 和 `table` 自动生成插入 SQL。 |
+| database | String | 否 | - | `generate_sink_sql = true` 时使用的数据库名。 |
+| table | String | 否 | - | `generate_sink_sql = true` 时使用的目标表名。 |
+| common-options | | 否 | - | Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
-警告：为了符合许可证要求，如果您使用 `GreenplumDriver`，则必须自己提供 Greenplum JDBC 驱动程序，例如将 greenplum-xxx.jar 复制到 $SEATUNNEL_HOME/lib（用于独立模式）。
+:::tip
 
-### url [string]
+出于许可证原因，SeaTunnel 不内置 Greenplum 原生 JDBC 驱动。如果使用 `com.pivotal.jdbc.GreenplumDriver`，请在运行任务前将 `greenplum-xxx.jar` 复制到对应引擎的依赖目录。
 
-JDBC 连接的 URL。如果使用 PostgreSQL 驱动程序，值为 `jdbc:postgresql://${yous_host}:${yous_port}/${yous_database}`，或者如果使用 Greenplum 驱动程序，值为 `jdbc:pivotal:greenplum://${yous_host}:${yous_port};DatabaseName=${yous_database}`
+:::
 
-### 通用选项
+## 任务示例
 
-Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 详见。
+### 写入 Greenplum
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 16
+    schema = {
+      fields {
+        age = "int"
+        name = "string"
+      }
+    }
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
+
+### Greenplum 读写示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
+
+### 自动生成写入 SQL
+
+```hocon
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    generate_sink_sql = true
+    database = "testdb"
+    table = "sink"
+  }
+}
+```
 
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/Greenplum.md
+++ b/docs/zh/connectors/source/Greenplum.md
@@ -6,37 +6,144 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过 [Jdbc 连接器](Jdbc.md) 读取 Greenplum 数据。
+通过 [Jdbc 连接器](Jdbc.md) 读取 Greenplum 数据。Greenplum 使用 PostgreSQL 协议，通常可以直接使用 PostgreSQL JDBC 驱动；如果使用 Greenplum 原生 JDBC 驱动，需要用户自行提供驱动 jar。
+
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 使用依赖
+
+### Spark/Flink 引擎
+
+> 1. 使用 `org.postgresql.Driver` 时，请确保 [PostgreSQL JDBC 驱动](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放到 `${SEATUNNEL_HOME}/plugins/`。
+> 2. 使用 `com.pivotal.jdbc.GreenplumDriver` 时，请自行下载 Greenplum JDBC 驱动，并放到 `${SEATUNNEL_HOME}/plugins/`。
+
+### SeaTunnel Zeta 引擎
+
+> 1. 使用 `org.postgresql.Driver` 时，请确保 [PostgreSQL JDBC 驱动](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放到 `${SEATUNNEL_HOME}/lib/`。
+> 2. 使用 `com.pivotal.jdbc.GreenplumDriver` 时，请自行下载 Greenplum JDBC 驱动，并放到 `${SEATUNNEL_HOME}/lib/`。
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义拆分](../../introduction/concepts/connector-v2-features.md)
 
-支持查询 SQL 并可以实现投影效果。
+> 支持通过查询 SQL 选择需要的列，从而实现列投影。
 
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+## 支持的数据源信息
+
+| 数据源 | 驱动 | URL | Maven |
+|--------|------|-----|-------|
+| 使用 PostgreSQL 驱动连接 Greenplum | `org.postgresql.Driver` | `jdbc:postgresql://localhost:5432/testdb` | [下载](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| 使用 Greenplum 原生驱动连接 Greenplum | `com.pivotal.jdbc.GreenplumDriver` | `jdbc:pivotal:greenplum://localhost:5432;DatabaseName=testdb` | 从 Greenplum 获取 |
 
 :::tip
 
-可选的 jdbc 驱动程序：
-- `org.postgresql.Driver`
-- `com.pivotal.jdbc.GreenplumDriver`
-
-警告：为了符合许可证要求，如果您使用 `GreenplumDriver`，必须自己提供 Greenplum JDBC 驱动程序，例如将 greenplum-xxx.jar 复制到 $SEATUNNEL_HOME/lib（用于独立模式）。
+出于许可证原因，SeaTunnel 不内置 Greenplum 原生 JDBC 驱动。如果使用 `com.pivotal.jdbc.GreenplumDriver`，请在运行任务前将 `greenplum-xxx.jar` 复制到对应引擎的依赖目录。
 
 :::
 
 ## 选项
 
-### 通用选项
+这里只列出 Greenplum 常用配置。其他 JDBC 源端配置，例如 `fetch_size`、`connection_check_timeout_sec`、`properties`、`table_path` 和多表读取能力，继承自 [Jdbc Source](Jdbc.md)。
 
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+| 名称 | 类型 | 是否必填 | 默认值 | 描述 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | JDBC 连接 URL。使用 PostgreSQL 驱动时格式为 `jdbc:postgresql://host:port/database`；使用 Greenplum 原生驱动时格式为 `jdbc:pivotal:greenplum://host:port;DatabaseName=database`。 |
+| driver | String | 是 | - | JDBC 驱动类名，通常为 `org.postgresql.Driver` 或 `com.pivotal.jdbc.GreenplumDriver`。 |
+| username | String | 否 | - | Greenplum 用户名。 |
+| password | String | 否 | - | Greenplum 密码。 |
+| query | String | 是 | - | 读取数据的 SQL，可以只选择需要的字段。 |
+| partition_column | String | 否 | - | 用于并行拆分读取的字段。 |
+| partition_lower_bound | Long | 否 | - | `partition_column` 的下界；不配置时 SeaTunnel 会查询最小值。 |
+| partition_upper_bound | Long | 否 | - | `partition_column` 的上界；不配置时 SeaTunnel 会查询最大值。 |
+| partition_num | Int | 否 | 作业并行度 | 拆分数量。 |
+| split.string_split_mode | String | 否 | sample | 字符串拆分算法。拆分字段是可打印 ASCII 字符串，并且希望使用确定性的范围类拆分时，可以配置为 `charset_based`。 |
+| common-options | | 否 | - | 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md)。 |
+
+### 小贴士
+
+> 不配置 `partition_column` 时，源端按单拆分读取；配置后，SeaTunnel 会按 `partition_num` 或作业并行度并行读取。
+
+## 任务示例
+
+### 读取 Greenplum 数据
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### 按字符串字段并行读取
+
+```hocon
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+```
+
+### Greenplum 读写示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "select age, name from source"
+    partition_column = "name"
+    split.string_split_mode = charset_based
+  }
+}
+
+sink {
+  Jdbc {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    username = "tester"
+    password = "pivotal"
+    query = "insert into sink(age, name) values(?, ?)"
+  }
+}
+```
 
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary

This PR improves the Greenplum connector documentation in both English and Chinese.

## Changes

- Add dependency and engine notes for PostgreSQL and Greenplum native JDBC drivers.
- Clarify Greenplum source and sink option usage inherited from the JDBC connector.
- Add Greenplum source, sink, parallel string split, read/write, and generated SQL examples.
- Align the Chinese feature labels and wording with the documented connector capabilities.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
