### PR TITLE
[Fix][Common] Reject invalid fractional time separators

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/TimeUtils.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/TimeUtils.java
@@ -45,7 +45,7 @@ public class TimeUtils {
     public static final Pattern[] PATTERN_ARRAY =
             new Pattern[] {
                 Pattern.compile("\\d{2}:\\d{2}:\\d{2}"),
-                Pattern.compile("\\d{2}:\\d{2}:\\d{2}.\\d{3}"),
+                Pattern.compile("\\d{2}:\\d{2}:\\d{2}\\.\\d{3}"),
             };
 
     public static Formatter matchTimeFormatter(String dateTime) {

--- a/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/TimeUtilsTest.java
+++ b/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/TimeUtilsTest.java
@@ -32,5 +32,7 @@ public class TimeUtilsTest {
         Assertions.assertEquals(
                 "12:12:12.123",
                 TimeUtils.parse(timeStr, TimeUtils.matchTimeFormatter(timeStr)).toString());
+
+        Assertions.assertNull(TimeUtils.matchTimeFormatter("12:12:12x123"));
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

TimeUtils uses an unescaped dot in the HH:mm:ss.SSS detection pattern. Because dot is a regex wildcard, values such as 12:12:12x123 are classified as millisecond timestamps even though DateTimeFormatter cannot parse them.

This patch escapes the decimal point and adds a regression assertion for the invalid separator.

### Does this PR introduce any user-facing change?

Yes. Fractional time values must now use a literal dot to be recognized as HH:mm:ss.SSS. Valid values such as 12:12:12.123 are unchanged.

### How was this patch tested?

- Added a negative assertion to TimeUtilsTest for 12:12:12x123.
- git diff --check passes.
- An equivalent local regex check confirmed that 12:12:12.123 is accepted and 12:12:12x123 is rejected.
- The Maven test command could not run locally because the environment has no Java runtime; upstream CI will compile and run the test.

### Check list

* [x] No new Jar binary packages are added.
* [x] No documentation update is necessary for this narrow validation fix.
* [x] No incompatible change entry is necessary.
* [x] This does not modify connector code.