### PR TITLE
[Docs][Connector-V2] Clarify Hive Metastore sync support for Hudi sink

### DIFF
--- a/docs/en/connectors/sink/Hudi.md
+++ b/docs/en/connectors/sink/Hudi.md
@@ -15,6 +15,12 @@ Used to write data to Hudi.
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
+:::caution Hive Metastore synchronization
+
+The SeaTunnel Hudi sink writes Hudi data files and `.hoodie` metadata, but it does not register the table in or synchronize the table with Hive Metastore. Options matching `hoodie.datasource.hive_sync.*` are not supported sink options and are not passed to the Hudi write client. Run Apache Hudi's `HiveSyncTool` or another table registration process separately when Hive Metastore registration is required.
+
+:::
+
 ## Options
 
 Base configuration:

--- a/docs/zh/connectors/sink/Hudi.md
+++ b/docs/zh/connectors/sink/Hudi.md
@@ -15,6 +15,12 @@ import ChangeLog from '../changelog/connector-hudi.md';
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
+:::caution Hive Metastore 同步
+
+SeaTunnel Hudi sink 会写入 Hudi 数据文件和 `.hoodie` 元数据，但不会在 Hive Metastore 中注册表或将表同步到 Hive Metastore。`hoodie.datasource.hive_sync.*` 配置不是受支持的 sink 选项，也不会传递给 Hudi 写入客户端。需要注册到 Hive Metastore 时，请单独运行 Apache Hudi `HiveSyncTool` 或其他表注册流程。
+
+:::
+
 ## 选项
 
 基础配置:


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11386.

Clarify that the SeaTunnel Hudi sink writes Hudi data and `.hoodie` metadata, but does not currently register or synchronize the table with Hive Metastore. The English and Chinese connector documentation now point users to Hudi's `HiveSyncTool` or another separate registration step instead of implying that `hoodie.datasource.hive_sync.*` options are handled by the connector.

### Does this PR introduce any user-facing change?

Yes. The Hudi sink documentation now includes a synchronized English/Chinese caution describing the Hive Metastore support boundary and the required follow-up step.

### How was this patch tested?

- `./mvnw --batch-mode --quiet --no-snapshot-updates spotless:check`
- Docusaurus English documentation build with Node.js 18.20.7
- Docusaurus Chinese documentation build with Node.js 18.20.7
- `git diff --check`

This is a documentation-only change, so connector code tests are not applicable.

### Check list

* [x] Does not contain any jar files
* [x] Does not introduce incompatible changes
* [x] Documentation has been updated
* [x] Connector code checklist is not applicable because this PR changes documentation only
