### PR TITLE
[Feature][Connector-V2] Support JDBC sink table_options for Oracle

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -382,6 +382,8 @@ Current support:
 | TiDB | Yes | `engine`, `charset`, `collate` (via MySQL JDBC protocol and `jdbc:mysql://`) |
 | OceanBase (MySQL mode) | Yes | `engine`, `charset`, `collate` |
 | PostgreSQL | Yes | `tablespace`, `fillfactor` |
+| Oracle | Yes | `tablespace`, `pctfree` |
+| OceanBase (Oracle mode) | Yes | `tablespace`, `pctfree` (via `compatible_mode=oracle` → Oracle dialect / DDL path) |
 | Other JDBC dialects | No | Non-empty `table_options` fails validation at job submission |
 
 Invalid or unsupported keys are validated early via `JdbcSinkFactory` option rules (`--check` and job submission), not only at runtime DDL.
@@ -390,10 +392,11 @@ Invalid or unsupported keys are validated early via `JdbcSinkFactory` option rul
 
 - **MySQL**: `engine`, `charset`, and `collate` are appended to `CREATE TABLE` and take effect.
 - **TiDB**: When connected via `jdbc:mysql://` with a MySQL JDBC driver, TiDB shares the same key whitelist and DDL merge path as MySQL. `charset` and `collate` take effect; `engine` is accepted for MySQL syntax compatibility but is **ignored** by TiDB (storage engine is not configurable).
-- **OceanBase (MySQL mode)**: Supported for `jdbc:oceanbase://` when not using Oracle-compatible mode. `charset` and `collate` must be values supported by your OceanBase version (typically a MySQL-compatible subset; use `SHOW CHARSET` / `SHOW COLLATION` on the target). Unsupported values fail when `CREATE TABLE` runs, not at job submission. OceanBase **Oracle-compatible mode** does not support `table_options`; a non-empty map fails at job submission.
+- **OceanBase (MySQL mode)**: Supported for `jdbc:oceanbase://` when not using Oracle-compatible mode. `charset` and `collate` must be values supported by your OceanBase version (typically a MySQL-compatible subset; use `SHOW CHARSET` / `SHOW COLLATION` on the target). Unsupported values fail when `CREATE TABLE` runs, not at job submission.
 - **PostgreSQL**: `fillfactor` is emitted as `WITH (fillfactor=<n>)` and must be an integer in `[10, 100]`; `tablespace` is emitted as `TABLESPACE "..."` using the configured name literally (not rewritten by `fieldIde`). Blank values and illegal characters in `tablespace` (for example `"`) are rejected at job submission. Only these curated keys are accepted (arbitrary `WITH` parameters are not supported). OpenGauss and HighGo inherit the same validation and DDL path via Postgres catalog/dialect.
+- **Oracle / OceanBase (Oracle mode)**: `pctfree` is emitted as `PCTFREE <n>` and must be an integer in `[0, 99]`; `tablespace` is emitted as `TABLESPACE "..."` using the configured name literally (not rewritten by `fieldIde`). Blank values and illegal characters in `tablespace` (for example `"`) are rejected at job submission. Only these curated keys are accepted (nested `STORAGE (...)` and LOB/partition clauses are not supported). The tablespace must already exist on the target.
 
-SeaTunnel validates the **key whitelist** at submission time for all dialects that support `table_options`. For PostgreSQL (and OpenGauss / HighGo via the same path), it also validates blank values and the `fillfactor` numeric range. Other dialects (for example MySQL) do not verify whether each value is supported by the target database beyond the key whitelist.
+SeaTunnel validates the **key whitelist** at submission time for all dialects that support `table_options`. For PostgreSQL (and OpenGauss / HighGo via the same path), it also validates blank values and the `fillfactor` numeric range. For Oracle / OceanBase (Oracle mode), it also validates blank values and the `pctfree` numeric range. Other dialects (for example MySQL) do not verify whether each value is supported by the target database beyond the key whitelist.
 
 Example (MySQL auto-create with engine and charset):
 
@@ -437,6 +440,28 @@ sink {
     table_options = {
       "tablespace" = "pg_default"
       "fillfactor" = "70"
+    }
+  }
+}
+```
+
+Example (Oracle auto-create with tablespace and pctfree):
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:oracle:thin:@localhost:1521/ORCLPDB1"
+    driver = "oracle.jdbc.OracleDriver"
+    username = "scott"
+    password = "tiger"
+    database = "SCOTT"
+    table = "ORDERS"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table_options = {
+      "tablespace" = "USERS"
+      "pctfree" = "10"
     }
   }
 }

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -373,6 +373,8 @@ Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_
 | TiDB | 是 | `engine`、`charset`、`collate`（通过 MySQL JDBC 协议与 `jdbc:mysql://` 连接） |
 | OceanBase（MySQL 模式） | 是 | `engine`、`charset`、`collate` |
 | PostgreSQL | 是 | `tablespace`、`fillfactor` |
+| Oracle | 是 | `tablespace`、`pctfree` |
+| OceanBase（Oracle 模式） | 是 | `tablespace`、`pctfree`（`compatible_mode=oracle` 时走 Oracle 方言 / DDL 路径） |
 | 其他 JDBC 方言 | 否 | 配置非空 `table_options` 时任务启动即校验失败 |
 
 非法或不支持的 key 会在 `JdbcSinkFactory` 的 option 规则阶段提前校验（`--check` 与作业提交），而非仅在运行时 DDL 阶段失败。
@@ -381,10 +383,11 @@ Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_
 
 - **MySQL**：`engine`、`charset`、`collate` 均会写入 `CREATE TABLE` 并生效。
 - **TiDB**：通过 `jdbc:mysql://` 与 MySQL JDBC 驱动连接时，与 MySQL 使用相同的 key 白名单与 DDL 拼接方式。`charset`、`collate` 会生效；`engine` 仅为 MySQL 兼容语法，TiDB 会解析但**忽略**存储引擎设置。
-- **OceanBase（MySQL 模式）**：`jdbc:oceanbase://` 且非 Oracle 兼容模式时支持上述三个 key。`charset`、`collate` 须为 OceanBase 当前版本支持的字符集与排序规则（通常为 MySQL 兼容子集，请以目标库 `SHOW CHARSET` / `SHOW COLLATION` 为准）；不支持的取值会在执行 `CREATE TABLE` 时报错，而非在作业提交阶段校验。OceanBase **Oracle 兼容模式**不支持 `table_options`，配置非空时任务启动即失败。
+- **OceanBase（MySQL 模式）**：`jdbc:oceanbase://` 且非 Oracle 兼容模式时支持上述三个 key。`charset`、`collate` 须为 OceanBase 当前版本支持的字符集与排序规则（通常为 MySQL 兼容子集，请以目标库 `SHOW CHARSET` / `SHOW COLLATION` 为准）；不支持的取值会在执行 `CREATE TABLE` 时报错，而非在作业提交阶段校验。
 - **PostgreSQL**：`fillfactor` 会生成 `WITH (fillfactor=<n>)`，取值须为 `[10, 100]` 的整数；`tablespace` 会生成 `TABLESPACE "..."`，按配置字面量引用（**不受** `fieldIde` 大小写改写）。空白值，以及 `tablespace` 中的非法字符（例如 `"`）会在作业提交阶段被拒绝。仅接受上述 curated key（不支持任意 `WITH` 参数）。OpenGauss、HighGo 通过 Postgres catalog/dialect 继承同一套校验与 DDL。
+- **Oracle / OceanBase（Oracle 模式）**：`pctfree` 会生成 `PCTFREE <n>`，取值须为 `[0, 99]` 的整数；`tablespace` 会生成 `TABLESPACE "..."`，按配置字面量引用（**不受** `fieldIde` 大小写改写）。空白值，以及 `tablespace` 中的非法字符（例如 `"`）会在作业提交阶段被拒绝。仅接受上述 curated key（不支持嵌套 `STORAGE (...)`、LOB/分区子句）。目标库中 tablespace 须事先存在。
 
-SeaTunnel 在提交时会对所有支持 `table_options` 的方言校验 **key 白名单**。对 PostgreSQL（以及 OpenGauss / HighGo 同源路径），还会校验空白值与 `fillfactor` 数值区间。其他方言（例如 MySQL）在白名单之外不额外校验具体取值是否被目标库支持。
+SeaTunnel 在提交时会对所有支持 `table_options` 的方言校验 **key 白名单**。对 PostgreSQL（以及 OpenGauss / HighGo 同源路径），还会校验空白值与 `fillfactor` 数值区间。对 Oracle / OceanBase（Oracle 模式），还会校验空白值与 `pctfree` 数值区间。其他方言（例如 MySQL）在白名单之外不额外校验具体取值是否被目标库支持。
 
 示例（MySQL 自动建表时指定存储引擎与字符集）：
 
@@ -428,6 +431,28 @@ sink {
     table_options = {
       "tablespace" = "pg_default"
       "fillfactor" = "70"
+    }
+  }
+}
+```
+
+示例（Oracle 自动建表时指定 tablespace 与 pctfree）：
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:oracle:thin:@localhost:1521/ORCLPDB1"
+    driver = "oracle.jdbc.OracleDriver"
+    username = "scott"
+    password = "tiger"
+    database = "SCOTT"
+    table = "ORDERS"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table_options = {
+      "tablespace" = "USERS"
+      "pctfree" = "10"
     }
   }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCatalog.java
@@ -43,6 +43,9 @@ import java.util.List;
 @Slf4j
 public class OracleCatalog extends AbstractJdbcCatalog {
 
+    public static final String TABLE_OPTION_TABLESPACE = "tablespace";
+    public static final String TABLE_OPTION_PCTFREE = "pctfree";
+
     private static final String SELECT_COLUMNS_SQL_TEMPLATE =
             "SELECT\n"
                     + "    cols.COLUMN_NAME,\n"

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilder.java
@@ -78,12 +78,13 @@ public class OracleCreateTableSqlBuilder {
         createTableSql.append(String.join(",\n", columnSqls));
         createTableSql.append("\n)");
         if (StringUtils.isNotBlank(pctfree)) {
-            createTableSql.append("\nPCTFREE ").append(pctfree);
+            // Value is validated as 0-99 by OracleDialect.validateTableOptions.
+            createTableSql.append("\nPCTFREE ").append(pctfree.trim());
         }
         if (StringUtils.isNotBlank(tablespace)) {
-            createTableSql
-                    .append("\nTABLESPACE ")
-                    .append(CatalogUtils.quoteIdentifier(tablespace, fieldIde, "\""));
+            // Tablespace is a storage object name: quote literally, do NOT apply fieldIde
+            // case rewriting (that policy is only for table/column identifiers).
+            createTableSql.append("\nTABLESPACE \"").append(tablespace.trim()).append("\"");
         }
         sqls.add(createTableSql.toString());
         if (comment != null) {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilder.java
@@ -39,6 +39,8 @@ public class OracleCreateTableSqlBuilder {
     private String comment;
     protected String sourceCatalogName;
     private String fieldIde;
+    private String tablespace;
+    private String pctfree;
     private boolean createIndex;
 
     public OracleCreateTableSqlBuilder(CatalogTable catalogTable, boolean createIndex) {
@@ -47,6 +49,8 @@ public class OracleCreateTableSqlBuilder {
         this.comment = catalogTable.getComment();
         this.sourceCatalogName = catalogTable.getCatalogName();
         this.fieldIde = catalogTable.getOptions().get("fieldIde");
+        this.tablespace = catalogTable.getOptions().get(OracleCatalog.TABLE_OPTION_TABLESPACE);
+        this.pctfree = catalogTable.getOptions().get(OracleCatalog.TABLE_OPTION_PCTFREE);
         this.createIndex = createIndex;
     }
 
@@ -73,6 +77,14 @@ public class OracleCreateTableSqlBuilder {
 
         createTableSql.append(String.join(",\n", columnSqls));
         createTableSql.append("\n)");
+        if (StringUtils.isNotBlank(pctfree)) {
+            createTableSql.append("\nPCTFREE ").append(pctfree);
+        }
+        if (StringUtils.isNotBlank(tablespace)) {
+            createTableSql
+                    .append("\nTABLESPACE ")
+                    .append(CatalogUtils.quoteIdentifier(tablespace, fieldIde, "\""));
+        }
         sqls.add(createTableSql.toString());
         if (comment != null) {
             String commentSql =

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
@@ -61,6 +61,11 @@ public class OracleDialect implements JdbcDialect {
 
     private static final int DEFAULT_ORACLE_FETCH_SIZE = 128;
 
+    /** Oracle PCTFREE legal range (inclusive). */
+    private static final int PCTFREE_MIN = 0;
+
+    private static final int PCTFREE_MAX = 99;
+
     private static final Set<String> SUPPORTED_TABLE_OPTIONS =
             Collections.unmodifiableSet(
                     new LinkedHashSet<>(
@@ -545,6 +550,66 @@ public class OracleDialect implements JdbcDialect {
                             dialectName(),
                             String.join(", ", unsupportedOptions),
                             String.join(", ", SUPPORTED_TABLE_OPTIONS)));
+        }
+
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (StringUtils.isBlank(value)) {
+                throw new JdbcConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "Invalid JDBC table_options for dialect '%s': key '%s' must not be blank",
+                                dialectName(), key));
+            }
+            String trimmed = value.trim();
+            if (OracleCatalog.TABLE_OPTION_PCTFREE.equals(key)) {
+                validatePctfree(trimmed);
+            } else if (OracleCatalog.TABLE_OPTION_TABLESPACE.equals(key)) {
+                validateTablespace(trimmed);
+            }
+        }
+    }
+
+    private void validatePctfree(String value) {
+        int pctfree;
+        try {
+            pctfree = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' must be an integer between %d and %d, but got '%s'",
+                            dialectName(),
+                            OracleCatalog.TABLE_OPTION_PCTFREE,
+                            PCTFREE_MIN,
+                            PCTFREE_MAX,
+                            value));
+        }
+        if (pctfree < PCTFREE_MIN || pctfree > PCTFREE_MAX) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' must be an integer between %d and %d, but got '%s'",
+                            dialectName(),
+                            OracleCatalog.TABLE_OPTION_PCTFREE,
+                            PCTFREE_MIN,
+                            PCTFREE_MAX,
+                            value));
+        }
+    }
+
+    private void validateTablespace(String value) {
+        // Always emitted as "TABLESPACE \"...\"", so reject quote / control chars that break DDL.
+        if (value.indexOf('"') >= 0
+                || value.indexOf('\n') >= 0
+                || value.indexOf('\r') >= 0
+                || value.indexOf(';') >= 0) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' contains illegal characters: '%s'",
+                            dialectName(), OracleCatalog.TABLE_OPTION_TABLESPACE, value));
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle;
 
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.converter.BasicTypeDefine;
@@ -27,7 +28,9 @@ import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableChangeColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableModifyColumnEvent;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.oracle.OracleCatalog;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
@@ -45,14 +48,26 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
 public class OracleDialect implements JdbcDialect {
 
     private static final int DEFAULT_ORACLE_FETCH_SIZE = 128;
+
+    private static final Set<String> SUPPORTED_TABLE_OPTIONS =
+            Collections.unmodifiableSet(
+                    new LinkedHashSet<>(
+                            Arrays.asList(
+                                    OracleCatalog.TABLE_OPTION_TABLESPACE,
+                                    OracleCatalog.TABLE_OPTION_PCTFREE)));
+
     public String fieldIde = FieldIdeEnum.ORIGINAL.getValue();
     private final boolean handleBlobAsString;
 
@@ -511,6 +526,25 @@ public class OracleDialect implements JdbcDialect {
             return sql.toString();
         } else {
             return "char_val";
+        }
+    }
+
+    @Override
+    public void validateTableOptions(Map<String, String> tableOptions) {
+        if (tableOptions == null || tableOptions.isEmpty()) {
+            return;
+        }
+
+        Set<String> unsupportedOptions = new LinkedHashSet<>(tableOptions.keySet());
+        unsupportedOptions.removeAll(SUPPORTED_TABLE_OPTIONS);
+        if (!unsupportedOptions.isEmpty()) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Unsupported JDBC table_options for dialect '%s': %s. Supported keys: %s",
+                            dialectName(),
+                            String.join(", ", unsupportedOptions),
+                            String.join(", ", SUPPORTED_TABLE_OPTIONS)));
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilderTest.java
@@ -38,8 +38,10 @@ import org.junit.jupiter.api.Test;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -154,6 +156,34 @@ public class OracleCreateTableSqlBuilderTest {
                         + ")";
         CONSOLE.println(expectSkipIndex);
         Assertions.assertEquals(expectSkipIndex, createTableSqlSkipIndex);
+    }
+
+    @Test
+    public void testBuildCreateTableSqlWithTableOptions() {
+        String dataBaseName = "test_database";
+        String tableName = "test_table";
+        TablePath tablePath = TablePath.of(dataBaseName, tableName);
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, "id"))
+                        .primaryKey(PrimaryKey.of("id", Lists.newArrayList("id")))
+                        .build();
+        Map<String, String> options = new HashMap<>();
+        options.put(OracleCatalog.TABLE_OPTION_TABLESPACE, "USERS");
+        options.put(OracleCatalog.TABLE_OPTION_PCTFREE, "10");
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("test_catalog", dataBaseName, tableName),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with options");
+
+        String createTableSql =
+                new OracleCreateTableSqlBuilder(catalogTable, false).build(tablePath).get(0);
+
+        Assertions.assertTrue(createTableSql.contains("PCTFREE 10"));
+        Assertions.assertTrue(createTableSql.contains("TABLESPACE \"USERS\""));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/oracle/OracleCreateTableSqlBuilderTest.java
@@ -187,6 +187,38 @@ public class OracleCreateTableSqlBuilderTest {
     }
 
     @Test
+    public void testBuildCreateTableSqlWithTableOptionsIgnoresFieldIde() {
+        String dataBaseName = "test_database";
+        String tableName = "test_table";
+        TablePath tablePath = TablePath.of(dataBaseName, tableName);
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, "id"))
+                        .primaryKey(PrimaryKey.of("id", Lists.newArrayList("id")))
+                        .build();
+        Map<String, String> options = new HashMap<>();
+        options.put("fieldIde", "LOWERCASE");
+        options.put(OracleCatalog.TABLE_OPTION_TABLESPACE, "USERS");
+        options.put(OracleCatalog.TABLE_OPTION_PCTFREE, "10");
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("test_catalog", dataBaseName, tableName),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with options");
+
+        String createTableSql =
+                new OracleCreateTableSqlBuilder(catalogTable, false).build(tablePath).get(0);
+
+        Assertions.assertTrue(createTableSql.contains("PCTFREE 10"));
+        Assertions.assertTrue(
+                createTableSql.contains("TABLESPACE \"USERS\""),
+                "tablespace must not be rewritten by fieldIde; got: " + createTableSql);
+        Assertions.assertFalse(createTableSql.contains("TABLESPACE \"users\""));
+    }
+
+    @Test
     public void testColumnSinkType() {
         OracleCreateTableSqlBuilder sqlBuilder = mock(OracleCreateTableSqlBuilder.class);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectTableOptionsTest.java
@@ -39,6 +39,15 @@ public class OracleDialectTableOptionsTest {
     }
 
     @Test
+    public void testValidateTableOptionsPctfreeBoundary() {
+        OracleDialect dialect = new OracleDialect();
+        Assertions.assertDoesNotThrow(
+                () -> dialect.validateTableOptions(Collections.singletonMap("pctfree", "0")));
+        Assertions.assertDoesNotThrow(
+                () -> dialect.validateTableOptions(Collections.singletonMap("pctfree", "99")));
+    }
+
+    @Test
     public void testValidateTableOptionsWithUnknownKey() {
         OracleDialect dialect = new OracleDialect();
 
@@ -50,5 +59,60 @@ public class OracleDialectTableOptionsTest {
                                         Collections.singletonMap("engine", "InnoDB")));
         Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
         Assertions.assertTrue(exception.getMessage().contains("Oracle"));
+    }
+
+    @Test
+    public void testValidateTableOptionsRejectBlankValues() {
+        OracleDialect dialect = new OracleDialect();
+
+        JdbcConnectorException blankTablespace =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("tablespace", " ")));
+        Assertions.assertTrue(blankTablespace.getMessage().contains("must not be blank"));
+
+        JdbcConnectorException blankPctfree =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("pctfree", " ")));
+        Assertions.assertTrue(blankPctfree.getMessage().contains("must not be blank"));
+    }
+
+    @Test
+    public void testValidateTableOptionsRejectInvalidPctfree() {
+        OracleDialect dialect = new OracleDialect();
+
+        JdbcConnectorException nonNumeric =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("pctfree", "abc")));
+        Assertions.assertTrue(nonNumeric.getMessage().contains("must be an integer between"));
+
+        JdbcConnectorException outOfRange =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("pctfree", "100")));
+        Assertions.assertTrue(outOfRange.getMessage().contains("must be an integer between"));
+    }
+
+    @Test
+    public void testValidateTableOptionsRejectIllegalTablespace() {
+        OracleDialect dialect = new OracleDialect();
+
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("tablespace", "USER\"S")));
+        Assertions.assertTrue(exception.getMessage().contains("illegal characters"));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectTableOptionsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OracleDialectTableOptionsTest {
+
+    @Test
+    public void testValidateTableOptions() {
+        OracleDialect dialect = new OracleDialect();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("tablespace", "USERS");
+        tableOptions.put("pctfree", "10");
+
+        Assertions.assertDoesNotThrow(() -> dialect.validateTableOptions(tableOptions));
+    }
+
+    @Test
+    public void testValidateTableOptionsWithUnknownKey() {
+        OracleDialect dialect = new OracleDialect();
+
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("engine", "InnoDB")));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
+        Assertions.assertTrue(exception.getMessage().contains("Oracle"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcTableOptionsConditionExtensionTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcTableOptionsConditionExtensionTest.java
@@ -110,7 +110,43 @@ class JdbcTableOptionsConditionExtensionTest {
     }
 
     @Test
-    void testOceanBaseOracleRejectsNonEmptyTableOptionsViaOptionRule() {
+    void testOracleTableOptionsPassViaOptionRule() {
+        Map<String, Object> config = oracleSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("tablespace", "USERS");
+        tableOptions.put("pctfree", "10");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(config));
+    }
+
+    @Test
+    void testOracleRejectsUnknownTableOptionsViaOptionRule() {
+        Map<String, Object> config = oracleSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("engine", "InnoDB");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSinkOptionRule(config));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
+        Assertions.assertTrue(exception.getMessage().contains("Oracle"));
+    }
+
+    @Test
+    void testOceanBaseOracleTableOptionsPassViaOptionRule() {
+        Map<String, Object> config = oceanBaseOracleSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("tablespace", "USERS");
+        tableOptions.put("pctfree", "10");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(config));
+    }
+
+    @Test
+    void testOceanBaseOracleRejectsUnknownTableOptionsViaOptionRule() {
         Map<String, Object> config = oceanBaseOracleSinkConfig();
         Map<String, String> tableOptions = new HashMap<>();
         tableOptions.put("engine", "InnoDB");
@@ -119,8 +155,8 @@ class JdbcTableOptionsConditionExtensionTest {
         OptionValidationException exception =
                 Assertions.assertThrows(
                         OptionValidationException.class, () -> validateSinkOptionRule(config));
-        Assertions.assertTrue(
-                exception.getMessage().contains("not supported for dialect 'Oracle'"));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
+        Assertions.assertTrue(exception.getMessage().contains("Oracle"));
     }
 
     private static void validateSinkOptionRule(Map<String, Object> config) {
@@ -148,6 +184,14 @@ class JdbcTableOptionsConditionExtensionTest {
         Map<String, Object> config = new HashMap<>();
         config.put("url", "jdbc:mysql://127.0.0.1:4000/test");
         config.put("driver", "com.mysql.cj.jdbc.Driver");
+        config.put("query", "INSERT INTO test_table VALUES (?)");
+        return config;
+    }
+
+    private static Map<String, Object> oracleSinkConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("url", "jdbc:oracle:thin:@127.0.0.1:1521:ORCL");
+        config.put("driver", "oracle.jdbc.OracleDriver");
         config.put("query", "INSERT INTO test_table VALUES (?)");
         return config;
     }


### PR DESCRIPTION
## Purpose
Extend JDBC sink `table_options` (SaveMode auto-create) to Oracle, as a follow-up to #11047 / #11101 / #11388.

## Changes
- Add Oracle curated key whitelist: `tablespace`, `pctfree`
- Wire `OracleDialect.validateTableOptions` and apply options in `OracleCreateTableSqlBuilder` DDL (`PCTFREE` / `TABLESPACE`)
- OceanBase Oracle mode inherits the same path via `OracleDialect` + `OceanBaseOracleCreateTableSqlBuilder extends OracleCreateTableSqlBuilder` (no separate OB Oracle implementation)
- Docs (en/zh): support matrix + dialect caveats + Oracle example
- Unit tests: dialect / DDL / OptionRule coverage (including OceanBase Oracle pass & unknown-key reject)

## Non-goals
- Nested `STORAGE (...)`, LOB, or partition clauses
- `ALTER TABLE` on existing tables (`table_options` only applies when SaveMode creates the table)
- Value-level validation beyond key whitelist (same as MySQL delivery)
- PostgreSQL (separate PR)

## Test plan
- [x] `OracleDialectTableOptionsTest`
- [x] `OracleCreateTableSqlBuilderTest#testBuildCreateTableSqlWithTableOptions`
- [x] `JdbcTableOptionsConditionExtensionTest` (Oracle / OceanBase Oracle)
- [x] `OceanBaseOracleCreateTableSqlBuilderTest` (regression)
- [ ] CI on this PR

## Related
- Issue: #11047
- MySQL: #11101
- TiDB / OceanBase MySQL: #11388
- StarRocks: #11242


Made with [Cursor](https://cursor.com)