### PR TITLE
[Docs][Connector-V2] Improve Jira Klaviyo and Lemlist docs

### DIFF
--- a/docs/en/connectors/source/Jira.md
+++ b/docs/en/connectors/source/Jira.md
@@ -6,295 +6,121 @@ import ChangeLog from '../changelog/connector-http-jira.md';
 
 ## Description
 
-Used to read data from Jira.
+Reads data from Jira REST APIs. The connector adds the Jira Basic authentication header from `email` and `api_token`, then uses the shared HTTP source runtime to parse the response.
 
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
+:::tip
+
+The Jira source is a batch-only connector. It throws an error when the job runs in streaming mode.
+
+:::
+
 ## Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| email                       | String  | Yes      | -             |
-| api_token                   | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| name                        | type   | required | default value | description |
+|-----------------------------|--------|----------|---------------|-------------|
+| url                         | String | Yes      | -             | Jira REST API URL. |
+| email                       | String | Yes      | -             | Jira account email used for Basic authentication. |
+| api_token                   | String | Yes      | -             | Jira API token used for Basic authentication. |
+| method                      | String | No       | GET           | HTTP method. Supported values are `GET` and `POST`. |
+| headers                     | Map    | No       | -             | Extra HTTP request headers. Do not put the Jira `Authorization` header here unless you intentionally want to override the generated header. |
+| params                      | Map    | No       | -             | HTTP query parameters. |
+| body                        | String | No       | -             | HTTP request body, usually used with `POST`. |
+| format                      | String | No       | TEXT          | Response format. Use `json` when the response should be parsed by `schema`, `json_field`, or `content_field`. |
+| schema                      | Config | No       | -             | Output schema. Required when `format = "json"`. |
+| json_field                  | Config | No       | -             | JSONPath mapping from response fields to output columns. Must be used together with `schema`. |
+| content_field               | String | No       | -             | JSONPath used to select the array or object that should be parsed as rows. |
+| pageing                     | Config | No       | -             | Pagination settings. See [Pagination](#pagination). |
+| poll_interval_millis        | int    | No       | -             | Poll interval in milliseconds. Jira source is batch-only, so this option is not useful for Jira streaming jobs. |
+| retry                       | int    | No       | -             | Maximum retry count when the request throws `IOException`. |
+| retry_backoff_multiplier_ms | int    | No       | 100           | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | int    | No       | 10000         | Maximum retry backoff in milliseconds. |
+| json_filed_missed_return_null | boolean | No    | false         | Return `null` when a field configured in `json_field` is missing. |
+| common-options              | config | No       | -             | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### url [String]
+### Authentication
 
-http request url
+Create a Jira API token from your Atlassian account and set:
 
-### email [String]
+- `email`: the Jira account email.
+- `api_token`: the Jira API token.
 
-Jira Email
+The connector builds the Basic authentication header automatically.
 
-### api_token [String]
+### Response Parsing
 
-Jira API Token
+The default `format` is `TEXT`, which returns the whole response as one `content` column.
 
-https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
+Use `format = "json"` and `schema` when you want structured output:
 
 ```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
-    }
+format = "json"
+schema = {
+  fields {
+    expand = string
+    startAt = int
+    maxResults = int
+    total = string
   }
 }
 ```
 
-Here is an example:
+Use `content_field` when the rows are inside a nested JSON node. Use `json_field` when columns need to be extracted from different JSONPath expressions.
 
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
+### Pagination
 
-### json_field [Config]
+`pageing` can be used when the target API needs paging parameters.
 
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+| name | type | required | default value | description |
+|------|------|----------|---------------|-------------|
+| total_page_size | long | No | 0 | Total number of pages to request. |
+| batch_size | int | No | 100 | Page size returned by each request. |
+| start_page_number | long | No | 1 | First page number. |
+| page_field | String | No | page | Request parameter name for page number pagination. |
+| page_type | String | No | PageNumber | Pagination type. Supported values are `PageNumber` and `Cursor`. |
+| cursor_field | String | No | - | Request parameter name for cursor pagination. |
+| cursor_response_field | String | No | - | JSONPath field used to read the next cursor from the response. |
+| use_placeholder_replacement | boolean | No | false | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
 ## Example
 
 ```hocon
-Jira {
-    url = "https://liugddx.atlassian.net/rest/api/3/search"
-    email = "test@test.com"
-    api_token = "xxx" 
-    schema {
-       fields {
-         expand = string
-         startAt = bigint
-         maxResults = int
-         total = int
-       }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        expand = string
+        startAt = int
+        maxResults = int
+        total = string
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira"
+  }
 }
 ```
 

--- a/docs/en/connectors/source/Klaviyo.md
+++ b/docs/en/connectors/source/Klaviyo.md
@@ -6,305 +6,134 @@ import ChangeLog from '../changelog/connector-http-klaviyo.md';
 
 ## Description
 
-Used to read data from Klaviyo.
+Reads data from Klaviyo APIs. The connector builds Klaviyo request headers from `private_key` and `revision`, then uses the shared HTTP source runtime to parse the response.
 
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
+:::tip
+
+In streaming mode, the connector repeatedly calls the configured API. Set `poll_interval_millis` to control the request interval.
+
+:::
+
 ## Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| private_key                 | String  | Yes      | -             |
-| revision                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| name                        | type   | required | default value | description |
+|-----------------------------|--------|----------|---------------|-------------|
+| url                         | String | Yes      | -             | Klaviyo API URL. |
+| private_key                 | String | Yes      | -             | Klaviyo private API key. |
+| revision                    | String | Yes      | -             | Klaviyo API revision, usually in `YYYY-MM-DD` format. |
+| method                      | String | No       | GET           | HTTP method. Supported values are `GET` and `POST`. |
+| headers                     | Map    | No       | -             | Extra HTTP request headers. The connector already sets `Authorization`, `Accept`, and `revision`. |
+| params                      | Map    | No       | -             | HTTP query parameters. |
+| body                        | String | No       | -             | HTTP request body, usually used with `POST`. |
+| format                      | String | No       | TEXT          | Response format. Use `json` when the response should be parsed by `schema`, `json_field`, or `content_field`. |
+| schema                      | Config | No       | -             | Output schema. Required when `format = "json"`. |
+| json_field                  | Config | No       | -             | JSONPath mapping from response fields to output columns. Must be used together with `schema`. |
+| content_field               | String | No       | -             | JSONPath used to select the array or object that should be parsed as rows. |
+| pageing                     | Config | No       | -             | Pagination settings. See [Pagination](#pagination). |
+| poll_interval_millis        | int    | No       | -             | Request interval in milliseconds for streaming jobs. |
+| retry                       | int    | No       | -             | Maximum retry count when the request throws `IOException`. |
+| retry_backoff_multiplier_ms | int    | No       | 100           | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | int    | No       | 10000         | Maximum retry backoff in milliseconds. |
+| json_filed_missed_return_null | boolean | No    | false         | Return `null` when a field configured in `json_field` is missing. |
+| common-options              | config | No       | -             | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### url [String]
+### Authentication
 
-http request url
+Set `private_key` to the Klaviyo private API key. The connector sends it as:
 
-### private_key [String]
-
-API private key for login, you can get more detail at this link:
-
-https://developers.klaviyo.com/en/docs/authenticate_#private-key-authentication
-
-### revision [String]
-
-API endpoint revision (format: YYYY-MM-DD)
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### schema [Config]
-The structure of the data, including field names and field types. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
+```text
+Authorization: Klaviyo-API-Key <private_key>
+Accept: application/json
+revision: <revision>
 ```
 
-you should assign schema as the following:
+### Response Parsing
+
+The default `format` is `TEXT`, which returns the whole response as one `content` column.
+
+Use `format = "json"` and `schema` when you want structured output:
 
 ```hocon
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
+format = "json"
+schema = {
+  fields {
+    type = string
+    id = string
+    attributes = {
+      name = string
+      created = string
+      updated = string
     }
-}
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-the schema fields of upstream data
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
+    links = {
+      self = string
     }
   }
 }
 ```
 
-Here is an example:
+Use `content_field` when the rows are inside a nested JSON node. Use `json_field` when columns need to be extracted from different JSONPath expressions.
 
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
+### Pagination
 
-### json_field [Config]
+`pageing` can be used when the target API needs paging parameters.
 
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+| name | type | required | default value | description |
+|------|------|----------|---------------|-------------|
+| total_page_size | long | No | 0 | Total number of pages to request. |
+| batch_size | int | No | 100 | Page size returned by each request. |
+| start_page_number | long | No | 1 | First page number. |
+| page_field | String | No | page | Request parameter name for page number pagination. |
+| page_type | String | No | PageNumber | Pagination type. Supported values are `PageNumber` and `Cursor`. |
+| cursor_field | String | No | - | Request parameter name for cursor pagination. |
+| cursor_response_field | String | No | - | JSONPath field used to read the next cursor from the response. |
+| use_placeholder_replacement | boolean | No | false | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
 ## Example
 
 ```hocon
-Klaviyo {
-    url = "https://a.klaviyo.com/api/lists/"
-    private_key = "SeaTunnel-test"
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo"
+    url = "https://a.klaviyo.com/api/lists"
+    private_key = "replace-with-private-key"
     revision = "2020-10-17"
     method = "GET"
     format = "json"
     schema = {
-          fields {
-            type = string
-            id = string
-            attributes = {
-                  name = string
-                  created = string
-                  updated = string
-            }
-            links = {
-                  self = string
-            }
-          }
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+        links = {
+          self = string
+        }
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo"
+  }
 }
 ```
 

--- a/docs/en/connectors/source/Lemlist.md
+++ b/docs/en/connectors/source/Lemlist.md
@@ -6,291 +6,131 @@ import ChangeLog from '../changelog/connector-http-lemlist.md';
 
 ## Description
 
-Used to read data from Lemlist.
+Reads data from Lemlist APIs. The connector uses `password` as the Lemlist API key, creates a Basic authentication header, and then uses the shared HTTP source runtime to parse the response.
 
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
+:::tip
+
+In streaming mode, the connector repeatedly calls the configured API. Set `poll_interval_millis` to control the request interval.
+
+:::
+
 ## Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| name                        | type   | required | default value | description |
+|-----------------------------|--------|----------|---------------|-------------|
+| url                         | String | Yes      | -             | Lemlist API URL. |
+| password                    | String | Yes      | -             | Lemlist API key. |
+| method                      | String | No       | GET           | HTTP method. Supported values are `GET` and `POST`. |
+| headers                     | Map    | No       | -             | Extra HTTP request headers. Do not put `Authorization` here unless you intentionally want to override the generated header. |
+| params                      | Map    | No       | -             | HTTP query parameters. |
+| body                        | String | No       | -             | HTTP request body, usually used with `POST`. |
+| format                      | String | No       | TEXT          | Response format. Use `json` when the response should be parsed by `schema`, `json_field`, or `content_field`. |
+| schema                      | Config | No       | -             | Output schema. Required when `format = "json"`. |
+| json_field                  | Config | No       | -             | JSONPath mapping from response fields to output columns. Must be used together with `schema`. |
+| content_field               | String | No       | -             | JSONPath used to select the array or object that should be parsed as rows. |
+| pageing                     | Config | No       | -             | Pagination settings. See [Pagination](#pagination). |
+| poll_interval_millis        | int    | No       | -             | Request interval in milliseconds for streaming jobs. |
+| retry                       | int    | No       | -             | Maximum retry count when the request throws `IOException`. |
+| retry_backoff_multiplier_ms | int    | No       | 100           | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | int    | No       | 10000         | Maximum retry backoff in milliseconds. |
+| json_filed_missed_return_null | boolean | No    | false         | Return `null` when a field configured in `json_field` is missing. |
+| common-options              | config | No       | -             | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### url [String]
+### Authentication
 
-http request url
+Set `password` to the Lemlist API key. The connector sends it through Basic authentication with an empty username.
 
-### password [String]
+### Response Parsing
 
-API key for login, you can get more detail at this link:
+The default `format` is `TEXT`, which returns the whole response as one `content` column.
 
-https://developer.lemlist.com/
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
+Use `format = "json"` and `schema` when you want structured output:
 
 ```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
+format = "json"
+schema = {
+  fields {
+    _id = string
+    name = string
+    userIds = "array<string>"
+    createdBy = string
+    createdAt = string
+    apiKey = string
+    billing = {
+      quantity = int
+      ok = boolean
+      plan = string
     }
   }
 }
 ```
 
-Here is an example:
+Use `content_field` when the rows are inside a nested JSON node. Use `json_field` when columns need to be extracted from different JSONPath expressions.
 
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
+### Pagination
 
-### json_field [Config]
+`pageing` can be used when the target API needs paging parameters.
 
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+| name | type | required | default value | description |
+|------|------|----------|---------------|-------------|
+| total_page_size | long | No | 0 | Total number of pages to request. |
+| batch_size | int | No | 100 | Page size returned by each request. |
+| start_page_number | long | No | 1 | First page number. |
+| page_field | String | No | page | Request parameter name for page number pagination. |
+| page_type | String | No | PageNumber | Pagination type. Supported values are `PageNumber` and `Cursor`. |
+| cursor_field | String | No | - | Request parameter name for cursor pagination. |
+| cursor_response_field | String | No | - | JSONPath field used to read the next cursor from the response. |
+| use_placeholder_replacement | boolean | No | false | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
 ## Example
 
 ```hocon
-Lemlist {
-    url = "https://api.lemlist.com/api/campaigns"
-    password = "SeaTunnel-test"
-    schema {
-       fields {
-         _id = string
-         name = string
-       }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Lemlist {
+    plugin_output = "lemlist"
+    url = "https://api.lemlist.com/api/team"
+    password = "replace-with-api-key"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        _id = string
+        name = string
+        userIds = "array<string>"
+        createdBy = string
+        createdAt = string
+        apiKey = string
+        billing = {
+          quantity = int
+          ok = boolean
+          plan = string
+        }
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "lemlist"
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/Jira.md
+++ b/docs/zh/connectors/source/Jira.md
@@ -6,295 +6,121 @@ import ChangeLog from '../changelog/connector-http-jira.md';
 
 ## 描述
 
-从 Jira 读取数据。
+用于从 Jira REST API 读取数据。连接器会根据 `email` 和 `api_token` 自动生成 Jira Basic 认证请求头，然后复用 HTTP Source 的能力解析返回结果。
 
 ## 关键特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户定义的分片](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
+
+:::tip
+
+Jira Source 只支持批处理。如果作业以流模式运行，连接器会报错。
+
+:::
 
 ## 选项
 
-|            名称             |  类型   |   必需   |     默认值    |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | 是       | -             |
-| email                       | String  | 是       | -             |
-| api_token                   | String  | 是       | -             |
-| method                      | String  | 否       | get           |
-| schema.fields               | Config  | 否       | -             |
-| format                      | String  | 否       | json          |
-| params                      | Map     | 否       | -             |
-| body                        | String  | 否       | -             |
-| json_field                  | Config  | 否       | -             |
-| content_json                | String  | 否       | -             |
-| poll_interval_millis        | int     | 否       | -             |
-| retry                       | int     | 否       | -             |
-| retry_backoff_multiplier_ms | int     | 否       | 100           |
-| retry_backoff_max_ms        | int     | 否       | 10000         |
-| enable_multi_lines          | boolean | 否       | false         |
-| common-options              | config  | 否       | -             |
+| 名称                        | 类型   | 是否必填 | 默认值 | 说明 |
+|-----------------------------|--------|----------|--------|------|
+| url                         | String | 是       | -      | Jira REST API 地址。 |
+| email                       | String | 是       | -      | 用于 Basic 认证的 Jira 账号邮箱。 |
+| api_token                   | String | 是       | -      | 用于 Basic 认证的 Jira API Token。 |
+| method                      | String | 否       | GET    | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| headers                     | Map    | 否       | -      | 额外的 HTTP 请求头。除非需要覆盖自动生成的 Jira 认证头，否则不要在这里配置 `Authorization`。 |
+| params                      | Map    | 否       | -      | HTTP 查询参数。 |
+| body                        | String | 否       | -      | HTTP 请求体，通常和 `POST` 一起使用。 |
+| format                      | String | 否       | TEXT   | 返回内容格式。如果要用 `schema`、`json_field` 或 `content_field` 解析 JSON，请设置为 `json`。 |
+| schema                      | Config | 否       | -      | 输出字段结构。`format = "json"` 时必须配置。 |
+| json_field                  | Config | 否       | -      | 用 JSONPath 把返回字段映射到输出列，必须和 `schema` 一起使用。 |
+| content_field               | String | 否       | -      | 用 JSONPath 选出需要按行解析的数组或对象。 |
+| pageing                     | Config | 否       | -      | 分页配置，见 [分页](#分页)。 |
+| poll_interval_millis        | int    | 否       | -      | 轮询间隔，单位毫秒。Jira Source 只支持批处理，因此这个配置不适用于 Jira 流作业。 |
+| retry                       | int    | 否       | -      | 请求出现 `IOException` 时的最大重试次数。 |
+| retry_backoff_multiplier_ms | int    | 否       | 100    | 重试退避时间倍数，单位毫秒。 |
+| retry_backoff_max_ms        | int    | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
+| json_filed_missed_return_null | boolean | 否     | false  | `json_field` 中配置的字段缺失时，是否返回 `null`。 |
+| common-options              | config | 否       | -      | 源连接器通用配置，见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### url [String]
+### 认证
 
-http 请求 url
+在 Atlassian 账号中创建 Jira API Token 后，配置：
 
-### email [String]
+- `email`：Jira 账号邮箱。
+- `api_token`：Jira API Token。
 
-Jira 邮件
+连接器会自动生成 Basic 认证请求头。
 
-### api_token [String]
+### 返回结果解析
 
-Jira API 接口
+`format` 默认值是 `TEXT`，会把完整响应作为一个 `content` 字段输出。
 
-https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
-
-### method [String]
-
-http 请求方法。目前支持 'GET'和 'POST'。 
-
-### params [Map]
-
-http 参数
-
-### body [String]
-
-http 请求体
-
-### poll_interval_millis [int]
-
-流程下请求 API 的间隔时间（毫秒）。
-
-### retry [int]
-
-请求失败 (`IOException`)时最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-重试退避时间倍数（毫秒）。
-
-### retry_backoff_max_ms [int]
-
-重试退避最大时间（毫秒）。
-
-### format [String]
-
-上游数据的格式，现在仅支持`json` `text`, 默认是 `json`.
-
-若你的数据格式为 `json`, 需同时配置 schema 选项，例如：
-
-上游数据如下：
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-您应该配置 schema 为以下内容：
+如果需要结构化输出，请配置 `format = "json"` 和 `schema`：
 
 ```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-连接器将生成如下数据：
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-若你设置格式为 `text`，连接器不会对上游数据做出任何改变，示例：
-
-上游数据如下：
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-连接器将生成如下数据：
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的字段定义。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-该参数可用于提取一些 json 数据。如果你只需要 “book” 部分的数据，可以配置 `content_field = "$.store.book.*"`.
-
-如果你的返回数据如下所示：
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-你可以配置 `content_field = "$.store.book.*"` 并且结果返回如下：
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-然后你可以通过更简单的 schema 配置获取所需的结果，例如：
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
-    }
+format = "json"
+schema = {
+  fields {
+    expand = string
+    startAt = int
+    maxResults = int
+    total = string
   }
 }
 ```
 
-示例：
+如果行数据在嵌套 JSON 节点里，用 `content_field` 选出对应节点。如果输出列需要从不同 JSONPath 中提取，用 `json_field`。
 
-- 测试数据可参考此链接： [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- 任务配置示例可参考此链接：[http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
+### 分页
 
-### json_field [Config]
+目标 API 需要分页参数时，可以配置 `pageing`。
 
-该参数用于帮助你配置 schema，因此必须与 schema 一起使用。
-
-如果你的数据如下所示：
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-你可以通过如下任务配置获取 “book” 部分的内容：
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- 测试数据可参考此链接： [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- 任务配置示例可参考此链接： [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### 通用配置
-
-源插件通用参数，请参考 [常用选项](../common-options/source-common-options.md) 获取详细说明
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| total_page_size | long | 否 | 0 | 请求的总页数。 |
+| batch_size | int | 否 | 100 | 每次请求返回的数据条数。 |
+| start_page_number | long | 否 | 1 | 起始页码。 |
+| page_field | String | 否 | page | 页码分页时，请求参数中的页码字段名。 |
+| page_type | String | 否 | PageNumber | 分页类型，支持 `PageNumber` 和 `Cursor`。 |
+| cursor_field | String | 否 | - | 游标分页时，请求参数中的游标字段名。 |
+| cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
+| use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
 ## 示例
 
 ```hocon
-Jira {
-    url = "https://liugddx.atlassian.net/rest/api/3/search"
-    email = "test@test.com"
-    api_token = "xxx" 
-    schema {
-       fields {
-         expand = string
-         startAt = bigint
-         maxResults = int
-         total = int
-       }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        expand = string
+        startAt = int
+        maxResults = int
+        total = string
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira"
+  }
 }
 ```
 

--- a/docs/zh/connectors/source/Klaviyo.md
+++ b/docs/zh/connectors/source/Klaviyo.md
@@ -6,178 +6,137 @@ import ChangeLog from '../changelog/connector-http-klaviyo.md';
 
 ## 描述
 
-用于从 Klaviyo 读取数据。
+用于从 Klaviyo API 读取数据。连接器会根据 `private_key` 和 `revision` 生成 Klaviyo 请求头，然后复用 HTTP Source 的能力解析返回结果。
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
+
+:::tip
+
+在流模式下，连接器会反复请求配置的 API。可以用 `poll_interval_millis` 控制请求间隔。
+
+:::
 
 ## 选项
 
-| 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                                         |
-|-----------------------------|---------|----|-------|------------------------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                                |
-| private_key                 | String  | 是  | -     | 用于登录的 API 私钥，您可以在此链接获取更多详情：https://developers.klaviyo.com/en/docs/authenticate_#private-key-authentication |
-| revision                    | String  | 是  | -     | API 端点版本（格式：YYYY-MM-DD）                                                                                    |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法                                                                                  |
-| schema                      | Config  | 否  | -     | 上游数据的模式。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。                                |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                                  |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                                     |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                                    |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                                   |
-| json_field                  | Config  | 否  | -     | JSON 字段配置                                                                                                  |
-| content_json                | String  | 否  | -     | 内容 JSON 字段                                                                                                 |
-| poll_interval_millis        | int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                                    |
-| retry                       | int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 时的最大重试次数                                                                        |
-| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                                      |
-| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                                    |
-| enable_multi_lines          | boolean | 否  | false | 启用多行                                                                                                       |
-| common-options              | config  | 否  | -     | 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。                                        |
+| 名称                        | 类型   | 是否必填 | 默认值 | 说明 |
+|-----------------------------|--------|----------|--------|------|
+| url                         | String | 是       | -      | Klaviyo API 地址。 |
+| private_key                 | String | 是       | -      | Klaviyo 私有 API Key。 |
+| revision                    | String | 是       | -      | Klaviyo API 版本，通常是 `YYYY-MM-DD` 格式。 |
+| method                      | String | 否       | GET    | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| headers                     | Map    | 否       | -      | 额外的 HTTP 请求头。连接器已经会设置 `Authorization`、`Accept` 和 `revision`。 |
+| params                      | Map    | 否       | -      | HTTP 查询参数。 |
+| body                        | String | 否       | -      | HTTP 请求体，通常和 `POST` 一起使用。 |
+| format                      | String | 否       | TEXT   | 返回内容格式。如果要用 `schema`、`json_field` 或 `content_field` 解析 JSON，请设置为 `json`。 |
+| schema                      | Config | 否       | -      | 输出字段结构。`format = "json"` 时必须配置。 |
+| json_field                  | Config | 否       | -      | 用 JSONPath 把返回字段映射到输出列，必须和 `schema` 一起使用。 |
+| content_field               | String | 否       | -      | 用 JSONPath 选出需要按行解析的数组或对象。 |
+| pageing                     | Config | 否       | -      | 分页配置，见 [分页](#分页)。 |
+| poll_interval_millis        | int    | 否       | -      | 流模式下的请求间隔，单位毫秒。 |
+| retry                       | int    | 否       | -      | 请求出现 `IOException` 时的最大重试次数。 |
+| retry_backoff_multiplier_ms | int    | 否       | 100    | 重试退避时间倍数，单位毫秒。 |
+| retry_backoff_max_ms        | int    | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
+| json_filed_missed_return_null | boolean | 否     | false  | `json_field` 中配置的字段缺失时，是否返回 `null`。 |
+| common-options              | config | 否       | -      | 源连接器通用配置，见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### url [String]
+### 认证
 
-HTTP 请求 URL
+把 `private_key` 配置为 Klaviyo 私有 API Key。连接器会发送以下请求头：
 
-### private_key [String]
-
-用于登录的 API 私钥，您可以在此链接获取更多详情：
-
-https://developers.klaviyo.com/en/docs/authenticate_#private-key-authentication
-
-### revision [String]
-
-API 端点版本（格式：YYYY-MM-DD）
-
-### method [String]
-
-HTTP 请求方法，仅支持 GET、POST 方法
-
-### params [Map]
-
-HTTP 参数
-
-### body [String]
-
-HTTP 请求体
-
-### poll_interval_millis [int]
-
-流模式下请求 HTTP API 的间隔（毫秒）
-
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 时的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-当您指定格式为 `json` 时，您还应该指定 schema 选项，例如：
-
-上游数据如下：
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
+```text
+Authorization: Klaviyo-API-Key <private_key>
+Accept: application/json
+revision: <revision>
 ```
 
-您应该指定 schema 如下：
+### 返回结果解析
+
+`format` 默认值是 `TEXT`，会把完整响应作为一个 `content` 字段输出。
+
+如果需要结构化输出，请配置 `format = "json"` 和 `schema`：
 
 ```hocon
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
+format = "json"
+schema = {
+  fields {
+    type = string
+    id = string
+    attributes = {
+      name = string
+      created = string
+      updated = string
     }
+    links = {
+      self = string
+    }
+  }
 }
 ```
 
-连接器将生成如下数据：
+如果行数据在嵌套 JSON 节点里，用 `content_field` 选出对应节点。如果输出列需要从不同 JSONPath 中提取，用 `json_field`。
 
-| code | data | success |
-|------|------|---------|
-| 200 | get success | true |
+### 分页
 
-当您指定格式为 `text` 时，连接器将对上游数据不做任何处理，例如：
+目标 API 需要分页参数时，可以配置 `pageing`。
 
-上游数据如下：
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-连接器将生成如下数据：
-
-| content |
-|---------|
-| {"code": 200, "data": "get success", "success": true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。如果您只需要 'book' 部分中的数据，请配置 `content_field = "$.store.book.*"`。
-
-### json_field [Config]
-
-此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
-
-### common options
-
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| total_page_size | long | 否 | 0 | 请求的总页数。 |
+| batch_size | int | 否 | 100 | 每次请求返回的数据条数。 |
+| start_page_number | long | 否 | 1 | 起始页码。 |
+| page_field | String | 否 | page | 页码分页时，请求参数中的页码字段名。 |
+| page_type | String | 否 | PageNumber | 分页类型，支持 `PageNumber` 和 `Cursor`。 |
+| cursor_field | String | 否 | - | 游标分页时，请求参数中的游标字段名。 |
+| cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
+| use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
 ## 示例
 
 ```hocon
-Klaviyo {
-    url = "https://a.klaviyo.com/api/lists/"
-    private_key = "SeaTunnel-test"
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo"
+    url = "https://a.klaviyo.com/api/lists"
+    private_key = "replace-with-private-key"
     revision = "2020-10-17"
     method = "GET"
     format = "json"
     schema = {
-          fields {
-            type = string
-            id = string
-            attributes = {
-                  name = string
-                  created = string
-                  updated = string
-            }
-            links = {
-                  self = string
-            }
-          }
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+        links = {
+          self = string
+        }
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo"
+  }
 }
 ```
 
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/Lemlist.md
+++ b/docs/zh/connectors/source/Lemlist.md
@@ -6,92 +6,131 @@ import ChangeLog from '../changelog/connector-http-lemlist.md';
 
 ## 描述
 
-用于从 Lemlist 读取数据。
+用于从 Lemlist API 读取数据。连接器会把 `password` 当作 Lemlist API Key，通过 Basic 认证生成请求头，然后复用 HTTP Source 的能力解析返回结果。
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
+
+:::tip
+
+在流模式下，连接器会反复请求配置的 API。可以用 `poll_interval_millis` 控制请求间隔。
+
+:::
 
 ## 选项
 
-| 参数名 | 类型 | 必须 | 默认值 | 描述 |
-|--------|------|------|--------|------|
-| url | String | 是 | - | HTTP 请求 URL |
-| password | String | 是 | - | API 密钥用于登录 |
-| method | String | 否 | get | HTTP 请求方法，仅支持 GET、POST 方法 |
-| schema.fields | Config | 否 | - | 上游数据的模式字段 |
-| format | String | 否 | json | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。 |
-| params | Map | 否 | - | HTTP 参数 |
-| body | String | 否 | - | HTTP 请求体 |
-| json_field | Config | 否 | - | JSON 字段配置 |
-| content_json | String | 否 | - | 内容 JSON 配置 |
-| poll_interval_millis | int | 否 | - | 流模式下请求 HTTP API 的间隔（毫秒） |
-| retry | int | 否 | - | 如果 HTTP 请求返回 `IOException` 的最大重试次数 |
-| retry_backoff_multiplier_ms | int | 否 | 100 | HTTP 请求失败时的重试退避倍数（毫秒） |
-| retry_backoff_max_ms | int | 否 | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒） |
-| enable_multi_lines | boolean | 否 | false | 是否启用多行模式 |
-| common-options | config | 否 | - | 源插件通用参数 |
+| 名称                        | 类型   | 是否必填 | 默认值 | 说明 |
+|-----------------------------|--------|----------|--------|------|
+| url                         | String | 是       | -      | Lemlist API 地址。 |
+| password                    | String | 是       | -      | Lemlist API Key。 |
+| method                      | String | 否       | GET    | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| headers                     | Map    | 否       | -      | 额外的 HTTP 请求头。除非需要覆盖自动生成的认证头，否则不要在这里配置 `Authorization`。 |
+| params                      | Map    | 否       | -      | HTTP 查询参数。 |
+| body                        | String | 否       | -      | HTTP 请求体，通常和 `POST` 一起使用。 |
+| format                      | String | 否       | TEXT   | 返回内容格式。如果要用 `schema`、`json_field` 或 `content_field` 解析 JSON，请设置为 `json`。 |
+| schema                      | Config | 否       | -      | 输出字段结构。`format = "json"` 时必须配置。 |
+| json_field                  | Config | 否       | -      | 用 JSONPath 把返回字段映射到输出列，必须和 `schema` 一起使用。 |
+| content_field               | String | 否       | -      | 用 JSONPath 选出需要按行解析的数组或对象。 |
+| pageing                     | Config | 否       | -      | 分页配置，见 [分页](#分页)。 |
+| poll_interval_millis        | int    | 否       | -      | 流模式下的请求间隔，单位毫秒。 |
+| retry                       | int    | 否       | -      | 请求出现 `IOException` 时的最大重试次数。 |
+| retry_backoff_multiplier_ms | int    | 否       | 100    | 重试退避时间倍数，单位毫秒。 |
+| retry_backoff_max_ms        | int    | 否       | 10000  | 最大重试退避时间，单位毫秒。 |
+| json_filed_missed_return_null | boolean | 否     | false  | `json_field` 中配置的字段缺失时，是否返回 `null`。 |
+| common-options              | config | 否       | -      | 源连接器通用配置，见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### url [String]
+### 认证
 
-HTTP 请求 URL
+把 `password` 配置为 Lemlist API Key。连接器会用空用户名和该 API Key 生成 Basic 认证请求头。
 
-### password [String]
+### 返回结果解析
 
-API 密钥用于登录，您可以在以下链接获取更多详情：
+`format` 默认值是 `TEXT`，会把完整响应作为一个 `content` 字段输出。
 
-https://developer.lemlist.com/
+如果需要结构化输出，请配置 `format = "json"` 和 `schema`：
 
-### method [String]
+```hocon
+format = "json"
+schema = {
+  fields {
+    _id = string
+    name = string
+    userIds = "array<string>"
+    createdBy = string
+    createdAt = string
+    apiKey = string
+    billing = {
+      quantity = int
+      ok = boolean
+      plan = string
+    }
+  }
+}
+```
 
-HTTP 请求方法，仅支持 GET、POST 方法
+如果行数据在嵌套 JSON 节点里，用 `content_field` 选出对应节点。如果输出列需要从不同 JSONPath 中提取，用 `json_field`。
 
-### params [Map]
+### 分页
 
-HTTP 参数
+目标 API 需要分页参数时，可以配置 `pageing`。
 
-### body [String]
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| total_page_size | long | 否 | 0 | 请求的总页数。 |
+| batch_size | int | 否 | 100 | 每次请求返回的数据条数。 |
+| start_page_number | long | 否 | 1 | 起始页码。 |
+| page_field | String | 否 | page | 页码分页时，请求参数中的页码字段名。 |
+| page_type | String | 否 | PageNumber | 分页类型，支持 `PageNumber` 和 `Cursor`。 |
+| cursor_field | String | 否 | - | 游标分页时，请求参数中的游标字段名。 |
+| cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
+| use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
-HTTP 请求体
+## 示例
 
-### poll_interval_millis [int]
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-流模式下请求 HTTP API 的间隔（毫秒）
+source {
+  Lemlist {
+    plugin_output = "lemlist"
+    url = "https://api.lemlist.com/api/team"
+    password = "replace-with-api-key"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        _id = string
+        name = string
+        userIds = "array<string>"
+        createdBy = string
+        createdAt = string
+        apiKey = string
+        billing = {
+          quantity = int
+          ok = boolean
+          plan = string
+        }
+      }
+    }
+  }
+}
 
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-当您指定格式为 `json` 时，您还应该指定 schema 选项。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。如果您只需要 'book' 部分中的数据，配置 `content_field = "$.store.book.*"`。
+sink {
+  Console {
+    plugin_input = "lemlist"
+  }
+}
+```
 
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
### Purpose

Improve the Jira, Klaviyo, and Lemlist source connector documentation so the docs match the current HTTP source option surface and provide clearer runnable examples.

### Changes

- Clarify authentication behavior for Jira, Klaviyo, and Lemlist.
- Fix the documented HTTP source option set, including `content_field`, `headers`, `pageing`, `json_filed_missed_return_null`, and the real default `format` value.
- Remove stale unsupported option wording such as `content_json` and `enable_multi_lines` from these connector pages.
- Refresh English and Chinese examples with concrete batch jobs for the three connectors.
- Align feature notes for batch, streaming, column projection, and single-split execution behavior.

### Duplicate check

I checked recent open and closed PRs updated since 2026-06-30 and did not find Jira, Klaviyo, or Lemlist connector documentation changes.

### Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`