### PR TITLE
[Docs][Connector-V2] Improve Console sink docs

### DIFF
--- a/docs/en/connectors/sink/Console.md
+++ b/docs/en/connectors/sink/Console.md
@@ -16,38 +16,57 @@ import ChangeLog from '../changelog/connector-console.md';
 
 ## Description
 
-Used to send data to Console. Both support streaming and batch mode.
+Used to print upstream rows to the SeaTunnel task log. Console supports both batch and streaming jobs. It is mainly used for debugging, local verification, and examples, not for durable production storage.
 
-> For example, if the data from upstream is [`age: 12, name: jared`], the content send to console is the following: `{"name":"jared","age":17}`
+For each non-empty row, Console prints the subtask index, row index, table id, row kind, and field values. Complex values such as arrays, maps, and nested rows are converted to readable strings before printing.
 
 ## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+Console can receive rows from multiple upstream tables and can apply schema change events for display. Because it writes to logs, it does not provide exactly-once delivery or CDC writes to an external system.
 
 ## Options
 
-|        Name        |  Type   | Required | Default |                                                 Description                                                 |
-|--------------------|---------|----------|---------|-------------------------------------------------------------------------------------------------------------|
-| common-options     |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details |
-| log.print.data     | boolean | No       | -       | Flag to determine whether data should be printed in the logs. The default value is `true`                   |
-| log.print.delay.ms | int     | No       | -       | Delay in milliseconds between printing each data item to the logs. The default value is `0`.                |
+| Name                     | Type    | Required | Default | Description                                                                                                  |
+|--------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
+| common-options           |         | No       | -       | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md) for details. |
+| log.print.data           | boolean | No       | true    | Whether to print row data to the task log. Set it to `false` when you only want to keep the sink in the job graph without printing every row. |
+| log.print.delay.ms       | int     | No       | 0       | Delay in milliseconds after each row is processed. It can slow down printing during debugging.                |
+| multi_table_sink_replica | int     | No       | 1       | Writer replica count for each table in a multi-table sink job.                                                |
+
+## Output Format
+
+Console prints the row type once when the writer starts, and then prints each row in this format:
+
+```text
+subtaskIndex=<subtask>  rowIndex=<index>:  SeaTunnelRow#tableId=<table-id> SeaTunnelRow#kind=<row-kind> : <field1>, <field2>, ...
+```
+
+- `subtaskIndex` is the sink task that printed the row.
+- `rowIndex` is counted inside each sink writer.
+- `tableId` identifies the upstream table in multi-table jobs. Single-table jobs usually print `-1`.
+- `row-kind` shows the row change type, such as `INSERT`, `UPDATE_BEFORE`, `UPDATE_AFTER`, or `DELETE`.
 
 ## Task Example
 
 ### Simple
 
-> This is a randomly generated data, written to the console, with a degree of parallelism of 1
+This example generates three rows and prints them to the task log.
 
-```
+```hocon
 env {
   parallelism = 1
-  job.mode = "STREAMING"
+  job.mode = "BATCH"
 }
 
 source {
   FakeSource {
     plugin_output = "fake"
+    row.num = 3
     schema = {
       fields {
         name = "string"
@@ -60,23 +79,26 @@ source {
 sink {
   Console {
     plugin_input = "fake"
+    log.print.data = true
+    log.print.delay.ms = 0
   }
 }
 ```
 
 ### Multiple Sources Simple
 
-> This is a multiple source and you can specify a data source to write to the specified end
+Use `plugin_input` to send different upstream datasets to different Console sinks.
 
-```
+```hocon
 env {
   parallelism = 1
-  job.mode = "STREAMING"
+  job.mode = "BATCH"
 }
 
 source {
   FakeSource {
     plugin_output = "fake1"
+    row.num = 3
     schema = {
       fields {
         id = "int"
@@ -88,6 +110,7 @@ source {
   }
    FakeSource {
     plugin_output = "fake2"
+    row.num = 3
     schema = {
       fields {
         name = "string"
@@ -107,11 +130,56 @@ sink {
 }
 ```
 
+### Multi-Table Input
+
+When the upstream source produces multiple tables, Console can print all of them in one sink. The table id in the log helps distinguish which table produced each row.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        row.num = 2
+        schema = {
+          table = "test.table1"
+          columns = [
+            { name = id, type = bigint }
+            { name = name, type = string }
+          ]
+        }
+      },
+      {
+        row.num = 2
+        schema = {
+          table = "test.table2"
+          columns = [
+            { name = id, type = bigint }
+            { name = age, type = int }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Console {
+    multi_table_sink_replica = 1
+  }
+}
+```
+
 ## Console Sample Data
 
 This is a printout from our console
 
-```
+```text
 2022-12-19 11:01:45,417 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - output rowType: name<STRING>, age<INT>
 2022-12-19 11:01:46,489 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=1: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: CpiOd, 8520946
 2022-12-19 11:01:46,490 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=2: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: eQqTs, 1256802974

--- a/docs/zh/connectors/sink/Console.md
+++ b/docs/zh/connectors/sink/Console.md
@@ -16,38 +16,57 @@ import ChangeLog from '../changelog/connector-console.md';
 
 ## 描述
 
-接收Source端传入的数据并打印到控制台。支持批同步和流同步两种模式。
+接收 Source 端传入的数据，并打印到 SeaTunnel 任务日志中。Console 支持批处理和流处理，主要用于调试、本地验证和示例任务，不适合作为生产环境的持久化存储。
 
-> 例如，来自上游的数据为 [`age: 12, name: jared`] ，则发送到控制台的内容为: `{"name":"jared"，"age":17}`
+对于每一条非空数据，Console 会打印子任务编号、行编号、表 ID、行类型和字段值。数组、Map、嵌套行等复杂类型会先转换为易读的字符串再打印。
 
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+Console 可以接收多个上游表的数据，也可以处理 Schema 变更事件并用于日志展示。由于它写入的是日志，不向外部系统持久化数据，因此不提供精确一次写入语义，也不属于真正的 CDC 写入目标。
 
 ## 接收器选项
 
-|         名称         |   类型    | 是否必须 | 默认值 |                            描述                             |
-|--------------------|---------|------|-----|-----------------------------------------------------------|
-| common-options     |         | 否    | -   | Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-common-options.md) 了解详情 |
-| log.print.data     | boolean | 否    | -   | 确定是否应在日志中打印数据的标志。默认值为`true`                               |
-| log.print.delay.ms | int     | 否    | -   | 将每个数据项打印到日志之间的延迟(以毫秒为单位)。默认值为`0`                          |
+| 名称                       | 类型      | 是否必须 | 默认值  | 描述                                                                 |
+|--------------------------|---------|------|------|--------------------------------------------------------------------|
+| common-options           |         | 否    | -    | Sink 插件通用参数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。 |
+| log.print.data           | boolean | 否    | true | 是否将行数据打印到任务日志。如果只想保留 Console 节点但不打印每行数据，可以设置为 `false`。       |
+| log.print.delay.ms       | int     | 否    | 0    | 每处理一行后的等待时间，单位为毫秒。调试时可以用它放慢打印速度。                              |
+| multi_table_sink_replica | int     | 否    | 1    | 多表写入时每张表对应的 Sink Writer 副本数。                                  |
+
+## 输出格式
+
+Console 会在 Writer 启动时先打印行类型，然后按如下格式打印每行数据：
+
+```text
+subtaskIndex=<子任务编号>  rowIndex=<行编号>:  SeaTunnelRow#tableId=<表 ID> SeaTunnelRow#kind=<行类型> : <字段1>, <字段2>, ...
+```
+
+- `subtaskIndex` 表示打印该行的 Sink 子任务。
+- `rowIndex` 是每个 Sink Writer 内部独立递增的行编号。
+- `tableId` 表示上游表标识。单表任务通常显示为 `-1`。
+- `row-kind` 表示行变更类型，例如 `INSERT`、`UPDATE_BEFORE`、`UPDATE_AFTER` 或 `DELETE`。
 
 ## 任务示例
 
 ### 简单示例
 
-> 随机生成的数据,包含两个字段，即 `name`（字符串类型）和 `age`（整型），写入控制台，并行度为 `1`
+下面的示例生成 3 行数据，并打印到任务日志。
 
-```
+```hocon
 env {
   parallelism = 1
-  job.mode = "STREAMING"
+  job.mode = "BATCH"
 }
 
 source {
   FakeSource {
     plugin_output = "fake"
+    row.num = 3
     schema = {
       fields {
         name = "string"
@@ -60,23 +79,26 @@ source {
 sink {
   Console {
     plugin_input = "fake"
+    log.print.data = true
+    log.print.delay.ms = 0
   }
 }
 ```
 
 ### 多数据源示例
 
-> 多数据源示例，通过配置可以指定数据源写入指定接收器
+通过 `plugin_input` 可以把不同上游数据分别写入不同的 Console Sink。
 
-```
+```hocon
 env {
   parallelism = 1
-  job.mode = "STREAMING"
+  job.mode = "BATCH"
 }
 
 source {
   FakeSource {
     plugin_output = "fake1"
+    row.num = 3
     schema = {
       fields {
         id = "int"
@@ -88,6 +110,7 @@ source {
   }
    FakeSource {
     plugin_output = "fake2"
+    row.num = 3
     schema = {
       fields {
         name = "string"
@@ -107,11 +130,56 @@ sink {
 }
 ```
 
+### 多表输入示例
+
+当上游 Source 产生多张表时，Console 可以在一个 Sink 中打印这些表的数据。日志中的表 ID 可以帮助区分每行数据来自哪张表。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        row.num = 2
+        schema = {
+          table = "test.table1"
+          columns = [
+            { name = id, type = bigint }
+            { name = name, type = string }
+          ]
+        }
+      },
+      {
+        row.num = 2
+        schema = {
+          table = "test.table2"
+          columns = [
+            { name = id, type = bigint }
+            { name = age, type = int }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+sink {
+  Console {
+    multi_table_sink_replica = 1
+  }
+}
+```
+
 ## 控制台示例数据
 
 控制台打印的输出:
 
-```
+```text
 2022-12-19 11:01:45,417 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - output rowType: name<STRING>, age<INT>
 2022-12-19 11:01:46,489 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=1: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: CpiOd, 8520946
 2022-12-19 11:01:46,490 INFO  org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkWriter - subtaskIndex=0 rowIndex=2: SeaTunnelRow#tableId=-1 SeaTunnelRow#kind=INSERT: eQqTs, 1256802974


### PR DESCRIPTION
## Summary
- Clarify that the Console sink prints rows to task logs for debugging and local verification.
- Document the real defaults for `log.print.data` and `log.print.delay.ms`.
- Add the `multi_table_sink_replica` option and a multi-table input example.
- Align the Chinese documentation with the English feature list and option descriptions.

## Verification
- Ran `git diff --check`.
- Confirmed the Console documentation files were not modified by PRs updated in the last seven days.