### PR TITLE
[Docs][Connector-V2] Improve OneSignal Notion and Persistiq docs

### DIFF
--- a/docs/en/connectors/source/Notion.md
+++ b/docs/en/connectors/source/Notion.md
@@ -6,303 +6,97 @@ import ChangeLog from '../changelog/connector-http-notion.md';
 
 ## Description
 
-Used to read data from Notion.
+The Notion source connector reads data from Notion HTTP APIs. It is built on the HTTP source connector and automatically adds the Notion `Authorization` and `Notion-Version` headers from `password` and `version`.
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Supported Data Source Info
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| version                     | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| Datasource | Dependency |
+|------------|------------|
+| Notion     | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-notion) |
 
-### url [String]
+## Source Options
 
-http request url
+| Name                          | Type    | Required | Default | Description |
+|-------------------------------|---------|----------|---------|-------------|
+| url                           | String  | Yes      | -       | Notion API request URL. |
+| password                      | String  | Yes      | -       | Notion integration token. The connector writes it to the `Authorization: Bearer ...` header. |
+| version                       | String  | Yes      | -       | Notion API version, for example `2022-06-28`. The connector writes it to the `Notion-Version` header. |
+| method                        | String  | No       | GET     | HTTP request method. `GET` and `POST` are supported. |
+| schema                        | Config  | No       | -       | SeaTunnel schema. Required when `format = json`. |
+| schema.fields                 | Config  | No       | -       | Output field names and types. |
+| format                        | String  | No       | text    | Response format. Supports `json`, `text`, and `binary`. Notion API reads normally use `json`. |
+| content_field                 | String  | No       | -       | JSONPath used to extract a JSON object or array before parsing it with `schema`. |
+| json_field                    | Config  | No       | -       | JSONPath mapping for individual output fields. Use it together with `schema`. |
+| headers                       | Map     | No       | -       | Extra HTTP headers. Notion authentication headers from `password` and `version` are added by the connector. |
+| params                        | Map     | No       | -       | HTTP query parameters. |
+| body                          | String  | No       | -       | HTTP request body. Usually used with `method = POST`. |
+| pageing                       | Config  | No       | -       | Pagination settings. Keep the option name spelling as `pageing`. |
+| poll_interval_millis          | Int     | No       | -       | Request interval in streaming jobs, in milliseconds. |
+| retry                         | Int     | No       | -       | Maximum retry count when the request fails with `IOException`. |
+| retry_backoff_multiplier_ms   | Int     | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms          | Int     | No       | 10000   | Maximum retry backoff in milliseconds. |
+| enable_multi_lines            | Boolean | No       | false   | Whether to split text responses by line. |
+| connect_timeout_ms            | Int     | No       | 12000   | HTTP connection timeout in milliseconds. |
+| socket_timeout_ms             | Int     | No       | 60000   | HTTP socket timeout in milliseconds. |
+| json_filed_missed_return_null | Boolean | No       | false   | When a JSON field is missing, return null instead of failing. Keep the option name spelling as `json_filed_missed_return_null`. |
+| common-options                | Config  | No       | -       | Source plugin common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### password [String]
+## Option Notes
 
-API key for login, you can get more detail at this link:
-
-https://developers.notion.com/docs/authorization
-
-### version [String]
-
-The Notion API is versioned. API versions are named for the date the version is released
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
-
-```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
-    }
-  }
-}
-```
-
-Here is an example:
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
-
-### json_field [Config]
-
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+- `format = json` requires `schema`; otherwise the connector reads the response as a single `content` text field.
+- Notion list APIs commonly return records inside `results`. Use `content_field = "$.results.*"` to parse each returned object as one SeaTunnel row.
+- Nested objects can be described in `schema.fields`, for example `person = { email = string }`.
+- This connector is source-only. It does not provide a sink connector, CDC, multi-table split discovery, or exactly-once guarantees.
+- Do not put secrets directly in shared configuration files. Use your deployment platform's secret management when possible.
 
 ## Example
 
 ```hocon
-Notion {
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Notion {
+    plugin_output = "notion_users"
     url = "https://api.notion.com/v1/users"
-    password = "SeaTunnel-test"
+    password = "YOUR_NOTION_TOKEN"
     version = "2022-06-28"
+    method = "GET"
+    format = "json"
     content_field = "$.results.*"
     schema = {
-       fields {
-          object = string
-          id = string
-          type = string
-          person = {
-              email = string
-          }
-          avatar_url = string
-       }
+      fields {
+        object = string
+        id = string
+        type = string
+        person = {
+          email = string
+        }
+        name = string
+        avatar_url = string
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "notion_users"
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/source/OneSignal.md
+++ b/docs/en/connectors/source/OneSignal.md
@@ -6,321 +6,94 @@ import ChangeLog from '../changelog/connector-http-onesignal.md';
 
 ## Description
 
-Used to read data from OneSignal.
+The OneSignal source connector reads data from OneSignal HTTP APIs. It is built on the HTTP source connector and automatically adds the OneSignal authentication headers from `password`.
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Supported Data Source Info
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| Datasource | Dependency |
+|------------|------------|
+| OneSignal  | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-onesignal) |
 
-### url [String]
+## Source Options
 
-http request url
+| Name                          | Type    | Required | Default | Description |
+|-------------------------------|---------|----------|---------|-------------|
+| url                           | String  | Yes      | -       | OneSignal API request URL. |
+| password                      | String  | Yes      | -       | OneSignal user auth key. The connector writes it to the `Authorization: Basic ...` header and also sets `Content-Type: application/json`. |
+| method                        | String  | No       | GET     | HTTP request method. `GET` and `POST` are supported. |
+| schema                        | Config  | No       | -       | SeaTunnel schema. Required when `format = json`. |
+| schema.fields                 | Config  | No       | -       | Output field names and types. |
+| format                        | String  | No       | text    | Response format. Supports `json`, `text`, and `binary`. OneSignal API reads normally use `json`. |
+| content_field                 | String  | No       | -       | JSONPath used to extract a JSON object or array before parsing it with `schema`. |
+| json_field                    | Config  | No       | -       | JSONPath mapping for individual output fields. Use it together with `schema`. |
+| headers                       | Map     | No       | -       | Extra HTTP headers. Authentication headers from `password` are added by the connector. |
+| params                        | Map     | No       | -       | HTTP query parameters. |
+| body                          | String  | No       | -       | HTTP request body. Usually used with `method = POST`. |
+| pageing                       | Config  | No       | -       | Pagination settings. Keep the option name spelling as `pageing`. |
+| poll_interval_millis          | Int     | No       | -       | Request interval in streaming jobs, in milliseconds. |
+| retry                         | Int     | No       | -       | Maximum retry count when the request fails with `IOException`. |
+| retry_backoff_multiplier_ms   | Int     | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms          | Int     | No       | 10000   | Maximum retry backoff in milliseconds. |
+| enable_multi_lines            | Boolean | No       | false   | Whether to split text responses by line. |
+| connect_timeout_ms            | Int     | No       | 12000   | HTTP connection timeout in milliseconds. |
+| socket_timeout_ms             | Int     | No       | 60000   | HTTP socket timeout in milliseconds. |
+| json_filed_missed_return_null | Boolean | No       | false   | When a JSON field is missing, return null instead of failing. Keep the option name spelling as `json_filed_missed_return_null`. |
+| common-options                | Config  | No       | -       | Source plugin common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### password [String]
+## Option Notes
 
-Auth key for login, you can get more detail at this link:
-
-https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
-
-```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
-    }
-  }
-}
-```
-
-Here is an example:
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
-
-### json_field [Config]
-
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+- `format = json` requires `schema`; otherwise the connector reads the response as a single `content` text field.
+- Use `content_field` when the OneSignal response wraps the records inside a JSON array or object.
+- This connector is source-only. It does not provide a sink connector, CDC, multi-table split discovery, or exactly-once guarantees.
+- Do not put secrets directly in shared configuration files. Use your deployment platform's secret management when possible.
 
 ## Example
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-OneSignal {
+source {
+  OneSignal {
+    plugin_output = "onesignal_apps"
     url = "https://onesignal.com/api/v1/apps"
-    password = "SeaTunnel-test"
+    password = "YOUR_ONESIGNAL_USER_AUTH_KEY"
+    method = "GET"
+    format = "json"
     schema = {
-       fields {
-         id = string
-         name = string
-         gcm_key = string
-         chrome_key = string
-         chrome_web_key = string
-         chrome_web_origin = string
-         chrome_web_gcm_sender_id = string
-         chrome_web_default_notification_icon = string
-         chrome_web_sub_domain = string
-         apns_env = string
-         apns_certificates = string
-         apns_p8 = string
-         apns_team_id = string
-         apns_key_id = string
-         apns_bundle_id = string
-         safari_apns_certificate = string
-         safari_site_origin = string
-         safari_push_id = string
-         safari_icon_16_16 = string
-         safari_icon_32_32 = string
-         safari_icon_64_64 = string
-         safari_icon_128_128 = string
-         safari_icon_256_256 = string
-         site_name = string
-         created_at = string
-         updated_at = string
-         players = int
-         messageable_players = int
-         basic_auth_key = string
-         additional_data_is_root_payload = string
-       }
-    }   
+      fields {
+        id = string
+        name = string
+        gcm_key = string
+        chrome_key = string
+        created_at = string
+        updated_at = string
+        players = int
+        messageable_players = int
+        basic_auth_key = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "onesignal_apps"
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/source/Persistiq.md
+++ b/docs/en/connectors/source/Persistiq.md
@@ -6,282 +6,73 @@ import ChangeLog from '../changelog/connector-http-persistiq.md';
 
 ## Description
 
-Used to read data from Persistiq.
+The Persistiq source connector reads data from Persistiq HTTP APIs. It is built on the HTTP source connector and automatically sends the Persistiq API key from `password` as the `x-api-key` header.
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [schema projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Supported Data Source Info
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| Datasource | Dependency |
+|------------|------------|
+| Persistiq  | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-persistiq) |
 
-### url [String]
+## Source Options
 
-http request url
+| Name                          | Type    | Required | Default | Description |
+|-------------------------------|---------|----------|---------|-------------|
+| url                           | String  | Yes      | -       | Persistiq API request URL. |
+| password                      | String  | Yes      | -       | Persistiq API key. The connector writes it to the `x-api-key` header. |
+| method                        | String  | No       | GET     | HTTP request method. `GET` and `POST` are supported. |
+| schema                        | Config  | No       | -       | SeaTunnel schema. Required when `format = json`. |
+| schema.fields                 | Config  | No       | -       | Output field names and types. |
+| format                        | String  | No       | text    | Response format. Supports `json`, `text`, and `binary`. Persistiq API reads normally use `json`. |
+| content_field                 | String  | No       | -       | JSONPath used to extract a JSON object or array before parsing it with `schema`. |
+| json_field                    | Config  | No       | -       | JSONPath mapping for individual output fields. Use it together with `schema`. |
+| headers                       | Map     | No       | -       | Extra HTTP headers. The API key header from `password` is added by the connector. |
+| params                        | Map     | No       | -       | HTTP query parameters. |
+| body                          | String  | No       | -       | HTTP request body. Usually used with `method = POST`. |
+| pageing                       | Config  | No       | -       | Pagination settings. Keep the option name spelling as `pageing`. |
+| poll_interval_millis          | Int     | No       | -       | Request interval in streaming jobs, in milliseconds. |
+| retry                         | Int     | No       | -       | Maximum retry count when the request fails with `IOException`. |
+| retry_backoff_multiplier_ms   | Int     | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms          | Int     | No       | 10000   | Maximum retry backoff in milliseconds. |
+| enable_multi_lines            | Boolean | No       | false   | Whether to split text responses by line. |
+| connect_timeout_ms            | Int     | No       | 12000   | HTTP connection timeout in milliseconds. |
+| socket_timeout_ms             | Int     | No       | 60000   | HTTP socket timeout in milliseconds. |
+| json_filed_missed_return_null | Boolean | No       | false   | When a JSON field is missing, return null instead of failing. Keep the option name spelling as `json_filed_missed_return_null`. |
+| common-options                | Config  | No       | -       | Source plugin common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### password [String]
+## Option Notes
 
-API key for login, you can get it at Persistiq website
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
-
-```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
-}
-
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
-
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
-
-```hocon
-Http {
-  url = "http://example.com/xyz"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
-    }
-  }
-}
-```
-
-Here is an example:
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
-
-### json_field [Config]
-
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
-
-```hocon
-source {
-  Http {
-    url = "http://example.com/xyz"
-    method = "GET"
-    format = "json"
-    json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
-    }
-    schema = {
-      fields {
-        category = string
-        author = string
-        title = string
-        price = string
-      }
-    }
-  }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+- `format = json` requires `schema`; otherwise the connector reads the response as a single `content` text field.
+- Persistiq list APIs commonly return records inside a wrapper object. Use `content_field`, for example `content_field = "$.users.*"`, to parse each record as one SeaTunnel row.
+- This connector is source-only. It does not provide a sink connector, CDC, multi-table split discovery, or exactly-once guarantees.
+- Do not put secrets directly in shared configuration files. Use your deployment platform's secret management when possible.
 
 ## Example
 
 ```hocon
-Persistiq{
-  url = "https://api.persistiq.com/v1/users"
-  password = "Your password"
-  content_field = "$.users.*"
-  schema = {
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Persistiq {
+    plugin_output = "persistiq_users"
+    url = "https://api.persistiq.com/v1/users"
+    password = "YOUR_PERSISTIQ_API_KEY"
+    method = "GET"
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
       fields {
         id = string
         name = string
@@ -290,6 +81,13 @@ Persistiq{
         default_mailbox_id = string
         salesforce_id = string
       }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "persistiq_users"
   }
 }
 ```

--- a/docs/zh/connectors/source/Notion.md
+++ b/docs/zh/connectors/source/Notion.md
@@ -6,99 +6,97 @@ import ChangeLog from '../changelog/connector-http-notion.md';
 
 ## 描述
 
-用于从 Notion 读取数据。
+Notion 源连接器用于从 Notion HTTP API 读取数据。它基于 HTTP 源连接器实现，并会根据 `password` 和 `version` 自动添加 Notion 的 `Authorization` 与 `Notion-Version` 请求头。
 
-## 关键特性
+## 主要特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 支持的数据源信息
 
-| 参数名 | 类型 | 必须 | 默认值 | 描述 |
-|--------|------|------|--------|------|
-| url | String | 是 | - | HTTP 请求 URL |
-| password | String | 是 | - | API 密钥用于登录 |
-| version | String | 是 | - | Notion API 版本 |
-| method | String | 否 | get | HTTP 请求方法，仅支持 GET、POST 方法 |
-| schema.fields | Config | 否 | - | 上游数据的模式字段 |
-| format | String | 否 | json | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。 |
-| params | Map | 否 | - | HTTP 参数 |
-| body | String | 否 | - | HTTP 请求体 |
-| json_field | Config | 否 | - | JSON 字段配置 |
-| content_json | String | 否 | - | 内容 JSON 配置 |
-| poll_interval_millis | int | 否 | - | 流模式下请求 HTTP API 的间隔（毫秒） |
-| retry | int | 否 | - | 如果 HTTP 请求返回 `IOException` 的最大重试次数 |
-| retry_backoff_multiplier_ms | int | 否 | 100 | HTTP 请求失败时的重试退避倍数（毫秒） |
-| retry_backoff_max_ms | int | 否 | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒） |
-| enable_multi_lines | boolean | 否 | false | 是否启用多行模式 |
-| common-options | config | 否 | - | 源插件通用参数 |
+| 数据源 | 依赖 |
+|--------|------|
+| Notion | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-notion) |
 
-### url [String]
+## 源选项
 
-HTTP 请求 URL
+| 名称 | 类型 | 是否必须 | 默认值 | 描述 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | Notion API 请求 URL。 |
+| password | String | 是 | - | Notion Integration Token。连接器会把它写入 `Authorization: Bearer ...` 请求头。 |
+| version | String | 是 | - | Notion API 版本，例如 `2022-06-28`。连接器会把它写入 `Notion-Version` 请求头。 |
+| method | String | 否 | GET | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| schema | Config | 否 | - | SeaTunnel 数据结构。`format = json` 时必须配置。 |
+| schema.fields | Config | 否 | - | 输出字段名称和类型。 |
+| format | String | 否 | text | 响应格式，支持 `json`、`text` 和 `binary`。读取 Notion API 时通常使用 `json`。 |
+| content_field | String | 否 | - | 用 JSONPath 先抽取某个 JSON 对象或数组，再按 `schema` 解析。 |
+| json_field | Config | 否 | - | 单个输出字段的 JSONPath 映射，需要和 `schema` 一起使用。 |
+| headers | Map | 否 | - | 额外 HTTP 请求头。连接器会根据 `password` 和 `version` 自动添加 Notion 认证请求头。 |
+| params | Map | 否 | - | HTTP 查询参数。 |
+| body | String | 否 | - | HTTP 请求体，通常和 `method = POST` 一起使用。 |
+| pageing | Config | 否 | - | 分页配置。参数名需要保持 `pageing` 这个拼写。 |
+| poll_interval_millis | Int | 否 | - | 流式作业的请求间隔，单位毫秒。 |
+| retry | Int | 否 | - | 请求因 `IOException` 失败时的最大重试次数。 |
+| retry_backoff_multiplier_ms | Int | 否 | 100 | 重试退避倍数，单位毫秒。 |
+| retry_backoff_max_ms | Int | 否 | 10000 | 最大重试退避时间，单位毫秒。 |
+| enable_multi_lines | Boolean | 否 | false | 是否按行拆分文本响应。 |
+| connect_timeout_ms | Int | 否 | 12000 | HTTP 连接超时时间，单位毫秒。 |
+| socket_timeout_ms | Int | 否 | 60000 | HTTP Socket 超时时间，单位毫秒。 |
+| json_filed_missed_return_null | Boolean | 否 | false | JSON 字段缺失时是否返回 null；参数名需要保持 `json_filed_missed_return_null` 这个拼写。 |
+| common-options | Config | 否 | - | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### password [String]
+## 参数说明
 
-API 密钥用于登录，您可以在以下链接获取更多详情：
+- `format = json` 时需要配置 `schema`；否则连接器会把响应内容作为单个 `content` 文本字段读取。
+- Notion 列表接口通常把记录放在 `results` 中。可以配置 `content_field = "$.results.*"`，让每个返回对象输出为一行。
+- `schema.fields` 支持描述嵌套对象，例如 `person = { email = string }`。
+- 该连接器只有 Source，没有对应 Sink；不提供 CDC、多表分片发现或精确一次语义。
+- 不建议把密钥直接写在共享配置文件里，生产环境优先使用部署平台的密钥管理能力。
 
-https://developers.notion.com/docs/authorization
+## 示例
 
-### version [String]
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-Notion API 是版本化的。API 版本以发布版本的日期命名
+source {
+  Notion {
+    plugin_output = "notion_users"
+    url = "https://api.notion.com/v1/users"
+    password = "YOUR_NOTION_TOKEN"
+    version = "2022-06-28"
+    method = "GET"
+    format = "json"
+    content_field = "$.results.*"
+    schema = {
+      fields {
+        object = string
+        id = string
+        type = string
+        person = {
+          email = string
+        }
+        name = string
+        avatar_url = string
+      }
+    }
+  }
+}
 
-### method [String]
-
-HTTP 请求方法，仅支持 GET、POST 方法
-
-### params [Map]
-
-HTTP 参数
-
-### body [String]
-
-HTTP 请求体
-
-### poll_interval_millis [int]
-
-流模式下请求 HTTP API 的间隔（毫秒）
-
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。
-
-### json_field [Config]
-
-此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
+sink {
+  Console {
+    plugin_input = "notion_users"
+  }
+}
+```
 
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/OneSignal.md
+++ b/docs/zh/connectors/source/OneSignal.md
@@ -6,118 +6,90 @@ import ChangeLog from '../changelog/connector-http-onesignal.md';
 
 ## 描述
 
-用于从 OneSignal 读取数据。
+OneSignal 源连接器用于从 OneSignal HTTP API 读取数据。它基于 HTTP 源连接器实现，并会根据 `password` 自动添加 OneSignal 认证请求头。
 
-## 关键特性
+## 主要特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 支持的数据源信息
 
-| 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                          |
-|-----------------------------|---------|----|-------|---------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                 |
-| password                    | String  | 是  | -     | 认证密钥用于登录                                                                                    |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法                                                                   |
-| schema                      | Config  | 否  | -     | HTTP 和 SeaTunnel 数据结构映射。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                   |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                      |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                     |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                    |
-| json_field                  | Config  | 否  | -     | JSON 字段配置                                                                                   |
-| content_json                | String  | 否  | -     | 内容 JSON 配置                                                                                  |
-| poll_interval_millis        | int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                     |
-| retry                       | int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 的最大重试次数                                                          |
-| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                       |
-| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                     |
-| enable_multi_lines          | boolean | 否  | false | 是否启用多行模式                                                                                    |
-| common-options              | config  | 否  | -     | 源插件通用参数                                                                                     |
+| 数据源 | 依赖 |
+|--------|------|
+| OneSignal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-onesignal) |
 
-### url [String]
+## 源选项
 
-HTTP 请求 URL
+| 名称 | 类型 | 是否必须 | 默认值 | 描述 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | OneSignal API 请求 URL。 |
+| password | String | 是 | - | OneSignal 用户认证密钥。连接器会把它写入 `Authorization: Basic ...` 请求头，并设置 `Content-Type: application/json`。 |
+| method | String | 否 | GET | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| schema | Config | 否 | - | SeaTunnel 数据结构。`format = json` 时必须配置。 |
+| schema.fields | Config | 否 | - | 输出字段名称和类型。 |
+| format | String | 否 | text | 响应格式，支持 `json`、`text` 和 `binary`。读取 OneSignal API 时通常使用 `json`。 |
+| content_field | String | 否 | - | 用 JSONPath 先抽取某个 JSON 对象或数组，再按 `schema` 解析。 |
+| json_field | Config | 否 | - | 单个输出字段的 JSONPath 映射，需要和 `schema` 一起使用。 |
+| headers | Map | 否 | - | 额外 HTTP 请求头。连接器会根据 `password` 自动添加认证请求头。 |
+| params | Map | 否 | - | HTTP 查询参数。 |
+| body | String | 否 | - | HTTP 请求体，通常和 `method = POST` 一起使用。 |
+| pageing | Config | 否 | - | 分页配置。参数名需要保持 `pageing` 这个拼写。 |
+| poll_interval_millis | Int | 否 | - | 流式作业的请求间隔，单位毫秒。 |
+| retry | Int | 否 | - | 请求因 `IOException` 失败时的最大重试次数。 |
+| retry_backoff_multiplier_ms | Int | 否 | 100 | 重试退避倍数，单位毫秒。 |
+| retry_backoff_max_ms | Int | 否 | 10000 | 最大重试退避时间，单位毫秒。 |
+| enable_multi_lines | Boolean | 否 | false | 是否按行拆分文本响应。 |
+| connect_timeout_ms | Int | 否 | 12000 | HTTP 连接超时时间，单位毫秒。 |
+| socket_timeout_ms | Int | 否 | 60000 | HTTP Socket 超时时间，单位毫秒。 |
+| json_filed_missed_return_null | Boolean | 否 | false | JSON 字段缺失时是否返回 null；参数名需要保持 `json_filed_missed_return_null` 这个拼写。 |
+| common-options | Config | 否 | - | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### password [String]
+## 参数说明
 
-认证密钥用于登录，您可以在以下链接获取更多详情：
-
-https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key
-
-### method [String]
-
-HTTP 请求方法，仅支持 GET、POST 方法
-
-### params [Map]
-
-HTTP 参数
-
-### body [String]
-
-HTTP 请求体
-
-### poll_interval_millis [int]
-
-流模式下请求 HTTP API 的间隔（毫秒）
-
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。
-
-### json_field [Config]
-
-此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
-
-### 通用选项
-
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+- `format = json` 时需要配置 `schema`；否则连接器会把响应内容作为单个 `content` 文本字段读取。
+- 当 OneSignal 响应把记录包在某个 JSON 数组或对象里时，可以用 `content_field` 先抽取要读取的部分。
+- 该连接器只有 Source，没有对应 Sink；不提供 CDC、多表分片发现或精确一次语义。
+- 不建议把密钥直接写在共享配置文件里，生产环境优先使用部署平台的密钥管理能力。
 
 ## 示例
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   OneSignal {
+    plugin_output = "onesignal_apps"
     url = "https://onesignal.com/api/v1/apps"
-    password = "SeaTunnel-test"
+    password = "YOUR_ONESIGNAL_USER_AUTH_KEY"
+    method = "GET"
+    format = "json"
     schema = {
-       fields {
-         id = string
-         name = string
-         gcm_key = string
-         chrome_key = string
-         created_at = string
-         updated_at = string
-         players = int
-         messageable_players = int
-         basic_auth_key = string
-       }
-    }   
+      fields {
+        id = string
+        name = string
+        gcm_key = string
+        chrome_key = string
+        created_at = string
+        updated_at = string
+        players = int
+        messageable_players = int
+        basic_auth_key = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "onesignal_apps"
   }
 }
 ```
@@ -125,4 +97,3 @@ source {
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/Persistiq.md
+++ b/docs/zh/connectors/source/Persistiq.md
@@ -6,114 +6,88 @@ import ChangeLog from '../changelog/connector-http-persistiq.md';
 
 ## 描述
 
-用于从 Persistiq 读取数据。
+Persistiq 源连接器用于从 Persistiq HTTP API 读取数据。它基于 HTTP 源连接器实现，并会把 `password` 配置为 Persistiq 需要的 `x-api-key` 请求头。
 
-## 关键特性
+## 主要特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [模式投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 支持的数据源信息
 
-| 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                          |
-|-----------------------------|---------|----|-------|---------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                 |
-| password                    | String  | 是  | -     | API 密钥用于登录                                                                                  |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法                                                                   |
-| schema                      | Config  | 否  | -     | HTTP 和 SeaTunnel 数据结构映射。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                   |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                      |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                     |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                    |
-| json_field                  | Config  | 否  | -     | JSON 字段配置                                                                                   |
-| content_json                | String  | 否  | -     | 内容 JSON 配置                                                                                  |
-| poll_interval_millis        | int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                     |
-| retry                       | int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 的最大重试次数                                                          |
-| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                       |
-| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                     |
-| enable_multi_lines          | boolean | 否  | false | 是否启用多行模式                                                                                    |
-| common-options              | config  | 否  | -     | 源插件通用参数                                                                                     |
+| 数据源 | 依赖 |
+|--------|------|
+| Persistiq | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-persistiq) |
 
-### url [String]
+## 源选项
 
-HTTP 请求 URL
+| 名称 | 类型 | 是否必须 | 默认值 | 描述 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | Persistiq API 请求 URL。 |
+| password | String | 是 | - | Persistiq API Key。连接器会把它写入 `x-api-key` 请求头。 |
+| method | String | 否 | GET | HTTP 请求方法，支持 `GET` 和 `POST`。 |
+| schema | Config | 否 | - | SeaTunnel 数据结构。`format = json` 时必须配置。 |
+| schema.fields | Config | 否 | - | 输出字段名称和类型。 |
+| format | String | 否 | text | 响应格式，支持 `json`、`text` 和 `binary`。读取 Persistiq API 时通常使用 `json`。 |
+| content_field | String | 否 | - | 用 JSONPath 先抽取某个 JSON 对象或数组，再按 `schema` 解析。 |
+| json_field | Config | 否 | - | 单个输出字段的 JSONPath 映射，需要和 `schema` 一起使用。 |
+| headers | Map | 否 | - | 额外 HTTP 请求头。连接器会根据 `password` 自动添加 API Key 请求头。 |
+| params | Map | 否 | - | HTTP 查询参数。 |
+| body | String | 否 | - | HTTP 请求体，通常和 `method = POST` 一起使用。 |
+| pageing | Config | 否 | - | 分页配置。参数名需要保持 `pageing` 这个拼写。 |
+| poll_interval_millis | Int | 否 | - | 流式作业的请求间隔，单位毫秒。 |
+| retry | Int | 否 | - | 请求因 `IOException` 失败时的最大重试次数。 |
+| retry_backoff_multiplier_ms | Int | 否 | 100 | 重试退避倍数，单位毫秒。 |
+| retry_backoff_max_ms | Int | 否 | 10000 | 最大重试退避时间，单位毫秒。 |
+| enable_multi_lines | Boolean | 否 | false | 是否按行拆分文本响应。 |
+| connect_timeout_ms | Int | 否 | 12000 | HTTP 连接超时时间，单位毫秒。 |
+| socket_timeout_ms | Int | 否 | 60000 | HTTP Socket 超时时间，单位毫秒。 |
+| json_filed_missed_return_null | Boolean | 否 | false | JSON 字段缺失时是否返回 null；参数名需要保持 `json_filed_missed_return_null` 这个拼写。 |
+| common-options | Config | 否 | - | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### password [String]
+## 参数说明
 
-API 密钥用于登录，您可以在 Persistiq 网站获取
-
-### method [String]
-
-HTTP 请求方法，仅支持 GET、POST 方法
-
-### params [Map]
-
-HTTP 参数
-
-### body [String]
-
-HTTP 请求体
-
-### poll_interval_millis [int]
-
-流模式下请求 HTTP API 的间隔（毫秒）
-
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。
-
-### json_field [Config]
-
-此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
-
-### 通用选项
-
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+- `format = json` 时需要配置 `schema`；否则连接器会把响应内容作为单个 `content` 文本字段读取。
+- Persistiq 列表接口通常会把记录包在外层对象里。可以配置 `content_field = "$.users.*"`，让每个用户对象输出为一行。
+- 该连接器只有 Source，没有对应 Sink；不提供 CDC、多表分片发现或精确一次语义。
+- 不建议把密钥直接写在共享配置文件里，生产环境优先使用部署平台的密钥管理能力。
 
 ## 示例
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
-  Persistiq{
+  Persistiq {
+    plugin_output = "persistiq_users"
     url = "https://api.persistiq.com/v1/users"
-    password = "Your password"
+    password = "YOUR_PERSISTIQ_API_KEY"
+    method = "GET"
+    format = "json"
     content_field = "$.users.*"
     schema = {
-        fields {
-          id = string
-          name = string
-          email = string
-          activated = boolean
-          default_mailbox_id = string
-          salesforce_id = string
-        }
+      fields {
+        id = string
+        name = string
+        email = string
+        activated = boolean
+        default_mailbox_id = string
+        salesforce_id = string
+      }
     }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "persistiq_users"
   }
 }
 ```
@@ -121,4 +95,3 @@ source {
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary

This PR improves the OneSignal, Notion, and Persistiq source connector documentation.

## Changes

- Corrects the documented HTTP option surface, including `content_field`, `headers`, timeout, retry, and missing-field behavior options.
- Clarifies connector-specific authentication behavior for OneSignal, Notion, and Persistiq.
- Adds source-only capability notes for CDC, sink support, multi-table discovery, and exactly-once guarantees.
- Refreshes English and Chinese examples with complete batch jobs and realistic JSON parsing settings.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
