### PR TITLE
[Docs][Connector-V2] Improve alert and API connector docs

### DIFF
--- a/docs/en/connectors/sink/Enterprise-WeChat.md
+++ b/docs/en/connectors/sink/Enterprise-WeChat.md
@@ -6,7 +6,8 @@ import ChangeLog from '../changelog/connector-http-wechat.md';
 
 ## Description
 
-A sink plugin which use Enterprise WeChat robot send message
+A sink plugin that sends SeaTunnel rows to an Enterprise WeChat robot webhook. The connector identifier in job
+configuration is `WeChat`.
 
 > For example, if the data from upstream is [`"alarmStatus": "firing", "alarmTime": "2022-08-03 01:38:49"，"alarmContent": "The disk usage exceeds the threshold"`], the output content to WeChat Robot is the following:
 >
@@ -16,32 +17,37 @@ A sink plugin which use Enterprise WeChat robot send message
 > alarmContent: The disk usage exceeds the threshold
 > ```
 >
-> **Tips: WeChat sink only support `string` webhook and the data from source will be treated as body content in web hook.**
+> **Tips: The WeChat sink sends text messages. Each row is formatted as `fieldName: fieldValue` lines before it is sent to the webhook.**
 
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 
 ## Options
 
-|         name          |  type  | required | default value |
-|-----------------------|--------|----------|---------------|
-| url                   | String | Yes      | -             |
-| mentioned_list        | array  | No       | -             |
-| mentioned_mobile_list | array  | No       | -             |
-| common-options        |        | no       | -             |
+|         name          |  type  | required | default value | description |
+|-----------------------|--------|----------|---------------|-------------|
+| url                   | String | Yes      | -             | Enterprise WeChat robot webhook URL. |
+| mentioned_list        | array  | No       | -             | User IDs to mention. Use `@all` to mention everyone. |
+| mentioned_mobile_list | array  | No       | -             | Mobile phone numbers to mention. Use `@all` to mention everyone. |
+| retry                 | int    | No       | -             | Maximum retry times when the HTTP request throws `IOException`. |
+| retry_backoff_multiplier_ms | int | No    | 100           | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms  | int    | No       | 10000         | Maximum retry backoff in milliseconds. |
+| multi_table_sink_replica | int | No       | -             | Number of sink replicas used when writing multiple tables. |
+| common-options        |        | no       | -             | Sink plugin common parameters. |
 
 ### url [string]
 
-Enterprise WeChat webhook url format is https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=XXXXXX（string）
+Enterprise WeChat webhook URL format is `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=XXXXXX`.
 
 ### mentioned_list [array]
 
-A list of userids to remind the specified members in the group (@ a member), @ all means to remind everyone. If the developer can't get the userid, he can use called_ mobile_ list
+A list of user IDs to mention in the group. Use `@all` to mention everyone. If the user ID is unavailable, use `mentioned_mobile_list`.
 
 ### mentioned_mobile_list [array]
 
-Mobile phone number list, remind the group member corresponding to the mobile phone number (@ a member), @ all means remind everyone
+Mobile phone numbers to mention in the group. Use `@all` to mention everyone.
 
 ### common options
 
@@ -53,20 +59,19 @@ simple:
 
 ```hocon
 WeChat {
-        url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
-    }
+  url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
+}
 ```
 
 ```hocon
 WeChat {
-        url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
-        mentioned_list=["wangqing","@all"]
-        mentioned_mobile_list=["13800001111","@all"]
-    }
+  url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
+  mentioned_list = ["wangqing", "@all"]
+  mentioned_mobile_list = ["13800001111", "@all"]
+}
 ```
 
 ## Changelog
 
 <ChangeLog />
-
 

--- a/docs/en/connectors/sink/Sentry.md
+++ b/docs/en/connectors/sink/Sentry.md
@@ -4,7 +4,8 @@ import ChangeLog from '../changelog/connector-sentry.md';
 
 ## Description
 
-Write message to Sentry.
+Write SeaTunnel rows to Sentry as messages. Each row is sent through the Sentry SDK by calling
+`Sentry.captureMessage(row.toString())`.
 
 ## Key features
 
@@ -12,17 +13,17 @@ Write message to Sentry.
 
 ## Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| dsn                         | string  | yes      | -             |
-| env                         | string  | no       | -             |
-| release                     | string  | no       | -             |
-| cacheDirPath                | string  | no       | -             |
-| enableExternalConfiguration | boolean | no       | -             |
-| maxCacheItems               | number  | no       | -             |
-| flushTimeoutMills           | number  | no       | -             |
-| maxQueueSize                | number  | no       | -             |
-| common-options              |         | no       | -             |
+|            name             |  type   | required | default value | description |
+|-----------------------------|---------|----------|---------------|-------------|
+| dsn                         | string  | yes      | -             | Sentry DSN used by the SDK. |
+| env                         | string  | no       | -             | Sentry environment name. |
+| release                     | string  | no       | -             | Sentry release value. |
+| cacheDirPath                | string  | no       | -             | Cache directory for offline Sentry events. |
+| enableExternalConfiguration | boolean | no       | -             | Whether the Sentry SDK can load external configuration. |
+| maxCacheItems               | int     | no       | -             | Maximum number of cached events. |
+| flushTimeoutMillis          | long    | no       | -             | Time in milliseconds to wait while flushing pending events. |
+| maxQueueSize                | int     | no       | -             | Maximum queue size before events are flushed to disk. |
+| common-options              |         | no       | -             | Sink plugin common parameters. |
 
 ### dsn [string]
 
@@ -48,9 +49,9 @@ if loading properties from external sources is enabled.
 
 The max cache items for capping the number of events Default is 30
 
-### flushTimeoutMillis [number]
+### flushTimeoutMillis [long]
 
-Controls how many seconds to wait before flushing down. Sentry SDKs cache events from a background queue and this queue is given a certain amount to drain pending events Default is 15000 = 15s
+Controls how many milliseconds to wait while flushing pending events.
 
 ### maxQueueSize [number]
 
@@ -62,17 +63,18 @@ Sink plugin common parameters, please refer to [Sink Common Options](../common-o
 
 ## Example
 
-```
+```hocon
+sink {
   Sentry {
     dsn = "https://xxx@sentry.xxx.com:9999/6"
     enableExternalConfiguration = true
     maxCacheItems = 1000
-    env = prod
+    flushTimeoutMillis = 15000
+    env = "prod"
   }
-
+}
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/en/connectors/sink/Slack.md
+++ b/docs/en/connectors/sink/Slack.md
@@ -17,21 +17,22 @@ import ChangeLog from '../changelog/connector-slack.md';
 
 ## Description
 
-Used to send data to Slack Channel. Both support streaming and batch mode.
+Used to send SeaTunnel rows to a Slack channel. Both streaming and batch jobs are supported.
 
-> For example, if the data from upstream is [`age: 12, name: huan`], the content send to socket server is the following: `{"name":"huan","age":17}`
+> The connector sends the row values as one comma-separated Slack message. For example, a row with values
+> `huan` and `17` is sent as `huan,17`.
 
 ## Data Type Mapping
 
-All data types are mapped to string.
+All field values are converted to strings before they are sent to Slack.
 
 ## Options
 
 |      Name      |  Type  | Required | Default |                                                 Description                                                 |
 |----------------|--------|----------|---------|-------------------------------------------------------------------------------------------------------------|
-| webhooks_url   | String | Yes      | -       | Slack webhook url                                                                                           |
-| oauth_token    | String | Yes      | -       | Slack oauth token used for the actual authentication                                                        |
-| slack_channel  | String | Yes      | -       | slack channel for data write                                                                                |
+| webhooks_url   | String | Yes      | -       | Slack webhook URL.                                                                                          |
+| oauth_token    | String | Yes      | -       | Slack OAuth token used to list channels and post messages.                                                   |
+| slack_channel  | String | Yes      | -       | Slack channel name for data writes.                                                                         |
 | common-options |        | no       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details |
 
 ## Task Example
@@ -40,10 +41,10 @@ All data types are mapped to string.
 
 ```hocon
 sink {
- SlackSink {
+ Slack {
   webhooks_url = "https://hooks.slack.com/services/xxxxxxxxxxxx/xxxxxxxxxxxx/xxxxxxxxxxxxxxxx"
   oauth_token = "xoxp-xxxxxxxxxx-xxxxxxxx-xxxxxxxxx-xxxxxxxxxxx"
-  slack_channel = "channel name"
+  slack_channel = "seatunnel-alerts"
  }
 }
 ```

--- a/docs/en/connectors/source/MyHours.md
+++ b/docs/en/connectors/source/MyHours.md
@@ -10,18 +10,10 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 
-## Key Features
-
-- [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
-- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
-- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
-
 ## Description
 
-Used to read data from My Hours.
+Used to read data from My Hours through the My Hours REST API. The connector logs in with the configured
+`email` and `password`, obtains an access token, and then sends the configured HTTP request with that token.
 
 ## Key features
 
@@ -43,26 +35,26 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 
 ## Source Options
 
-|            Name             |  Type   | Required | Default |                                                             Description                                                              |
-|-----------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
-| url                         | String  | Yes      | -       | Http request url.                                                                                                                    |
-| email                       | String  | Yes      | -       | My hours login email address.                                                                                                        |
-| password                    | String  | Yes      | -       | My hours login password.                                                                                                             |
-| schema                      | Config  | No       | -       | Http and seatunnel data structure mapping. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).                                                                                            |
-| schema.fields               | Config  | No       | -       | The schema fields of upstream data                                                                                                   |
-| json_field                  | Config  | No       | -       | This parameter helps you configure the schema,so this parameter must be used with schema.                                            |
-| content_json                | String  | No       | -       | This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`. |
-| format                      | String  | No       | json    | The format of upstream data, now only support `json` `text`, default `json`.                                                         |
-| method                      | String  | No       | get     | Http request method, only supports GET, POST method.                                                                                 |
-| headers                     | Map     | No       | -       | Http headers.                                                                                                                        |
-| params                      | Map     | No       | -       | Http params.                                                                                                                         |
-| body                        | String  | No       | -       | Http body.                                                                                                                           |
-| poll_interval_millis        | Int     | No       | -       | Request http api interval(millis) in stream mode.                                                                                    |
-| retry                       | Int     | No       | -       | The max retry times if request http return to `IOException`.                                                                         |
-| retry_backoff_multiplier_ms | Int     | No       | 100     | The retry-backoff times(millis) multiplier if request http failed.                                                                   |
-| retry_backoff_max_ms        | Int     | No       | 10000   | The maximum retry-backoff times(millis) if request http failed                                                                       |
-| enable_multi_lines          | Boolean | No       | false   |                                                                                                                                      |
-| common-options              |         | No       | -       | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details                    |
+|            Name             |  Type   | Required | Default | Description                                                                                                           |
+|-----------------------------|---------|----------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| url                         | String  | Yes      | -       | My Hours API request URL.                                                                                             |
+| email                       | String  | Yes      | -       | My Hours login email address.                                                                                         |
+| password                    | String  | Yes      | -       | My Hours login password.                                                                                              |
+| schema                      | Config  | No       | -       | Required when `format` is `json`. For more details, see [Schema Feature](../../introduction/concepts/schema-feature.md). |
+| schema.fields               | Config  | No       | -       | The schema fields of upstream data.                                                                                   |
+| json_field                  | Config  | No       | -       | Extract fields from a JSON response by JSONPath. Use it together with `schema`.                                       |
+| content_field               | String  | No       | -       | Extract one part of a JSON response, such as `$.store.book.*`, before schema parsing.                                 |
+| format                      | String  | No       | text    | Response format. Supports `json` and `text`. Set `json` when using `schema`, `json_field`, or `content_field`.        |
+| method                      | String  | No       | GET     | HTTP request method. Supports `GET` and `POST`.                                                                       |
+| headers                     | Map     | No       | -       | Extra HTTP headers. The connector adds the My Hours `Authorization` header after login.                               |
+| params                      | Map     | No       | -       | HTTP query parameters.                                                                                                |
+| body                        | String  | No       | -       | HTTP request body.                                                                                                    |
+| poll_interval_millis        | Int     | No       | -       | Request interval in milliseconds for stream mode.                                                                      |
+| retry                       | Int     | No       | -       | Maximum retry times when the request throws `IOException`.                                                            |
+| retry_backoff_multiplier_ms | Int     | No       | 100     | Retry backoff multiplier in milliseconds.                                                                             |
+| retry_backoff_max_ms        | Int     | No       | 10000   | Maximum retry backoff in milliseconds.                                                                                |
+| json_filed_missed_return_null | Boolean | No     | false   | Return `null` when a configured JSON field is missing.                                                                |
+| common-options              |         | No       | -       | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md).             |
 
 ## How to Create a My Hours Data Synchronization Jobs
 
@@ -72,10 +64,13 @@ env {
   job.mode = "BATCH"
 }
 
-MyHours{
+source {
+  MyHours {
     url = "https://api2.myhours.com/api/Projects/getAll"
     email = "seatunnel@test.com"
-    password = "seatunnel"
+    password = "********"
+    method = "GET"
+    format = "json"
     schema {
        fields {
          name = string
@@ -103,6 +98,7 @@ MyHours{
          id = string
        }
     }
+  }
 }
 
 # Console printing of the read data
@@ -167,7 +163,7 @@ connector will generate data as the following:
 |----------------------------------------------------------|
 | {"code":  200, "data":  "get success", "success":  true} |
 
-### content_json
+### content_field
 
 This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
 
@@ -221,8 +217,10 @@ You can configure `content_field = "$.store.book.*"` and the result returned loo
 Then you can get the desired result with a simpler schema,like
 
 ```hocon
-Http {
+MyHours {
   url = "http://mockserver:1080/contentjson/mock"
+  email = "seatunnel@test.com"
+  password = "********"
   method = "GET"
   format = "json"
   content_field = "$.store.book.*"
@@ -236,11 +234,6 @@ Http {
   }
 }
 ```
-
-Here is an example:
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
 
 ### json_field
 
@@ -278,8 +271,10 @@ You can get the contents of 'book' by configuring the task as follows:
 
 ```hocon
 source {
-  Http {
+  MyHours {
     url = "http://mockserver:1080/jsonpath/mock"
+    email = "seatunnel@test.com"
+    password = "********"
     method = "GET"
     format = "json"
     json_field = {
@@ -299,9 +294,6 @@ source {
   }
 }
 ```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
 
 ## Changelog
 

--- a/docs/en/connectors/source/OpenMldb.md
+++ b/docs/en/connectors/source/OpenMldb.md
@@ -19,22 +19,22 @@ Used to read data from OpenMldb.
 
 ## Options
 
-|      name       |  type   | required | default value |
-|-----------------|---------|----------|---------------|
-| cluster_mode    | boolean | yes      | -             |
-| sql             | string  | yes      | -             |
-| database        | string  | yes      | -             |
-| host            | string  | no       | -             |
-| port            | int     | no       | -             |
-| zk_path         | string  | no       | -             |
-| zk_host         | string  | no       | -             |
-| session_timeout | int     | no       | 10000         |
-| request_timeout | int     | no       | 60000         |
-| common-options  |         | no       | -             |
+|      name       |  type   | required | default value | description |
+|-----------------|---------|----------|---------------|-------------|
+| cluster_mode    | boolean | yes      | -             | Whether to connect to OpenMLDB in cluster mode. |
+| sql             | string  | yes      | -             | SQL statement to read data. |
+| database        | string  | yes      | -             | Database name. |
+| host            | string  | no       | -             | Required when `cluster_mode` is `false`. |
+| port            | int     | no       | -             | Required when `cluster_mode` is `false`. |
+| zk_host         | string  | no       | -             | Required when `cluster_mode` is `true`. |
+| zk_path         | string  | no       | -             | Required when `cluster_mode` is `true`. |
+| session_timeout | int     | no       | 10000         | OpenMLDB session timeout in milliseconds. |
+| request_timeout | int     | no       | 60000         | OpenMLDB request timeout in milliseconds. |
+| common-options  |         | no       | -             | Source plugin common parameters. |
 
-### cluster_mode [string]
+### cluster_mode [boolean]
 
-OpenMldb is or not cluster mode
+Whether to connect to OpenMLDB in cluster mode. When it is `false`, configure `host` and `port`. When it is `true`, configure `zk_host` and `zk_path`.
 
 ### sql [string]
 
@@ -62,11 +62,11 @@ Zookeeper path, only supported on OpenMldb cluster mode
 
 ### session_timeout [int]
 
-OpenMldb session timeout(ms), default 60000
+OpenMLDB session timeout in milliseconds.
 
 ### request_timeout [int]
 
-OpenMldb request timeout(ms), default 10000
+OpenMLDB request timeout in milliseconds.
 
 ### common options
 
@@ -75,7 +75,7 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
 ## Example
 
 ```hocon
-
+source {
   OpenMldb {
     host = "172.17.0.2"
     port = 6527
@@ -83,7 +83,21 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
     database = "demo_db"
     cluster_mode = false
   }
+}
+```
 
+Cluster mode example:
+
+```hocon
+source {
+  OpenMldb {
+    zk_host = "zk-1:2181,zk-2:2181,zk-3:2181"
+    zk_path = "/openmldb"
+    sql = "select * from demo_table1"
+    database = "demo_db"
+    cluster_mode = true
+  }
+}
 ```
 
 ## Changelog

--- a/docs/zh/connectors/sink/Enterprise-WeChat.md
+++ b/docs/zh/connectors/sink/Enterprise-WeChat.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-http-wechat.md';
 
 ## 描述
 
-一个使用 Enterprise WeChat 机器人发送消息的接收插件
+一个将 SeaTunnel 行数据发送到企业微信机器人 webhook 的接收插件。作业配置中的连接器标识符是 `WeChat`。
 
 > 例如，如果来自上游的数据是 [`"alarmStatus": "firing", "alarmTime": "2022-08-03 01:38:49"，"alarmContent": "The disk usage exceeds the threshold"`], 微信机器人的输出内容如下:
 >
@@ -16,32 +16,37 @@ import ChangeLog from '../changelog/connector-http-wechat.md';
 > alarmContent: The disk usage exceeds the threshold
 > ```
 >
-> **小贴士: WeChat 接收器仅支持 `string` 类型 webhook ，源数据将被视为webhook中的正文内容.**
+> **提示：WeChat 接收器发送文本消息。每一行数据会先格式化为 `字段名: 字段值` 的多行文本，再发送到 webhook。**
 
 ## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-|         名称           |  类型  | 必需 | 默认值 |
-|-----------------------|--------|----|---------------|
-| url                   | String | 是  | -             |
-| mentioned_list        | array  | 否  | -             |
-| mentioned_mobile_list | array  | 否 | -             |
-| common-options        |        | 否 | -             |
+| 名称                  | 类型   | 必需 | 默认值 | 描述 |
+|-----------------------|--------|------|--------|------|
+| url                   | String | 是   | -      | 企业微信机器人 webhook URL。 |
+| mentioned_list        | array  | 否   | -      | 需要提醒的用户 ID 列表，使用 `@all` 提醒所有人。 |
+| mentioned_mobile_list | array  | 否   | -      | 需要提醒的手机号列表，使用 `@all` 提醒所有人。 |
+| retry                 | int    | 否   | -      | HTTP 请求抛出 `IOException` 时的最大重试次数。 |
+| retry_backoff_multiplier_ms | int | 否 | 100    | 重试退避倍数，单位毫秒。 |
+| retry_backoff_max_ms  | int    | 否   | 10000  | 最大重试退避时间，单位毫秒。 |
+| multi_table_sink_replica | int | 否   | -      | 多表写入时使用的 sink 副本数。 |
+| common-options        |        | 否   | -      | 接收器插件通用参数。 |
 
 ### url [string]
 
-企业微信网络挂钩 url 格式为 https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=XXXXXX（string）
+企业微信 webhook URL 格式为 `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=XXXXXX`。
 
 ### mentioned_list [array]
 
-一个用户标识列表，用于提醒组中的指定成员（@A成员），@all意味着提醒每个人。如果开发人员无法获得用户ID，他可以使用called_mobile_list
+需要提醒的用户 ID 列表，使用 `@all` 提醒所有人。如果无法获取用户 ID，可以使用 `mentioned_mobile_list`。
 
 ### mentioned_mobile_list [array]
 
-手机号码列表，提醒群组成员对应的手机号码（@a成员），@all表示提醒大家
+需要提醒的手机号列表，使用 `@all` 提醒所有人。
 
 ### common options
 
@@ -53,16 +58,16 @@ import ChangeLog from '../changelog/connector-http-wechat.md';
 
 ```hocon
 WeChat {
-        url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
-    }
+  url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
+}
 ```
 
 ```hocon
 WeChat {
-        url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
-        mentioned_list=["wangqing","@all"]
-        mentioned_mobile_list=["13800001111","@all"]
-    }
+  url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=693axxx6-7aoc-4bc4-97a0-0ec2sifa5aaa"
+  mentioned_list = ["wangqing", "@all"]
+  mentioned_mobile_list = ["13800001111", "@all"]
+}
 ```
 
 ## 变更日志

--- a/docs/zh/connectors/sink/Sentry.md
+++ b/docs/zh/connectors/sink/Sentry.md
@@ -4,7 +4,7 @@ import ChangeLog from '../changelog/connector-sentry.md';
 
 ## 描述
 
-给哨兵写入消息.
+将 SeaTunnel 行数据作为消息写入 Sentry。每一行会通过 Sentry SDK 以 `Sentry.captureMessage(row.toString())` 的方式发送。
 
 ## 关键特性
 
@@ -12,17 +12,17 @@ import ChangeLog from '../changelog/connector-sentry.md';
 
 ## 选项
 
-|            名称                 |  类型   | 必需 | 默认值 |
-|-----------------------------|---------|----|---------------|
-| dsn                         | string  | 是  | -             |
-| env                         | string  | 否  | -             |
-| release                     | string  | 否 | -             |
-| cacheDirPath                | string  | 否 | -             |
-| enableExternalConfiguration | boolean | 否 | -             |
-| maxCacheItems               | number  | 否 | -             |
-| flushTimeoutMills           | number  | 否 | -             |
-| maxQueueSize                | number  | 否 | -             |
-| common-options              |         | 否 | -             |
+| 名称                        | 类型    | 必需 | 默认值 | 描述 |
+|-----------------------------|---------|------|--------|------|
+| dsn                         | string  | 是   | -      | Sentry SDK 使用的 DSN。 |
+| env                         | string  | 否   | -      | Sentry 环境名称。 |
+| release                     | string  | 否   | -      | Sentry release 值。 |
+| cacheDirPath                | string  | 否   | -      | 离线事件缓存目录。 |
+| enableExternalConfiguration | boolean | 否   | -      | 是否允许 Sentry SDK 加载外部配置。 |
+| maxCacheItems               | int     | 否   | -      | 最大缓存事件数量。 |
+| flushTimeoutMillis          | long    | 否   | -      | 刷新待发送事件时的等待时间，单位毫秒。 |
+| maxQueueSize                | int     | 否   | -      | 事件刷新到磁盘前的最大队列大小。 |
+| common-options              |         | 否   | -      | 接收器插件通用参数。 |
 
 ### dsn [string]
 
@@ -48,9 +48,9 @@ DSN告诉SDK将事件发送到何处.
 
 用于限制事件数量的最大缓存项默认值为30
 
-### flushTimeoutMillis [number]
+### flushTimeoutMillis [long]
 
-控制冲洗前等待的秒数。Sentry SDK缓存来自后台队列的事件，并为该队列提供一定数量的待处理事件。默认值为15000=15s
+刷新待发送事件时的等待时间，单位毫秒。
 
 ### maxQueueSize [number]
 
@@ -62,14 +62,16 @@ DSN告诉SDK将事件发送到何处.
 
 ## 示例
 
-```
+```hocon
+sink {
   Sentry {
     dsn = "https://xxx@sentry.xxx.com:9999/6"
     enableExternalConfiguration = true
     maxCacheItems = 1000
-    env = prod
+    flushTimeoutMillis = 15000
+    env = "prod"
   }
-
+}
 ```
 
 ## 变更日志

--- a/docs/zh/connectors/sink/Slack.md
+++ b/docs/zh/connectors/sink/Slack.md
@@ -17,22 +17,23 @@ import ChangeLog from '../changelog/connector-slack.md';
 
 ## 描述
 
-用于将数据发送到Slack Channel.两者都支持流媒体和批处理模式.
+用于将 SeaTunnel 行数据发送到 Slack 频道。流处理和批处理作业都支持。
 
-> 例如，如果来自上游的数据是 [`age: 12, name: huan`], 则发送到套接字服务器的内容如下: `{"name":"huan","age":17}`
+> 连接器会把一行中的字段值拼成一条用逗号分隔的 Slack 消息。例如，字段值为 `huan` 和 `17` 时，
+> 发送内容为 `huan,17`。
 
 ## 数据类型映射
 
-所有数据类型都映射到字符串.
+所有字段值在发送到 Slack 前都会转换为字符串。
 
 ## 选项
 
-|      名称                 |  类型   | 必需 | 默认值 | 描述                                                             |
-|----------------|--------|----------|---------|----------------------------------------------------------------|
-| webhooks_url   | String | Yes      | -       | Slack webhook 的 url                                            |
-| oauth_token    | String | Yes      | -       | 用于实际身份验证的Slack oauth令牌                                         |
-| slack_channel  | String | Yes      | -       | 用于数据写入的slack channel                                           |
-| common-options |        | no       | -       | 接收器插件常用参数, 详见 [Sink 常见选项](../common-options/sink-common-options.md) |
+| 名称           | 类型   | 必需 | 默认值 | 描述 |
+|----------------|--------|------|--------|------|
+| webhooks_url   | String | 是   | -      | Slack webhook URL。 |
+| oauth_token    | String | 是   | -      | 用于列出频道并发送消息的 Slack OAuth 令牌。 |
+| slack_channel  | String | 是   | -      | 写入数据的 Slack 频道名称。 |
+| common-options |        | 否   | -      | 接收器插件通用参数，详见 [Sink 常见选项](../common-options/sink-common-options.md)。 |
 
 ## 任务示例
 
@@ -40,10 +41,10 @@ import ChangeLog from '../changelog/connector-slack.md';
 
 ```hocon
 sink {
- SlackSink {
+ Slack {
   webhooks_url = "https://hooks.slack.com/services/xxxxxxxxxxxx/xxxxxxxxxxxx/xxxxxxxxxxxxxxxx"
   oauth_token = "xoxp-xxxxxxxxxx-xxxxxxxx-xxxxxxxxx-xxxxxxxxxxx"
-  slack_channel = "channel name"
+  slack_channel = "seatunnel-alerts"
  }
 }
 ```

--- a/docs/zh/connectors/source/MyHours.md
+++ b/docs/zh/connectors/source/MyHours.md
@@ -12,16 +12,17 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
-用于从 My Hours 读取数据。
+用于通过 My Hours REST API 读取数据。连接器会先使用配置的 `email` 和 `password` 登录获取访问令牌，
+然后在后续请求中自动携带该令牌。
 
 ## 支持的数据源信息
 
@@ -34,26 +35,26 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 
 ## 源选项
 
-| 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                          |
-|-----------------------------|---------|----|-------|---------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                 |
-| email                       | String  | 是  | -     | My Hours 登录电子邮件地址                                                                           |
-| password                    | String  | 是  | -     | My Hours 登录密码                                                                               |
-| schema                      | Config  | 否  | -     | HTTP 和 SeaTunnel 数据结构映射。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                   |
-| json_field                  | Config  | 否  | -     | 此参数帮助您配置模式，因此此参数必须与 schema 一起使用。                                                            |
-| content_json                | String  | 否  | -     | 此参数可以获取一些 JSON 数据。                                                                          |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                      |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法。                                                                  |
-| headers                     | Map     | 否  | -     | HTTP 请求头                                                                                    |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                     |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                    |
-| poll_interval_millis        | Int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                     |
-| retry                       | Int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 的最大重试次数                                                          |
-| retry_backoff_multiplier_ms | Int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                       |
-| retry_backoff_max_ms        | Int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                     |
-| enable_multi_lines          | Boolean | 否  | false | 是否启用多行模式                                                                                    |
-| common-options              |         | 否  | -     | 源插件通用参数                                                                                     |
+| 参数名                         | 类型      | 必须 | 默认值 | 描述                                                                                               |
+|-------------------------------|---------|------|--------|----------------------------------------------------------------------------------------------------|
+| url                           | String  | 是   | -      | My Hours API 请求 URL。                                                                            |
+| email                         | String  | 是   | -      | My Hours 登录邮箱。                                                                                |
+| password                      | String  | 是   | -      | My Hours 登录密码。                                                                                |
+| schema                        | Config  | 否   | -      | 当 `format` 为 `json` 时需要配置。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
+| schema.fields                 | Config  | 否   | -      | 上游数据字段。                                                                                      |
+| json_field                    | Config  | 否   | -      | 通过 JSONPath 从响应中抽取字段，需要与 `schema` 一起使用。                                           |
+| content_field                 | String  | 否   | -      | 在解析 schema 前抽取 JSON 响应中的一部分，例如 `$.store.book.*`。                                  |
+| format                        | String  | 否   | text   | 响应格式，支持 `json` 和 `text`。使用 `schema`、`json_field` 或 `content_field` 时请设置为 `json`。 |
+| method                        | String  | 否   | GET    | HTTP 请求方法，支持 `GET` 和 `POST`。                                                              |
+| headers                       | Map     | 否   | -      | 额外 HTTP 请求头。连接器登录后会自动添加 My Hours `Authorization` 请求头。                         |
+| params                        | Map     | 否   | -      | HTTP 查询参数。                                                                                    |
+| body                          | String  | 否   | -      | HTTP 请求体。                                                                                      |
+| poll_interval_millis          | Int     | 否   | -      | 流模式下请求 HTTP API 的间隔，单位毫秒。                                                            |
+| retry                         | Int     | 否   | -      | 请求抛出 `IOException` 时的最大重试次数。                                                           |
+| retry_backoff_multiplier_ms   | Int     | 否   | 100    | 重试退避倍数，单位毫秒。                                                                            |
+| retry_backoff_max_ms          | Int     | 否   | 10000  | 最大重试退避时间，单位毫秒。                                                                        |
+| json_filed_missed_return_null | Boolean | 否   | false  | 配置的 JSON 字段缺失时返回 `null`。                                                                |
+| common-options                |         | 否   | -      | 源插件通用参数。                                                                                   |
 
 ## 如何创建 My Hours 数据同步作业
 
@@ -64,10 +65,12 @@ env {
 }
 
 source {
-  MyHours{
+  MyHours {
     url = "https://api2.myhours.com/api/Projects/getAll"
     email = "seatunnel@test.com"
-    password = "seatunnel"
+    password = "********"
+    method = "GET"
+    format = "json"
     schema {
        fields {
          name = string
@@ -112,9 +115,9 @@ sink {
 
 当您指定格式为 `json` 时，您还应该指定 schema 选项。
 
-### content_json
+### content_field
 
-此参数可以获取一些 JSON 数据。如果您只需要 'book' 部分中的数据，配置 `content_field = "$.store.book.*"`。
+此参数可以获取响应中的一部分 JSON 数据。如果只需要 `book` 部分，可配置 `content_field = "$.store.book.*"`。
 
 ### json_field
 
@@ -123,4 +126,3 @@ sink {
 ## 变更日志
 
 <ChangeLog />
-

--- a/docs/zh/connectors/source/OpenMldb.md
+++ b/docs/zh/connectors/source/OpenMldb.md
@@ -19,22 +19,22 @@ import ChangeLog from '../changelog/connector-openmldb.md';
 
 ## 选项
 
-|      名称           |  类型  | 必需 | 默认值 |
-|-----------------|---------|----------|---------------|
-| cluster_mode    | boolean | 是      | -             |
-| sql             | string  | 是      | -             |
-| database        | string  | 是      | -             |
-| host            | string  | 否       | -             |
-| port            | int     | 否       | -             |
-| zk_path         | string  | 否       | -             |
-| zk_host         | string  | 否       | -             |
-| session_timeout | int     | 否       | 10000         |
-| request_timeout | int     | 否       | 60000         |
-| common-options  |         | 否       | -             |
+|      名称       | 类型    | 必需 | 默认值 | 描述 |
+|-----------------|---------|------|--------|------|
+| cluster_mode    | boolean | 是   | -      | 是否以 OpenMLDB 集群模式连接。 |
+| sql             | string  | 是   | -      | 用于读取数据的 SQL 语句。 |
+| database        | string  | 是   | -      | 数据库名称。 |
+| host            | string  | 否   | -      | 当 `cluster_mode` 为 `false` 时必填。 |
+| port            | int     | 否   | -      | 当 `cluster_mode` 为 `false` 时必填。 |
+| zk_host         | string  | 否   | -      | 当 `cluster_mode` 为 `true` 时必填。 |
+| zk_path         | string  | 否   | -      | 当 `cluster_mode` 为 `true` 时必填。 |
+| session_timeout | int     | 否   | 10000  | OpenMLDB 会话超时时间，单位毫秒。 |
+| request_timeout | int     | 否   | 60000  | OpenMLDB 请求超时时间，单位毫秒。 |
+| common-options  |         | 否   | -      | 源插件通用参数。 |
 
-### cluster_mode [string]
+### cluster_mode [boolean]
 
-OpenMldb 是否处于群集模式
+是否以 OpenMLDB 集群模式连接。为 `false` 时配置 `host` 和 `port`；为 `true` 时配置 `zk_host` 和 `zk_path`。
 
 ### sql [string]
 
@@ -62,11 +62,11 @@ Zookeeper路径，仅在OpenMldb集群模式下受支持
 
 ### session_timeout [int]
 
-OpenMldb会话超时（ms），默认值60000
+OpenMLDB 会话超时时间，单位毫秒。
 
 ### request_timeout [int]
 
-OpenMldb请求超时（ms），默认值为10000
+OpenMLDB 请求超时时间，单位毫秒。
 
 ### common options
 
@@ -75,7 +75,7 @@ OpenMldb请求超时（ms），默认值为10000
 ## 示例
 
 ```hocon
-
+source {
   OpenMldb {
     host = "172.17.0.2"
     port = 6527
@@ -83,7 +83,21 @@ OpenMldb请求超时（ms），默认值为10000
     database = "demo_db"
     cluster_mode = false
   }
+}
+```
 
+集群模式示例：
+
+```hocon
+source {
+  OpenMldb {
+    zk_host = "zk-1:2181,zk-2:2181,zk-3:2181"
+    zk_path = "/openmldb"
+    sql = "select * from demo_table1"
+    database = "demo_db"
+    cluster_mode = true
+  }
+}
 ```
 
 ## 变更日志


### PR DESCRIPTION
## Summary

This PR improves documentation for five connector docs that had not been modified by recent connector-doc PRs:

- Enterprise WeChat sink
- Slack sink
- Sentry sink
- My Hours source
- OpenMLDB source

## Changes

- Align option names, required flags, and defaults with the current connector factories and option rules.
- Fix incorrect examples, including the Slack connector identifier and My Hours JSON parsing setup.
- Clarify conditional OpenMLDB single-node vs cluster-mode options.
- Correct the Sentry `flushTimeoutMillis` option spelling and example usage.
- Keep English and Chinese docs consistent, including Chinese feature wording.

## Verification

- Checked existing open PRs to avoid overlapping these documentation files.
- Verified no recent connector-doc PR modified these connector docs.
- Ran `git diff --check`.
