### PR TITLE
[Docs][Connector-V2] Improve OceanBase connector docs

### DIFF
--- a/docs/en/connectors/sink/OceanBase.md
+++ b/docs/en/connectors/sink/OceanBase.md
@@ -12,13 +12,16 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Key Features
 
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+> Exactly-once uses XA transactions. Enable it with `is_exactly_once = true`, `max_retries = 0`, and a valid OceanBase XA data source class from the OceanBase JDBC driver.
 
 ## Description
 
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once semantics.
+Write data to OceanBase through JDBC. The sink supports batch and streaming jobs, CDC row kinds, generated SQL, save modes, multi-table writes, and exactly-once semantics when XA transactions are configured.
 
 ## Supported DataSource Info
 
@@ -76,25 +79,39 @@ Write data through jdbc. Support Batch mode and Streaming mode, support concurre
 | driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source, should be `com.oceanbase.jdbc.Driver`.                                                                                                                                          |
 | username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                  |
 | password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                   |
-| query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
+| query                                     | String  | No       | -       | Use this SQL to write upstream data to OceanBase, for example `INSERT ...`. When `generate_sink_sql = false`, `query` is required. Save mode options do not run in custom `query` mode.                                                        |
 | compatible_mode                           | String  | Yes      | -       | The compatible mode of OceanBase, can be 'mysql' or 'oracle'.                                                                                                                                                                                  |
-| database                                  | String  | No       | -       | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                       |
-| table                                     | String  | No       | -       | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                           |
+| database                                  | String  | No       | -       | Database used when `generate_sink_sql = true`. This option is required when generated SQL is enabled.                                                                                                                                          |
+| table                                     | String  | No       | -       | Target table used when `generate_sink_sql = true`. It supports placeholders such as `${schema_name}` and `${table_name}` for multi-table writes.                                                                                               |
 | primary_keys                              | Array   | No       | -       | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql.                                                                                                                            |
 | connection_check_timeout_sec              | Int     | No       | 30      | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                            |
 | max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
-| batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
+| batch_size                                | Int     | No       | 1000    | For batch writing, when buffered record count reaches `batch_size`, data is flushed to OceanBase. If `batch_interval_ms` is greater than 0, elapsed time can also trigger a flush.                                                             |
+| batch_interval_ms                         | Long    | No       | 0       | Write-triggered flush interval in milliseconds. `0` disables time-based flushing. When greater than 0, the writer checks elapsed time on each record and flushes synchronously when the interval is reached.                                  |
+| is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics through XA transactions. If enabled, set `xa_data_source_class_name` and keep `max_retries = 0`.                                                                                                     |
 | generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
+| xa_data_source_class_name                 | String  | No       | -       | XA data source class name from the OceanBase JDBC driver. Required when `is_exactly_once = true`.                                                                                                                                              |
 | max_commit_attempts                       | Int     | No       | 3       | The number of retries for transaction commit failures                                                                                                                                                                                          |
 | transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
 | auto_commit                               | Boolean | No       | true    | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
+| field_ide                                 | String  | No       | -       | Controls field name case conversion. Available values are `ORIGINAL`, `UPPERCASE`, and `LOWERCASE`.                                                                                                                                           |
 | properties                                | Map     | No       | -       | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL. |
+| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Controls how target table structure is handled before the job starts.                                                                                                                                                           |
+| data_save_mode                            | Enum    | No       | APPEND_DATA | Controls how existing target table data is handled before the job starts.                                                                                                                                                                      |
+| custom_sql                                | String  | No       | -       | SQL executed before synchronization when `data_save_mode = CUSTOM_PROCESSING`. This option is not executed in custom `query` mode.                                                                                                             |
 | common-options                            |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                                    |
 | enable_upsert                             | Boolean | No       | true    | Enable upsert by primary_keys exist, If the task has no key duplicate data, setting this parameter to `false` can speed up data import                                                                                                         |
+| is_primary_key_updated                    | Boolean | No       | true    | Whether primary key fields are included when generated update statements are built.                                                                                                                                                             |
+| support_upsert_by_insert_only             | Boolean | No       | false   | Whether to support upsert behavior through insert-only statements for compatible dialects.                                                                                                                                                      |
+| multi_table_sink_replica                  | Int     | No       | 1       | Number of sink writer replicas used when writing multiple tables.                                                                                                                                                                              |
 
 ### Tips
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
+> Configure `compatible_mode = "mysql"` for OceanBase MySQL mode and `compatible_mode = "oracle"` for OceanBase Oracle mode.
+>
+> Use `query` when you want to provide the full write SQL yourself. Use `generate_sink_sql = true` with `database` and `table` when you want SeaTunnel to generate INSERT/UPSERT SQL and apply save mode settings.
+>
+> To consume CDC data, use generated SQL and configure `primary_keys`; otherwise UPDATE and DELETE events cannot be mapped safely.
 
 ## Task Example
 
@@ -165,6 +182,26 @@ sink {
 }
 ```
 
+### Generated SQL With Save Mode
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "sink_table"
+    primary_keys = ["id"]
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
+  }
+}
+```
+
 ### CDC(Change Data Capture) Event
 
 > CDC change data is also supported by us In this case, you need config database, table and primary_keys.
@@ -183,6 +220,42 @@ sink {
         table = sink_table
         primary_keys = ["id","name"]
     }
+}
+```
+
+### Oracle-Compatible Mode
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "INSERT INTO SINK_TABLE (ID, NAME, CREATE_TIME) VALUES (?, ?, ?)"
+  }
+}
+```
+
+### Multiple Table Write
+
+Use placeholders in `table` when rows from upstream carry table identity.
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "${table_name}_sink"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
 }
 ```
 

--- a/docs/en/connectors/source/OceanBase.md
+++ b/docs/en/connectors/source/OceanBase.md
@@ -18,10 +18,11 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
 
-Read external data source data through JDBC.
+Read OceanBase data through JDBC. OceanBase can run in MySQL-compatible mode or Oracle-compatible mode, so every OceanBase job should set `compatible_mode` to `mysql` or `oracle`.
 
 ## Supported DataSource Info
 
@@ -84,19 +85,41 @@ Read external data source data through JDBC.
 | username                         | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                         |
 | password                     | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                          |
 | compatible_mode              | String     | Yes      | -               | The compatible mode of OceanBase, can be 'mysql' or 'oracle'.                                                                                                                                                                                                         |
-| query                        | String     | Yes      | -               | Query statement                                                                                                                                                                                                                                                       |
+| query                        | String     | No       | -               | Query statement. Configure one of `query`, `table_path`, or `table_list`.                                                                                                                                                                                             |
+| table_path                   | String     | No       | -               | Full table path used instead of `query`, for example `test.source`.                                                                                                                                                                                                   |
+| table_list                   | Array      | No       | -               | List of tables to read. Use it for multi-table reads. Each item can contain `table_path`, `query`, `partition_column`, and other table-level settings.                                                                                                                 |
+| where_condition              | String     | No       | -               | Common row filter for all tables or queries. It must start with `where`, for example `where id > 100`.                                                                                                                                                                |
 | connection_check_timeout_sec | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete                                                                                                                                                                    |
 | partition_column             | String     | No       | -               | The column name for parallelism's partition, only support numeric type column and string type column.                                                                                                                                                                 |
 | partition_lower_bound        | BigDecimal | No       | -               | The partition_column min value for scan, if not set SeaTunnel will query database get min value.                                                                                                                                                                      |
 | partition_upper_bound        | BigDecimal | No       | -               | The partition_column max value for scan, if not set SeaTunnel will query database get max value.                                                                                                                                                                      |
-| partition_num                | Int        | No       | job parallelism | The number of partition count, only support positive integer. Default value is job parallelism.                                                                                                                                                                       |
+| partition_num                | Int        | No       | job parallelism | The number of partition count, only support positive integer. When reading by `table_path`, prefer `split.size` to control split size.                                                                                                                                |
 | fetch_size                   | Int        | No       | 0               | For queries that return a large number of objects, you can configure <br/> the row fetch size used in the query to improve performance by <br/> reducing the number database hits required to satisfy the selection criteria.<br/> Zero means use jdbc default value. |
+| split.size                   | Int        | No       | 8096            | Number of rows in one split when reading by `table_path`.                                                                                                                                                                                                             |
+| split.even-distribution.factor.lower-bound | Double | No | 0.05 | Lower bound used to judge whether split-key values are evenly distributed.                                                                                                                                                                                             |
+| split.even-distribution.factor.upper-bound | Double | No | 100 | Upper bound used to judge whether split-key values are evenly distributed.                                                                                                                                                                                             |
+| split.sample-sharding.threshold | Int     | No       | 1000            | Estimated shard count threshold that triggers sample-based sharding for uneven data.                                                                                                                                                                                  |
+| split.inverse-sampling.rate  | Int        | No       | 1000            | Sampling rate denominator used by sample-based sharding.                                                                                                                                                                                                              |
+| split.allow-sampling         | Boolean    | No       | true            | Whether to allow sample-based sharding.                                                                                                                                                                                                                               |
+| split.string_split_mode      | String     | No       | sample          | String split algorithm. Available value includes `sample` and `charset_based`.                                                                                                                                                                                        |
+| split.string-strategy        | String     | No       | -               | String partition strategy. Available values are `none`, `hash`, `range`, and `auto`.                                                                                                                                                                                  |
+| split.string_split_mode_collate | String  | No       | -               | Collation used when `split.string_split_mode` is `charset_based`.                                                                                                                                                                                                     |
+| use_select_count             | Boolean    | No       | false           | Use `select count` during dynamic chunk split. It is mainly used by Oracle-compatible read scenarios.                                                                                                                                                                  |
+| skip_analyze                 | Boolean    | No       | false           | Skip table count analysis during dynamic chunk split. It is mainly used by Oracle-compatible read scenarios.                                                                                                                                                          |
+| use_regex                    | Boolean    | No       | false           | Treat `table_path` as a regular expression when matching tables.                                                                                                                                                                                                      |
+| decimal_type_narrowing       | Boolean    | No       | true            | In Oracle-compatible mode, narrow decimal values to INT or BIGINT when it can be done without losing precision.                                                                                                                                                       |
+| int_type_narrowing           | Boolean    | No       | true            | In MySQL-compatible mode, narrow `TINYINT(1)` to BOOLEAN when it can be done without losing precision.                                                                                                                                                                |
+| dialect                      | String     | No       | -               | Appointed JDBC dialect. OceanBase is usually detected from the URL, so this is only needed for special compatibility cases.                                                                                                                                            |
 | properties                   | Map        | No       | -               | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL.                        |
 | common-options               |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details                                                                                                                                                     |
 
 ### Tips
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
+> Configure one of `query`, `table_path`, or `table_list`.
+>
+> If `partition_column` is not set and SeaTunnel cannot find a suitable primary key or unique key from the table metadata, the source runs with one reader. If a supported split column is available, SeaTunnel can read in parallel.
+>
+> For OceanBase MySQL mode, JDBC connection URLs usually include MySQL-compatible parameters such as `rewriteBatchedStatements=true`. For OceanBase Oracle mode, use the Oracle-compatible tenant and set `compatible_mode = "oracle"`.
 
 ## Task Example
 
@@ -176,6 +199,62 @@ source {
     partition_lower_bound = 1
     # Read end boundary
     partition_upper_bound = 500
+  }
+}
+```
+
+### Table Path
+
+Use `table_path` when you want SeaTunnel to discover table metadata and split the table automatically.
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_path = "test.source"
+    split.size = 8096
+  }
+}
+```
+
+### Oracle-Compatible Mode
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "SELECT ID, NAME, CREATE_TIME FROM SOURCE"
+  }
+}
+```
+
+### Multiple Table Read
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_list = [
+      {
+        table_path = "test.source_1"
+      },
+      {
+        table_path = "test.source_2"
+      }
+    ]
+    where_condition = "where id > 100"
   }
 }
 ```

--- a/docs/zh/connectors/sink/OceanBase.md
+++ b/docs/zh/connectors/sink/OceanBase.md
@@ -12,18 +12,22 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 关键特性
 
-- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+> 精确一次依赖 XA 事务。启用时需要配置 `is_exactly_once = true`、`max_retries = 0`，并填写 OceanBase JDBC 驱动提供的有效 XA 数据源类名。
 
 ## 描述
 
-通过jdbc写入数据。支持批处理模式和流模式，支持并发写入，支持精确一次语义。
+通过 JDBC 写入 OceanBase。该 Sink 支持批处理和流处理任务、CDC 行类型、自动生成 SQL、保存模式、多表写入，以及配置 XA 事务后的精确一次语义。
 
 ## 支持的数据源信息
 
 | 数据源      |       支持版本       |          Driver           |                 Url                  |                                     Maven                                     |
 |------------|---------------------|---------------------------|--------------------------------------|-------------------------------------------------------------------------------|
-| OceanBase  | 所有OceanBase服务版本 | com.oceanbase.jdbc.Driver | jdbc:oceanbase://localhost:2883/test | [Download](https://mvnrepository.com/artifact/com.oceanbase/oceanbase-client) |
+| OceanBase  | 所有 OceanBase 服务版本 | com.oceanbase.jdbc.Driver | jdbc:oceanbase://localhost:2883/test | [下载](https://mvnrepository.com/artifact/com.oceanbase/oceanbase-client) |
 
 ## 数据库相关依赖
 
@@ -32,9 +36,9 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 数据类型映射
 
-### Mysql模式
+### MySQL 模式
 
-|                                                          Mysql Data type                                                          |                                                                 SeaTunnel Data type                                                                 |
+|                                                        MySQL 数据类型                                                        |                                                                 SeaTunnel 数据类型                                                                 |
 |-----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | BIT(1)<br/>INT UNSIGNED                                                                                                           | BOOLEAN                                                                                                                                             |
 | TINYINT<br/>TINYINT UNSIGNED<br/>SMALLINT<br/>SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR | INT                                                                                                                                                 |
@@ -50,11 +54,11 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | TIME                                                                                                                              | TIME                                                                                                                                                |
 | DATETIME<br/>TIMESTAMP                                                                                                            | TIMESTAMP                                                                                                                                           |
 | TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINAR<br/>BIT(n)                                                  | BYTES                                                                                                                                               |
-| GEOMETRY<br/>UNK否WN                                                                                                              | 否t supported yet                                                                                                                                   |
+| GEOMETRY<br/>UNKNOWN                                                                                                              | 暂不支持                                                                                                                                             |
 
 ### Oracle 模式
 
-|                     Oracle Data type                      | SeaTunnel Data type |
+|                     Oracle 数据类型                      | SeaTunnel 数据类型 |
 |-----------------------------------------------------------|---------------------|
 | Number(p), p <= 9                                         | INT                 |
 | Number(p), p <= 18                                        | BIGINT              |
@@ -65,35 +69,49 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | DATE                                                      | DATE                |
 | TIMESTAMP<br/>TIMESTAMP WITH LOCAL TIME ZONE              | TIMESTAMP           |
 | BLOB<br/>RAW<br/>LONG RAW<br/>BFILE                       | BYTES               |
-| UNK否WN                                                   | 否t supported yet   |
+| UNKNOWN                                                   | 暂不支持             |
 
 ## Sink 选项
 
-| Name                         |  Type   | Required | Default |                                                                                                                  Description                                                                                                                   |
+| 参数名                       | 类型    | 是否必填 | 默认值  | 描述 |
 |------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url                          | String  | 是       | -       | JDBC连接的URL。参考案例: jdbc:oceanbase://localhost:2883/test                                                                                                                                                          |
 | driver                       | String  | 是       | -       | 用于连接到远程数据源的jdbc类名应为 `com.oceanbase.jdbc.Driver`.                                                                                                                                          |
 | username                     | String  | 否       | -       | 连接实例用户名                                                                                                                                                                                                                  |
 | password                     | String  | 否       | -       | 连接实例密码                                                                                                                                                                                                                   |
-| query                        | String  | 否       | -       | 使用此sql将上游输入数据写入数据库。例如“insert…”查询具有更高的优先级                                                                                                                                         |
+| query                        | String  | 否       | -       | 使用该 SQL 将上游数据写入 OceanBase，例如 `INSERT ...`。当 `generate_sink_sql = false` 时必须配置 `query`。自定义 `query` 模式下不会执行保存模式相关配置。 |
 | compatible_mode              | String  | 是       | -       | OceanBase的兼容模式可以是“mysql”或“oracle”。                                                                                                                                                                                 |
-| database                     | String  | 否       | -       | 使用这个“database”和“table-name”自动生成sql并接收上游输入数据写入数据库<br/>此选项与“query”互斥，具有更高的优先级。                                                       |
-| table                        | String  | 否       | -       | 使用数据库和此表名自动生成sql并接收上游输入数据写入数据库<br/>此选项与“query”互斥，并且具有更高的 priority.                                                           |
+| database                     | String  | 否       | -       | `generate_sink_sql = true` 时使用的数据库，并且此时必须配置。 |
+| table                        | String  | 否       | -       | `generate_sink_sql = true` 时使用的目标表。多表写入时支持 `${schema_name}`、`${table_name}` 等占位符。 |
 | primary_keys                 | Array   | 否       | -       | 此选项用于在自动生成sql时支持“insert”、“delete”和“update”等操作。                                                                                                                           |
 | connection_check_timeout_sec | Int     | 否       | 30      | 等待用于验证连接的数据库操作完成的时间（秒）。                                                                                                                                            |
 | max_retries                  | Int     | 否       | 0       | 提交失败的重试次数(executeBatch)                                                                                                                                                                                          |
-| batch_size                   | Int     | 否       | 1000    | 对于批量写入，当缓冲记录的数量达到“batch_size”的数量或时间达到“checkpoint.interval”<br/>时，数据将被刷新到数据库中                                                           |
+| batch_size                   | Int     | 否       | 1000    | 对于批量写入，当缓冲记录数达到 `batch_size` 时，数据会刷新到 OceanBase。如果 `batch_interval_ms` 大于 0，经过指定时间也会触发刷新。 |
+| batch_interval_ms            | Long    | 否       | 0       | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 0 时，写入器会在每条记录写入时检查间隔，达到间隔后同步刷新。 |
+| is_exactly_once              | Boolean | 否       | false   | 是否通过 XA 事务启用精确一次语义。启用后需要配置 `xa_data_source_class_name`，并保持 `max_retries = 0`。 |
 | generate_sink_sql            | Boolean | 否       | false   | 根据要写入的数据库表生成sql语句                                                                                                                            |
+| xa_data_source_class_name    | String  | 否       | -       | OceanBase JDBC 驱动提供的 XA 数据源类名。`is_exactly_once = true` 时必须配置。 |
 | max_commit_attempts          | Int     | 否       | 3       | 事务提交失败的重试次数                                                                                                                                                                                          |
-| transaction_timeout_sec      | Int     | 否       | -1      | 事务打开后的超时，默认值为-1（永不超时）。请注意，设置超时可能会影响＜br/＞精确一次语义                                                                                           |
+| transaction_timeout_sec      | Int     | 否       | -1      | 事务打开后的超时时间，默认值为 -1，表示永不超时。设置超时可能影响精确一次语义。 |
 | auto_commit                  | Boolean | 否       | true    | 默认情况下启用自动事务提交                                                                                                                                                                                             |
+| field_ide                    | String  | 否       | -       | 控制字段名大小写转换，可选 `ORIGINAL`、`UPPERCASE`、`LOWERCASE`。 |
 | properties                   | Map     | 否       | -       | 其他连接配置参数，当属性和URL具有相同的参数时，优先级由驱动程序的特定实现决定。例如，在MySQL中，属性优先于URL。 |
-| common-options               |         | 否       | -       | Sink插件常用参数，详见[Sink common Options](../common-options/sink-common-options.md)                                                                                                                                    |
+| schema_save_mode             | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 同步任务启动前，对目标表结构的处理方式。 |
+| data_save_mode               | Enum    | 否       | APPEND_DATA | 同步任务启动前，对目标表已有数据的处理方式。 |
+| custom_sql                   | String  | 否       | -       | `data_save_mode = CUSTOM_PROCESSING` 时，在同步前执行的 SQL。自定义 `query` 模式下不会执行该 SQL。 |
+| common-options               |         | 否       | -       | Sink 插件通用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)                                                                                                                                    |
 | enable_upsert                | Boolean | 否       | true    | 通过primary_keys存在启用upsert，如果任务没有键重复数据，将此参数设置为“false”可以加快数据导入                                                                                                         |
+| is_primary_key_updated       | Boolean | 否       | true    | 自动生成更新语句时，是否把主键字段放入更新字段中。 |
+| support_upsert_by_insert_only | Boolean | 否      | false   | 兼容方言下是否通过仅 INSERT 语句实现 upsert。 |
+| multi_table_sink_replica     | Int     | 否       | 1       | 多表写入时使用的 Sink Writer 副本数量。 |
 
 ### 提示
 
-> 如果未设置partition_column，它将以单并发运行，如果设置了partition_column，它将根据任务的并发数并行执行。
+> OceanBase MySQL 模式请配置 `compatible_mode = "mysql"`，OceanBase Oracle 模式请配置 `compatible_mode = "oracle"`。
+>
+> 想自己写完整写入 SQL 时使用 `query`。想让 SeaTunnel 自动生成 INSERT/UPSERT SQL 并执行保存模式时，使用 `generate_sink_sql = true`，并配置 `database` 和 `table`。
+>
+> 消费 CDC 数据时，建议使用自动生成 SQL 并配置 `primary_keys`，否则 UPDATE 和 DELETE 事件无法安全映射。
 
 ## 任务示例
 
@@ -164,6 +182,26 @@ sink {
 }
 ```
 
+### 自动生成 SQL 并设置保存模式
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "sink_table"
+    primary_keys = ["id"]
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
+  }
+}
+```
+
 ### CDC(Change Data Capture) 数据变更事件
 
 > 我们也支持CDC变更数据。在这种情况下，您需要配置数据库、表和主键。
@@ -182,6 +220,42 @@ sink {
         table = sink_table
         primary_keys = ["id","name"]
     }
+}
+```
+
+### Oracle 兼容模式
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "INSERT INTO SINK_TABLE (ID, NAME, CREATE_TIME) VALUES (?, ?, ?)"
+  }
+}
+```
+
+### 多表写入
+
+当上游数据带有表身份信息时，可以在 `table` 中使用占位符。
+
+```
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "${table_name}_sink"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
 }
 ```
 

--- a/docs/zh/connectors/source/OceanBase.md
+++ b/docs/zh/connectors/source/OceanBase.md
@@ -17,11 +17,12 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [x] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
-通过 JDBC 读取外部数据源数据。
+通过 JDBC 读取 OceanBase 数据。OceanBase 支持 MySQL 兼容模式和 Oracle 兼容模式，因此 OceanBase 任务应将 `compatible_mode` 设置为 `mysql` 或 `oracle`。
 
 ## 支持的数据源信息
 
@@ -84,19 +85,41 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | username | String | 否 | - | 连接实例用户名 |
 | password | String | 否 | - | 连接实例密码 |
 | compatible_mode | String | 是 | - | OceanBase 的兼容模式，可以是 'mysql' 或 'oracle'。 |
-| query | String | 是 | - | 查询语句 |
+| query | String | 否 | - | 查询语句。`query`、`table_path`、`table_list` 三者至少配置一个。 |
+| table_path | String | 否 | - | 完整表路径，可替代 `query` 使用，例如 `test.source`。 |
+| table_list | Array | 否 | - | 待读取的表列表，用于多表读取。每个表配置中可以包含 `table_path`、`query`、`partition_column` 等表级参数。 |
+| where_condition | String | 否 | - | 所有表或查询共用的过滤条件，必须以 `where` 开头，例如 `where id > 100`。 |
 | connection_check_timeout_sec | Int | 否 | 30 | 等待用于验证连接的数据库操作完成的时间（秒） |
 | partition_column | String | 否 | - | 用于并行性分割的列名，仅支持数值类型列和字符串类型列。 |
 | partition_lower_bound | BigDecimal | 否 | - | partition_column 的最小值用于扫描，如果未设置，SeaTunnel 将查询数据库获取最小值。 |
 | partition_upper_bound | BigDecimal | 否 | - | partition_column 的最大值用于扫描，如果未设置，SeaTunnel 将查询数据库获取最大值。 |
-| partition_num | Int | 否 | job parallelism | 分割数量，仅支持正整数。默认值是任务并行度。 |
+| partition_num | Int | 否 | job parallelism | 分片数量，仅支持正整数。使用 `table_path` 读取时，推荐通过 `split.size` 控制单个分片大小。 |
 | fetch_size | Int | 否 | 0 | 对于返回大量对象的查询，您可以配置查询中使用的行提取大小，以通过减少满足选择条件所需的数据库命中次数来提高性能。零表示使用 jdbc 默认值。 |
+| split.size | Int | 否 | 8096 | 使用 `table_path` 读取时，每个分片包含的行数。 |
+| split.even-distribution.factor.lower-bound | Double | 否 | 0.05 | 判断分片键数据是否均匀分布的下限。 |
+| split.even-distribution.factor.upper-bound | Double | 否 | 100 | 判断分片键数据是否均匀分布的上限。 |
+| split.sample-sharding.threshold | Int | 否 | 1000 | 数据分布不均时，触发采样分片的预估分片数阈值。 |
+| split.inverse-sampling.rate | Int | 否 | 1000 | 采样分片使用的采样率分母。 |
+| split.allow-sampling | Boolean | 否 | true | 是否允许使用采样分片策略。 |
+| split.string_split_mode | String | 否 | sample | 字符串分片算法，可选 `sample`、`charset_based`。 |
+| split.string-strategy | String | 否 | - | 字符串分片策略，可选 `none`、`hash`、`range`、`auto`。 |
+| split.string_split_mode_collate | String | 否 | - | `split.string_split_mode` 为 `charset_based` 时使用的排序规则。 |
+| use_select_count | Boolean | 否 | false | 动态分片阶段使用 `select count` 统计行数，主要用于 Oracle 兼容读取场景。 |
+| skip_analyze | Boolean | 否 | false | 动态分片阶段跳过表行数分析，主要用于 Oracle 兼容读取场景。 |
+| use_regex | Boolean | 否 | false | 是否将 `table_path` 当作正则表达式匹配表。 |
+| decimal_type_narrowing | Boolean | 否 | true | Oracle 兼容模式下，在不丢失精度时将 Decimal 收窄为 INT 或 BIGINT。 |
+| int_type_narrowing | Boolean | 否 | true | MySQL 兼容模式下，在不丢失精度时将 `TINYINT(1)` 收窄为 BOOLEAN。 |
+| dialect | String | 否 | - | 指定 JDBC 方言。OceanBase 通常会根据 URL 自动识别，只有特殊兼容场景才需要显式配置。 |
 | properties | Map | 否 | - | 其他连接配置参数，当 properties 和 URL 具有相同参数时，优先级由驱动程序的具体实现确定。例如，在 MySQL 中，properties 优先于 URL。 |
-| common-options | | 否 | - | 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。 |
+| common-options | | 否 | - | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。 |
 
 ### 提示
 
-> 如果未设置 partition_column，它将以单并发运行，如果设置了 partition_column，它将根据任务的并发度并行执行。
+> `query`、`table_path`、`table_list` 三者至少配置一个。
+>
+> 如果未设置 `partition_column`，并且 SeaTunnel 无法从表元数据中找到合适的主键或唯一键，则源端会以单并发读取。配置了支持的分片列后，SeaTunnel 可以并行读取。
+>
+> OceanBase MySQL 模式的 JDBC URL 通常会带上 `rewriteBatchedStatements=true` 等 MySQL 兼容参数；OceanBase Oracle 模式需要使用 Oracle 兼容租户，并配置 `compatible_mode = "oracle"`。
 
 ## 任务示例
 
@@ -180,7 +203,62 @@ source {
 }
 ```
 
+### 表路径读取
+
+希望 SeaTunnel 自动发现表结构并进行分片时，可以使用 `table_path`。
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_path = "test.source"
+    split.size = 8096
+  }
+}
+```
+
+### Oracle 兼容模式
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "SELECT ID, NAME, CREATE_TIME FROM SOURCE"
+  }
+}
+```
+
+### 多表读取
+
+```
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_list = [
+      {
+        table_path = "test.source_1"
+      },
+      {
+        table_path = "test.source_2"
+      }
+    ]
+    where_condition = "where id > 100"
+  }
+}
+```
+
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Summary

- Improve OceanBase source and sink documentation in English and Chinese.
- Add missing source options for table path, table list, split tuning, regex matching, and type narrowing.
- Add missing sink options for generated SQL, save modes, XA exactly-once, timed flushing, CDC/upsert, and multi-table writes.
- Add OceanBase MySQL and Oracle compatible mode examples for source and sink usage.

## Verification

- Ran `git diff --check`.
- Ran a markdown table column-count check for the updated OceanBase docs.
- Checked recent PRs mentioning OceanBase docs to avoid duplicating another docs PR.