### PR TITLE
[Improve][Docs] Improve Kubernetes deployment guide

### DIFF
--- a/docs/en/getting-started/kubernetes/configuration.md
+++ b/docs/en/getting-started/kubernetes/configuration.md
@@ -8,7 +8,10 @@ This page describes common configuration and recommended practices for deploying
 
 ## ConfigMap and Secret
 
-Store non-sensitive configuration in ConfigMap and mount the required files with `subPath`, for example `/opt/seatunnel/config/seatunnel.yaml` or `/opt/seatunnel/config/hazelcast-master.yaml`. Do not mount a ConfigMap over the whole `/opt/seatunnel/config` directory unless the ConfigMap also contains all files required by the image, such as `jvm_options`, `jvm_master_options`, and `jvm_worker_options`.
+Store non-sensitive configuration in ConfigMap and mount the required files with `subPath`, for example `/opt/seatunnel/config/seatunnel.yaml` or `/opt/seatunnel/config/hazelcast-master.yaml`.
+
+:::caution Warning
+Do not mount a ConfigMap over the whole `/opt/seatunnel/config` directory unless the ConfigMap also contains all files required by the image, such as `jvm_options`, `jvm_master_options`, and `jvm_worker_options`.
 
 Do not write sensitive values directly into ConfigMap, including:
 
@@ -17,6 +20,7 @@ Do not write sensitive values directly into ConfigMap, including:
 - Tokens, private keys, and other credentials.
 
 Store sensitive values in Kubernetes Secret and inject them through environment variables or mounted files. ConfigMap file content does not resolve Kubernetes `secretKeyRef`; SeaTunnel, Hazelcast, and the underlying filesystem must read final usable configuration values or a credential mechanism they support, such as environment variables, Hadoop credential provider, cloud-provider credential chains, or mounted credential files.
+:::
 
 ## Hazelcast Kubernetes Discovery
 
@@ -37,7 +41,11 @@ spec:
     app: seatunnel
 ```
 
-The matching `hazelcast.yaml` must use the same namespace, service name, and port:
+Choose one of the following Hazelcast Kubernetes discovery modes.
+
+### API Discovery
+
+API discovery uses the Kubernetes API to resolve members from the configured namespace and Service. The matching `hazelcast.yaml` must use the same namespace, service name, and port:
 
 ```yaml
 hazelcast:
@@ -51,6 +59,56 @@ hazelcast:
 ```
 
 If SeaTunnel is deployed in a namespace other than `default`, update `namespace` accordingly. Also update `hazelcast-client.yaml` `cluster-members`, for example `seatunnel-cluster.<namespace>.svc.cluster.local:5801`, so the job submission client connects to the same namespace.
+
+:::caution Warning
+When `namespace`, `service-name`, and `service-port` are used, Hazelcast Kubernetes discovery queries the Kubernetes API during member bootstrap. In RBAC-enabled clusters, the SeaTunnel Pods therefore need a ServiceAccount bound to read Pods, Services, and Endpoints in the deployment namespace. Create the RBAC resources before starting the StatefulSet, and set `serviceAccountName: seatunnel` in the Pod template.
+:::
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
+```
+
+### DNS Discovery
+
+DNS discovery resolves the Headless Service through Kubernetes DNS. It does not require Hazelcast to call the Kubernetes API, so no additional Role or RoleBinding is needed for member discovery. This mode is simpler when the cluster only needs to discover members behind one stable Headless Service:
+
+```yaml
+hazelcast:
+  network:
+    join:
+      kubernetes:
+        enabled: true
+        service-dns: seatunnel-cluster.default.svc.cluster.local
+        service-dns-timeout: 10
+```
+
+:::info Note
+If SeaTunnel is deployed in a namespace other than `default`, update `service-dns` and `hazelcast-client.yaml` `cluster-members` to the same namespace. Keep `publishNotReadyAddresses: true` on the Headless Service so DNS discovery can resolve Pods while the cluster is bootstrapping.
+:::
 
 SeaTunnel server settings come from `seatunnel.engine` in `seatunnel.yaml`; cluster member discovery comes from `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml`.
 
@@ -132,9 +190,11 @@ hazelcast:
         enabled: false
 ```
 
+:::info Note
 This IMap stores checkpoint overview and history data used by REST APIs and UI observability. It is not the authoritative checkpoint recovery state. Checkpoint recovery state is written by `seatunnel.engine.checkpoint.storage` to HDFS, S3, OSS, or another configured checkpoint storage backend.
 
 This override is optional. Use it when you want to avoid persisting observability-only data and reduce MapStore/WAL write amplification. Omit it if you want checkpoint monitor overview/history to use the same MapStore settings as other `engine*` IMaps.
+:::
 
 ### HDFS
 
@@ -179,7 +239,11 @@ hazelcast:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 ```
 
-If you want to inject credentials from Kubernetes Secret as environment variables, do not put `secretKeyRef` inside the ConfigMap content. Inject the AWS SDK environment variables into the Pod, and do not pin `fs.s3a.aws.credentials.provider` to `SimpleAWSCredentialsProvider`. The current Hadoop AWS 3.1.4 default credential chain already reads AWS environment variables when no provider is configured explicitly. If you want to allow only environment-variable authentication, set the S3A provider to `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`:
+:::caution Warning
+If you want to inject credentials from Kubernetes Secret as environment variables, do not put `secretKeyRef` inside the ConfigMap content. Inject the AWS SDK environment variables into the Pod, and do not pin `fs.s3a.aws.credentials.provider` to `SimpleAWSCredentialsProvider`.
+:::
+
+The current Hadoop AWS 3.1.4 default credential chain already reads AWS environment variables when no provider is configured explicitly. If you want to allow only environment-variable authentication, set the S3A provider to `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`:
 
 ```yaml
 env:
@@ -244,7 +308,9 @@ If you do not want to render OSS credentials into the final ConfigMap, use Hadoo
 
 When `backup-count: 1` is used, at least 2 Master replicas are required to store IMap backup replicas.
 
+:::caution Warning
 Do not commit real access keys or secret keys to ConfigMaps or Git repositories. Kubernetes does not resolve `secretKeyRef` inside ConfigMap file content. SeaTunnel and Hazelcast must read a final, usable YAML configuration. In production, generate the final ConfigMap through Helm, Kustomize, External Secrets, CI/CD, or the image build process, or use credential mechanisms actually supported by the underlying filesystem, such as Hadoop credential provider, AWS SDK environment variable provider, cloud-provider credential chains, or mounted credential files. Make sure every Master Pod has the same read/write permission to the object store.
+:::
 
 When S3 or OSS is used, the SeaTunnel image must also contain the corresponding Hadoop filesystem implementation and dependencies, such as Hadoop AWS/AWS SDK or Hadoop Aliyun/OSS SDK. Checkpoint storage and IMap MapStore can use the same object storage service, but use different `namespace` prefixes, for example `/seatunnel/checkpoint/` and `/seatunnel/imap`.
 
@@ -252,29 +318,50 @@ When S3 or OSS is used, the SeaTunnel image must also contain the corresponding 
 
 The base Master and Worker StatefulSets do not include custom plugin loading logic. Custom plugins are an additional deployment concern. Manage them separately according to cluster requirements and make sure Master and Worker use the same plugin versions.
 
-Common plugin loading approaches:
+Use the SeaTunnel runtime directories according to how the jar is loaded:
+
+| Directory | Use for | Do not use for |
+| --- | --- | --- |
+| `${SEATUNNEL_HOME}/plugins` | Custom connector plugin jars or plugin packages | Transform plugin jars or general runtime jars |
+| `${SEATUNNEL_HOME}/lib` | Transform plugin jars and rare runtime extension jars that must be on the SeaTunnel process classpath | Connector plugin jars |
+
+:::info Note
+SeaTunnel uses different loading paths for different plugin types. The `plugins/` directory is for custom connectors, not Transform plugins or unrelated runtime jars. If a custom connector needs drivers or client libraries, package those jars together with the custom connector plugin you place under `plugins/`. Transform plugins that are shipped with SeaTunnel, such as `seatunnel-transforms-v2.jar`, are packaged under `lib/` and discovered from the runtime classpath. Only put a custom jar under `lib/` when it is a Transform plugin or a runtime extension that must be visible to the SeaTunnel process classpath.
+:::
+
+:::caution Warning
+Putting a Transform plugin jar only under `plugins/` can fail if it is not on the runtime classpath. Do not use `lib/` for custom connector plugin jars.
+:::
+
+Common loading approaches:
 
 | Approach | Use case | Description |
 | --- | --- | --- |
-| Build plugins into the SeaTunnel image | Stable production environments | Most repeatable and recommended for production |
-| Inject plugins with initContainer overlay | Plugin set changes frequently | Add an initContainer to the StatefulSet as an overlay, copy plugins from a plugin image to `emptyDir`, and mount them |
-| Mount from PersistentVolume or object storage | Large plugin sets | Requires extra version consistency management |
+| Build custom connector plugins and Transform jars into the SeaTunnel image | Stable production environments | Most repeatable and recommended for production |
+| Inject custom connector plugins with initContainer overlay | Connector set changes frequently | Add an initContainer to the StatefulSet as an overlay, copy plugin files from a plugin image to `emptyDir`, and mount them |
+| Mount from PersistentVolume or object storage | Large connector sets | Requires extra version consistency management |
 
 ### Use a Custom Image
 
-For stable production environments, build custom plugins into the SeaTunnel image:
+For stable production environments, build custom connector plugin jars, Transform plugin jars, and required runtime extension jars into the SeaTunnel image:
 
 ```Dockerfile
 FROM seatunnel:3.0.0
 
+# Optional: custom connector plugin jars or plugin packages.
 COPY plugins/ /opt/seatunnel/plugins/
+
+# Optional: Transform plugin jars or runtime extension jars that require process classpath.
+COPY lib/ /opt/seatunnel/lib/
 ```
+
+Keep custom connector plugin jars under `/opt/seatunnel/plugins/`. Use `/opt/seatunnel/lib/` only for Transform plugin jars or runtime extension jars that must be on the SeaTunnel process classpath.
 
 Then use the same image tag in both Master and Worker StatefulSets.
 
 ### Use an initContainer Overlay
 
-If plugins need to be released independently, build a plugin-only image and add the following fragment to both Master and Worker StatefulSets as an overlay. This fragment is not part of the base deployment manifest.
+If custom connector plugins need to be released independently from the main image, add the following fragment to both Master and Worker StatefulSets. This fragment is not part of the base deployment manifest. Because the `plugins` `emptyDir` mount replaces the image directory at runtime, the plugin image must contain all custom connector plugin files required by the submitted jobs.
 
 ```yaml
 initContainers:
@@ -283,22 +370,48 @@ initContainers:
     command:
       - sh
       - -c
-      - cp /opt/seatunnel/plugins/plugin.jar /mnt/lib/
+      - |
+        cp -R /plugin/plugins/. /mnt/plugins/
     volumeMounts:
-      - name: plugin-lib
-        mountPath: /mnt/lib
+      - name: plugin-dependencies
+        mountPath: /mnt/plugins
 containers:
   - name: app
     volumeMounts:
-      - name: plugin-lib
-        mountPath: /opt/seatunnel/lib/plugin.jar
-        subPath: plugin.jar
+      - name: plugin-dependencies
+        mountPath: /opt/seatunnel/plugins
 volumes:
-  - name: plugin-lib
+  - name: plugin-dependencies
     emptyDir: {}
 ```
 
-If the plugin directory contains multiple jars, mount the whole plugin directory instead of mounting only one jar file.
+:::caution Warning
+Do not mount an `emptyDir` over the whole `/opt/seatunnel/lib` directory unless it contains every runtime jar from the base image; use `subPath` for an individual Transform plugin jar or runtime extension jar, or build it into the image. Make sure every Master and Worker Pod gets the same plugin and dependency versions.
+:::
+
+If you also need to inject a Transform plugin jar, add it with `subPath` instead of replacing the whole `lib` directory. When you already use the overlay above, merge the `runtime-lib` mount and copy command into the same initContainer. A minimal standalone fragment looks like:
+
+```yaml
+initContainers:
+  - name: plugin-loader
+    image: seatunnel-plugin:v1.0.0
+    volumeMounts:
+      - name: runtime-lib
+        mountPath: /mnt/lib
+    command:
+      - sh
+      - -c
+      - cp /plugin/lib/custom-transform.jar /mnt/lib/
+containers:
+  - name: app
+    volumeMounts:
+      - name: runtime-lib
+        mountPath: /opt/seatunnel/lib/custom-transform.jar
+        subPath: custom-transform.jar
+volumes:
+  - name: runtime-lib
+    emptyDir: {}
+```
 
 ## Logging
 

--- a/docs/en/getting-started/kubernetes/configuration.md
+++ b/docs/en/getting-started/kubernetes/configuration.md
@@ -54,23 +54,20 @@ If SeaTunnel is deployed in a namespace other than `default`, update `namespace`
 
 SeaTunnel server settings come from `seatunnel.engine` in `seatunnel.yaml`; cluster member discovery comes from `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml`.
 
-Use the following Hazelcast `properties` as the recommended production baseline for Kubernetes. They are not universally optimal for every cluster, but they are a solid starting point: they improve member invocation retries, use the `phi-accrual` heartbeat failure detector, and align graceful shutdown with `terminationGracePeriodSeconds`. Tune them before production rollout based on network latency, Pod eviction behavior, cluster size, and job concurrency.
+Use the following Hazelcast `properties` as the baseline configuration. They are aligned with the current SeaTunnel default Hazelcast configuration so that the Kubernetes examples stay consistent with the codebase. Tune them before production rollout based on CPU limits, network latency, Pod eviction behavior, cluster size, and job concurrency.
 
 ```yaml
 properties:
-  hazelcast.invocation.max.retry.count: 50
-  hazelcast.tcp.join.port.try.count: 10
+  hazelcast.invocation.max.retry.count: 20
+  hazelcast.tcp.join.port.try.count: 30
   hazelcast.logging.type: log4j2
-  hazelcast.phone.home.enabled: false
-  hazelcast.operation.generic.thread.count: 32
+  hazelcast.operation.generic.thread.count: 50
   hazelcast.heartbeat.failuredetector.type: phi-accrual
-  hazelcast.heartbeat.interval.seconds: 5
-  hazelcast.max.no.heartbeat.seconds: 30
+  hazelcast.heartbeat.interval.seconds: 2
+  hazelcast.max.no.heartbeat.seconds: 180
   hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
   hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
   hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-  hazelcast.shutdownhook.policy: GRACEFUL
-  hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ## Separate Master and Worker Configuration

--- a/docs/en/getting-started/kubernetes/configuration.md
+++ b/docs/en/getting-started/kubernetes/configuration.md
@@ -120,6 +120,22 @@ Master nodes handle IMap state storage. In production, enable MapStore and write
 
 MapStore uses `FileMapStoreFactory`. The `type: hdfs` entry is the identifier of the IMap file storage factory and must stay unchanged even when S3 or OSS is used. The actual backend is selected by `storage.type`, which currently supports `hdfs`, `s3`, and `oss`.
 
+### Checkpoint Monitor MapStore
+
+If you do not want to persist checkpoint monitor data, add an explicit override for `engine_checkpoint_monitor`:
+
+```yaml
+hazelcast:
+  map:
+    engine_checkpoint_monitor:
+      map-store:
+        enabled: false
+```
+
+This IMap stores checkpoint overview and history data used by REST APIs and UI observability. It is not the authoritative checkpoint recovery state. Checkpoint recovery state is written by `seatunnel.engine.checkpoint.storage` to HDFS, S3, OSS, or another configured checkpoint storage backend.
+
+This override is optional. Use it when you want to avoid persisting observability-only data and reduce MapStore/WAL write amplification. Omit it if you want checkpoint monitor overview/history to use the same MapStore settings as other `engine*` IMaps.
+
 ### HDFS
 
 ```yaml

--- a/docs/en/getting-started/kubernetes/configuration.md
+++ b/docs/en/getting-started/kubernetes/configuration.md
@@ -1,0 +1,300 @@
+---
+sidebar_position: 5
+---
+
+# Kubernetes Configuration
+
+This page describes common configuration and recommended practices for deploying SeaTunnel on Kubernetes.
+
+## ConfigMap and Secret
+
+Store non-sensitive configuration in ConfigMap and mount the required files with `subPath`, for example `/opt/seatunnel/config/seatunnel.yaml` or `/opt/seatunnel/config/hazelcast-master.yaml`. Do not mount a ConfigMap over the whole `/opt/seatunnel/config` directory unless the ConfigMap also contains all files required by the image, such as `jvm_options`, `jvm_master_options`, and `jvm_worker_options`.
+
+Do not write sensitive values directly into ConfigMap, including:
+
+- Database passwords.
+- Object storage access keys and secret keys.
+- Tokens, private keys, and other credentials.
+
+Store sensitive values in Kubernetes Secret and inject them through environment variables or mounted files. ConfigMap file content does not resolve Kubernetes `secretKeyRef`; SeaTunnel, Hazelcast, and the underlying filesystem must read final usable configuration values or a credential mechanism they support, such as environment variables, Hadoop credential provider, cloud-provider credential chains, or mounted credential files.
+
+## Hazelcast Kubernetes Discovery
+
+Cluster mode depends on Hazelcast to discover other members. On Kubernetes, use a Headless Service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+  selector:
+    app: seatunnel
+```
+
+The matching `hazelcast.yaml` must use the same namespace, service name, and port:
+
+```yaml
+hazelcast:
+  network:
+    join:
+      kubernetes:
+        enabled: true
+        namespace: default
+        service-name: seatunnel-cluster
+        service-port: 5801
+```
+
+If SeaTunnel is deployed in a namespace other than `default`, update `namespace` accordingly. Also update `hazelcast-client.yaml` `cluster-members`, for example `seatunnel-cluster.<namespace>.svc.cluster.local:5801`, so the job submission client connects to the same namespace.
+
+SeaTunnel server settings come from `seatunnel.engine` in `seatunnel.yaml`; cluster member discovery comes from `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml`.
+
+Use the following Hazelcast `properties` as the recommended production baseline for Kubernetes. They are not universally optimal for every cluster, but they are a solid starting point: they improve member invocation retries, use the `phi-accrual` heartbeat failure detector, and align graceful shutdown with `terminationGracePeriodSeconds`. Tune them before production rollout based on network latency, Pod eviction behavior, cluster size, and job concurrency.
+
+```yaml
+properties:
+  hazelcast.invocation.max.retry.count: 50
+  hazelcast.tcp.join.port.try.count: 10
+  hazelcast.logging.type: log4j2
+  hazelcast.phone.home.enabled: false
+  hazelcast.operation.generic.thread.count: 32
+  hazelcast.heartbeat.failuredetector.type: phi-accrual
+  hazelcast.heartbeat.interval.seconds: 5
+  hazelcast.max.no.heartbeat.seconds: 30
+  hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+  hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+  hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+  hazelcast.shutdownhook.policy: GRACEFUL
+  hazelcast.graceful.shutdown.max.wait: 120
+```
+
+## Separate Master and Worker Configuration
+
+In separated cluster mode, use different Hazelcast configuration for Master and Worker:
+
+- Master configures IMap MapStore and conservative heartbeat settings.
+- Worker configures `member-attributes.rule=worker` and does not carry IMap MapStore.
+- `seatunnel.yaml` can be shared, but some settings only take effect for one role.
+
+## Slot Configuration
+
+Worker slots are cluster scheduling resources. Static slots are recommended for production:
+
+```yaml
+seatunnel:
+  engine:
+    slot-service:
+      dynamic-slot: false
+      slot-num: 8
+    job-schedule-strategy: WAIT
+```
+
+Plan `slot-num` together with Worker CPU, memory, and job parallelism. When too many Worker Pods are terminated at the same time, available slots drop quickly. Use StatefulSet for Workers and check slot capacity before rolling updates or scale-down.
+
+## Checkpoint Storage
+
+Multi-node clusters must use shared storage or object storage as checkpoint backend. Common choices include HDFS, S3, OSS, COS, OBS, TOS, or Kubernetes PersistentVolume.
+
+```yaml
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 180000
+      timeout: 30000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: hdfs
+          namespace: /seatunnel/checkpoint/
+          fs.defaultFS: hdfs://namenode:8020
+```
+
+If object storage is used, every Master and Worker Pod must have network access and the same read/write permissions.
+
+## IMap MapStore
+
+Master nodes handle IMap state storage. In production, enable MapStore and write data to shared storage or object storage. In separated cluster mode, configure MapStore only in `hazelcast-master.yaml`; Workers do not need MapStore.
+
+MapStore uses `FileMapStoreFactory`. The `type: hdfs` entry is the identifier of the IMap file storage factory and must stay unchanged even when S3 or OSS is used. The actual backend is selected by `storage.type`, which currently supports `hdfs`, `s3`, and `oss`.
+
+### HDFS
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: hdfs
+          fs.defaultFS: hdfs://namenode:8020
+```
+
+### S3 or Compatible Object Storage
+
+S3-compatible storage uses Hadoop S3A configuration. When AWS S3 is used, rely on Hadoop S3A default endpoint resolution. Compatible services such as MinIO or Ceph RGW usually require their own `fs.s3a.endpoint` and `fs.s3a.path.style.access: true`.
+
+If static credentials are provided in the final YAML, use the fixed Hadoop S3A keys: `fs.s3a.access.key` and `fs.s3a.secret.key`. When `SimpleAWSCredentialsProvider` is configured explicitly, both keys are required. In this mode, Hadoop uses the values from YAML directly; do not write them as `${AWS_SECRET_ACCESS_KEY}` or `{AWS_SECRET_ACCESS_KEY}`.
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: s3
+          s3.bucket: s3a://seatunnel-bucket
+          fs.s3a.access.key: YOUR_ACCESS_KEY
+          fs.s3a.secret.key: YOUR_SECRET_KEY
+          fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+```
+
+If you want to inject credentials from Kubernetes Secret as environment variables, do not put `secretKeyRef` inside the ConfigMap content. Inject the AWS SDK environment variables into the Pod, and do not pin `fs.s3a.aws.credentials.provider` to `SimpleAWSCredentialsProvider`. The current Hadoop AWS 3.1.4 default credential chain already reads AWS environment variables when no provider is configured explicitly. If you want to allow only environment-variable authentication, set the S3A provider to `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`:
+
+```yaml
+env:
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: seatunnel-s3-credentials
+        key: access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: seatunnel-s3-credentials
+        key: secret-access-key
+```
+
+```yaml
+properties:
+  type: hdfs
+  namespace: /seatunnel/imap
+  clusterName: seatunnel-cluster
+  storage.type: s3
+  s3.bucket: s3a://seatunnel-bucket
+  fs.s3a.aws.credentials.provider: com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+```
+
+For temporary credentials, also inject `AWS_SESSION_TOKEN`. The AWS SDK also accepts `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`, but `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are recommended.
+
+If MinIO, Ceph RGW, or another S3-compatible service is used, add the service endpoint to the S3 configuration:
+
+```yaml
+properties:
+  fs.s3a.endpoint: https://s3-compatible-endpoint.example.com
+  fs.s3a.path.style.access: true
+```
+
+### OSS
+
+Alibaba Cloud OSS uses Hadoop OSS configuration and selects the target bucket with `oss.bucket`. Set `fs.oss.endpoint` to the actual endpoint of the bucket region, private cloud, or OSS-compatible service.
+
+The default Hadoop Aliyun OSS credential provider reads `fs.oss.accessKeyId` and `fs.oss.accessKeySecret`. Temporary credentials can additionally set `fs.oss.securityToken`. It does not provide a default environment-variable credential chain like Hadoop S3A, so credentials injected from Kubernetes Secret as environment variables are not used automatically.
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: oss
+          oss.bucket: oss://seatunnel-bucket
+          fs.oss.endpoint: https://oss-<region>.aliyuncs.com
+          fs.oss.accessKeyId: YOUR_ACCESS_KEY_ID
+          fs.oss.accessKeySecret: YOUR_ACCESS_KEY_SECRET
+```
+
+If you do not want to render OSS credentials into the final ConfigMap, use Hadoop credential provider for `fs.oss.accessKeyId` and `fs.oss.accessKeySecret`, or set `fs.oss.credentials.provider` to a custom provider. The custom provider must implement the Aliyun OSS SDK `com.aliyun.oss.common.auth.CredentialsProvider` interface and must be available in the SeaTunnel image.
+
+When `backup-count: 1` is used, at least 2 Master replicas are required to store IMap backup replicas.
+
+Do not commit real access keys or secret keys to ConfigMaps or Git repositories. Kubernetes does not resolve `secretKeyRef` inside ConfigMap file content. SeaTunnel and Hazelcast must read a final, usable YAML configuration. In production, generate the final ConfigMap through Helm, Kustomize, External Secrets, CI/CD, or the image build process, or use credential mechanisms actually supported by the underlying filesystem, such as Hadoop credential provider, AWS SDK environment variable provider, cloud-provider credential chains, or mounted credential files. Make sure every Master Pod has the same read/write permission to the object store.
+
+When S3 or OSS is used, the SeaTunnel image must also contain the corresponding Hadoop filesystem implementation and dependencies, such as Hadoop AWS/AWS SDK or Hadoop Aliyun/OSS SDK. Checkpoint storage and IMap MapStore can use the same object storage service, but use different `namespace` prefixes, for example `/seatunnel/checkpoint/` and `/seatunnel/imap`.
+
+## Plugin Loading
+
+The base Master and Worker StatefulSets do not include custom plugin loading logic. Custom plugins are an additional deployment concern. Manage them separately according to cluster requirements and make sure Master and Worker use the same plugin versions.
+
+Common plugin loading approaches:
+
+| Approach | Use case | Description |
+| --- | --- | --- |
+| Build plugins into the SeaTunnel image | Stable production environments | Most repeatable and recommended for production |
+| Inject plugins with initContainer overlay | Plugin set changes frequently | Add an initContainer to the StatefulSet as an overlay, copy plugins from a plugin image to `emptyDir`, and mount them |
+| Mount from PersistentVolume or object storage | Large plugin sets | Requires extra version consistency management |
+
+### Use a Custom Image
+
+For stable production environments, build custom plugins into the SeaTunnel image:
+
+```Dockerfile
+FROM seatunnel:3.0.0
+
+COPY plugins/ /opt/seatunnel/plugins/
+```
+
+Then use the same image tag in both Master and Worker StatefulSets.
+
+### Use an initContainer Overlay
+
+If plugins need to be released independently, build a plugin-only image and add the following fragment to both Master and Worker StatefulSets as an overlay. This fragment is not part of the base deployment manifest.
+
+```yaml
+initContainers:
+  - name: plugin-loader
+    image: seatunnel-plugin:v1.0.0
+    command:
+      - sh
+      - -c
+      - cp /opt/seatunnel/plugins/plugin.jar /mnt/lib/
+    volumeMounts:
+      - name: plugin-lib
+        mountPath: /mnt/lib
+containers:
+  - name: app
+    volumeMounts:
+      - name: plugin-lib
+        mountPath: /opt/seatunnel/lib/plugin.jar
+        subPath: plugin.jar
+volumes:
+  - name: plugin-lib
+    emptyDir: {}
+```
+
+If the plugin directory contains multiple jars, mount the whole plugin directory instead of mounting only one jar file.
+
+## Logging
+
+Keep console logs so Kubernetes log collectors can collect them. You can also use `log4j2.properties` to write local rolling logs. If logs are collected by sidecar or DaemonSet, make sure log paths, file names, and collection rules are consistent.
+
+The default log path is usually:
+
+```text
+/opt/seatunnel/logs
+```
+
+For production environments, limit log retention time and file size to avoid filling Pod local disk.

--- a/docs/en/getting-started/kubernetes/helm.md
+++ b/docs/en/getting-started/kubernetes/helm.md
@@ -2,17 +2,12 @@
 sidebar_position: 4
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Set Up with Helm
 
 This section provides a quick guide to use SeaTunnel with Helm.
 
-:::tip
-
+:::tip Tip
 In Zeta cluster mode, both Master and Worker should be deployed with StatefulSet for production. The current Helm chart is suitable for a quick start, but it still renders Master and Worker as Deployment. Before using Helm in production, read [Kubernetes Deployment](kubernetes.mdx), [Separated Cluster Mode](separated-cluster-mode.md), and [Kubernetes Configuration](configuration.md) to understand the StatefulSet-based topology, Headless Service, checkpoint, IMap MapStore, and slot planning practices.
-
 :::
 
 ## Prerequisites
@@ -44,13 +39,13 @@ helm install seatunnel .
 ```
 Install with another namespace.
 ```bash
-helm install seatunnel . -n <your namespace>
+helm install seatunnel . -n <your-namespace>
 ```
 
 For managed Kubernetes services, keep provider-specific changes in a separate values file and pass it with `-f`, for example:
 
 ```bash
-helm install seatunnel . -n <your namespace> -f values-eks.yaml
+helm install seatunnel . -n <your-namespace> -f values-eks.yaml
 ```
 
 Common managed-cluster values to review include:
@@ -66,8 +61,9 @@ Common managed-cluster values to review include:
 
 The default configuration does not enable Ingress, so forward the Master REST API port first.
 ```bash
-kubectl port-forward -n default svc/seatunnel-master 8080:8080
+kubectl port-forward -n <namespace> svc/seatunnel-master 8080:8080
 ```
+Use `default` as `<namespace>` if you installed the chart without `-n`.
 Then you can access REST API with `http://127.0.0.1:8080/`.
 
 If you want to use Ingress, update `values.yaml`.
@@ -85,9 +81,9 @@ Then you can access REST API with `http://<your-domain>`.
 Or you can just go into master pod, and use local curl command.
 ```commandline
 # get one of the master pods
-MASTER_POD=$(kubectl get po -l  'app.kubernetes.io/name=seatunnel-master' | sed '1d' | awk '{print $1}' | head -n1)
+MASTER_POD=$(kubectl get po -n <namespace> -l 'app.kubernetes.io/name=seatunnel-master' | sed '1d' | awk '{print $1}' | head -n1)
 # go into master pod container.
-kubectl -n default exec -it $MASTER_POD -- /bin/bash
+kubectl -n <namespace> exec -it $MASTER_POD -- /bin/bash
 
 curl http://127.0.0.1:8080/running-jobs
 curl http://127.0.0.1:8080/system-monitoring-information
@@ -97,5 +93,5 @@ After that, submit jobs through [REST API V2](../../engines/zeta/rest-api-v2.md)
 
 ## What's More
 
-For now, you have taken a quick look at SeaTunnel, and you can see [connector](../../connectors/source) to find all sources and sinks SeaTunnel supported.
+For now, you have taken a quick look at SeaTunnel. See the connector documentation to find all supported sources and sinks.
 For handwritten Kubernetes manifests and production deployment recommendations, see [Separated Cluster Mode](separated-cluster-mode.md) and [Kubernetes Operations](operations.md).

--- a/docs/en/getting-started/kubernetes/helm.md
+++ b/docs/en/getting-started/kubernetes/helm.md
@@ -9,6 +9,12 @@ import TabItem from '@theme/TabItem';
 
 This section provides a quick guide to use SeaTunnel with Helm.
 
+:::tip
+
+In Zeta cluster mode, both Master and Worker should be deployed with StatefulSet for production. The current Helm chart is suitable for a quick start, but it still renders Master and Worker as Deployment. Before using Helm in production, read [Kubernetes Deployment](kubernetes.mdx), [Separated Cluster Mode](separated-cluster-mode.md), and [Kubernetes Configuration](configuration.md) to understand the StatefulSet-based topology, Headless Service, checkpoint, IMap MapStore, and slot planning practices.
+
+:::
+
 ## Prerequisites
 
 We assume that you have one local installation as follow:
@@ -58,13 +64,13 @@ Common managed-cluster values to review include:
 
 ## Submit Job
 
-The default config doesn't enable ingress, so you need forward the master restapi.
+The default configuration does not enable Ingress, so forward the Master REST API port first.
 ```bash
-kubectl port-forward -n default svc/seatunnel-master 5801:5801
+kubectl port-forward -n default svc/seatunnel-master 8080:8080
 ```
-Then you can access restapi with "http://127.0.0.1/5801/"
+Then you can access REST API with `http://127.0.0.1:8080/`.
 
-If you want to use ingress, update `value.yaml`
+If you want to use Ingress, update `values.yaml`.
 
 for example:
 ```commandline
@@ -72,9 +78,9 @@ ingress:
   enabled: true
   host: "<your domain>"
 ```
-Then upgrade seatunnel.
+Then upgrade SeaTunnel.
 
-Then you can access restapi with `http://<your domain>`
+Then you can access REST API with `http://<your-domain>`.
 
 Or you can just go into master pod, and use local curl command.
 ```commandline
@@ -83,13 +89,13 @@ MASTER_POD=$(kubectl get po -l  'app.kubernetes.io/name=seatunnel-master' | sed 
 # go into master pod container.
 kubectl -n default exec -it $MASTER_POD -- /bin/bash
 
-curl http://127.0.0.1:5801/running-jobs
-curl http://127.0.0.1:5801/system-monitoring-information
+curl http://127.0.0.1:8080/running-jobs
+curl http://127.0.0.1:8080/system-monitoring-information
 ```
 
-After that you can submit your job by [rest-api-v2](../../engines/zeta/rest-api-v2.md)
+After that, submit jobs through [REST API V2](../../engines/zeta/rest-api-v2.md).
 
 ## What's More
 
 For now, you have taken a quick look at SeaTunnel, and you can see [connector](../../connectors/source) to find all sources and sinks SeaTunnel supported.
-Or see [deployment](../../engines/zeta/deployment.md) if you want to submit your application in another kind of your engine cluster.
+For handwritten Kubernetes manifests and production deployment recommendations, see [Separated Cluster Mode](separated-cluster-mode.md) and [Kubernetes Operations](operations.md).

--- a/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -1,0 +1,288 @@
+---
+sidebar_position: 3
+---
+
+# Hybrid Cluster Mode
+
+In Hybrid Cluster Mode, SeaTunnel Engine Master and Worker run in the same process. Every node can participate in Master election and execute tasks.
+
+This mode is simple to deploy and suitable for small clusters. For production environments, [Separated Cluster Mode](separated-cluster-mode.md) is recommended because it isolates scheduling resources from execution resources.
+
+## Deployment Principles
+
+- Deploy hybrid cluster nodes with StatefulSet.
+- Use a Headless Service for Hazelcast Kubernetes discovery.
+- Use the same `hazelcast.yaml`, `hazelcast-client.yaml`, and `seatunnel.yaml` for all nodes.
+- Each node handles both scheduling and execution, so resource settings must cover both Master and Worker load.
+
+## Create ConfigMaps
+
+Store sensitive values in Secret for production environments. The following example only shows non-sensitive configuration. Split ConfigMaps by responsibility to avoid an overly long YAML file.
+
+### Hazelcast ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-hazelcast-config
+data:
+  hazelcast.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+```
+
+### Hazelcast Client ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-client-config
+data:
+  hazelcast-client.yaml: |
+    hazelcast-client:
+      cluster-name: seatunnel-cluster
+      properties:
+        hazelcast.logging.type: log4j2
+      connection-strategy:
+        connection-retry:
+          cluster-connect-timeout-millis: 7000
+      network:
+        cluster-members:
+          # Replace `default` with your namespace if SeaTunnel is deployed elsewhere.
+          - seatunnel-cluster.default.svc.cluster.local:5801
+```
+
+### SeaTunnel Engine ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-engine-config
+data:
+  seatunnel.yaml: |
+    seatunnel:
+      engine:
+        backup-count: 1
+        history-job-expire-minutes: 1440
+        print-execution-info-interval: 300
+        classloader-cache-mode: true
+        slot-service:
+          dynamic-slot: false
+          slot-num: 8
+        job-schedule-strategy: WAIT
+        checkpoint:
+          interval: 180000
+          timeout: 30000
+          storage:
+            type: hdfs
+            max-retained: 3
+            plugin-config:
+              namespace: /seatunnel/checkpoint/
+              storage.type: hdfs
+              fs.defaultFS: hdfs://namenode:8020
+        http:
+          enable-http: true
+          port: 8080
+```
+
+## Create Services
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+  labels:
+    app: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: hybrid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel
+  labels:
+    app: seatunnel
+    component: hybrid
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: hybrid
+```
+
+## Create StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel
+  labels:
+    app: seatunnel
+    component: hybrid
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 3
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: hybrid
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: hybrid
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          volumeMounts:
+            - name: hazelcast-config
+              mountPath: /opt/seatunnel/config/hazelcast.yaml
+              subPath: hazelcast.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-config
+          configMap:
+            name: seatunnel-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+## Health Check and Graceful Shutdown
+
+For cluster mode, add `startupProbe`, health checks, and `preStop` to each SeaTunnel container to avoid killing slow starts and to reduce the impact of rolling updates or node eviction.
+
+```yaml
+startupProbe:
+  tcpSocket:
+    port: 5801
+  periodSeconds: 10
+  failureThreshold: 30
+readinessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          /opt/seatunnel/bin/stop-seatunnel-cluster.sh
+          while kill -0 $(ps -ef | grep SeaTunnelServer | grep -v grep | awk '{print $2}') 2>/dev/null; do
+            sleep 1
+          done
+```
+
+Apply the manifests:
+
+```bash
+kubectl apply -f seatunnel-hazelcast-config.yaml
+kubectl apply -f seatunnel-client-config.yaml
+kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-services.yaml
+kubectl apply -f seatunnel-hybrid.yaml
+```
+
+## Access REST API
+
+```bash
+kubectl port-forward svc/seatunnel 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+```
+
+## Recommendation
+
+In Hybrid Cluster Mode, Master nodes also run tasks. When task load is high, execution load may affect Master election, scheduling, and REST API stability. For a more stable production deployment, use [Separated Cluster Mode](separated-cluster-mode.md).

--- a/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -48,19 +48,16 @@ data:
             service-name: seatunnel-cluster
             service-port: 5801
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ### Hazelcast Client ConfigMap

--- a/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -6,7 +6,11 @@ sidebar_position: 3
 
 In Hybrid Cluster Mode, SeaTunnel Engine Master and Worker run in the same process. Every node can participate in Master election and execute tasks.
 
-This mode is simple to deploy and suitable for small clusters. For production environments, [Separated Cluster Mode](separated-cluster-mode.md) is recommended because it isolates scheduling resources from execution resources.
+This mode is simple to deploy and suitable for small clusters.
+
+:::tip Tip
+For production environments, [Separated Cluster Mode](separated-cluster-mode.md) is recommended because it isolates scheduling resources from execution resources.
+:::
 
 ## Deployment Principles
 
@@ -17,7 +21,11 @@ This mode is simple to deploy and suitable for small clusters. For production en
 
 ## Create ConfigMaps
 
-Store sensitive values in Secret for production environments. The following example only shows non-sensitive configuration. Split ConfigMaps by responsibility to avoid an overly long YAML file.
+:::caution Warning
+Store sensitive values in Secret for production environments. The following example only shows non-sensitive configuration.
+:::
+
+Split ConfigMaps by responsibility to avoid an overly long YAML file.
 
 ### Hazelcast ConfigMap
 
@@ -59,6 +67,20 @@ data:
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
 ```
+
+This example uses Hazelcast Kubernetes API discovery. If you prefer DNS discovery and do not want Hazelcast to call the Kubernetes API, replace the `join.kubernetes` block with:
+
+```yaml
+join:
+  kubernetes:
+    enabled: true
+    service-dns: seatunnel-cluster.default.svc.cluster.local
+    service-dns-timeout: 10
+```
+
+:::info Note
+When DNS discovery is used, the RBAC section below is not required for member discovery. If you skip the RBAC manifest, also remove `serviceAccountName: seatunnel` from the StatefulSet or create that ServiceAccount separately.
+:::
 
 ### Hazelcast Client ConfigMap
 
@@ -114,6 +136,38 @@ data:
         http:
           enable-http: true
           port: 8080
+```
+
+## Create RBAC for API Discovery
+
+The default `namespace`, `service-name`, and `service-port` settings in `hazelcast.yaml` use Hazelcast Kubernetes API discovery. In RBAC-enabled clusters, create a ServiceAccount, Role, and RoleBinding before starting the StatefulSet. Skip this section if you use `service-dns` discovery instead:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
 ```
 
 ## Create Services
@@ -180,6 +234,7 @@ spec:
         app: seatunnel
         component: hybrid
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -265,10 +320,15 @@ lifecycle:
 
 Apply the manifests:
 
+:::info Note
+Apply `seatunnel-rbac.yaml` only when API discovery is used, or when the StatefulSet keeps `serviceAccountName: seatunnel`.
+:::
+
 ```bash
 kubectl apply -f seatunnel-hazelcast-config.yaml
 kubectl apply -f seatunnel-client-config.yaml
 kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-rbac.yaml
 kubectl apply -f seatunnel-services.yaml
 kubectl apply -f seatunnel-hybrid.yaml
 ```
@@ -282,4 +342,6 @@ curl http://127.0.0.1:8080/system-monitoring-information
 
 ## Recommendation
 
+:::tip Tip
 In Hybrid Cluster Mode, Master nodes also run tasks. When task load is high, execution load may affect Master election, scheduling, and REST API stability. For a more stable production deployment, use [Separated Cluster Mode](separated-cluster-mode.md).
+:::

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -20,7 +20,7 @@ In Zeta cluster mode, both Master and Worker should be deployed with StatefulSet
 
 StatefulSet provides stable Pod names, stable network identities, and ordered rolling updates. Master nodes handle leader election, job scheduling, REST API, and IMap state management, so stable Pod identity helps member discovery and failure recovery. Worker nodes do not store IMap data in separated cluster mode, but they still provide the execution slots required by running jobs. If Deployment is used, rolling updates, eviction, or rescheduling may terminate multiple Worker Pods at the same time. Available slots can drop suddenly, causing scheduling, failover, or cluster stability issues.
 
-The recommended production topology is shown below. This follows the Kubernetes StatefulSet model: StatefulSet manages ordered Pods, while the Headless Service provides Pod network identity and DNS-based discovery.
+The recommended production topology is shown below. This follows the Kubernetes StatefulSet model: StatefulSet manages ordered Pods, while the Headless Service provides Pod network identity and the stable Service target used by Hazelcast member discovery.
 
 ```mermaid
 flowchart TB
@@ -55,6 +55,15 @@ flowchart TB
   master0 <-->|Hazelcast member traffic| worker0
   master1 <-->|Hazelcast member traffic| worker1
   master0 <-->|Hazelcast member traffic| worker2
+
+  classDef layerBlue fill:#0f1d33,stroke:#5db8e2,stroke-width:2px,color:#f8fbff;
+  classDef layerCyan fill:#0c2530,stroke:#2dd4bf,stroke-width:2px,color:#f8fbff;
+  classDef layerPurple fill:#1f1a34,stroke:#8d7cf6,stroke-width:2px,color:#f8fbff;
+
+  class ns,masterSet,workerSet layerBlue;
+  class masterSvc,discoverySvc layerCyan;
+  class client,master0,master1,worker0,worker1,worker2 layerPurple;
+  linkStyle default stroke:#5db8e2,stroke-width:2px;
 ```
 
 Here, `seatunnel-cluster` is a Headless Service used only for Hazelcast member discovery. `seatunnel-master` is a regular ClusterIP Service used to expose the Master REST API.
@@ -112,7 +121,7 @@ The examples can be adapted to managed Kubernetes services such as Amazon EKS, G
 | --- | --- |
 | Image registry | SeaTunnel images and plugin images must be pullable by the cluster. Configure `imagePullSecrets` for private images. |
 | Namespace and access | Use a dedicated namespace and configure ServiceAccount, Role, and RoleBinding as needed. |
-| Network discovery | Hazelcast Kubernetes discovery depends on the Headless Service. `namespace`, `service-name`, and `service-port` in `hazelcast*.yaml` must match the Service. |
+| Network discovery | Hazelcast Kubernetes discovery depends on the Headless Service. For API discovery, `namespace`, `service-name`, and `service-port` in `hazelcast*.yaml` must match the Service. For DNS discovery, `service-dns` must point to the same Headless Service. |
 | Config and secrets | Store non-sensitive config in ConfigMap. Mount passwords, access keys, tokens, and other secrets through Secret or a cloud secret service. |
 | Checkpoint and state storage | Multi-node clusters must use shared storage or object storage so state can be recovered after any Pod is recreated. |
 | Scheduling | Plan Worker requests, limits, slots, and job parallelism together. When cluster autoscaling is enabled, Worker requests must be large enough to trigger scale-out. |

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -82,7 +82,7 @@ For production environments, pin the SeaTunnel image tag and build commonly used
 ```Dockerfile
 FROM seatunnelhub/openjdk:8u342
 
-ENV SEATUNNEL_VERSION="3.0.0"
+ARG SEATUNNEL_VERSION
 ENV SEATUNNEL_HOME="/opt/seatunnel"
 
 RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
@@ -95,9 +95,12 @@ RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
 Build and load the image:
 
 ```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-minikube image load seatunnel:3.0.0
+SEATUNNEL_VERSION=your-release-version
+docker build --build-arg SEATUNNEL_VERSION=${SEATUNNEL_VERSION} -t seatunnel:${SEATUNNEL_VERSION} -f Dockerfile .
+minikube image load seatunnel:${SEATUNNEL_VERSION}
 ```
+
+Replace `your-release-version` with an available Apache SeaTunnel release version.
 
 In production clusters, push the image to a registry reachable by Kubernetes nodes.
 

--- a/docs/en/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/en/getting-started/kubernetes/kubernetes.mdx
@@ -1,789 +1,124 @@
 ---
-sidebar_position: 4
+sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+# Kubernetes Deployment
 
-# Set Up with Kubernetes
+This guide explains how to deploy SeaTunnel Zeta Engine on Kubernetes. SeaTunnel supports local mode, hybrid cluster mode, and separated cluster mode. For production environments, use separated cluster mode and deploy both Master and Worker with StatefulSet.
 
-This section provides a quick guide to use SeaTunnel with Kubernetes.
+## Deployment Modes
+
+| Mode | Kubernetes workload | Use case | Production recommendation |
+| --- | --- | --- | --- |
+| [Local Mode](local-mode.md) | Pod or Job | Local verification, demos, temporary jobs | Not recommended as a long-running cluster |
+| [Hybrid Cluster Mode](hybrid-cluster-mode.md) | StatefulSet | Small clusters where Master and Worker run in the same process | Supported for simple scenarios, but not the first choice |
+| [Separated Cluster Mode](separated-cluster-mode.md) | Master StatefulSet + Worker StatefulSet | Production clusters, stable scheduling, independent scaling | Recommended |
+
+## Why StatefulSet Is Recommended for Cluster Mode
+
+In Zeta cluster mode, both Master and Worker should be deployed with StatefulSet. Deployment is not recommended for cluster members.
+
+StatefulSet provides stable Pod names, stable network identities, and ordered rolling updates. Master nodes handle leader election, job scheduling, REST API, and IMap state management, so stable Pod identity helps member discovery and failure recovery. Worker nodes do not store IMap data in separated cluster mode, but they still provide the execution slots required by running jobs. If Deployment is used, rolling updates, eviction, or rescheduling may terminate multiple Worker Pods at the same time. Available slots can drop suddenly, causing scheduling, failover, or cluster stability issues.
+
+The recommended production topology is shown below. This follows the Kubernetes StatefulSet model: StatefulSet manages ordered Pods, while the Headless Service provides Pod network identity and DNS-based discovery.
+
+```mermaid
+flowchart TB
+  client["SeaTunnel Client / REST Client"]
+
+  subgraph ns["Kubernetes Namespace"]
+    masterSvc["ClusterIP Service<br/>seatunnel-master<br/>REST API: 8080"]
+    discoverySvc["Headless Service<br/>seatunnel-cluster<br/>Hazelcast discovery: 5801"]
+
+    subgraph masterSet["StatefulSet: seatunnel-master"]
+      master0["seatunnel-master-0<br/>role: master"]
+      master1["seatunnel-master-1<br/>role: master"]
+    end
+
+    subgraph workerSet["StatefulSet: seatunnel-worker"]
+      worker0["seatunnel-worker-0<br/>role: worker"]
+      worker1["seatunnel-worker-1<br/>role: worker"]
+      worker2["seatunnel-worker-2<br/>role: worker"]
+    end
+  end
+
+  client --> masterSvc
+  masterSvc --> master0
+  masterSvc --> master1
+
+  discoverySvc -. "DNS records" .-> master0
+  discoverySvc -. "DNS records" .-> master1
+  discoverySvc -. "DNS records" .-> worker0
+  discoverySvc -. "DNS records" .-> worker1
+  discoverySvc -. "DNS records" .-> worker2
+
+  master0 <-->|Hazelcast member traffic| worker0
+  master1 <-->|Hazelcast member traffic| worker1
+  master0 <-->|Hazelcast member traffic| worker2
+```
+
+Here, `seatunnel-cluster` is a Headless Service used only for Hazelcast member discovery. `seatunnel-master` is a regular ClusterIP Service used to expose the Master REST API.
 
 ## Prerequisites
 
-We assume that you have one local installation as follow:
+Before deployment, prepare:
 
-- [docker](https://docs.docker.com/)
-- [kubernetes](https://kubernetes.io/)
-- [helm](https://helm.sh/docs/intro/quickstart/)
+- A Kubernetes cluster.
+- A client environment that can run `kubectl`.
+- A SeaTunnel image, for example `seatunnel:3.0.0`.
+- An image registry reachable by the cluster. Configure `imagePullSecrets` for private images.
+- Shared storage or object storage for checkpoint and IMap MapStore in production.
 
-So that the `kubectl` and `helm` commands are available on your local system.
-
-Take kubernetes [minikube](https://minikube.sigs.k8s.io/docs/start/) as an example, you can start a cluster with the following command:
+For example, start a local Minikube cluster:
 
 ```bash
 minikube start --kubernetes-version=v1.23.3
 ```
 
+## Image Recommendation
+
+For production environments, pin the SeaTunnel image tag and build commonly used connectors, dependencies, and base configuration into the image. This avoids uncertainty caused by downloading dependencies at runtime.
+
+```Dockerfile
+FROM seatunnelhub/openjdk:8u342
+
+ENV SEATUNNEL_VERSION="3.0.0"
+ENV SEATUNNEL_HOME="/opt/seatunnel"
+
+RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
+RUN mkdir -p ${SEATUNNEL_HOME}/logs
+RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
+```
+
+Build and load the image:
+
+```bash
+docker build -t seatunnel:3.0.0 -f Dockerfile .
+minikube image load seatunnel:3.0.0
+```
+
+In production clusters, push the image to a registry reachable by Kubernetes nodes.
+
 ## Managed Kubernetes Notes
 
-The examples below use Minikube, but the same manifests can be adapted to managed Kubernetes services such as Amazon EKS, Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), Alibaba Cloud ACK, Tencent TKE, Huawei Cloud CCE, Volcengine VKE, and Red Hat OpenShift. Before applying the manifests to a managed cluster, check the following platform-specific settings.
+The examples can be adapted to managed Kubernetes services such as Amazon EKS, Google Kubernetes Engine, Azure Kubernetes Service, Alibaba Cloud ACK, Tencent TKE, Huawei Cloud CCE, Volcengine VKE, and Red Hat OpenShift. Before production rollout, verify:
 
 | Area | What to verify |
 | --- | --- |
-| Image registry | Push the SeaTunnel image to a registry reachable by the cluster, such as ECR, Artifact Registry, ACR, ACK Container Registry, TCR, SWR, Volcengine Container Registry, or the internal OpenShift registry. Update `image` and `imagePullSecrets` when the image is private. |
-| Namespace and access | Create a dedicated namespace for SeaTunnel and bind the required ServiceAccount, Role, and RoleBinding there. OpenShift deployments may also need a SecurityContextConstraint compatible with the container user. |
-| Config and secrets | Keep non-sensitive SeaTunnel configuration in ConfigMaps and mount credentials through Secrets or the cloud provider's secret integration. Avoid putting connector credentials directly into the job ConfigMap. |
-| Connector packaging | Package commonly used connectors in the image for repeatable deployments, or mount connector libraries from a PersistentVolume or object-storage backed init step when connector sets change frequently. |
-| Storage and checkpoints | Use the storage service that matches the cloud, such as S3, GCS, Azure Blob Storage, OSS, COS, OBS, TOS, or a Kubernetes PersistentVolume. Confirm that the SeaTunnel pods have both network access and credentials for the chosen checkpoint or state path. |
-| Networking | Use `ClusterIP` for in-cluster access, `LoadBalancer` or Ingress for external access, and the cloud provider's annotations when a specific load balancer type, subnet, or certificate is required. |
-| Scheduling | Set CPU and memory requests, node selectors, tolerations, or affinity rules when the cluster has mixed node pools. If cluster autoscaling is enabled, make sure worker pods have enough requested resources to trigger scale-out before jobs are submitted. |
-| Observability | Send pod logs and SeaTunnel metrics to the managed logging and monitoring stack. For example, use CloudWatch, Cloud Logging, Azure Monitor, Alibaba Cloud Log Service, Tencent CLS, Huawei LTS, Volcengine TLS, or OpenShift monitoring. |
-
-For production environments, pin the SeaTunnel image tag, keep platform-specific values in separate manifests or Helm values files, and test upgrades in a staging namespace before changing the running cluster.
-
-## Installation
-
-### SeaTunnel Docker Image
-
-To run the image with SeaTunnel, first create a `Dockerfile`:
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-```Dockerfile
-FROM flink:1.13
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-Then run the following commands to build the image:
-```bash
-docker build -t seatunnel:3.0.0-flink-1.13 -f Dockerfile .
-```
-Image `seatunnel:3.0.0-flink-1.13` needs to be present in the host (minikube) so that the deployment can take place.
-
-Load image to minikube via:
-```bash
-minikube image load seatunnel:3.0.0-flink-1.13
-```
-
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-```Dockerfile
-FROM seatunnelhub/openjdk:8u342
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-Then run the following commands to build the image:
-```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-```
-Image `seatunnel:3.0.0` need to be present in the host (minikube) so that the deployment can take place.
-
-Load image to minikube via:
-```bash
-minikube image load seatunnel:3.0.0
-```
-
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-
-```Dockerfile
-FROM seatunnelhub/openjdk:8u342
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-RUN mkdir -p $SEATUNNEL_HOME/logs
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-Then run the following commands to build the image:
-```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-```
-Image `seatunnel:3.0.0` needs to be present in the host (minikube) so that the deployment can take place.
-
-Load image to minikube via:
-```bash
-minikube image load seatunnel:3.0.0
-```
-
-</TabItem>
-</Tabs>
-
-
-### Deploying The Operator
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-The steps below provide a quick walk-through on setting up the Flink Kubernetes Operator.
-You can refer to [Flink Kubernetes Operator - Quick Start](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/) for more details.
-
-> Notice: All the Kubernetes resources bellow are created in default namespace.
-
-Install the certificate manager on your Kubernetes cluster to enable adding the webhook component (only needed once per Kubernetes cluster):
-
-```bash
-kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
-```
-Now you can deploy the latest stable Flink Kubernetes Operator version using the included Helm chart:
-
-```bash
-helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.3.1/
-
-helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
---set image.repository=apache/flink-kubernetes-operator
-```
-
-You may verify your installation via `kubectl`:
-
-```bash
-kubectl get pods
-NAME                                                   READY   STATUS    RESTARTS      AGE
-flink-kubernetes-operator-5f466b8549-mgchb             1/1     Running   3 (23h ago)   16d
-
-```
-
-</TabItem>
-
-
-<TabItem value="Zeta (local-mode)">
-none
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-none
-</TabItem>
-</Tabs>
-
-## Run SeaTunnel Application
-
-**Run Application:**: SeaTunnel already providers out-of-the-box [configurations](https://github.com/apache/seatunnel/tree/dev/config).
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-In this guide we will use [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template):
-
-```conf
-env {
-  parallelism = 1
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-    FakeSource {
-      plugin_output = "fake"
-      row.num = 160000
-      schema = {
-        fields {
-          name = "string"
-          age = "int"
-        }
-      }
-    }
-}
-
-transform {
-  FieldMapper {
-    plugin_input = "fake"
-    plugin_output = "fake1"
-    field_mapper = {
-      age = age
-      name = new_name
-    }
-  }
-}
-
-sink {
-  Console {
-    plugin_input = "fake1"
-  }
-}
-```
-
-Generate a configmap named seatunnel-config in Kubernetes for the seatunnel.streaming.conf so that we can mount the config content in pod.
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-
-Once the Flink Kubernetes Operator is running as seen in the previous steps you are ready to submit a Flink (SeaTunnel) job:
-- Create `seatunnel-flink.yaml` FlinkDeployment manifest:
-```yaml
-apiVersion: flink.apache.org/v1beta1
-kind: FlinkDeployment
-metadata:
-  name: seatunnel-flink-streaming-example
-spec:
-  image: seatunnel:3.0.0-flink-1.13
-  flinkVersion: v1_13
-  flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink
-  jobManager:
-    replicas: 1
-    resource:
-      memory: "1024m"
-      cpu: 1
-  taskManager:
-    resource:
-      memory: "1024m"
-      cpu: 1
-  podTemplate:
-    spec:
-      containers:
-        - name: flink-main-container
-          volumeMounts:
-            - name: seatunnel-config
-              mountPath: /data/seatunnel.streaming.conf
-              subPath: seatunnel.streaming.conf
-      volumes:
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-  job:
-    jarURI: local:///opt/seatunnel/starter/seatunnel-flink-13-starter.jar
-    entryClass: org.apache.seatunnel.core.starter.flink.SeaTunnelFlink
-    args: ["--config", "/data/seatunnel.streaming.conf"]
-    parallelism: 2
-    upgradeMode: stateless
-```
-
-- Run the example application:
-```bash
-kubectl apply -f seatunnel-flink.yaml
-```
-
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-In this guide we will use [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template):
-
-```conf
-env {
-  parallelism = 2
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-  FakeSource {
-    parallelism = 2
-    plugin_output = "fake"
-    row.num = 16
-    schema = {
-      fields {
-        name = "string"
-        age = "int"
-      }
-    }
-  }
-}
-
-sink {
-  Console {
-  }
-}
-```
-
-Generate a configmap named seatunnel-config in Kubernetes for the seatunnel.streaming.conf so that we can mount the config content in pod.
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-- Create `seatunnel.yaml`:
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: seatunnel
-spec:
-  containers:
-  - name: seatunnel
-    image: seatunnel:3.0.0
-    command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel.sh --config /data/seatunnel.streaming.conf -e local"]
-    resources:
-      limits:
-        cpu: "1"
-        memory: 4G
-      requests:
-        cpu: "1"
-        memory: 2G
-    volumeMounts:
-      - name: seatunnel-config
-        mountPath: /data/seatunnel.streaming.conf
-        subPath: seatunnel.streaming.conf
-  volumes:
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-```
-
-- Run the example application:
-```bash
-kubectl apply -f seatunnel.yaml
-```
-
-</TabItem>
-
-
-<TabItem value="Zeta (cluster-mode)">
-
-In this guide we will use [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template):
-
-```conf
-env {
-  parallelism = 2
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-  FakeSource {
-    parallelism = 2
-    plugin_output = "fake"
-    row.num = 16
-    schema = {
-      fields {
-        name = "string"
-        age = "int"
-      }
-    }
-  }
-}
-
-sink {
-  Console {
-  }
-}
-```
-
-Generate a configmap named seatunnel-config in Kubernetes for the seatunnel.streaming.conf so that we can mount the config content in pod.
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-
-Then, we use the following command to load some configuration files used by the seatunnel cluster into the configmap
-
-Create the yaml file locally as follows
-
-- Create `hazelcast-client.yaml`:
-
-```yaml
-
-hazelcast-client:
-  cluster-name: seatunnel
-  properties:
-    hazelcast.logging.type: log4j2
-  network:
-    cluster-members:
-      - localhost:5801
-
-```
-- Create `hazelcast.yaml`:
-
-```yaml
-
-hazelcast:
-  cluster-name: seatunnel
-  network:
-    rest-api:
-      enabled: true
-      endpoint-groups:
-        CLUSTER_WRITE:
-          enabled: true
-        DATA:
-          enabled: true
-    join:
-      tcp-ip:
-        enabled: true
-        member-list:
-          - localhost
-    port:
-      auto-increment: false
-      port: 5801
-  properties:
-    hazelcast.invocation.max.retry.count: 20
-    hazelcast.tcp.join.port.try.count: 30
-    hazelcast.logging.type: log4j2
-    hazelcast.operation.generic.thread.count: 50
-
-```
-- Create `seatunnel.yaml`:
-
-```yaml
-seatunnel:
-  engine:
-    history-job-expire-minutes: 1440
-    backup-count: 1
-    queue-type: blockingqueue
-    print-execution-info-interval: 60
-    print-job-metrics-info-interval: 60
-    slot-service:
-      dynamic-slot: true
-    checkpoint:
-      interval: 10000
-      timeout: 60000
-      storage:
-        type: hdfs
-        max-retained: 3
-        plugin-config:
-          namespace: /tmp/seatunnel/checkpoint_snapshot
-          storage.type: hdfs
-          fs.defaultFS: file:///tmp/ # Ensure that the directory has written permission
-```
-
-Create congfigmaps for the configuration file using the following command
-
-```bash
-kubectl create configmap hazelcast-client  --from-file=hazelcast-client.yaml
-kubectl create configmap hazelcast  --from-file=hazelcast.yaml
-kubectl create configmap seatunnelmap  --from-file=seatunnel.yaml
-
-```
-
-Deploy Reloader to achieve hot deployment
-We use the Reloader here to automatically restart the pod when the configuration file or other modifications are made. You can also directly give the value of the configuration file and do not use the Reloader
-
-- [Reloader](https://github.com/stakater/Reloader/)
-
-```bash
-wget https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/reloader.yaml
-kubectl apply -f reloader.yaml
-
-```
-
-- Create `seatunnel-cluster.yml`:
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: seatunnel
-spec:
-  selector:
-    app: seatunnel
-  ports:
-  - port: 5801
-    name: seatunnel
-  clusterIP: None
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: seatunnel
-  annotations:
-    configmap.reloader.stakater.com/reload: "hazelcast,hazelcast-client,seatunnelmap"
-spec:
-  serviceName: "seatunnel"
-  replicas: 3  # modify replicas according to your case
-  selector:
-    matchLabels:
-      app: seatunnel
-  template:
-    metadata:
-      labels:
-        app: seatunnel
-    spec:
-      containers:
-        - name: seatunnel
-          image: seatunnel:3.0.0
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 5801
-              name: client
-          command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption=-Xms2G -Xmx2G"]
-          resources:
-            limits:
-              cpu: "1"
-              memory: 4G
-            requests:
-              cpu: "1"
-              memory: 2G
-          volumeMounts:
-            - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
-              name: hazelcast
-              subPath: hazelcast.yaml
-            - mountPath: "/opt/seatunnel/config/hazelcast-client.yaml"
-              name: hazelcast-client
-              subPath: hazelcast-client.yaml
-            - mountPath: "/opt/seatunnel/config/seatunnel.yaml"
-              name: seatunnelmap
-              subPath: seatunnel.yaml
-            - mountPath: /data/seatunnel.streaming.conf
-              name: seatunnel-config
-              subPath: seatunnel.streaming.conf
-      volumes:
-        - name: hazelcast
-          configMap:
-            name: hazelcast
-        - name: hazelcast-client
-          configMap:
-            name: hazelcast-client
-        - name: seatunnelmap
-          configMap:
-            name: seatunnelmap
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-```
-
-- Starting a cluster:
-```bash
-kubectl apply -f seatunnel-cluster.yml
-```
-Then modify the seatunnel configuration in pod using the following command:
-
-```bash
-kubectl edit cm hazelcast
-```
-Change the member-list option to your cluster address
-
-This uses the headless service access mode
-
-The format for accessing between general pods is [pod-name].[service-name].[namespace].svc.cluster.local
-
-for example:
-```bash
-- seatunnel-0.seatunnel.default.svc.cluster.local
-- seatunnel-1.seatunnel.default.svc.cluster.local
-- seatunnel-2.seatunnel.default.svc.cluster.local
-```
-```bash
-kubectl edit cm hazelcast-client
-```
-Change the cluster-members option to your cluster address
-
-for example:
-```bash
-- seatunnel-0.seatunnel.default.svc.cluster.local:5801
-- seatunnel-1.seatunnel.default.svc.cluster.local:5801
-- seatunnel-2.seatunnel.default.svc.cluster.local:5801
-```
-Later, you will see that the pod automatically restarts and updates the seatunnel configuration
-
-```bash
-kubectl edit cm hazelcast-client
-```
-After we wait for all pod updates to be completed, we can use the following command to check if the configuration inside the pod has been updated
-
-```bash
-kubectl exec -it  seatunnel-0  -- cat /opt/seatunnel/config/hazelcast-client.yaml
-```
-Afterwards, we can submit tasks to any pod
-
-```bash
-kubectl exec -it  seatunnel-0  -- /opt/seatunnel/bin/seatunnel.sh --config /data/seatunnel.streaming.conf
-```
-</TabItem>
-
-</Tabs>
-
-**See The Output**
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-You may follow the logs of your job, after a successful startup (which can take on the order of a minute in a fresh environment, seconds afterwards) you can:
-
-```bash
-kubectl logs -f deploy/seatunnel-flink-streaming-example
-```
-looks like the below:
-
-```shell
-...
-2023-01-31 12:13:54,349 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from SCHEDULED to DEPLOYING.
-2023-01-31 12:13:56,684 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Deploying Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (attempt #0) with attempt id 1665d2d011b2f6cf6525c0e5e75ec251 to seatunnel-flink-streaming-example-taskmanager-1-1 @ 100.103.244.106 (dataPort=39137) with allocation id fbe162650c4126649afcdaff00e46875
-2023-01-31 12:13:57,794 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from DEPLOYING to INITIALIZING.
-2023-01-31 12:13:58,203 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from INITIALIZING to RUNNING.
-```
-
-If OOM error accur in the log, you can decrease the `row.num` value in seatunnel.streaming.conf
-
-To expose the Flink Dashboard you may add a port-forward rule:
-```bash
-kubectl port-forward svc/seatunnel-flink-streaming-example-rest 8081
-```
-Now the Flink Dashboard is accessible at [localhost:8081](http://localhost:8081).
-
-Or launch `minikube dashboard` for a web-based Kubernetes user interface.
-
-The content printed in the TaskManager Stdout log:
-```bash
-kubectl logs \
--l 'app in (seatunnel-flink-streaming-example), component in (taskmanager)' \
---tail=-1 \
--f
-```
-looks like the below (your content may be different since we use `FakeSource` to automatically generate random stream data):
-
-```shell
-...
-subtaskIndex=0: row=159991 : VVgpp, 978840000
-subtaskIndex=0: row=159992 : JxrOC, 1493825495
-subtaskIndex=0: row=159993 : YmCZR, 654146216
-subtaskIndex=0: row=159994 : LdmUn, 643140261
-subtaskIndex=0: row=159995 : tURkE, 837012821
-subtaskIndex=0: row=159996 : uPDfd, 2021489045
-subtaskIndex=0: row=159997 : mjrdG, 2074957853
-subtaskIndex=0: row=159998 : xbeUi, 864518418
-subtaskIndex=0: row=159999 : sSWLb, 1924451911
-subtaskIndex=0: row=160000 : AuPlM, 1255017876
-```
-
-To stop your job and delete your FlinkDeployment you can simply:
-
-```bash
-kubectl delete -f seatunnel-flink.yaml
-```
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-You may follow the logs of your job, after a successful startup (which can take on the order of a minute in a fresh environment, seconds afterwards) you can:
-
-```bash
-kubectl logs -f  seatunnel
-```
-
-looks like the below (your content may be different since we use `FakeSource` to automatically generate random stream data):
-
-```shell
-...
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25673:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : hRJdE, 1295862507
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25674:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : kXlew, 935460726
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25675:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : FrNOT, 1714358118
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25676:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : kSajX, 126709414
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25677:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : YhpQv, 2020198351
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25678:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : nApin, 691339553
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25679:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : KZNNa, 1720773736
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25680:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : uCUBI, 490868386
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25681:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : oTLmO, 98770781
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25682:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : UECud, 835494636
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25683:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : XNegY, 1602828896
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25684:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : LcFBx, 1400869177
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25685:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : EqSfF, 1933614060
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25686:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : BODIs, 1839533801
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25687:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : doxcI, 970104616
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25688:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : IEVYn, 371893767
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25689:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : YXYfq, 1719257882
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25690:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : LFWEm, 725033360
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25691:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : ypUrY, 1591744616
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25692:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : rlnzJ, 412162913
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25693:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : zWKnt, 976816261
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25694:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : PXrsk, 43554541
-
-```
-
-To stop your job and delete your FlinkDeployment you can simply:
-
-```bash
-kubectl delete -f seatunnel.yaml
-```
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-
-You may follow the logs of your job, after a successful startup (which can take on the order of a minute in a fresh environment, seconds afterwards) you can:
-
-```bash
-kubectl exec -it  seatunnel-1  -- tail -f /opt/seatunnel/logs/seatunnel-engine-server.log | grep ConsoleSinkWriter
-```
-
-looks like the below (your content may be different since we use `FakeSource` to automatically generate random stream data):
-
-```shell
-...
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=7:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : IibHk, 820962465
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=8:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : lmKdb, 1072498088
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=9:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : iqGva, 918730371
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=10:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : JMHmq, 1130771733
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=11:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : rxoHF, 189596686
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=12:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : OSblw, 559472064
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=13:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : yTZjG, 1842482272
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=14:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : RRiMg, 1713777214
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=15:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : lRcsd, 1626041649
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=16:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : QrNNW, 41355294
-
-```
-
-To stop your job and delete your FlinkDeployment you can simply:
-
-```bash
-kubectl delete -f  seatunnel-cluster.yaml
-```
-</TabItem>
-</Tabs>
-
-
-Happy SeaTunneling!
-
-## What's More
-
-For now, you have taken a quick look at SeaTunnel, and you can see [connector](../../connectors/source) to find all sources and sinks SeaTunnel supported.
-Or see [deployment](../../engines/zeta/deployment.md) if you want to submit your application in another kind of your engine cluster.
+| Image registry | SeaTunnel images and plugin images must be pullable by the cluster. Configure `imagePullSecrets` for private images. |
+| Namespace and access | Use a dedicated namespace and configure ServiceAccount, Role, and RoleBinding as needed. |
+| Network discovery | Hazelcast Kubernetes discovery depends on the Headless Service. `namespace`, `service-name`, and `service-port` in `hazelcast*.yaml` must match the Service. |
+| Config and secrets | Store non-sensitive config in ConfigMap. Mount passwords, access keys, tokens, and other secrets through Secret or a cloud secret service. |
+| Checkpoint and state storage | Multi-node clusters must use shared storage or object storage so state can be recovered after any Pod is recreated. |
+| Scheduling | Plan Worker requests, limits, slots, and job parallelism together. When cluster autoscaling is enabled, Worker requests must be large enough to trigger scale-out. |
+| Observability | Integrate logs and metrics with the cluster monitoring stack and retain SeaTunnel engine logs. |
+
+## Next Steps
+
+- For a quick trial, see [Local Mode](local-mode.md).
+- For a small cluster, see [Hybrid Cluster Mode](hybrid-cluster-mode.md).
+- For production deployment, start with [Separated Cluster Mode](separated-cluster-mode.md).
+- For configuration details, see [Kubernetes Configuration](configuration.md).
+- For operations, see [Kubernetes Operations](operations.md).

--- a/docs/en/getting-started/kubernetes/local-mode.md
+++ b/docs/en/getting-started/kubernetes/local-mode.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 2
+---
+
+# Local Mode
+
+Local Mode runs one SeaTunnel job in Kubernetes with a single Pod or Job. It does not provide cluster high availability and is not suitable as a long-running production cluster.
+
+## Create Job Configuration
+
+Create `seatunnel.streaming.conf`:
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 2000
+}
+
+source {
+  FakeSource {
+    parallelism = 2
+    plugin_output = "fake"
+    row.num = 16
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+  }
+}
+```
+
+Create a ConfigMap:
+
+```bash
+kubectl create configmap seatunnel-job-config \
+  --from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
+```
+
+## Create Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seatunnel-local
+  labels:
+    app: seatunnel
+    mode: local
+spec:
+  restartPolicy: Never
+  containers:
+    - name: seatunnel
+      image: seatunnel:3.0.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - /opt/seatunnel/bin/seatunnel.sh --config /data/seatunnel.streaming.conf -e local
+      env:
+        - name: SEATUNNEL_HOME
+          value: /opt/seatunnel
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 4Gi
+      volumeMounts:
+        - name: job-config
+          mountPath: /data/seatunnel.streaming.conf
+          subPath: seatunnel.streaming.conf
+  volumes:
+    - name: job-config
+      configMap:
+        name: seatunnel-job-config
+```
+
+Apply it:
+
+```bash
+kubectl apply -f seatunnel-local.yaml
+```
+
+View logs:
+
+```bash
+kubectl logs -f seatunnel-local
+```
+
+Delete the Pod:
+
+```bash
+kubectl delete -f seatunnel-local.yaml
+```
+
+## Recommendation
+
+Use Local Mode to verify images, connectors, and job configuration. If you need long-running service, REST API submission, cluster failover, or independent scaling, use [Separated Cluster Mode](separated-cluster-mode.md).

--- a/docs/en/getting-started/kubernetes/operations.md
+++ b/docs/en/getting-started/kubernetes/operations.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 6
+---
+
+# Kubernetes Operations
+
+This page describes common operations for SeaTunnel Zeta Engine on Kubernetes.
+
+## Check Cluster Status
+
+```bash
+kubectl get pods -l app=seatunnel
+kubectl get statefulset
+kubectl get svc
+```
+
+View Master logs:
+
+```bash
+kubectl logs -f seatunnel-master-0
+```
+
+View Worker logs:
+
+```bash
+kubectl logs -f seatunnel-worker-0
+```
+
+## Access REST API
+
+Inside the cluster, access REST API through the `seatunnel-master` Service. For debugging, use port forwarding:
+
+```bash
+kubectl port-forward svc/seatunnel-master 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+curl http://127.0.0.1:8080/running-jobs
+```
+
+In production, expose REST API through Ingress or LoadBalancer as needed, and add authentication, network policy, and access control.
+
+## Scale Worker Up
+
+Scaling Workers increases available slots:
+
+```bash
+kubectl scale statefulset seatunnel-worker --replicas=4
+```
+
+Confirm Workers are Ready:
+
+```bash
+kubectl get pods -l app=seatunnel,component=worker
+```
+
+Before submitting large jobs, scale Workers first to avoid long waits caused by insufficient slots.
+
+## Scale Worker Down
+
+Before scaling down, confirm:
+
+- Running jobs do not depend on the Worker being removed.
+- Remaining Workers have enough slots for current and future jobs.
+- Checkpoints have completed successfully.
+
+Do not scale down multiple Workers at once. Decrease replicas one by one and observe job status.
+
+## Rolling Updates
+
+When image or configuration changes, StatefulSet updates Pods in order. Recommended practices:
+
+- Configure `preStop` to call `stop-seatunnel-cluster.sh`.
+- Set a long enough `terminationGracePeriodSeconds`.
+- Check Master replicas and Worker slot capacity before updates.
+- Avoid updating Master and Worker at the same time during peak hours.
+- If configuration files are mounted through `subPath`, ConfigMap updates are not propagated into the running container automatically. Run a rolling restart or use a tool such as Reloader to trigger restarts.
+
+If tools such as Reloader automatically restart Pods, ensure they do not restart too many Workers in a short time.
+
+## PodDisruptionBudget
+
+Configure PodDisruptionBudget for Master and Worker in production to limit unavailable Pods during voluntary disruption:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: seatunnel-master-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: master
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: seatunnel-worker-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: worker
+```
+
+## Troubleshooting
+
+### Pod Cannot Join the Cluster
+
+Check:
+
+- Whether the `seatunnel-cluster` Headless Service exists.
+- Whether `namespace`, `service-name`, and `service-port` in `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml` match the Service.
+- Whether port 5801 is exposed by the Service.
+- Whether Pod labels match Service selectors.
+
+### Worker Readiness Fails
+
+Check:
+
+- Whether the container starts normally.
+- Whether `/opt/seatunnel/config/hazelcast-worker.yaml` or `/opt/seatunnel/config/hazelcast.yaml` is mounted correctly.
+- Whether the connector or custom plugin jars required by the job exist.
+- Whether port 5801 is listening.
+
+### Available Slots Are Insufficient
+
+Check:
+
+- Whether Worker replica count is enough.
+- Whether `slot-service.dynamic-slot` and `slot-num` match expectation.
+- Whether Workers are rolling, evicted, or restarting.
+- Whether too many Worker Pods were terminated at once.
+
+### Checkpoint or MapStore Write Fails
+
+Check:
+
+- Whether the storage path is shared storage or object storage.
+- Whether Pods have network access.
+- Whether Secret or mounted credentials are correct.
+- Whether the storage path has read/write permissions.
+
+### REST API Cannot Be Accessed
+
+Check:
+
+- Whether the `seatunnel-master` Service exists.
+- Whether `seatunnel.engine.http.enable-http` in `seatunnel.yaml` is `true`.
+- Whether the REST API port matches Service targetPort.
+- Whether Ingress or LoadBalancer forwarding rules are correct.

--- a/docs/en/getting-started/kubernetes/operations.md
+++ b/docs/en/getting-started/kubernetes/operations.md
@@ -36,7 +36,9 @@ curl http://127.0.0.1:8080/system-monitoring-information
 curl http://127.0.0.1:8080/running-jobs
 ```
 
+:::caution Warning
 In production, expose REST API through Ingress or LoadBalancer as needed, and add authentication, network policy, and access control.
+:::
 
 ## Scale Worker Up
 
@@ -62,7 +64,9 @@ Before scaling down, confirm:
 - Remaining Workers have enough slots for current and future jobs.
 - Checkpoints have completed successfully.
 
+:::caution Warning
 Do not scale down multiple Workers at once. Decrease replicas one by one and observe job status.
+:::
 
 ## Rolling Updates
 
@@ -74,7 +78,9 @@ When image or configuration changes, StatefulSet updates Pods in order. Recommen
 - Avoid updating Master and Worker at the same time during peak hours.
 - If configuration files are mounted through `subPath`, ConfigMap updates are not propagated into the running container automatically. Run a rolling restart or use a tool such as Reloader to trigger restarts.
 
+:::caution Warning
 If tools such as Reloader automatically restart Pods, ensure they do not restart too many Workers in a short time.
+:::
 
 ## PodDisruptionBudget
 
@@ -111,7 +117,9 @@ spec:
 Check:
 
 - Whether the `seatunnel-cluster` Headless Service exists.
-- Whether `namespace`, `service-name`, and `service-port` in `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml` match the Service.
+- For API discovery, whether `namespace`, `service-name`, and `service-port` in `hazelcast.yaml`, `hazelcast-master.yaml`, or `hazelcast-worker.yaml` match the Service.
+- For API discovery in RBAC-enabled clusters, whether the Pod uses a ServiceAccount with permission to `get`, `list`, and `watch` Pods, Services, and Endpoints.
+- For DNS discovery, whether `service-dns` points to the `seatunnel-cluster` Headless Service in the correct namespace.
 - Whether port 5801 is exposed by the Service.
 - Whether Pod labels match Service selectors.
 

--- a/docs/en/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/separated-cluster-mode.md
@@ -1,0 +1,478 @@
+---
+sidebar_position: 4
+---
+
+# Separated Cluster Mode
+
+In Separated Cluster Mode, SeaTunnel Engine Master and Worker run in separate processes. Master handles job scheduling, REST API, job submission, and IMap state storage. Worker executes tasks, does not participate in Master election, and does not store IMap data.
+
+This is the recommended deployment mode for Kubernetes production environments. Deploy both Master and Worker with StatefulSet to avoid election instability or sudden slot shortage when rolling updates, node eviction, or rescheduling terminate too many nodes at once.
+
+## Recommended Topology
+
+| Component | Recommended workload | Minimum replicas | Production recommendation |
+| --- | --- | --- | --- |
+| Master | StatefulSet | 1 | At least 2 for HA and IMap backup |
+| Worker | StatefulSet | 1 | Scale according to job parallelism and slot planning |
+| Hazelcast discovery | Headless Service | 1 | `publishNotReadyAddresses: true` |
+| REST API | ClusterIP Service | 1 | Expose with Ingress or LoadBalancer as needed |
+
+:::tip
+
+A single Master can start the cluster, but it does not provide high availability. If `backup-count: 1` is used, deploy at least 2 Masters. Otherwise, the cluster cannot rely on backup replicas to recover IMap state after a Master failure.
+
+:::
+
+## Create ConfigMaps
+
+Split configuration by role to avoid an overly long YAML file and to make Master, Worker, and client configuration easier to update independently. Access keys, passwords, and tokens must be managed through Secret in production and should not be written directly into ConfigMap.
+
+### Master Hazelcast ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-master-hazelcast-config
+data:
+  hazelcast-master.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      map:
+        engine*:
+          map-store:
+            enabled: true
+            initial-mode: EAGER
+            factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+            properties:
+              type: hdfs
+              namespace: /seatunnel/imap
+              clusterName: seatunnel-cluster
+              storage.type: hdfs
+              fs.defaultFS: hdfs://namenode:8020
+        engine_checkpoint_monitor:
+          map-store:
+            enabled: false
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+```
+
+### Worker Hazelcast ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-worker-hazelcast-config
+data:
+  hazelcast-worker.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+      member-attributes:
+        rule:
+          type: string
+          value: worker
+```
+
+### Hazelcast Client ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-client-config
+data:
+  hazelcast-client.yaml: |
+    hazelcast-client:
+      cluster-name: seatunnel-cluster
+      properties:
+        hazelcast.logging.type: log4j2
+      connection-strategy:
+        connection-retry:
+          cluster-connect-timeout-millis: 7000
+      network:
+        cluster-members:
+          # Replace `default` with your namespace if SeaTunnel is deployed elsewhere.
+          - seatunnel-cluster.default.svc.cluster.local:5801
+```
+
+### SeaTunnel Engine ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-engine-config
+data:
+  seatunnel.yaml: |
+    seatunnel:
+      engine:
+        backup-count: 1
+        history-job-expire-minutes: 1440
+        print-execution-info-interval: 300
+        classloader-cache-mode: true
+        telemetry:
+          metric:
+            enabled: false
+          logs:
+            scheduled-deletion-enable: true
+        slot-service:
+          dynamic-slot: false
+          slot-num: 8
+        job-schedule-strategy: WAIT
+        checkpoint:
+          interval: 180000
+          timeout: 30000
+          storage:
+            type: hdfs
+            max-retained: 3
+            plugin-config:
+              storage.type: hdfs
+              namespace: /seatunnel/checkpoint/
+              fs.defaultFS: hdfs://namenode:8020
+        http:
+          enable-http: true
+          port: 8080
+```
+
+If S3, OSS, COS, OBS, TOS, or another object store is used for checkpoint or MapStore, every Pod must have network access and credentials. Do not put `secretKeyRef` inside the YAML content stored in ConfigMap. Render the final configuration before deployment, or use credential mechanisms supported by the underlying filesystem, such as Hadoop credential provider, cloud-provider credential chains, or mounted credential files.
+
+## Create Services
+
+`seatunnel-cluster` is the Headless Service for Hazelcast member discovery. Both Master and Worker use it to join the same cluster.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+  labels:
+    app: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-master
+  labels:
+    app: seatunnel-master
+    component: master
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-worker
+  labels:
+    app: seatunnel-worker
+    component: worker
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: worker
+```
+
+## Create Master StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel-master
+  labels:
+    app: seatunnel
+    component: master
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 2
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: master
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: master
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+            - -r
+            - master
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+            limits:
+              cpu: "1"
+              memory: 4Gi
+          volumeMounts:
+            - name: hazelcast-master-config
+              mountPath: /opt/seatunnel/config/hazelcast-master.yaml
+              subPath: hazelcast-master.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-master-config
+          configMap:
+            name: seatunnel-master-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+## Create Worker StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel-worker
+  labels:
+    app: seatunnel
+    component: worker
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 2
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: worker
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+            - -r
+            - worker
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 5Gi
+          volumeMounts:
+            - name: hazelcast-worker-config
+              mountPath: /opt/seatunnel/config/hazelcast-worker.yaml
+              subPath: hazelcast-worker.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-worker-config
+          configMap:
+            name: seatunnel-worker-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+Custom plugins are not included in the base StatefulSet. If extra plugins are required, see [Plugin Loading](configuration.md#plugin-loading) and manage them separately with a custom image, initContainer overlay, PersistentVolume, or object storage.
+
+## Health Check and Graceful Shutdown
+
+Add the following container fragment to both Master and Worker. `startupProbe` avoids killing slow starts. `preStop` calls the SeaTunnel stop script first, then waits for the `SeaTunnelServer` process to exit. Together with `terminationGracePeriodSeconds`, this reduces the impact of rolling updates and node eviction on running jobs.
+
+```yaml
+startupProbe:
+  tcpSocket:
+    port: 5801
+  periodSeconds: 10
+  failureThreshold: 30
+readinessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 31
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          /opt/seatunnel/bin/stop-seatunnel-cluster.sh
+          while kill -0 $(ps -ef | grep SeaTunnelServer | grep -v grep | awk '{print $2}') 2>/dev/null; do
+            sleep 1
+          done
+```
+
+## Apply Manifests
+
+```bash
+kubectl apply -f seatunnel-master-hazelcast-config.yaml
+kubectl apply -f seatunnel-worker-hazelcast-config.yaml
+kubectl apply -f seatunnel-client-config.yaml
+kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-services.yaml
+kubectl apply -f seatunnel-master.yaml
+kubectl apply -f seatunnel-worker.yaml
+```
+
+Check Pod status:
+
+```bash
+kubectl get pods -l app=seatunnel
+```
+
+Access REST API:
+
+```bash
+kubectl port-forward svc/seatunnel-master 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+```
+
+To submit jobs, see [REST API V2](../../engines/zeta/rest-api-v2.md).
+
+## Scale Worker
+
+Scaling Workers increases available slots:
+
+```bash
+kubectl scale statefulset seatunnel-worker --replicas=4
+```
+
+Before scaling down, confirm that no critical running job depends on the Worker being removed and that remaining Workers have enough slots for current jobs. Stop or migrate jobs before scaling down Workers.

--- a/docs/en/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/separated-cluster-mode.md
@@ -67,9 +67,6 @@ data:
               clusterName: seatunnel-cluster
               storage.type: hdfs
               fs.defaultFS: hdfs://namenode:8020
-        engine_checkpoint_monitor:
-          map-store:
-            enabled: false
       properties:
         hazelcast.invocation.max.retry.count: 20
         hazelcast.tcp.join.port.try.count: 30

--- a/docs/en/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/separated-cluster-mode.md
@@ -17,10 +17,8 @@ This is the recommended deployment mode for Kubernetes production environments. 
 | Hazelcast discovery | Headless Service | 1 | `publishNotReadyAddresses: true` |
 | REST API | ClusterIP Service | 1 | Expose with Ingress or LoadBalancer as needed |
 
-:::tip
-
+:::tip Tip
 A single Master can start the cluster, but it does not provide high availability. If `backup-count: 1` is used, deploy at least 2 Masters. Otherwise, the cluster cannot rely on backup replicas to recover IMap state after a Master failure.
-
 :::
 
 ## Create ConfigMaps
@@ -125,6 +123,20 @@ data:
           value: worker
 ```
 
+These examples use Hazelcast Kubernetes API discovery. If you prefer DNS discovery and do not want Hazelcast to call the Kubernetes API, replace the `join.kubernetes` block in both `hazelcast-master.yaml` and `hazelcast-worker.yaml` with:
+
+```yaml
+join:
+  kubernetes:
+    enabled: true
+    service-dns: seatunnel-cluster.default.svc.cluster.local
+    service-dns-timeout: 10
+```
+
+:::info Note
+When DNS discovery is used, the RBAC section below is not required for member discovery. If you skip the RBAC manifest, also remove `serviceAccountName: seatunnel` from both StatefulSets or create that ServiceAccount separately.
+:::
+
 ### Hazelcast Client ConfigMap
 
 ```yaml
@@ -186,7 +198,41 @@ data:
           port: 8080
 ```
 
+:::caution Warning
 If S3, OSS, COS, OBS, TOS, or another object store is used for checkpoint or MapStore, every Pod must have network access and credentials. Do not put `secretKeyRef` inside the YAML content stored in ConfigMap. Render the final configuration before deployment, or use credential mechanisms supported by the underlying filesystem, such as Hadoop credential provider, cloud-provider credential chains, or mounted credential files.
+:::
+
+## Create RBAC for API Discovery
+
+The default `namespace`, `service-name`, and `service-port` settings in `hazelcast-master.yaml` and `hazelcast-worker.yaml` use Hazelcast Kubernetes API discovery. In RBAC-enabled clusters, create a ServiceAccount, Role, and RoleBinding before starting the StatefulSets. Skip this section if you use `service-dns` discovery instead:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
+```
 
 ## Create Services
 
@@ -273,6 +319,7 @@ spec:
         app: seatunnel
         component: master
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -344,6 +391,7 @@ spec:
         app: seatunnel
         component: worker
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -433,11 +481,16 @@ lifecycle:
 
 ## Apply Manifests
 
+:::info Note
+Apply `seatunnel-rbac.yaml` only when API discovery is used, or when the StatefulSets keep `serviceAccountName: seatunnel`.
+:::
+
 ```bash
 kubectl apply -f seatunnel-master-hazelcast-config.yaml
 kubectl apply -f seatunnel-worker-hazelcast-config.yaml
 kubectl apply -f seatunnel-client-config.yaml
 kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-rbac.yaml
 kubectl apply -f seatunnel-services.yaml
 kubectl apply -f seatunnel-master.yaml
 kubectl apply -f seatunnel-worker.yaml

--- a/docs/en/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/en/getting-started/kubernetes/separated-cluster-mode.md
@@ -71,19 +71,16 @@ data:
           map-store:
             enabled: false
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ### Worker Hazelcast ConfigMap
@@ -115,19 +112,16 @@ data:
             service-name: seatunnel-cluster
             service-port: 5801
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
       member-attributes:
         rule:
           type: string

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,6 +68,11 @@ const sidebars = {
                     "label": "Kubernetes",
                     "items": [
                         "getting-started/kubernetes/kubernetes",
+                        "getting-started/kubernetes/local-mode",
+                        "getting-started/kubernetes/hybrid-cluster-mode",
+                        "getting-started/kubernetes/separated-cluster-mode",
+                        "getting-started/kubernetes/configuration",
+                        "getting-started/kubernetes/operations",
                         "getting-started/kubernetes/helm"
                     ]
                 }

--- a/docs/zh/getting-started/kubernetes/configuration.md
+++ b/docs/zh/getting-started/kubernetes/configuration.md
@@ -120,6 +120,22 @@ Master 节点负责 IMap 状态存储。生产环境建议启用 MapStore，并�
 
 MapStore 使用 `FileMapStoreFactory`。其中 `type: hdfs` 是 IMap 文件存储工厂的标识，使用 S3 或 OSS 时也保持不变；真正的底层存储由 `storage.type` 决定，当前支持 `hdfs`、`s3` 和 `oss`。
 
+### Checkpoint Monitor MapStore
+
+如果不希望持久化 checkpoint monitor 数据，可以为 `engine_checkpoint_monitor` 添加显式覆盖：
+
+```yaml
+hazelcast:
+  map:
+    engine_checkpoint_monitor:
+      map-store:
+        enabled: false
+```
+
+这个 IMap 存储的是 REST API 和 UI 观测使用的 checkpoint overview/history 数据，并不是用于恢复的权威 checkpoint 状态。真正的 checkpoint 恢复状态由 `seatunnel.engine.checkpoint.storage` 写入 HDFS、S3、OSS 或其他已配置的 checkpoint 存储后端。
+
+这个覆盖是可选的。需要避免持久化仅用于观测的数据、减少 MapStore/WAL 写放大时可以使用；如果希望 checkpoint monitor 的 overview/history 与其他 `engine*` IMap 使用相同的 MapStore 配置，可以不添加该覆盖。
+
 ### HDFS
 
 ```yaml

--- a/docs/zh/getting-started/kubernetes/configuration.md
+++ b/docs/zh/getting-started/kubernetes/configuration.md
@@ -8,7 +8,10 @@ sidebar_position: 5
 
 ## ConfigMap 与 Secret
 
-非敏感配置建议放入 ConfigMap，并通过 `subPath` 只挂载需要覆盖的文件，例如 `/opt/seatunnel/config/seatunnel.yaml` 或 `/opt/seatunnel/config/hazelcast-master.yaml`。不要直接用 ConfigMap 覆盖整个 `/opt/seatunnel/config` 目录，除非该 ConfigMap 同时包含镜像启动所需的所有文件，例如 `jvm_options`、`jvm_master_options` 和 `jvm_worker_options`。
+非敏感配置建议放入 ConfigMap，并通过 `subPath` 只挂载需要覆盖的文件，例如 `/opt/seatunnel/config/seatunnel.yaml` 或 `/opt/seatunnel/config/hazelcast-master.yaml`。
+
+:::caution 注意
+不要直接用 ConfigMap 覆盖整个 `/opt/seatunnel/config` 目录，除非该 ConfigMap 同时包含镜像启动所需的所有文件，例如 `jvm_options`、`jvm_master_options` 和 `jvm_worker_options`。
 
 敏感信息不应直接写入 ConfigMap，包括：
 
@@ -17,6 +20,7 @@ sidebar_position: 5
 - token、证书私钥和其他凭据。
 
 推荐将敏感信息放入 Kubernetes Secret，并通过环境变量或文件挂载方式注入。ConfigMap 文件内容不会解析 Kubernetes `secretKeyRef`；SeaTunnel、Hazelcast 和底层文件系统读取到的必须是最终可用的配置值，或者它们真实支持的凭据机制，例如环境变量、Hadoop credential provider、云厂商凭据链或挂载凭据文件。
+:::
 
 ## Hazelcast Kubernetes 发现
 
@@ -37,7 +41,11 @@ spec:
     app: seatunnel
 ```
 
-对应的 `hazelcast.yaml` 中需要配置相同的命名空间、服务名和端口：
+可以在下面两种 Hazelcast Kubernetes discovery 方式中选择一种。
+
+### API 发现
+
+API 发现会通过 Kubernetes API，根据配置的命名空间和 Service 解析成员。对应的 `hazelcast.yaml` 中需要配置相同的命名空间、服务名和端口：
 
 ```yaml
 hazelcast:
@@ -51,6 +59,56 @@ hazelcast:
 ```
 
 如果部署在非 `default` 命名空间，需要同步修改 `namespace`。同时也要修改 `hazelcast-client.yaml` 的 `cluster-members`，例如 `seatunnel-cluster.<namespace>.svc.cluster.local:5801`，确保提交任务的客户端连接到同一个命名空间。
+
+:::caution 注意
+使用 `namespace`、`service-name` 和 `service-port` 时，Hazelcast Kubernetes discovery 会在成员启动阶段查询 Kubernetes API。在启用 RBAC 的集群中，SeaTunnel Pod 需要使用绑定了读取 Pod、Service 和 Endpoint 权限的 ServiceAccount。请在启动 StatefulSet 前创建以下 RBAC 资源，并在 Pod 模板中设置 `serviceAccountName: seatunnel`。
+:::
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
+```
+
+### DNS 发现
+
+DNS 发现通过 Kubernetes DNS 解析 Headless Service，不需要 Hazelcast 访问 Kubernetes API，因此成员发现不需要额外的 Role 或 RoleBinding。当集群只需要通过一个稳定的 Headless Service 发现成员时，这种方式更简单：
+
+```yaml
+hazelcast:
+  network:
+    join:
+      kubernetes:
+        enabled: true
+        service-dns: seatunnel-cluster.default.svc.cluster.local
+        service-dns-timeout: 10
+```
+
+:::info 说明
+如果部署在非 `default` 命名空间，需要同步修改 `service-dns` 和 `hazelcast-client.yaml` 的 `cluster-members`。Headless Service 仍建议保留 `publishNotReadyAddresses: true`，这样集群启动阶段 DNS discovery 也能解析到 Pod。
+:::
 
 SeaTunnel 服务端配置由 `seatunnel.yaml` 中的 `seatunnel.engine` 提供；集群成员发现由 `hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 提供。
 
@@ -132,9 +190,11 @@ hazelcast:
         enabled: false
 ```
 
+:::info 说明
 这个 IMap 存储的是 REST API 和 UI 观测使用的 checkpoint overview/history 数据，并不是用于恢复的权威 checkpoint 状态。真正的 checkpoint 恢复状态由 `seatunnel.engine.checkpoint.storage` 写入 HDFS、S3、OSS 或其他已配置的 checkpoint 存储后端。
 
 这个覆盖是可选的。需要避免持久化仅用于观测的数据、减少 MapStore/WAL 写放大时可以使用；如果希望 checkpoint monitor 的 overview/history 与其他 `engine*` IMap 使用相同的 MapStore 配置，可以不添加该覆盖。
+:::
 
 ### HDFS
 
@@ -179,7 +239,11 @@ hazelcast:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 ```
 
-如果希望通过 Kubernetes Secret 注入环境变量，不要在 ConfigMap 中写 `secretKeyRef`。需要在 Pod 中注入 AWS SDK 约定的环境变量，并且不要把 `fs.s3a.aws.credentials.provider` 固定为 `SimpleAWSCredentialsProvider`。当前 Hadoop AWS 3.1.4 在未显式配置 provider 时，默认认证链已经会读取 AWS 环境变量；如果希望只允许环境变量认证，也可以显式配置 `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`：
+:::caution 注意
+如果希望通过 Kubernetes Secret 注入环境变量，不要在 ConfigMap 中写 `secretKeyRef`。需要在 Pod 中注入 AWS SDK 约定的环境变量，并且不要把 `fs.s3a.aws.credentials.provider` 固定为 `SimpleAWSCredentialsProvider`。
+:::
+
+当前 Hadoop AWS 3.1.4 在未显式配置 provider 时，默认认证链已经会读取 AWS 环境变量；如果希望只允许环境变量认证，也可以显式配置 `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`：
 
 ```yaml
 env:
@@ -244,7 +308,9 @@ hazelcast:
 
 `backup-count: 1` 时，Master 至少需要 2 个副本，才能保存 IMap 备份副本。
 
+:::caution 注意
 不要把真实 access key、secret key 直接提交到 ConfigMap 或 Git 仓库。Kubernetes 不会在 ConfigMap 文件内容中解析 `secretKeyRef`，SeaTunnel/Hazelcast 读取到的必须是最终可用的 YAML 配置。生产环境建议通过 Helm、Kustomize、External Secrets、CI/CD 或镜像构建流程生成最终 ConfigMap，或者使用 Hadoop credential provider、AWS SDK 环境变量 provider、云厂商凭据链、挂载凭据文件等底层文件系统真正支持的凭据方式，并确保所有 Master Pod 具有相同的对象存储读写权限。
+:::
 
 如果使用 S3 或 OSS，SeaTunnel 镜像中还需要包含对应 Hadoop 文件系统实现及其依赖，例如 Hadoop AWS/AWS SDK 或 Hadoop Aliyun/OSS SDK。Checkpoint 存储和 IMap MapStore 可以使用同一个对象存储服务，但建议使用不同的 `namespace` 前缀，例如 `/seatunnel/checkpoint/` 和 `/seatunnel/imap`。
 
@@ -252,29 +318,50 @@ hazelcast:
 
 基础 Master/Worker StatefulSet 不包含自定义插件加载逻辑。自定义插件属于额外部署内容，应按集群需要单独管理，并确保 Master 和 Worker 使用一致的插件版本。
 
-常见插件加载方式有三种：
+需要根据 jar 的加载方式选择 SeaTunnel 运行目录：
+
+| 目录 | 适合放置 | 不适合放置 |
+| --- | --- | --- |
+| `${SEATUNNEL_HOME}/plugins` | 自定义连接器插件 jar 或插件包 | Transform 插件 jar 或通用 runtime jar |
+| `${SEATUNNEL_HOME}/lib` | Transform 插件 jar，以及少数必须进入 SeaTunnel 进程 classpath 的 runtime extension jar | 连接器插件 jar |
+
+:::info 说明
+SeaTunnel 对不同插件类型使用不同的加载路径。`plugins/` 目录用于自定义连接器，不用于 Transform 插件或无关 runtime jar。如果自定义连接器需要驱动或客户端库，应将这些 jar 与自定义连接器插件一起打包后放到 `plugins/`。SeaTunnel 自带的 Transform 插件，例如 `seatunnel-transforms-v2.jar`，会打包到 `lib/`，并从 runtime classpath 中发现。只有当自定义 jar 是 Transform 插件，或者是必须被 SeaTunnel 进程 classpath 可见的 runtime extension jar 时，才放到 `lib/`。
+:::
+
+:::caution 注意
+仅把 Transform 插件 jar 放到 `plugins/` 下，如果没有进入 runtime classpath，也可能无法被发现。不要把自定义连接器插件 jar 放到 `lib/`。
+:::
+
+常见加载方式有三种：
 
 | 方式 | 适用场景 | 说明 |
 | --- | --- | --- |
-| 插件打入 SeaTunnel 镜像 | 稳定生产环境 | 最可重复，推荐生产使用 |
-| initContainer overlay 注入插件 | 插件组合经常变化 | 在 StatefulSet 上额外添加 initContainer，将插件从插件镜像复制到 `emptyDir` 后挂载 |
-| PersistentVolume 或对象存储挂载 | 插件包较多 | 需要额外管理版本一致性 |
+| 自定义连接器插件和 Transform jar 打入 SeaTunnel 镜像 | 稳定生产环境 | 最可重复，推荐生产使用 |
+| initContainer overlay 注入自定义连接器插件 | 连接器组合经常变化 | 在 StatefulSet 上额外添加 initContainer，将插件文件从插件镜像复制到 `emptyDir` 后挂载 |
+| PersistentVolume 或对象存储挂载 | 连接器包较多 | 需要额外管理版本一致性 |
 
 ### 使用自定义镜像
 
-稳定生产环境推荐将自定义插件构建到 SeaTunnel 镜像中：
+稳定生产环境推荐将自定义连接器插件 jar、Transform 插件 jar 和必需的 runtime extension jar 构建到 SeaTunnel 镜像中：
 
 ```Dockerfile
 FROM seatunnel:3.0.0
 
+# 可选：自定义连接器插件 jar 或插件包。
 COPY plugins/ /opt/seatunnel/plugins/
+
+# 可选：Transform 插件 jar 或需要进程 classpath 的 runtime extension jar。
+COPY lib/ /opt/seatunnel/lib/
 ```
+
+自定义连接器插件 jar 放在 `/opt/seatunnel/plugins/`。只有 Transform 插件 jar 或必须进入 SeaTunnel 进程 classpath 的 runtime extension jar 才放在 `/opt/seatunnel/lib/`。
 
 然后在 Master 和 Worker StatefulSet 中使用同一个镜像 tag。
 
 ### 使用 initContainer overlay
 
-如果插件需要独立发布，可以构建一个只包含插件的镜像，并把以下片段作为 overlay 添加到 Master 和 Worker StatefulSet。该片段不属于基础部署清单。
+如果自定义连接器插件需要与主镜像独立发布，可以把以下片段添加到 Master 和 Worker StatefulSet。该片段不属于基础部署清单。由于 `plugins` 的 `emptyDir` 挂载会在运行时替换镜像内的对应目录，插件镜像必须包含提交作业所需的所有自定义连接器插件文件。
 
 ```yaml
 initContainers:
@@ -283,22 +370,48 @@ initContainers:
     command:
       - sh
       - -c
-      - cp /opt/seatunnel/plugins/plugin.jar /mnt/lib/
+      - |
+        cp -R /plugin/plugins/. /mnt/plugins/
     volumeMounts:
-      - name: plugin-lib
-        mountPath: /mnt/lib
+      - name: plugin-dependencies
+        mountPath: /mnt/plugins
 containers:
   - name: app
     volumeMounts:
-      - name: plugin-lib
-        mountPath: /opt/seatunnel/lib/plugin.jar
-        subPath: plugin.jar
+      - name: plugin-dependencies
+        mountPath: /opt/seatunnel/plugins
 volumes:
-  - name: plugin-lib
+  - name: plugin-dependencies
     emptyDir: {}
 ```
 
-如果插件目录中包含多个 jar，建议挂载整个插件目录，而不是只挂载单个 jar 文件。
+:::caution 注意
+不要用 `emptyDir` 覆盖整个 `/opt/seatunnel/lib` 目录，除非其中也包含基础镜像内全部 runtime jar；补充单个 Transform 插件 jar 或 runtime extension jar 时建议使用 `subPath`，或直接构建到镜像中。所有 Master 和 Worker Pod 必须使用相同的插件和依赖版本。
+:::
+
+如果还需要注入 Transform 插件 jar，建议用 `subPath` 单独挂载，不要替换整个 `lib` 目录。如果已经使用了上面的 overlay，请把 `runtime-lib` 挂载和复制命令合并到同一个 initContainer 中。下面是一个最小独立片段：
+
+```yaml
+initContainers:
+  - name: plugin-loader
+    image: seatunnel-plugin:v1.0.0
+    volumeMounts:
+      - name: runtime-lib
+        mountPath: /mnt/lib
+    command:
+      - sh
+      - -c
+      - cp /plugin/lib/custom-transform.jar /mnt/lib/
+containers:
+  - name: app
+    volumeMounts:
+      - name: runtime-lib
+        mountPath: /opt/seatunnel/lib/custom-transform.jar
+        subPath: custom-transform.jar
+volumes:
+  - name: runtime-lib
+    emptyDir: {}
+```
 
 ## 日志配置
 

--- a/docs/zh/getting-started/kubernetes/configuration.md
+++ b/docs/zh/getting-started/kubernetes/configuration.md
@@ -54,23 +54,20 @@ hazelcast:
 
 SeaTunnel 服务端配置由 `seatunnel.yaml` 中的 `seatunnel.engine` 提供；集群成员发现由 `hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 提供。
 
-Kubernetes 环境推荐使用下面这组 Hazelcast `properties` 作为生产基线配置。它不是所有集群的绝对最优值，但适合作为生产部署的起点：提高成员调用重试能力，使用 `phi-accrual` 心跳故障检测，并配合 `terminationGracePeriodSeconds` 做优雅关闭。上线前应结合网络延迟、Pod 驱逐策略、节点规模和作业并发压测调整。
+下面这组 Hazelcast `properties` 与当前 SeaTunnel 默认 Hazelcast 配置保持一致，Kubernetes 示例也以这组配置作为基线。生产上线前应结合 CPU limit、网络延迟、Pod 驱逐策略、节点规模和作业并发压测调整。
 
 ```yaml
 properties:
-  hazelcast.invocation.max.retry.count: 50
-  hazelcast.tcp.join.port.try.count: 10
+  hazelcast.invocation.max.retry.count: 20
+  hazelcast.tcp.join.port.try.count: 30
   hazelcast.logging.type: log4j2
-  hazelcast.phone.home.enabled: false
-  hazelcast.operation.generic.thread.count: 32
+  hazelcast.operation.generic.thread.count: 50
   hazelcast.heartbeat.failuredetector.type: phi-accrual
-  hazelcast.heartbeat.interval.seconds: 5
-  hazelcast.max.no.heartbeat.seconds: 30
+  hazelcast.heartbeat.interval.seconds: 2
+  hazelcast.max.no.heartbeat.seconds: 180
   hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
   hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
   hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-  hazelcast.shutdownhook.policy: GRACEFUL
-  hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ## Master 与 Worker 配置分离

--- a/docs/zh/getting-started/kubernetes/configuration.md
+++ b/docs/zh/getting-started/kubernetes/configuration.md
@@ -1,0 +1,300 @@
+---
+sidebar_position: 5
+---
+
+# Kubernetes 配置
+
+本页说明 SeaTunnel 在 Kubernetes 上部署时常见的配置项和推荐实践。
+
+## ConfigMap 与 Secret
+
+非敏感配置建议放入 ConfigMap，并通过 `subPath` 只挂载需要覆盖的文件，例如 `/opt/seatunnel/config/seatunnel.yaml` 或 `/opt/seatunnel/config/hazelcast-master.yaml`。不要直接用 ConfigMap 覆盖整个 `/opt/seatunnel/config` 目录，除非该 ConfigMap 同时包含镜像启动所需的所有文件，例如 `jvm_options`、`jvm_master_options` 和 `jvm_worker_options`。
+
+敏感信息不应直接写入 ConfigMap，包括：
+
+- 数据库密码。
+- 对象存储 access key 和 secret key。
+- token、证书私钥和其他凭据。
+
+推荐将敏感信息放入 Kubernetes Secret，并通过环境变量或文件挂载方式注入。ConfigMap 文件内容不会解析 Kubernetes `secretKeyRef`；SeaTunnel、Hazelcast 和底层文件系统读取到的必须是最终可用的配置值，或者它们真实支持的凭据机制，例如环境变量、Hadoop credential provider、云厂商凭据链或挂载凭据文件。
+
+## Hazelcast Kubernetes 发现
+
+集群模式依赖 Hazelcast 发现其他成员。Kubernetes 中推荐使用 Headless Service：
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+  selector:
+    app: seatunnel
+```
+
+对应的 `hazelcast.yaml` 中需要配置相同的命名空间、服务名和端口：
+
+```yaml
+hazelcast:
+  network:
+    join:
+      kubernetes:
+        enabled: true
+        namespace: default
+        service-name: seatunnel-cluster
+        service-port: 5801
+```
+
+如果部署在非 `default` 命名空间，需要同步修改 `namespace`。同时也要修改 `hazelcast-client.yaml` 的 `cluster-members`，例如 `seatunnel-cluster.<namespace>.svc.cluster.local:5801`，确保提交任务的客户端连接到同一个命名空间。
+
+SeaTunnel 服务端配置由 `seatunnel.yaml` 中的 `seatunnel.engine` 提供；集群成员发现由 `hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 提供。
+
+Kubernetes 环境推荐使用下面这组 Hazelcast `properties` 作为生产基线配置。它不是所有集群的绝对最优值，但适合作为生产部署的起点：提高成员调用重试能力，使用 `phi-accrual` 心跳故障检测，并配合 `terminationGracePeriodSeconds` 做优雅关闭。上线前应结合网络延迟、Pod 驱逐策略、节点规模和作业并发压测调整。
+
+```yaml
+properties:
+  hazelcast.invocation.max.retry.count: 50
+  hazelcast.tcp.join.port.try.count: 10
+  hazelcast.logging.type: log4j2
+  hazelcast.phone.home.enabled: false
+  hazelcast.operation.generic.thread.count: 32
+  hazelcast.heartbeat.failuredetector.type: phi-accrual
+  hazelcast.heartbeat.interval.seconds: 5
+  hazelcast.max.no.heartbeat.seconds: 30
+  hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+  hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+  hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+  hazelcast.shutdownhook.policy: GRACEFUL
+  hazelcast.graceful.shutdown.max.wait: 120
+```
+
+## Master 与 Worker 配置分离
+
+分离集群模式下建议为 Master 和 Worker 使用不同的 Hazelcast 配置：
+
+- Master 配置 IMap MapStore 和更稳健的心跳参数。
+- Worker 配置 `member-attributes.rule=worker`，并避免承载 IMap MapStore。
+- `seatunnel.yaml` 可以共用，但部分配置只对某一类角色生效。
+
+## Slot 配置
+
+Worker 的 slot 是集群调度资源。生产环境建议使用静态 slot：
+
+```yaml
+seatunnel:
+  engine:
+    slot-service:
+      dynamic-slot: false
+      slot-num: 8
+    job-schedule-strategy: WAIT
+```
+
+`slot-num` 需要结合 Worker 的 CPU、内存和任务并行度规划。Worker Pod 被同时终止过多时，可用 slot 会快速下降，因此 Worker 也推荐 StatefulSet，并在滚动更新或缩容前确认 slot 余量。
+
+## Checkpoint 存储
+
+多节点集群必须使用共享存储或对象存储作为 checkpoint 后端。常见选择包括 HDFS、S3、OSS、COS、OBS、TOS 或 Kubernetes PersistentVolume。
+
+```yaml
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 180000
+      timeout: 30000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          storage.type: hdfs
+          namespace: /seatunnel/checkpoint/
+          fs.defaultFS: hdfs://namenode:8020
+```
+
+如果使用对象存储，需要保证每个 Master 和 Worker Pod 都能访问对象存储网络，并具备相同的读写权限。
+
+## IMap MapStore
+
+Master 节点负责 IMap 状态存储。生产环境建议启用 MapStore，并将数据写入共享存储或对象存储。分离集群模式下只需要在 `hazelcast-master.yaml` 中配置 MapStore，Worker 不需要配置。
+
+MapStore 使用 `FileMapStoreFactory`。其中 `type: hdfs` 是 IMap 文件存储工厂的标识，使用 S3 或 OSS 时也保持不变；真正的底层存储由 `storage.type` 决定，当前支持 `hdfs`、`s3` 和 `oss`。
+
+### HDFS
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: hdfs
+          fs.defaultFS: hdfs://namenode:8020
+```
+
+### S3 或兼容对象存储
+
+S3 兼容存储使用 Hadoop S3A 配置。使用 AWS S3 时，可以依赖 Hadoop S3A 默认 endpoint 解析；MinIO、Ceph RGW 等兼容服务通常需要配置自己的 `fs.s3a.endpoint`，并设置 `fs.s3a.path.style.access: true`。
+
+如果直接在最终 YAML 中提供静态凭据，使用 Hadoop S3A 的固定 key：`fs.s3a.access.key` 和 `fs.s3a.secret.key`。显式配置 `SimpleAWSCredentialsProvider` 时，必须提供这两个 key。此时 Hadoop 会直接使用 YAML 中的值，不需要写成 `${AWS_SECRET_ACCESS_KEY}` 或 `{AWS_SECRET_ACCESS_KEY}`。
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: s3
+          s3.bucket: s3a://seatunnel-bucket
+          fs.s3a.access.key: YOUR_ACCESS_KEY
+          fs.s3a.secret.key: YOUR_SECRET_KEY
+          fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+```
+
+如果希望通过 Kubernetes Secret 注入环境变量，不要在 ConfigMap 中写 `secretKeyRef`。需要在 Pod 中注入 AWS SDK 约定的环境变量，并且不要把 `fs.s3a.aws.credentials.provider` 固定为 `SimpleAWSCredentialsProvider`。当前 Hadoop AWS 3.1.4 在未显式配置 provider 时，默认认证链已经会读取 AWS 环境变量；如果希望只允许环境变量认证，也可以显式配置 `com.amazonaws.auth.EnvironmentVariableCredentialsProvider`：
+
+```yaml
+env:
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: seatunnel-s3-credentials
+        key: access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: seatunnel-s3-credentials
+        key: secret-access-key
+```
+
+```yaml
+properties:
+  type: hdfs
+  namespace: /seatunnel/imap
+  clusterName: seatunnel-cluster
+  storage.type: s3
+  s3.bucket: s3a://seatunnel-bucket
+  fs.s3a.aws.credentials.provider: com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+```
+
+临时凭据还可以额外注入 `AWS_SESSION_TOKEN`。AWS SDK 也兼容 `AWS_ACCESS_KEY` 和 `AWS_SECRET_KEY`，但推荐使用 `AWS_ACCESS_KEY_ID` 和 `AWS_SECRET_ACCESS_KEY`。
+
+如果使用 MinIO、Ceph RGW 或其他 S3 兼容服务，在上述 S3 配置中增加服务自己的 endpoint：
+
+```yaml
+properties:
+  fs.s3a.endpoint: https://s3-compatible-endpoint.example.com
+  fs.s3a.path.style.access: true
+```
+
+### OSS
+
+阿里云 OSS 使用 Hadoop OSS 配置，并通过 `oss.bucket` 指定目标 bucket。`fs.oss.endpoint` 需要按 bucket 所在地域、专有云或兼容 OSS 服务的实际地址填写。
+
+Hadoop Aliyun OSS 的默认凭据 provider 读取 `fs.oss.accessKeyId`、`fs.oss.accessKeySecret`，临时凭据可额外配置 `fs.oss.securityToken`。它没有像 Hadoop S3A 一样的默认环境变量认证链，因此 Kubernetes Secret 注入成环境变量后不会自动生效。
+
+```yaml
+hazelcast:
+  map:
+    engine*:
+      map-store:
+        enabled: true
+        initial-mode: EAGER
+        factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+        properties:
+          type: hdfs
+          namespace: /seatunnel/imap
+          clusterName: seatunnel-cluster
+          storage.type: oss
+          oss.bucket: oss://seatunnel-bucket
+          fs.oss.endpoint: https://oss-<region>.aliyuncs.com
+          fs.oss.accessKeyId: YOUR_ACCESS_KEY_ID
+          fs.oss.accessKeySecret: YOUR_ACCESS_KEY_SECRET
+```
+
+如果不希望把 OSS 凭据渲染到最终 ConfigMap，可以使用 Hadoop credential provider 存储 `fs.oss.accessKeyId`、`fs.oss.accessKeySecret`，或通过 `fs.oss.credentials.provider` 指定自定义 provider。自定义 provider 需要实现 Aliyun OSS SDK 的 `com.aliyun.oss.common.auth.CredentialsProvider`，并在 SeaTunnel 镜像中可被加载。
+
+`backup-count: 1` 时，Master 至少需要 2 个副本，才能保存 IMap 备份副本。
+
+不要把真实 access key、secret key 直接提交到 ConfigMap 或 Git 仓库。Kubernetes 不会在 ConfigMap 文件内容中解析 `secretKeyRef`，SeaTunnel/Hazelcast 读取到的必须是最终可用的 YAML 配置。生产环境建议通过 Helm、Kustomize、External Secrets、CI/CD 或镜像构建流程生成最终 ConfigMap，或者使用 Hadoop credential provider、AWS SDK 环境变量 provider、云厂商凭据链、挂载凭据文件等底层文件系统真正支持的凭据方式，并确保所有 Master Pod 具有相同的对象存储读写权限。
+
+如果使用 S3 或 OSS，SeaTunnel 镜像中还需要包含对应 Hadoop 文件系统实现及其依赖，例如 Hadoop AWS/AWS SDK 或 Hadoop Aliyun/OSS SDK。Checkpoint 存储和 IMap MapStore 可以使用同一个对象存储服务，但建议使用不同的 `namespace` 前缀，例如 `/seatunnel/checkpoint/` 和 `/seatunnel/imap`。
+
+## 插件加载
+
+基础 Master/Worker StatefulSet 不包含自定义插件加载逻辑。自定义插件属于额外部署内容，应按集群需要单独管理，并确保 Master 和 Worker 使用一致的插件版本。
+
+常见插件加载方式有三种：
+
+| 方式 | 适用场景 | 说明 |
+| --- | --- | --- |
+| 插件打入 SeaTunnel 镜像 | 稳定生产环境 | 最可重复，推荐生产使用 |
+| initContainer overlay 注入插件 | 插件组合经常变化 | 在 StatefulSet 上额外添加 initContainer，将插件从插件镜像复制到 `emptyDir` 后挂载 |
+| PersistentVolume 或对象存储挂载 | 插件包较多 | 需要额外管理版本一致性 |
+
+### 使用自定义镜像
+
+稳定生产环境推荐将自定义插件构建到 SeaTunnel 镜像中：
+
+```Dockerfile
+FROM seatunnel:3.0.0
+
+COPY plugins/ /opt/seatunnel/plugins/
+```
+
+然后在 Master 和 Worker StatefulSet 中使用同一个镜像 tag。
+
+### 使用 initContainer overlay
+
+如果插件需要独立发布，可以构建一个只包含插件的镜像，并把以下片段作为 overlay 添加到 Master 和 Worker StatefulSet。该片段不属于基础部署清单。
+
+```yaml
+initContainers:
+  - name: plugin-loader
+    image: seatunnel-plugin:v1.0.0
+    command:
+      - sh
+      - -c
+      - cp /opt/seatunnel/plugins/plugin.jar /mnt/lib/
+    volumeMounts:
+      - name: plugin-lib
+        mountPath: /mnt/lib
+containers:
+  - name: app
+    volumeMounts:
+      - name: plugin-lib
+        mountPath: /opt/seatunnel/lib/plugin.jar
+        subPath: plugin.jar
+volumes:
+  - name: plugin-lib
+    emptyDir: {}
+```
+
+如果插件目录中包含多个 jar，建议挂载整个插件目录，而不是只挂载单个 jar 文件。
+
+## 日志配置
+
+建议保留控制台日志，便于 Kubernetes 日志系统采集；同时可以使用 `log4j2.properties` 输出本地滚动日志。若使用 sidecar 或 DaemonSet 收集日志，需要保证日志路径、文件名和采集规则一致。
+
+默认日志路径通常为：
+
+```text
+/opt/seatunnel/logs
+```
+
+生产环境建议限制日志保留周期和单文件大小，避免 Pod 本地磁盘被写满。

--- a/docs/zh/getting-started/kubernetes/helm.md
+++ b/docs/zh/getting-started/kubernetes/helm.md
@@ -5,9 +5,15 @@ sidebar_position: 4
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# 使用Helm部署
+# 使用 Helm 部署
 
-使用Helm快速部署Seatunnel集群。
+使用 Helm 快速部署 SeaTunnel 集群。
+
+:::tip
+
+在 Zeta 集群模式下，生产环境推荐 Master 和 Worker 都使用 StatefulSet 部署。当前 Helm Chart 适合快速体验，但 Master 和 Worker 仍会渲染为 Deployment。生产环境使用 Helm 前，建议先阅读 [Kubernetes 部署](kubernetes.mdx)、[分离集群模式](separated-cluster-mode.md) 和 [Kubernetes 配置](configuration.md)，了解基于 StatefulSet 的拓扑、Headless Service、checkpoint、IMap MapStore 与 slot 规划等生产实践。
+
+:::
 
 ## 准备
 
@@ -17,7 +23,7 @@ import TabItem from '@theme/TabItem';
 - [kubernetes](https://kubernetes.io/)
 - [helm](https://helm.sh/docs/intro/quickstart/)
 
-在您的本地环境中能够正常执行`kubectl`和`helm`命令。
+在您的本地环境中能够正常执行 `kubectl` 和 `helm` 命令。
  
 以 [minikube](https://minikube.sigs.k8s.io/docs/start/) 为例, 您可以使用如下命令启动一个集群:
 
@@ -27,9 +33,9 @@ minikube start --kubernetes-version=v1.23.3
 
 ## 安装
 
-使用默认配置安装
+使用默认配置安装：
 ```bash
-# Choose the corresponding version yourself
+# 自行选择对应版本
 export VERSION=2.3.10
 helm pull oci://registry-1.docker.io/apache/seatunnel-helm --version ${VERSION}
 tar -xvf seatunnel-helm-${VERSION}.tgz
@@ -37,15 +43,15 @@ cd seatunnel-helm
 helm install seatunnel .
 ```
 
-如果您需要使用其他命名空间进行安装。
-```
-helm install seatunnel . -n <your namespace>
+如果您需要使用其他命名空间进行安装：
+```bash
+helm install seatunnel . -n <your-namespace>
 ```
 
 对于托管 Kubernetes 服务，建议将云厂商相关的差异化配置单独维护在一个 values 文件中，并通过 `-f` 传入，例如：
 
 ```bash
-helm install seatunnel . -n <your namespace> -f values-eks.yaml
+helm install seatunnel . -n <your-namespace> -f values-eks.yaml
 ```
 
 在托管集群上常见需要复核的 values 包括：
@@ -59,13 +65,13 @@ helm install seatunnel . -n <your namespace> -f values-eks.yaml
 
 ## 提交任务
 
-当前默认的配置没有启用ingress，所以需要使用转发命令将master的restapi端口转发出来。
+当前默认配置没有启用 Ingress，所以需要使用转发命令将 Master 的 REST API 端口转发出来。
 ```bash
-kubectl port-forward -n default svc/seatunnel-master 5801:5801
+kubectl port-forward -n default svc/seatunnel-master 8080:8080
 ```
-然后可以通过地址 "http://127.0.0.1/5801/" 访问master的restapi。
+然后可以通过地址 `http://127.0.0.1:8080/` 访问 Master 的 REST API。
 
-如果想要使用ingress, 需要更新 `value.yaml`
+如果想要使用 Ingress，需要更新 `values.yaml`。
 
 例如:
 ```commandline
@@ -73,23 +79,23 @@ ingress:
   enabled: true
   host: "<your domain>"
 ```
-然后更新seatunnel。
+然后更新 SeaTunnel。
 
-就可以使用域名`http://<your domain>`进行访问了。
+就可以使用域名 `http://<your-domain>` 进行访问了。
 
-或者您可以直接进入master的POD执行curl命令。.
+或者您可以直接进入 Master Pod 执行 curl 命令。
 ```commandline
-# 获取其中一个master pod
+# 获取其中一个 Master Pod
 MASTER_POD=$(kubectl get po -l  'app.kubernetes.io/name=seatunnel-master' | sed '1d' | awk '{print $1}' | head -n1)
-# 进入master pod
+# 进入 Master Pod
 kubectl -n default exec -it $MASTER_POD -- /bin/bash
-# 执行 restapi
-curl http://127.0.0.1:5801/running-jobs
-curl http://127.0.0.1:5801/system-monitoring-information
+# 执行 REST API
+curl http://127.0.0.1:8080/running-jobs
+curl http://127.0.0.1:8080/system-monitoring-information
 ```
 
-后面就可以使用[rest-api-v2](../../engines/zeta/rest-api-v2.md)提交任务了。
+后面就可以使用 [REST API V2](../../engines/zeta/rest-api-v2.md) 提交任务了。
 
 ## 下一步
-到现在为止，您已经安装好Seatunnel集群了，你可以查看Seatunnel有哪些[连接器](../../connectors).
-或者选择其他方式 [部署](../../engines/zeta/deployment.md).
+到现在为止，您已经安装好 SeaTunnel 集群了，可以查看 SeaTunnel 支持哪些[连接器](../../connectors)。
+如需手写 Kubernetes manifest 或了解生产部署建议，请查看 [分离集群模式](separated-cluster-mode.md) 和 [Kubernetes 运维](operations.md)。

--- a/docs/zh/getting-started/kubernetes/helm.md
+++ b/docs/zh/getting-started/kubernetes/helm.md
@@ -2,17 +2,12 @@
 sidebar_position: 4
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # 使用 Helm 部署
 
 使用 Helm 快速部署 SeaTunnel 集群。
 
-:::tip
-
+:::tip 提示
 在 Zeta 集群模式下，生产环境推荐 Master 和 Worker 都使用 StatefulSet 部署。当前 Helm Chart 适合快速体验，但 Master 和 Worker 仍会渲染为 Deployment。生产环境使用 Helm 前，建议先阅读 [Kubernetes 部署](kubernetes.mdx)、[分离集群模式](separated-cluster-mode.md) 和 [Kubernetes 配置](configuration.md)，了解基于 StatefulSet 的拓扑、Headless Service、checkpoint、IMap MapStore 与 slot 规划等生产实践。
-
 :::
 
 ## 准备
@@ -67,8 +62,9 @@ helm install seatunnel . -n <your-namespace> -f values-eks.yaml
 
 当前默认配置没有启用 Ingress，所以需要使用转发命令将 Master 的 REST API 端口转发出来。
 ```bash
-kubectl port-forward -n default svc/seatunnel-master 8080:8080
+kubectl port-forward -n <namespace> svc/seatunnel-master 8080:8080
 ```
+如果安装时没有通过 `-n` 指定命名空间，`<namespace>` 使用 `default`。
 然后可以通过地址 `http://127.0.0.1:8080/` 访问 Master 的 REST API。
 
 如果想要使用 Ingress，需要更新 `values.yaml`。
@@ -86,9 +82,9 @@ ingress:
 或者您可以直接进入 Master Pod 执行 curl 命令。
 ```commandline
 # 获取其中一个 Master Pod
-MASTER_POD=$(kubectl get po -l  'app.kubernetes.io/name=seatunnel-master' | sed '1d' | awk '{print $1}' | head -n1)
+MASTER_POD=$(kubectl get po -n <namespace> -l 'app.kubernetes.io/name=seatunnel-master' | sed '1d' | awk '{print $1}' | head -n1)
 # 进入 Master Pod
-kubectl -n default exec -it $MASTER_POD -- /bin/bash
+kubectl -n <namespace> exec -it $MASTER_POD -- /bin/bash
 # 执行 REST API
 curl http://127.0.0.1:8080/running-jobs
 curl http://127.0.0.1:8080/system-monitoring-information
@@ -97,5 +93,5 @@ curl http://127.0.0.1:8080/system-monitoring-information
 后面就可以使用 [REST API V2](../../engines/zeta/rest-api-v2.md) 提交任务了。
 
 ## 下一步
-到现在为止，您已经安装好 SeaTunnel 集群了，可以查看 SeaTunnel 支持哪些[连接器](../../connectors)。
+到现在为止，您已经安装好 SeaTunnel 集群了，可以继续查看连接器文档，了解 SeaTunnel 支持哪些 source 和 sink。
 如需手写 Kubernetes manifest 或了解生产部署建议，请查看 [分离集群模式](separated-cluster-mode.md) 和 [Kubernetes 运维](operations.md)。

--- a/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -48,19 +48,16 @@ data:
             service-name: seatunnel-cluster
             service-port: 5801
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ### Hazelcast Client 配置

--- a/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -6,7 +6,11 @@ sidebar_position: 3
 
 混合集群模式中，SeaTunnel Engine 的 Master 与 Worker 运行在同一个进程中。所有节点都可以参与 Master 选举，也都可以执行任务。
 
-该模式部署简单，适合小规模集群。生产环境更推荐使用 [分离集群模式](separated-cluster-mode.md)，将调度与执行资源隔离。
+该模式部署简单，适合小规模集群。
+
+:::tip 提示
+生产环境更推荐使用 [分离集群模式](separated-cluster-mode.md)，将调度与执行资源隔离。
+:::
 
 ## 部署原则
 
@@ -17,7 +21,11 @@ sidebar_position: 3
 
 ## 创建 ConfigMap
 
-生产环境应将敏感信息放入 Secret。以下示例只展示非敏感配置。建议按配置职责拆分 ConfigMap，避免单个 YAML 过长。
+:::caution 注意
+生产环境应将敏感信息放入 Secret。以下示例只展示非敏感配置。
+:::
+
+建议按配置职责拆分 ConfigMap，避免单个 YAML 过长。
 
 ### Hazelcast 配置
 
@@ -59,6 +67,20 @@ data:
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
 ```
+
+该示例使用 Hazelcast Kubernetes API 发现。如果希望使用 DNS 发现，并避免 Hazelcast 访问 Kubernetes API，可以将 `join.kubernetes` 替换为：
+
+```yaml
+join:
+  kubernetes:
+    enabled: true
+    service-dns: seatunnel-cluster.default.svc.cluster.local
+    service-dns-timeout: 10
+```
+
+:::info 说明
+使用 DNS 发现时，下面的 RBAC 章节不是成员发现所必需的。如果跳过 RBAC 清单，也需要从 StatefulSet 中移除 `serviceAccountName: seatunnel`，或单独创建这个 ServiceAccount。
+:::
 
 ### Hazelcast Client 配置
 
@@ -114,6 +136,38 @@ data:
         http:
           enable-http: true
           port: 8080
+```
+
+## 为 API 发现创建 RBAC
+
+`hazelcast.yaml` 默认使用的 `namespace`、`service-name` 和 `service-port` 属于 Hazelcast Kubernetes API 发现。在启用 RBAC 的集群中，请先创建 ServiceAccount、Role 和 RoleBinding，再启动 StatefulSet。如果改用 `service-dns` 发现，可以跳过本节：
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
 ```
 
 ## 创建 Service
@@ -180,6 +234,7 @@ spec:
         app: seatunnel
         component: hybrid
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -265,10 +320,15 @@ lifecycle:
 
 应用配置：
 
+:::info 说明
+仅在使用 API 发现，或 StatefulSet 保留 `serviceAccountName: seatunnel` 时应用 `seatunnel-rbac.yaml`。
+:::
+
 ```bash
 kubectl apply -f seatunnel-hazelcast-config.yaml
 kubectl apply -f seatunnel-client-config.yaml
 kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-rbac.yaml
 kubectl apply -f seatunnel-services.yaml
 kubectl apply -f seatunnel-hybrid.yaml
 ```
@@ -282,4 +342,6 @@ curl http://127.0.0.1:8080/system-monitoring-information
 
 ## 使用建议
 
+:::tip 提示
 混合集群模式中，Master 节点同时运行任务。当任务负载较高时，执行负载可能影响 Master 选举、调度和 REST API 稳定性。需要更稳定的生产部署时，请使用 [分离集群模式](separated-cluster-mode.md)。
+:::

--- a/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/hybrid-cluster-mode.md
@@ -1,0 +1,288 @@
+---
+sidebar_position: 3
+---
+
+# 混合集群模式
+
+混合集群模式中，SeaTunnel Engine 的 Master 与 Worker 运行在同一个进程中。所有节点都可以参与 Master 选举，也都可以执行任务。
+
+该模式部署简单，适合小规模集群。生产环境更推荐使用 [分离集群模式](separated-cluster-mode.md)，将调度与执行资源隔离。
+
+## 部署原则
+
+- 使用 StatefulSet 部署混合集群节点。
+- 使用 Headless Service 提供 Hazelcast Kubernetes discovery。
+- 所有节点使用同一份 `hazelcast.yaml`、`hazelcast-client.yaml` 和 `seatunnel.yaml`。
+- 节点既承担调度职责，也承担执行职责，资源配置需要同时考虑 Master 与 Worker 负载。
+
+## 创建 ConfigMap
+
+生产环境应将敏感信息放入 Secret。以下示例只展示非敏感配置。建议按配置职责拆分 ConfigMap，避免单个 YAML 过长。
+
+### Hazelcast 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-hazelcast-config
+data:
+  hazelcast.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+```
+
+### Hazelcast Client 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-client-config
+data:
+  hazelcast-client.yaml: |
+    hazelcast-client:
+      cluster-name: seatunnel-cluster
+      properties:
+        hazelcast.logging.type: log4j2
+      connection-strategy:
+        connection-retry:
+          cluster-connect-timeout-millis: 7000
+      network:
+        cluster-members:
+          # 如果 SeaTunnel 部署在其他命名空间，需要将 default 替换为实际命名空间。
+          - seatunnel-cluster.default.svc.cluster.local:5801
+```
+
+### SeaTunnel Engine 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-engine-config
+data:
+  seatunnel.yaml: |
+    seatunnel:
+      engine:
+        backup-count: 1
+        history-job-expire-minutes: 1440
+        print-execution-info-interval: 300
+        classloader-cache-mode: true
+        slot-service:
+          dynamic-slot: false
+          slot-num: 8
+        job-schedule-strategy: WAIT
+        checkpoint:
+          interval: 180000
+          timeout: 30000
+          storage:
+            type: hdfs
+            max-retained: 3
+            plugin-config:
+              namespace: /seatunnel/checkpoint/
+              storage.type: hdfs
+              fs.defaultFS: hdfs://namenode:8020
+        http:
+          enable-http: true
+          port: 8080
+```
+
+## 创建 Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+  labels:
+    app: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: hybrid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel
+  labels:
+    app: seatunnel
+    component: hybrid
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: hybrid
+```
+
+## 创建 StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel
+  labels:
+    app: seatunnel
+    component: hybrid
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 3
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: hybrid
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: hybrid
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          volumeMounts:
+            - name: hazelcast-config
+              mountPath: /opt/seatunnel/config/hazelcast.yaml
+              subPath: hazelcast.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-config
+          configMap:
+            name: seatunnel-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+## 健康检查和优雅停止
+
+集群模式建议为每个 SeaTunnel 容器添加 `startupProbe`、健康检查和 `preStop`，避免启动期误杀，并减少滚动更新或节点驱逐对集群的影响。
+
+```yaml
+startupProbe:
+  tcpSocket:
+    port: 5801
+  periodSeconds: 10
+  failureThreshold: 30
+readinessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          /opt/seatunnel/bin/stop-seatunnel-cluster.sh
+          while kill -0 $(ps -ef | grep SeaTunnelServer | grep -v grep | awk '{print $2}') 2>/dev/null; do
+            sleep 1
+          done
+```
+
+应用配置：
+
+```bash
+kubectl apply -f seatunnel-hazelcast-config.yaml
+kubectl apply -f seatunnel-client-config.yaml
+kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-services.yaml
+kubectl apply -f seatunnel-hybrid.yaml
+```
+
+## 访问 REST API
+
+```bash
+kubectl port-forward svc/seatunnel 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+```
+
+## 使用建议
+
+混合集群模式中，Master 节点同时运行任务。当任务负载较高时，执行负载可能影响 Master 选举、调度和 REST API 稳定性。需要更稳定的生产部署时，请使用 [分离集群模式](separated-cluster-mode.md)。

--- a/docs/zh/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/zh/getting-started/kubernetes/kubernetes.mdx
@@ -1,755 +1,124 @@
 ---
-sidebar_position: 4
+sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+# Kubernetes 部署
 
-# 使用 Kubernetes 部署
+本文介绍如何在 Kubernetes 上部署 SeaTunnel Zeta Engine。SeaTunnel 支持本地模式、混合集群模式和分离集群模式。生产环境推荐使用分离集群模式，并且 Master 与 Worker 都使用 StatefulSet 部署。
 
-本部分提供了使用 SeaTunnel 与 Kubernetes 的快速指南。
+## 部署模式
+
+| 模式 | Kubernetes 工作负载 | 适用场景 | 生产建议 |
+| --- | --- | --- | --- |
+| [本地模式](local-mode.md) | Pod 或 Job | 本地验证、功能演示、临时任务 | 不推荐作为长期集群 |
+| [混合集群模式](hybrid-cluster-mode.md) | StatefulSet | 小规模集群，Master 与 Worker 在同一进程中 | 可用于简单场景，但不作为首选 |
+| [分离集群模式](separated-cluster-mode.md) | Master StatefulSet + Worker StatefulSet | 生产集群、稳定调度、独立扩缩容 | 推荐 |
+
+## 为什么集群模式推荐 StatefulSet
+
+在 Zeta 集群模式下，Master 和 Worker 都推荐使用 StatefulSet 部署，不建议使用 Deployment。
+
+StatefulSet 能提供稳定的 Pod 名称、稳定的网络身份和有序滚动更新。Master 节点负责选主、作业调度、REST API 与 IMap 状态管理，稳定的 Pod 身份有利于集群成员发现和故障恢复。Worker 节点即使在分离集群模式下不存储 IMap 数据，也仍然提供作业执行所需的 slot 资源。如果使用 Deployment，滚动更新、节点驱逐或重新调度时可能同时终止多个 Worker Pod，导致可用 slot 突然不足，并触发任务调度、容错恢复或集群稳定性问题。
+
+推荐的生产拓扑如下。这个画法与 Kubernetes StatefulSet 的推荐模型一致：StatefulSet 管理有序 Pod，Headless Service 负责 Pod 网络身份和 DNS 发现。
+
+```mermaid
+flowchart TB
+  client["SeaTunnel Client / REST Client"]
+
+  subgraph ns["Kubernetes Namespace"]
+    masterSvc["ClusterIP Service<br/>seatunnel-master<br/>REST API: 8080"]
+    discoverySvc["Headless Service<br/>seatunnel-cluster<br/>Hazelcast discovery: 5801"]
+
+    subgraph masterSet["StatefulSet: seatunnel-master"]
+      master0["seatunnel-master-0<br/>role: master"]
+      master1["seatunnel-master-1<br/>role: master"]
+    end
+
+    subgraph workerSet["StatefulSet: seatunnel-worker"]
+      worker0["seatunnel-worker-0<br/>role: worker"]
+      worker1["seatunnel-worker-1<br/>role: worker"]
+      worker2["seatunnel-worker-2<br/>role: worker"]
+    end
+  end
+
+  client --> masterSvc
+  masterSvc --> master0
+  masterSvc --> master1
+
+  discoverySvc -. "DNS records" .-> master0
+  discoverySvc -. "DNS records" .-> master1
+  discoverySvc -. "DNS records" .-> worker0
+  discoverySvc -. "DNS records" .-> worker1
+  discoverySvc -. "DNS records" .-> worker2
+
+  master0 <-->|Hazelcast member traffic| worker0
+  master1 <-->|Hazelcast member traffic| worker1
+  master0 <-->|Hazelcast member traffic| worker2
+```
+
+其中 `seatunnel-cluster` 是 Headless Service，只用于 Hazelcast 成员发现；`seatunnel-master` 是普通 ClusterIP Service，用于暴露 Master 的 REST API。
 
 ## 前置条件
 
-我们假设您已经在本地安装了以下内容：
+部署前需要准备：
 
-- [docker](https://docs.docker.com/)
-- [kubernetes](https://kubernetes.io/)
-- [helm](https://helm.sh/docs/intro/quickstart/)
+- Kubernetes 集群。
+- 可执行 `kubectl` 命令的客户端环境。
+- SeaTunnel 镜像，例如 `seatunnel:3.0.0`。
+- 集群可访问的镜像仓库；私有镜像需要配置 `imagePullSecrets`。
+- 生产环境中的 checkpoint 和 IMap MapStore 需要使用共享存储或对象存储。
 
-以便 `kubectl` 和 `helm` 命令在您的本地系统上可用。
-
-以 kubernetes [minikube](https://minikube.sigs.k8s.io/docs/start/) 为例，您可以使用以下命令启动集群：
+以 Minikube 为例，可以使用以下命令启动本地 Kubernetes 集群：
 
 ```bash
 minikube start --kubernetes-version=v1.23.3
 ```
 
+## 镜像建议
+
+生产环境建议固定 SeaTunnel 镜像 tag，并将常用连接器、依赖和基础配置构建到镜像中，避免运行时下载依赖带来的不确定性。
+
+```Dockerfile
+FROM seatunnelhub/openjdk:8u342
+
+ENV SEATUNNEL_VERSION="3.0.0"
+ENV SEATUNNEL_HOME="/opt/seatunnel"
+
+RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
+RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
+RUN mkdir -p ${SEATUNNEL_HOME}/logs
+RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
+```
+
+构建并加载镜像：
+
+```bash
+docker build -t seatunnel:3.0.0 -f Dockerfile .
+minikube image load seatunnel:3.0.0
+```
+
+在生产集群中，应将镜像推送到 Kubernetes 节点可访问的镜像仓库。
+
 ## 托管 Kubernetes 注意事项
 
-下面的示例使用 Minikube，但相同的 manifest 可以适配到各种托管 Kubernetes 服务，例如 Amazon EKS、Google Kubernetes Engine (GKE)、Azure Kubernetes Service (AKS)、阿里云 ACK、腾讯云 TKE、华为云 CCE、火山引擎 VKE 和 Red Hat OpenShift。在将 manifest 应用到托管集群之前，请按下表检查与平台相关的设置。
+下面的示例可以适配到 Amazon EKS、Google Kubernetes Engine、Azure Kubernetes Service、阿里云 ACK、腾讯云 TKE、华为云 CCE、火山引擎 VKE 和 Red Hat OpenShift 等托管 Kubernetes 服务。上线前需要确认：
 
 | 项目 | 需要确认的内容 |
 | --- | --- |
-| 镜像仓库 | 将 SeaTunnel 镜像推送到集群可访问的镜像仓库，例如 ECR、Artifact Registry、ACR、ACK 容器镜像服务、TCR、SWR、Volcengine Container Registry 或 OpenShift 内置镜像仓库。当镜像为私有镜像时，需要同步更新 `image` 与 `imagePullSecrets`。 |
-| 命名空间与权限 | 为 SeaTunnel 创建专用命名空间，并在该命名空间下绑定所需的 ServiceAccount、Role 与 RoleBinding。在 OpenShift 上部署时，可能还需要配置与容器用户兼容的 SecurityContextConstraint。 |
-| 配置与密钥 | 将非敏感的 SeaTunnel 配置放入 ConfigMap，通过 Secret 或云厂商的密钥管理服务挂载凭据，避免把连接器凭据直接写入任务的 ConfigMap。 |
-| 连接器打包 | 对于稳定的部署，建议将常用连接器一并打入镜像；当连接器组合经常变更时，可以通过 PersistentVolume 或对象存储 + init 容器的方式挂载连接器依赖。 |
-| 存储与 Checkpoint | 选择与所在云相匹配的存储服务，例如 S3、GCS、Azure Blob Storage、OSS、COS、OBS、TOS，或 Kubernetes PersistentVolume。确保 SeaTunnel Pod 对所选 checkpoint / state 路径同时具有网络可达性和访问凭据。 |
-| 网络访问 | 集群内部访问使用 `ClusterIP`，外部访问使用 `LoadBalancer` 或 Ingress；当需要指定负载均衡器类型、子网或证书时，请使用对应云厂商的 annotation。 |
-| 资源调度 | 在混合节点池的集群上，按需要设置 CPU、内存 request、node selector、toleration 与 affinity；如果开启了集群自动扩缩容，请确保 worker Pod 的资源 request 足以触发节点扩容后再提交任务。 |
-| 可观测性 | 将 Pod 日志和 SeaTunnel 指标接入云厂商的日志与监控栈，例如 CloudWatch、Cloud Logging、Azure Monitor、阿里云日志服务 SLS、腾讯云 CLS、华为云 LTS、火山引擎 TLS 或 OpenShift 内置监控。 |
-
-对于生产环境，请固定 SeaTunnel 镜像 tag，把云厂商相关的 values 单独维护在独立的 manifest 或 Helm values 文件中，并在改动正在运行的集群之前，先在 staging 命名空间中验证升级。
-
-## 安装
-
-### SeaTunnel Docker 镜像
-
-要使用 SeaTunnel 运行镜像，首先创建一个 `Dockerfile`：
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-```Dockerfile
-FROM flink:1.13
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-然后运行以下命令来构建镜像：
-```bash
-docker build -t seatunnel:3.0.0-flink-1.13 -f Dockerfile .
-```
-镜像 `seatunnel:3.0.0-flink-1.13` 需要存在于主机（minikube）中，以便部署可以进行。
-
-通过以下方式将镜像加载到 minikube：
-```bash
-minikube image load seatunnel:3.0.0-flink-1.13
-```
-
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-```Dockerfile
-FROM seatunnelhub/openjdk:8u342
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-然后运行以下命令来构建镜像：
-```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-```
-镜像 `seatunnel:3.0.0` 需要存在于主机（minikube）中，以便部署可以进行。
-
-通过以下方式将镜像加载到 minikube：
-```bash
-minikube image load seatunnel:3.0.0
-```
-
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-
-```Dockerfile
-FROM seatunnelhub/openjdk:8u342
-
-ENV SEATUNNEL_VERSION="3.0.0"
-ENV SEATUNNEL_HOME="/opt/seatunnel"
-
-RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN tar -xzvf apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
-RUN mv apache-seatunnel-${SEATUNNEL_VERSION} ${SEATUNNEL_HOME}
-RUN mkdir -p $SEATUNNEL_HOME/logs
-RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
-```
-
-然后运行以下命令来构建镜像：
-```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-```
-镜像 `seatunnel:3.0.0` 需要存在于主机（minikube）中，以便部署可以进行。
-
-通过以下方式将镜像加载到 minikube：
-```bash
-minikube image load seatunnel:3.0.0
-```
-
-</TabItem>
-</Tabs>
-
-
-### 部署操作员
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-以下步骤提供了设置 Flink Kubernetes Operator 的快速演练。
-您可以参考 [Flink Kubernetes Operator - Quick Start](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/) 了解更多详情。
-
-> 注意：以下所有 Kubernetes 资源都在默认命名空间中创建。
-
-在您的 Kubernetes 集群上安装证书管理器以启用添加 webhook 组件（每个 Kubernetes 集群只需一次）：
-
-```bash
-kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
-```
-现在您可以使用包含的 Helm chart 部署最新稳定的 Flink Kubernetes Operator 版本：
-
-```bash
-helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.3.1/
-
-helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
---set image.repository=apache/flink-kubernetes-operator
-```
-
-您可以通过 `kubectl` 验证您的安装：
-
-```bash
-kubectl get pods
-NAME                                                   READY   STATUS    RESTARTS      AGE
-flink-kubernetes-operator-5f466b8549-mgchb             1/1     Running   3 (23h ago)   16d
-
-```
-
-</TabItem>
-
-
-<TabItem value="Zeta (local-mode)">
-无
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-无
-</TabItem>
-</Tabs>
-
-## 运行 SeaTunnel 应用
-
-**运行应用**：SeaTunnel 已经提供了开箱即用的 [配置](https://github.com/apache/seatunnel/tree/dev/config)。
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-在本指南中，我们将使用 [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template)：
-
-```conf
-env {
-  parallelism = 1
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-    FakeSource {
-      plugin_output = "fake"
-      row.num = 160000
-      schema = {
-        fields {
-          name = "string"
-          age = "int"
-        }
-      }
-    }
-}
-
-transform {
-  FieldMapper {
-    plugin_input = "fake"
-    plugin_output = "fake1"
-    field_mapper = {
-      age = age
-      name = new_name
-    }
-  }
-}
-
-sink {
-  Console {
-    plugin_input = "fake1"
-  }
-}
-```
-
-在 Kubernetes 中为 seatunnel.streaming.conf 生成一个名为 seatunnel-config 的 configmap，以便我们可以在 pod 中挂载配置内容。
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-
-一旦 Flink Kubernetes Operator 按照前面的步骤运行，您就可以提交一个 Flink（SeaTunnel）作业：
-- 创建 `seatunnel-flink.yaml` FlinkDeployment 清单：
-```yaml
-apiVersion: flink.apache.org/v1beta1
-kind: FlinkDeployment
-metadata:
-  name: seatunnel-flink-streaming-example
-spec:
-  image: seatunnel:3.0.0-flink-1.13
-  flinkVersion: v1_13
-  flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink
-  jobManager:
-    replicas: 1
-    resource:
-      memory: "1024m"
-      cpu: 1
-  taskManager:
-    resource:
-      memory: "1024m"
-      cpu: 1
-  podTemplate:
-    spec:
-      containers:
-        - name: flink-main-container
-          volumeMounts:
-            - name: seatunnel-config
-              mountPath: /data/seatunnel.streaming.conf
-              subPath: seatunnel.streaming.conf
-      volumes:
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-  job:
-    jarURI: local:///opt/seatunnel/starter/seatunnel-flink-13-starter.jar
-    entryClass: org.apache.seatunnel.core.starter.flink.SeaTunnelFlink
-    args: ["--config", "/data/seatunnel.streaming.conf"]
-    parallelism: 2
-    upgradeMode: stateless
-```
-
-- 运行示例应用：
-```bash
-kubectl apply -f seatunnel-flink.yaml
-```
-
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-在本指南中，我们将使用 [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template)：
-
-```conf
-env {
-  parallelism = 2
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-  FakeSource {
-    parallelism = 2
-    plugin_output = "fake"
-    row.num = 16
-    schema = {
-      fields {
-        name = "string"
-        age = "int"
-      }
-    }
-  }
-}
-
-sink {
-  Console {
-  }
-}
-```
-
-在 Kubernetes 中为 seatunnel.streaming.conf 生成一个名为 seatunnel-config 的 configmap，以便我们可以在 pod 中挂载配置内容。
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-- 创建 `seatunnel.yaml`：
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: seatunnel
-spec:
-  containers:
-  - name: seatunnel
-    image: seatunnel:3.0.0
-    command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel.sh --config /data/seatunnel.streaming.conf -e local"]
-    resources:
-      limits:
-        cpu: "1"
-        memory: 4G
-      requests:
-        cpu: "1"
-        memory: 2G
-    volumeMounts:
-      - name: seatunnel-config
-        mountPath: /data/seatunnel.streaming.conf
-        subPath: seatunnel.streaming.conf
-  volumes:
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-```
-
-- 运行示例应用：
-```bash
-kubectl apply -f seatunnel.yaml
-```
-
-</TabItem>
-
-
-<TabItem value="Zeta (cluster-mode)">
-
-在本指南中，我们将使用 [seatunnel.streaming.conf](https://github.com/apache/seatunnel/blob/3.0.0-release/config/v2.streaming.conf.template)：
-
-```conf
-env {
-  parallelism = 2
-  job.mode = "STREAMING"
-  checkpoint.interval = 2000
-}
-
-source {
-  FakeSource {
-    parallelism = 2
-    plugin_output = "fake"
-    row.num = 16
-    schema = {
-      fields {
-        name = "string"
-        age = "int"
-      }
-    }
-  }
-}
-
-sink {
-  Console {
-  }
-}
-```
-
-在 Kubernetes 中为 seatunnel.streaming.conf 生成一个名为 seatunnel-config 的 configmap，以便我们可以在 pod 中挂载配置内容。
-```bash
-kubectl create cm seatunnel-config \
---from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
-```
-
-然后，我们使用以下命令将 seatunnel 集群使用的一些配置文件加载到 configmap 中
-
-在本地创建 yaml 文件如下
-
-- 创建 `hazelcast-client.yaml`：
-
-```yaml
-
-hazelcast-client:
-  cluster-name: seatunnel
-  properties:
-    hazelcast.logging.type: log4j2
-  network:
-    cluster-members:
-      - localhost:5801
-
-```
-- 创建 `hazelcast.yaml`：
-
-```yaml
-
-hazelcast:
-  cluster-name: seatunnel
-  network:
-    rest-api:
-      enabled: true
-      endpoint-groups:
-        CLUSTER_WRITE:
-          enabled: true
-        DATA:
-          enabled: true
-    join:
-      tcp-ip:
-        enabled: true
-        member-list:
-          - localhost
-    port:
-      auto-increment: false
-      port: 5801
-  properties:
-    hazelcast.invocation.max.retry.count: 20
-    hazelcast.tcp.join.port.try.count: 30
-    hazelcast.logging.type: log4j2
-    hazelcast.operation.generic.thread.count: 50
-
-```
-- 创建 `seatunnel.yaml`：
-
-```yaml
-seatunnel:
-  engine:
-    history-job-expire-minutes: 1440
-    backup-count: 1
-    queue-type: blockingqueue
-    print-execution-info-interval: 60
-    print-job-metrics-info-interval: 60
-    slot-service:
-      dynamic-slot: true
-    checkpoint:
-      interval: 10000
-      timeout: 60000
-      storage:
-        type: hdfs
-        max-retained: 3
-        plugin-config:
-          namespace: /tmp/seatunnel/checkpoint_snapshot
-          storage.type: hdfs
-          fs.defaultFS: file:///tmp/ # 确保目录具有写入权限
-```
-
-使用以下命令为配置文件创建 configmaps
-
-```bash
-kubectl create configmap hazelcast-client  --from-file=hazelcast-client.yaml
-kubectl create configmap hazelcast  --from-file=hazelcast.yaml
-kubectl create configmap seatunnelmap  --from-file=seatunnel.yaml
-
-```
-
-部署 Reloader 以实现热部署
-我们在这里使用 Reloader 在修改配置文件或进行其他修改时自动重启 pod。您也可以直接给出配置文件的值，不使用 Reloader
-
-- [Reloader](https://github.com/stakater/Reloader/)
-
-```bash
-wget https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/reloader.yaml
-kubectl apply -f reloader.yaml
-
-```
-
-- 创建 `seatunnel-cluster.yml`：
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: seatunnel
-spec:
-  selector:
-    app: seatunnel
-  ports:
-  - port: 5801
-    name: seatunnel
-  clusterIP: None
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: seatunnel
-  annotations:
-    configmap.reloader.stakater.com/reload: "hazelcast,hazelcast-client,seatunnelmap"
-spec:
-  serviceName: "seatunnel"
-  replicas: 3  # 根据您的情况修改副本数
-  selector:
-    matchLabels:
-      app: seatunnel
-  template:
-    metadata:
-      labels:
-        app: seatunnel
-    spec:
-      containers:
-        - name: seatunnel
-          image: seatunnel:3.0.0
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 5801
-              name: client
-          command: ["/bin/sh","-c","/opt/seatunnel/bin/seatunnel-cluster.sh -DJvmOption=-Xms2G -Xmx2G"]
-          resources:
-            limits:
-              cpu: "1"
-              memory: 4G
-            requests:
-              cpu: "1"
-              memory: 2G
-          volumeMounts:
-            - mountPath: "/opt/seatunnel/config/hazelcast.yaml"
-              name: hazelcast
-              subPath: hazelcast.yaml
-            - mountPath: "/opt/seatunnel/config/hazelcast-client.yaml"
-              name: hazelcast-client
-              subPath: hazelcast-client.yaml
-            - mountPath: "/opt/seatunnel/config/seatunnel.yaml"
-              name: seatunnelmap
-              subPath: seatunnel.yaml
-            - mountPath: /data/seatunnel.streaming.conf
-              name: seatunnel-config
-              subPath: seatunnel.streaming.conf
-      volumes:
-        - name: hazelcast
-          configMap:
-            name: hazelcast
-            items:
-            - key: hazelcast.yaml
-              path: hazelcast.yaml
-        - name: hazelcast-client
-          configMap:
-            name: hazelcast-client
-            items:
-            - key: hazelcast-client.yaml
-              path: hazelcast-client.yaml
-        - name: seatunnelmap
-          configMap:
-            name: seatunnelmap
-            items:
-            - key: seatunnel.yaml
-              path: seatunnel.yaml
-        - name: seatunnel-config
-          configMap:
-            name: seatunnel-config
-            items:
-            - key: seatunnel.streaming.conf
-              path: seatunnel.streaming.conf
-```
-
-- 运行示例应用：
-```bash
-kubectl apply -f seatunnel-cluster.yml
-```
-
-</TabItem>
-</Tabs>
-
-**查看输出**
-
-<Tabs
-  groupId="engine-type"
-  defaultValue="Zeta (local-mode)"
-  values={[
-    {label: 'Flink', value: 'flink'},
-    {label: 'Zeta (local-mode)', value: 'Zeta (local-mode)'},
-    {label: 'Zeta (cluster-mode)', value: 'Zeta (cluster-mode)'},
-  ]}>
-<TabItem value="flink">
-
-您可以在成功启动后跟踪您的作业日志（在新环境中可能需要大约一分钟，之后需要几秒钟），您可以：
-
-```bash
-kubectl logs -f deploy/seatunnel-flink-streaming-example
-```
-看起来如下：
-
-```shell
-...
-2023-01-31 12:13:54,349 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from SCHEDULED to DEPLOYING.
-2023-01-31 12:13:56,684 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Deploying Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (attempt #0) with attempt id 1665d2d011b2f6cf6525c0e5e75ec251 to seatunnel-flink-streaming-example-taskmanager-1-1 @ 100.103.244.106 (dataPort=39137) with allocation id fbe162650c4126649afcdaff00e46875
-2023-01-31 12:13:57,794 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from DEPLOYING to INITIALIZING.
-2023-01-31 12:13:58,203 INFO  org.apache.flink.runtime.executiongraph.ExecutionGraph       [] - Source: SeaTunnel FakeSource -> Sink Writer: Console (1/1) (1665d2d011b2f6cf6525c0e5e75ec251) switched from INITIALIZING to RUNNING.
-```
-
-如果日志中出现 OOM 错误，您可以在 seatunnel.streaming.conf 中减少 `row.num` 值
-
-要公开 Flink Dashboard，您可以添加端口转发规则：
-```bash
-kubectl port-forward svc/seatunnel-flink-streaming-example-rest 8081
-```
-现在可以在 [localhost:8081](http://localhost:8081) 访问 Flink Dashboard。
-
-或启动 `minikube dashboard` 以获得基于 Web 的 Kubernetes 用户界面。
-
-TaskManager Stdout 日志中打印的内容：
-```bash
-kubectl logs \
--l 'app in (seatunnel-flink-streaming-example), component in (taskmanager)' \
---tail=-1 \
--f
-```
-看起来如下（您的内容可能不同，因为我们使用 `FakeSource` 自动生成随机流数据）：
-
-```shell
-...
-subtaskIndex=0: row=159991 : VVgpp, 978840000
-subtaskIndex=0: row=159992 : JxrOC, 1493825495
-subtaskIndex=0: row=159993 : YmCZR, 654146216
-subtaskIndex=0: row=159994 : LdmUn, 643140261
-subtaskIndex=0: row=159995 : tURkE, 837012821
-subtaskIndex=0: row=159996 : uPDfd, 2021489045
-subtaskIndex=0: row=159997 : mjrdG, 2074957853
-subtaskIndex=0: row=159998 : xbeUi, 864518418
-subtaskIndex=0: row=159999 : sSWLb, 1924451911
-subtaskIndex=0: row=160000 : AuPlM, 1255017876
-```
-
-要停止您的作业并删除您的 FlinkDeployment，您可以简单地：
-
-```bash
-kubectl delete -f seatunnel-flink.yaml
-```
-</TabItem>
-
-<TabItem value="Zeta (local-mode)">
-
-您可以在成功启动后跟踪您的作业日志（在新环境中可能需要大约一分钟，之后需要几秒钟），您可以：
-
-```bash
-kubectl logs -f  seatunnel
-```
-
-看起来如下（您的内容可能不同，因为我们使用 `FakeSource` 自动生成随机流数据）：
-
-```shell
-...
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25673:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : hRJdE, 1295862507
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25674:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : kXlew, 935460726
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25675:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : FrNOT, 1714358118
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25676:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : kSajX, 126709414
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25677:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : YhpQv, 2020198351
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25678:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : nApin, 691339553
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25679:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : KZNNa, 1720773736
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25680:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : uCUBI, 490868386
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25681:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : oTLmO, 98770781
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25682:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : UECud, 835494636
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25683:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : XNegY, 1602828896
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25684:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : LcFBx, 1400869177
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25685:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : EqSfF, 1933614060
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25686:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : BODIs, 1839533801
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25687:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : doxcI, 970104616
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25688:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : IEVYn, 371893767
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25689:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : YXYfq, 1719257882
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25690:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : LFWEm, 725033360
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25691:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : ypUrY, 1591744616
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25692:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : rlnzJ, 412162913
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25693:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : zWKnt, 976816261
-2023-10-07 08:20:12,797 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0  rowIndex=25694:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : PXrsk, 43554541
-
-```
-
-要停止您的作业并删除您的 FlinkDeployment，您可以简单地：
-
-```bash
-kubectl delete -f seatunnel.yaml
-```
-</TabItem>
-
-<TabItem value="Zeta (cluster-mode)">
-
-您可以在成功启动后跟踪您的作业日志（在新环境中可能需要大约一分钟，之后需要几秒钟），您可以：
-
-```bash
-kubectl exec -it  seatunnel-1  -- tail -f /opt/seatunnel/logs/seatunnel-engine-server.log | grep ConsoleSinkWriter
-```
-
-看起来如下（您的内容可能不同，因为我们使用 `FakeSource` 自动生成随机流数据）：
-
-```shell
-...
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=7:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : IibHk, 820962465
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=8:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : lmKdb, 1072498088
-2023-10-10 08:05:07,283 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=9:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : iqGva, 918730371
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=10:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : JMHmq, 1130771733
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=11:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : rxoHF, 189596686
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=12:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : OSblw, 559472064
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=13:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : yTZjG, 1842482272
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=14:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : RRiMg, 1713777214
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=15:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : lRcsd, 1626041649
-2023-10-10 08:05:07,284 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=1  rowIndex=16:  SeaTunnelRow#tableId= SeaTunnelRow#kind=INSERT : QrNNW, 41355294
-
-```
-
-要停止您的作业并删除您的 FlinkDeployment，您可以简单地：
-
-```bash
-kubectl delete -f  seatunnel-cluster.yaml
-```
-</TabItem>
-</Tabs>
-
-
-祝您 SeaTunnel 使用愉快！
-
-## 更多内容
-
-现在，您已经快速了解了 SeaTunnel，您可以查看 [连接器](../../connectors/source) 以找到 SeaTunnel 支持的所有源和汇。
-或者如果您想在另一种引擎集群中提交您的应用程序，请查看 [部署](../../engines/zeta/deployment.md)。
+| 镜像仓库 | SeaTunnel 镜像和插件镜像必须能被集群拉取。私有镜像需要配置 `imagePullSecrets`。 |
+| 命名空间与权限 | 建议使用独立命名空间，并按需配置 ServiceAccount、Role、RoleBinding。 |
+| 网络发现 | Hazelcast Kubernetes discovery 依赖 Headless Service，`hazelcast*.yaml` 中的 `namespace`、`service-name` 和 `service-port` 需要与 Service 保持一致。 |
+| 配置与密钥 | 非敏感配置放入 ConfigMap，密码、访问密钥、token 等敏感信息应通过 Secret 或云厂商密钥服务挂载。 |
+| Checkpoint 与状态存储 | 多节点集群必须使用共享存储或对象存储，保证任意 Pod 重建后仍能恢复状态。 |
+| 资源调度 | Worker 的 request/limit、slot 数和任务并行度应一起规划。启用集群自动扩缩容时，Worker request 需要足以触发节点扩容。 |
+| 可观测性 | 建议接入日志采集和指标系统，并保留 SeaTunnel 引擎日志。 |
+
+## 下一步
+
+- 快速体验请阅读 [本地模式](local-mode.md)。
+- 小规模集群请阅读 [混合集群模式](hybrid-cluster-mode.md)。
+- 生产部署请优先阅读 [分离集群模式](separated-cluster-mode.md)。
+- 配置说明请阅读 [Kubernetes 配置](configuration.md)。
+- 运维操作请阅读 [Kubernetes 运维](operations.md)。

--- a/docs/zh/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/zh/getting-started/kubernetes/kubernetes.mdx
@@ -82,7 +82,7 @@ minikube start --kubernetes-version=v1.23.3
 ```Dockerfile
 FROM seatunnelhub/openjdk:8u342
 
-ENV SEATUNNEL_VERSION="3.0.0"
+ARG SEATUNNEL_VERSION
 ENV SEATUNNEL_HOME="/opt/seatunnel"
 
 RUN wget https://dlcdn.apache.org/seatunnel/${SEATUNNEL_VERSION}/apache-seatunnel-${SEATUNNEL_VERSION}-bin.tar.gz
@@ -95,9 +95,12 @@ RUN cd ${SEATUNNEL_HOME} && sh bin/install-plugin.sh ${SEATUNNEL_VERSION}
 构建并加载镜像：
 
 ```bash
-docker build -t seatunnel:3.0.0 -f Dockerfile .
-minikube image load seatunnel:3.0.0
+SEATUNNEL_VERSION=your-release-version
+docker build --build-arg SEATUNNEL_VERSION=${SEATUNNEL_VERSION} -t seatunnel:${SEATUNNEL_VERSION} -f Dockerfile .
+minikube image load seatunnel:${SEATUNNEL_VERSION}
 ```
+
+请将 `your-release-version` 替换为已发布的 Apache SeaTunnel 版本。
 
 在生产集群中，应将镜像推送到 Kubernetes 节点可访问的镜像仓库。
 

--- a/docs/zh/getting-started/kubernetes/kubernetes.mdx
+++ b/docs/zh/getting-started/kubernetes/kubernetes.mdx
@@ -20,7 +20,7 @@ sidebar_position: 1
 
 StatefulSet 能提供稳定的 Pod 名称、稳定的网络身份和有序滚动更新。Master 节点负责选主、作业调度、REST API 与 IMap 状态管理，稳定的 Pod 身份有利于集群成员发现和故障恢复。Worker 节点即使在分离集群模式下不存储 IMap 数据，也仍然提供作业执行所需的 slot 资源。如果使用 Deployment，滚动更新、节点驱逐或重新调度时可能同时终止多个 Worker Pod，导致可用 slot 突然不足，并触发任务调度、容错恢复或集群稳定性问题。
 
-推荐的生产拓扑如下。这个画法与 Kubernetes StatefulSet 的推荐模型一致：StatefulSet 管理有序 Pod，Headless Service 负责 Pod 网络身份和 DNS 发现。
+推荐的生产拓扑如下。这个画法与 Kubernetes StatefulSet 的推荐模型一致：StatefulSet 管理有序 Pod，Headless Service 提供 Pod 网络身份，以及 Hazelcast 成员发现使用的稳定 Service 目标。
 
 ```mermaid
 flowchart TB
@@ -55,6 +55,15 @@ flowchart TB
   master0 <-->|Hazelcast member traffic| worker0
   master1 <-->|Hazelcast member traffic| worker1
   master0 <-->|Hazelcast member traffic| worker2
+
+  classDef layerBlue fill:#0f1d33,stroke:#5db8e2,stroke-width:2px,color:#f8fbff;
+  classDef layerCyan fill:#0c2530,stroke:#2dd4bf,stroke-width:2px,color:#f8fbff;
+  classDef layerPurple fill:#1f1a34,stroke:#8d7cf6,stroke-width:2px,color:#f8fbff;
+
+  class ns,masterSet,workerSet layerBlue;
+  class masterSvc,discoverySvc layerCyan;
+  class client,master0,master1,worker0,worker1,worker2 layerPurple;
+  linkStyle default stroke:#5db8e2,stroke-width:2px;
 ```
 
 其中 `seatunnel-cluster` 是 Headless Service，只用于 Hazelcast 成员发现；`seatunnel-master` 是普通 ClusterIP Service，用于暴露 Master 的 REST API。
@@ -112,7 +121,7 @@ minikube image load seatunnel:${SEATUNNEL_VERSION}
 | --- | --- |
 | 镜像仓库 | SeaTunnel 镜像和插件镜像必须能被集群拉取。私有镜像需要配置 `imagePullSecrets`。 |
 | 命名空间与权限 | 建议使用独立命名空间，并按需配置 ServiceAccount、Role、RoleBinding。 |
-| 网络发现 | Hazelcast Kubernetes discovery 依赖 Headless Service，`hazelcast*.yaml` 中的 `namespace`、`service-name` 和 `service-port` 需要与 Service 保持一致。 |
+| 网络发现 | Hazelcast Kubernetes discovery 依赖 Headless Service。使用 API 发现时，`hazelcast*.yaml` 中的 `namespace`、`service-name` 和 `service-port` 需要与 Service 保持一致；使用 DNS 发现时，`service-dns` 需要指向同一个 Headless Service。 |
 | 配置与密钥 | 非敏感配置放入 ConfigMap，密码、访问密钥、token 等敏感信息应通过 Secret 或云厂商密钥服务挂载。 |
 | Checkpoint 与状态存储 | 多节点集群必须使用共享存储或对象存储，保证任意 Pod 重建后仍能恢复状态。 |
 | 资源调度 | Worker 的 request/limit、slot 数和任务并行度应一起规划。启用集群自动扩缩容时，Worker request 需要足以触发节点扩容。 |

--- a/docs/zh/getting-started/kubernetes/local-mode.md
+++ b/docs/zh/getting-started/kubernetes/local-mode.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 2
+---
+
+# 本地模式
+
+本地模式用于在 Kubernetes 中快速运行一个 SeaTunnel 作业。该模式只启动一个 Pod 或 Job，不提供集群高可用能力，也不适合作为长期运行的生产集群。
+
+## 创建作业配置
+
+创建 `seatunnel.streaming.conf`：
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 2000
+}
+
+source {
+  FakeSource {
+    parallelism = 2
+    plugin_output = "fake"
+    row.num = 16
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+  }
+}
+```
+
+创建 ConfigMap：
+
+```bash
+kubectl create configmap seatunnel-job-config \
+  --from-file=seatunnel.streaming.conf=seatunnel.streaming.conf
+```
+
+## 创建 Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seatunnel-local
+  labels:
+    app: seatunnel
+    mode: local
+spec:
+  restartPolicy: Never
+  containers:
+    - name: seatunnel
+      image: seatunnel:3.0.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - /opt/seatunnel/bin/seatunnel.sh --config /data/seatunnel.streaming.conf -e local
+      env:
+        - name: SEATUNNEL_HOME
+          value: /opt/seatunnel
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 4Gi
+      volumeMounts:
+        - name: job-config
+          mountPath: /data/seatunnel.streaming.conf
+          subPath: seatunnel.streaming.conf
+  volumes:
+    - name: job-config
+      configMap:
+        name: seatunnel-job-config
+```
+
+应用配置：
+
+```bash
+kubectl apply -f seatunnel-local.yaml
+```
+
+查看日志：
+
+```bash
+kubectl logs -f seatunnel-local
+```
+
+删除 Pod：
+
+```bash
+kubectl delete -f seatunnel-local.yaml
+```
+
+## 使用建议
+
+本地模式适合验证镜像、连接器和作业配置是否可用。需要长期运行、REST API 提交任务、集群容错或独立扩缩容时，请使用 [分离集群模式](separated-cluster-mode.md)。

--- a/docs/zh/getting-started/kubernetes/operations.md
+++ b/docs/zh/getting-started/kubernetes/operations.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 6
+---
+
+# Kubernetes 运维
+
+本页介绍 SeaTunnel Zeta Engine 在 Kubernetes 上的常见运维操作。
+
+## 查看集群状态
+
+```bash
+kubectl get pods -l app=seatunnel
+kubectl get statefulset
+kubectl get svc
+```
+
+查看 Master 日志：
+
+```bash
+kubectl logs -f seatunnel-master-0
+```
+
+查看 Worker 日志：
+
+```bash
+kubectl logs -f seatunnel-worker-0
+```
+
+## 访问 REST API
+
+在集群内可以通过 `seatunnel-master` Service 访问 REST API。调试时可以使用端口转发：
+
+```bash
+kubectl port-forward svc/seatunnel-master 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+curl http://127.0.0.1:8080/running-jobs
+```
+
+生产环境可以通过 Ingress 或 LoadBalancer 暴露 REST API，并按需增加认证、网络策略和访问控制。
+
+## 扩容 Worker
+
+Worker 扩容会增加集群可用 slot：
+
+```bash
+kubectl scale statefulset seatunnel-worker --replicas=4
+```
+
+扩容后确认 Worker Ready：
+
+```bash
+kubectl get pods -l app=seatunnel,component=worker
+```
+
+提交大任务前，建议先完成 Worker 扩容，避免任务提交后因 slot 不足等待过久。
+
+## 缩容 Worker
+
+缩容前需要确认：
+
+- 当前运行作业不依赖即将被删除的 Worker。
+- 剩余 Worker 的 slot 足够承载当前和后续任务。
+- checkpoint 已正常完成。
+
+不建议直接一次性缩容多个 Worker。可以逐个降低副本数，并观察作业状态。
+
+## 滚动更新
+
+更新镜像或配置时，StatefulSet 会按顺序滚动更新 Pod。建议：
+
+- 配置 `preStop` 调用 `stop-seatunnel-cluster.sh`。
+- 设置足够长的 `terminationGracePeriodSeconds`。
+- 更新前确认 Master 副本数和 Worker slot 余量。
+- 避免在高峰期同时更新 Master 和 Worker。
+- 如果配置文件通过 `subPath` 挂载，ConfigMap 更新不会自动同步到容器内，需要执行滚动重启或通过 Reloader 等工具触发重启。
+
+如果使用 Reloader 等工具自动重启 Pod，需要确保不会在短时间内同时重启过多 Worker。
+
+## PodDisruptionBudget
+
+生产环境建议为 Master 和 Worker 配置 PodDisruptionBudget，限制自愿驱逐时的不可用 Pod 数：
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: seatunnel-master-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: master
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: seatunnel-worker-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: worker
+```
+
+## 常见问题
+
+### Pod 无法加入集群
+
+检查：
+
+- `seatunnel-cluster` Headless Service 是否存在。
+- `hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 中的 `namespace`、`service-name` 和 `service-port` 是否与 Service 一致。
+- 5801 端口是否被 Service 暴露。
+- Pod 标签是否匹配 Service selector。
+
+### Worker Ready 失败
+
+检查：
+
+- 容器是否正常启动。
+- `/opt/seatunnel/config/hazelcast-worker.yaml` 或 `/opt/seatunnel/config/hazelcast.yaml` 是否挂载正确。
+- 作业需要的连接器或自定义插件 jar 是否存在。
+- 5801 端口是否监听。
+
+### 可用 slot 不足
+
+检查：
+
+- Worker 副本数是否足够。
+- `slot-service.dynamic-slot` 和 `slot-num` 是否符合预期。
+- 是否有 Worker 正在滚动更新、驱逐或重启。
+- 是否一次性终止了过多 Worker Pod。
+
+### Checkpoint 或 MapStore 写入失败
+
+检查：
+
+- 存储路径是否为共享存储或对象存储。
+- Pod 是否具备网络访问能力。
+- Secret 或挂载凭据是否正确。
+- 存储路径是否有读写权限。
+
+### REST API 无法访问
+
+检查：
+
+- `seatunnel-master` Service 是否存在。
+- `seatunnel.yaml` 中 `seatunnel.engine.http.enable-http` 是否为 `true`。
+- REST API 端口是否与 Service targetPort 一致。
+- Ingress 或 LoadBalancer 的转发规则是否正确。

--- a/docs/zh/getting-started/kubernetes/operations.md
+++ b/docs/zh/getting-started/kubernetes/operations.md
@@ -36,7 +36,9 @@ curl http://127.0.0.1:8080/system-monitoring-information
 curl http://127.0.0.1:8080/running-jobs
 ```
 
+:::caution 注意
 生产环境可以通过 Ingress 或 LoadBalancer 暴露 REST API，并按需增加认证、网络策略和访问控制。
+:::
 
 ## 扩容 Worker
 
@@ -62,7 +64,9 @@ kubectl get pods -l app=seatunnel,component=worker
 - 剩余 Worker 的 slot 足够承载当前和后续任务。
 - checkpoint 已正常完成。
 
+:::caution 注意
 不建议直接一次性缩容多个 Worker。可以逐个降低副本数，并观察作业状态。
+:::
 
 ## 滚动更新
 
@@ -74,7 +78,9 @@ kubectl get pods -l app=seatunnel,component=worker
 - 避免在高峰期同时更新 Master 和 Worker。
 - 如果配置文件通过 `subPath` 挂载，ConfigMap 更新不会自动同步到容器内，需要执行滚动重启或通过 Reloader 等工具触发重启。
 
+:::caution 注意
 如果使用 Reloader 等工具自动重启 Pod，需要确保不会在短时间内同时重启过多 Worker。
+:::
 
 ## PodDisruptionBudget
 
@@ -111,7 +117,9 @@ spec:
 检查：
 
 - `seatunnel-cluster` Headless Service 是否存在。
-- `hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 中的 `namespace`、`service-name` 和 `service-port` 是否与 Service 一致。
+- 使用 API 发现时，`hazelcast.yaml`、`hazelcast-master.yaml` 或 `hazelcast-worker.yaml` 中的 `namespace`、`service-name` 和 `service-port` 是否与 Service 一致。
+- 在启用 RBAC 的集群中使用 API 发现时，Pod 使用的 ServiceAccount 是否具有 `get`、`list` 和 `watch` Pod、Service、Endpoint 的权限。
+- 使用 DNS 发现时，`service-dns` 是否指向正确命名空间中的 `seatunnel-cluster` Headless Service。
 - 5801 端口是否被 Service 暴露。
 - Pod 标签是否匹配 Service selector。
 

--- a/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
@@ -71,19 +71,16 @@ data:
           map-store:
             enabled: false
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
 ```
 
 ### Worker Hazelcast 配置
@@ -115,19 +112,16 @@ data:
             service-name: seatunnel-cluster
             service-port: 5801
       properties:
-        hazelcast.invocation.max.retry.count: 50
-        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.invocation.max.retry.count: 20
+        hazelcast.tcp.join.port.try.count: 30
         hazelcast.logging.type: log4j2
-        hazelcast.phone.home.enabled: false
-        hazelcast.operation.generic.thread.count: 32
+        hazelcast.operation.generic.thread.count: 50
         hazelcast.heartbeat.failuredetector.type: phi-accrual
-        hazelcast.heartbeat.interval.seconds: 5
-        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.interval.seconds: 2
+        hazelcast.max.no.heartbeat.seconds: 180
         hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
         hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
         hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
-        hazelcast.shutdownhook.policy: GRACEFUL
-        hazelcast.graceful.shutdown.max.wait: 120
       member-attributes:
         rule:
           type: string

--- a/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
@@ -67,9 +67,6 @@ data:
               clusterName: seatunnel-cluster
               storage.type: hdfs
               fs.defaultFS: hdfs://namenode:8020
-        engine_checkpoint_monitor:
-          map-store:
-            enabled: false
       properties:
         hazelcast.invocation.max.retry.count: 20
         hazelcast.tcp.join.port.try.count: 30

--- a/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
@@ -1,0 +1,478 @@
+---
+sidebar_position: 4
+---
+
+# 分离集群模式
+
+分离集群模式中，SeaTunnel Engine 的 Master 与 Worker 分别运行在独立进程中。Master 负责作业调度、REST API、任务提交和 IMap 状态存储；Worker 负责执行任务，不参与 Master 选举，也不存储 IMap 数据。
+
+这是 Kubernetes 生产环境推荐的部署方式。Master 和 Worker 都应使用 StatefulSet 部署，避免滚动更新、节点驱逐或重新调度时同时终止过多节点，导致选主抖动或可用 slot 突然不足。
+
+## 推荐拓扑
+
+| 组件 | 推荐工作负载 | 最小副本数 | 生产建议 |
+| --- | --- | --- | --- |
+| Master | StatefulSet | 1 | 至少 2 个，用于 HA 和 IMap 备份 |
+| Worker | StatefulSet | 1 | 按任务并行度和 slot 规划扩缩容 |
+| Hazelcast discovery | Headless Service | 1 | `publishNotReadyAddresses: true` |
+| REST API | ClusterIP Service | 1 | 可按需通过 Ingress 或 LoadBalancer 暴露 |
+
+:::tip
+
+单 Master 可以启动集群，但不具备高可用能力。若 `backup-count: 1`，建议至少部署 2 个 Master，否则 Master 宕机后集群无法依赖备份副本恢复 IMap 状态。
+
+:::
+
+## 创建 ConfigMap
+
+建议按角色拆分 ConfigMap，避免单个 YAML 过长，也便于分别更新 Master、Worker 和客户端配置。生产环境中的访问密钥、密码和 token 应通过 Secret 管理，不应直接写入 ConfigMap。
+
+### Master Hazelcast 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-master-hazelcast-config
+data:
+  hazelcast-master.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      map:
+        engine*:
+          map-store:
+            enabled: true
+            initial-mode: EAGER
+            factory-class-name: org.apache.seatunnel.engine.server.persistence.FileMapStoreFactory
+            properties:
+              type: hdfs
+              namespace: /seatunnel/imap
+              clusterName: seatunnel-cluster
+              storage.type: hdfs
+              fs.defaultFS: hdfs://namenode:8020
+        engine_checkpoint_monitor:
+          map-store:
+            enabled: false
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+```
+
+### Worker Hazelcast 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-worker-hazelcast-config
+data:
+  hazelcast-worker.yaml: |
+    hazelcast:
+      cluster-name: seatunnel-cluster
+      network:
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            CLUSTER_WRITE:
+              enabled: true
+            DATA:
+              enabled: true
+        port:
+          auto-increment: false
+          port: 5801
+        join:
+          kubernetes:
+            enabled: true
+            namespace: default
+            service-name: seatunnel-cluster
+            service-port: 5801
+      properties:
+        hazelcast.invocation.max.retry.count: 50
+        hazelcast.tcp.join.port.try.count: 10
+        hazelcast.logging.type: log4j2
+        hazelcast.phone.home.enabled: false
+        hazelcast.operation.generic.thread.count: 32
+        hazelcast.heartbeat.failuredetector.type: phi-accrual
+        hazelcast.heartbeat.interval.seconds: 5
+        hazelcast.max.no.heartbeat.seconds: 30
+        hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10
+        hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
+        hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+        hazelcast.shutdownhook.policy: GRACEFUL
+        hazelcast.graceful.shutdown.max.wait: 120
+      member-attributes:
+        rule:
+          type: string
+          value: worker
+```
+
+### Hazelcast Client 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-client-config
+data:
+  hazelcast-client.yaml: |
+    hazelcast-client:
+      cluster-name: seatunnel-cluster
+      properties:
+        hazelcast.logging.type: log4j2
+      connection-strategy:
+        connection-retry:
+          cluster-connect-timeout-millis: 7000
+      network:
+        cluster-members:
+          # 如果 SeaTunnel 部署在其他命名空间，需要将 default 替换为实际命名空间。
+          - seatunnel-cluster.default.svc.cluster.local:5801
+```
+
+### SeaTunnel Engine 配置
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seatunnel-engine-config
+data:
+  seatunnel.yaml: |
+    seatunnel:
+      engine:
+        backup-count: 1
+        history-job-expire-minutes: 1440
+        print-execution-info-interval: 300
+        classloader-cache-mode: true
+        telemetry:
+          metric:
+            enabled: false
+          logs:
+            scheduled-deletion-enable: true
+        slot-service:
+          dynamic-slot: false
+          slot-num: 8
+        job-schedule-strategy: WAIT
+        checkpoint:
+          interval: 180000
+          timeout: 30000
+          storage:
+            type: hdfs
+            max-retained: 3
+            plugin-config:
+              storage.type: hdfs
+              namespace: /seatunnel/checkpoint/
+              fs.defaultFS: hdfs://namenode:8020
+        http:
+          enable-http: true
+          port: 8080
+```
+
+如果使用 S3、OSS、COS、OBS、TOS 等对象存储作为 checkpoint 或 MapStore 后端，需要保证每个 Pod 都具备网络访问能力和对应凭据。不要在 ConfigMap 的 YAML 内容中写 `secretKeyRef`；需要在部署前渲染最终配置，或使用 Hadoop credential provider、云厂商凭据链、挂载凭据文件等底层文件系统支持的方式。
+
+## 创建 Service
+
+`seatunnel-cluster` 是 Headless Service，用于 Hazelcast 成员发现。Master 和 Worker 都会通过该服务加入同一个集群。
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-cluster
+  labels:
+    app: seatunnel-cluster
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-master
+  labels:
+    app: seatunnel-master
+    component: master
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seatunnel-worker
+  labels:
+    app: seatunnel-worker
+    component: worker
+spec:
+  type: ClusterIP
+  ports:
+    - name: rest-api
+      port: 8080
+      targetPort: 8080
+    - name: hazelcast
+      port: 5801
+      targetPort: 5801
+  selector:
+    app: seatunnel
+    component: worker
+```
+
+## 创建 Master StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel-master
+  labels:
+    app: seatunnel
+    component: master
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 2
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: master
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: master
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+            - -r
+            - master
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: 500m
+              memory: 3Gi
+            limits:
+              cpu: "1"
+              memory: 4Gi
+          volumeMounts:
+            - name: hazelcast-master-config
+              mountPath: /opt/seatunnel/config/hazelcast-master.yaml
+              subPath: hazelcast-master.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-master-config
+          configMap:
+            name: seatunnel-master-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+## 创建 Worker StatefulSet
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seatunnel-worker
+  labels:
+    app: seatunnel
+    component: worker
+spec:
+  serviceName: seatunnel-cluster
+  replicas: 2
+  selector:
+    matchLabels:
+      app: seatunnel
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: seatunnel
+        component: worker
+    spec:
+      containers:
+        - name: app
+          image: seatunnel:3.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/seatunnel/bin/seatunnel-cluster.sh
+            - -r
+            - worker
+          env:
+            - name: SEATUNNEL_HOME
+              value: /opt/seatunnel
+            - name: HAZELCAST_CLUSTER_NAME
+              value: seatunnel-cluster
+          ports:
+            - containerPort: 8080
+              name: rest-api
+            - containerPort: 5801
+              name: hazelcast
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 5Gi
+          volumeMounts:
+            - name: hazelcast-worker-config
+              mountPath: /opt/seatunnel/config/hazelcast-worker.yaml
+              subPath: hazelcast-worker.yaml
+            - name: client-config
+              mountPath: /opt/seatunnel/config/hazelcast-client.yaml
+              subPath: hazelcast-client.yaml
+            - name: engine-config
+              mountPath: /opt/seatunnel/config/seatunnel.yaml
+              subPath: seatunnel.yaml
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: hazelcast-worker-config
+          configMap:
+            name: seatunnel-worker-hazelcast-config
+        - name: client-config
+          configMap:
+            name: seatunnel-client-config
+        - name: engine-config
+          configMap:
+            name: seatunnel-engine-config
+```
+
+自定义插件不包含在基础 StatefulSet 中。需要额外插件时，请参考 [插件加载](configuration.md#插件加载)，通过自定义镜像、initContainer overlay、PersistentVolume 或对象存储单独管理插件。
+
+## 健康检查和优雅停止
+
+Master 和 Worker 都建议添加以下容器片段。`startupProbe` 可以避免启动期误杀；`preStop` 会先调用 SeaTunnel 停止脚本，再等待 `SeaTunnelServer` 进程退出，配合 `terminationGracePeriodSeconds` 可以降低滚动更新和节点驱逐对运行任务的影响。
+
+```yaml
+startupProbe:
+  tcpSocket:
+    port: 5801
+  periodSeconds: 10
+  failureThreshold: 30
+readinessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 31
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  tcpSocket:
+    port: 5801
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          /opt/seatunnel/bin/stop-seatunnel-cluster.sh
+          while kill -0 $(ps -ef | grep SeaTunnelServer | grep -v grep | awk '{print $2}') 2>/dev/null; do
+            sleep 1
+          done
+```
+
+## 应用配置
+
+```bash
+kubectl apply -f seatunnel-master-hazelcast-config.yaml
+kubectl apply -f seatunnel-worker-hazelcast-config.yaml
+kubectl apply -f seatunnel-client-config.yaml
+kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-services.yaml
+kubectl apply -f seatunnel-master.yaml
+kubectl apply -f seatunnel-worker.yaml
+```
+
+检查 Pod 状态：
+
+```bash
+kubectl get pods -l app=seatunnel
+```
+
+访问 REST API：
+
+```bash
+kubectl port-forward svc/seatunnel-master 8080:8080
+curl http://127.0.0.1:8080/system-monitoring-information
+```
+
+提交作业请参考 [REST API V2](../../engines/zeta/rest-api-v2.md)。
+
+## 扩缩容 Worker
+
+Worker 扩容可以增加可用 slot：
+
+```bash
+kubectl scale statefulset seatunnel-worker --replicas=4
+```
+
+缩容前应确认被缩容的 Worker 上没有正在运行的关键任务，且剩余 Worker 的 slot 能承载当前作业。建议先停止或迁移作业，再缩容 Worker。

--- a/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
+++ b/docs/zh/getting-started/kubernetes/separated-cluster-mode.md
@@ -17,10 +17,8 @@ sidebar_position: 4
 | Hazelcast discovery | Headless Service | 1 | `publishNotReadyAddresses: true` |
 | REST API | ClusterIP Service | 1 | 可按需通过 Ingress 或 LoadBalancer 暴露 |
 
-:::tip
-
+:::tip 提示
 单 Master 可以启动集群，但不具备高可用能力。若 `backup-count: 1`，建议至少部署 2 个 Master，否则 Master 宕机后集群无法依赖备份副本恢复 IMap 状态。
-
 :::
 
 ## 创建 ConfigMap
@@ -125,6 +123,20 @@ data:
           value: worker
 ```
 
+这些示例使用 Hazelcast Kubernetes API 发现。如果希望使用 DNS 发现，并避免 Hazelcast 访问 Kubernetes API，可以将 `hazelcast-master.yaml` 和 `hazelcast-worker.yaml` 中的 `join.kubernetes` 都替换为：
+
+```yaml
+join:
+  kubernetes:
+    enabled: true
+    service-dns: seatunnel-cluster.default.svc.cluster.local
+    service-dns-timeout: 10
+```
+
+:::info 说明
+使用 DNS 发现时，下面的 RBAC 章节不是成员发现所必需的。如果跳过 RBAC 清单，也需要从两个 StatefulSet 中移除 `serviceAccountName: seatunnel`，或单独创建这个 ServiceAccount。
+:::
+
 ### Hazelcast Client 配置
 
 ```yaml
@@ -186,7 +198,41 @@ data:
           port: 8080
 ```
 
+:::caution 注意
 如果使用 S3、OSS、COS、OBS、TOS 等对象存储作为 checkpoint 或 MapStore 后端，需要保证每个 Pod 都具备网络访问能力和对应凭据。不要在 ConfigMap 的 YAML 内容中写 `secretKeyRef`；需要在部署前渲染最终配置，或使用 Hadoop credential provider、云厂商凭据链、挂载凭据文件等底层文件系统支持的方式。
+:::
+
+## 为 API 发现创建 RBAC
+
+`hazelcast-master.yaml` 和 `hazelcast-worker.yaml` 默认使用的 `namespace`、`service-name` 和 `service-port` 属于 Hazelcast Kubernetes API 发现。在启用 RBAC 的集群中，请先创建 ServiceAccount、Role 和 RoleBinding，再启动 StatefulSet。如果改用 `service-dns` 发现，可以跳过本节：
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seatunnel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seatunnel-hazelcast-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seatunnel-hazelcast-discovery
+subjects:
+  - kind: ServiceAccount
+    name: seatunnel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seatunnel-hazelcast-discovery
+```
 
 ## 创建 Service
 
@@ -273,6 +319,7 @@ spec:
         app: seatunnel
         component: master
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -344,6 +391,7 @@ spec:
         app: seatunnel
         component: worker
     spec:
+      serviceAccountName: seatunnel
       containers:
         - name: app
           image: seatunnel:3.0.0
@@ -433,11 +481,16 @@ lifecycle:
 
 ## 应用配置
 
+:::info 说明
+仅在使用 API 发现，或 StatefulSet 保留 `serviceAccountName: seatunnel` 时应用 `seatunnel-rbac.yaml`。
+:::
+
 ```bash
 kubectl apply -f seatunnel-master-hazelcast-config.yaml
 kubectl apply -f seatunnel-worker-hazelcast-config.yaml
 kubectl apply -f seatunnel-client-config.yaml
 kubectl apply -f seatunnel-engine-config.yaml
+kubectl apply -f seatunnel-rbac.yaml
 kubectl apply -f seatunnel-services.yaml
 kubectl apply -f seatunnel-master.yaml
 kubectl apply -f seatunnel-worker.yaml


### PR DESCRIPTION
## Purpose

Improve the Kubernetes getting-started documentation for SeaTunnel Zeta Engine production deployments.

## Changes

- Rework the Kubernetes overview and add dedicated pages for local mode, hybrid cluster mode, separated cluster mode, configuration, and operations.
- Recommend StatefulSet-based deployment for both Master and Worker in cluster mode.
- Split long Kubernetes examples into role-based ConfigMaps and manifests.
- Document Hazelcast Kubernetes discovery with namespace, service name, and service port.
- Add production notes for checkpoint storage, IMap MapStore, S3-compatible storage, OSS, plugin loading, health checks, graceful shutdown, PDB, scaling, and REST API access.
- Update English and Chinese docs, sidebar navigation, and Helm quick-start guidance.

## Validation

- Parsed Kubernetes YAML fenced blocks in the updated docs.
- Checked local Markdown links in the Kubernetes docs.
- Scanned for stale REST API port examples, `service-dns` usage, direct full config directory mounts, and accidental secret-like values.
- Reviewed Kubernetes manifest keys and SeaTunnel/Hazelcast/Hadoop storage keys for unsupported custom fields.
