### PR TITLE
[Feature][Connector-V2] Support table_options for Paimon sink SaveMode auto-create

### DIFF
--- a/docs/en/connectors/sink/Paimon.md
+++ b/docs/en/connectors/sink/Paimon.md
@@ -78,7 +78,7 @@ libfb303-xxx.jar
 | paimon.table.primary-keys    | String  | No       | -                            | Default comma-separated list of columns (primary key) that identify a row in tables.(Notice: The partition field needs to be included in the primary key fields) |
 | paimon.table.partition-keys  | String  | No       | -                            | Default comma-separated list of partition fields to use when creating tables.                                                                                    |
 | paimon.table.write-props     | Map     | No       | -                            | Properties passed through to paimon table initialization, [reference](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions).            |
-| table_options                | Map     | No       | -                            | Sink-specific table options merged into write-props for SaveMode auto-create. See below.                                                                         |
+| table_options                | Map     | No       | -                            | Sink-specific table options for SaveMode auto-create only (not runtime write-props). See below.                                                                  |
 | paimon.hadoop.conf           | Map     | No       | -                            | Properties in hadoop conf                                                                                                                                        |
 | paimon.hadoop.conf-path      | String  | No       | -                            | The specified loading path for the 'core-site.xml', 'hdfs-site.xml', 'hive-site.xml' files                                                                       |
 | paimon.table.non-primary-key | Boolean | No       | false                        | Switch to create `table with PK` or `table without PK`. true : `table without PK`, false : `table with PK`                                                       |
@@ -86,9 +86,9 @@ libfb303-xxx.jar
 
 ### table_options [Map]
 
-Sink-specific table options applied when SaveMode auto-creates the target table. They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** alter an existing table.
+Sink-specific table options applied when SaveMode auto-creates the target table. They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** alter an existing table and do **not** change runtime writer settings such as `changelog-producer` / `changelog-tmp-path` derived from `paimon.table.write-props`.
 
-`table_options` are merged into the effective `paimon.table.write-props` used by schema creation. **On key conflict, `paimon.table.write-props` wins**, so existing jobs that only set write-props keep their current behavior. Use CoreOptions keys from the [Paimon CoreOptions documentation](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions); SeaTunnel does not maintain an allowlist—invalid keys fail when Paimon creates the table. Blank keys and null values are rejected at job submission.
+`table_options` are merged into the schema options used by auto-create. **On key conflict, `paimon.table.write-props` wins**, so existing jobs that only set write-props keep their current behavior. `paimon.table.write-props` remains the runtime writer config. Use CoreOptions keys from the [Paimon CoreOptions documentation](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions); SeaTunnel does not maintain an allowlist—invalid keys fail when Paimon creates the table. Blank keys and null values are rejected at job submission.
 
 Example:
 

--- a/docs/en/connectors/sink/Paimon.md
+++ b/docs/en/connectors/sink/Paimon.md
@@ -78,11 +78,38 @@ libfb303-xxx.jar
 | paimon.table.primary-keys    | String  | No       | -                            | Default comma-separated list of columns (primary key) that identify a row in tables.(Notice: The partition field needs to be included in the primary key fields) |
 | paimon.table.partition-keys  | String  | No       | -                            | Default comma-separated list of partition fields to use when creating tables.                                                                                    |
 | paimon.table.write-props     | Map     | No       | -                            | Properties passed through to paimon table initialization, [reference](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions).            |
+| table_options                | Map     | No       | -                            | Sink-specific table options merged into write-props for SaveMode auto-create. See below.                                                                         |
 | paimon.hadoop.conf           | Map     | No       | -                            | Properties in hadoop conf                                                                                                                                        |
 | paimon.hadoop.conf-path      | String  | No       | -                            | The specified loading path for the 'core-site.xml', 'hdfs-site.xml', 'hive-site.xml' files                                                                       |
 | paimon.table.non-primary-key | Boolean | No       | false                        | Switch to create `table with PK` or `table without PK`. true : `table without PK`, false : `table with PK`                                                       |
 | branch                       | String  | No       | -                            | The branch name of Paimon table to write data to. If omitted, data is written to the main branch. For non-main branches, the main table and target branch must already exist, and `schema_save_mode=RECREATE_SCHEMA` or `data_save_mode=DROP_DATA` is not supported. |
 
+### table_options [Map]
+
+Sink-specific table options applied when SaveMode auto-creates the target table. They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** alter an existing table.
+
+`table_options` are merged into the effective `paimon.table.write-props` used by schema creation. **On key conflict, `paimon.table.write-props` wins**, so existing jobs that only set write-props keep their current behavior. Use CoreOptions keys from the [Paimon CoreOptions documentation](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions); SeaTunnel does not maintain an allowlist—invalid keys fail when Paimon creates the table. Blank keys and null values are rejected at job submission.
+
+Example:
+
+```hocon
+sink {
+  Paimon {
+    warehouse = "file:///tmp/paimon"
+    database = "seatunnel"
+    table = "test"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    table_options = {
+      bucket = "4"
+      file.format = "parquet"
+    }
+    # Wins over table_options when the same key is set
+    paimon.table.write-props = {
+      bucket = "8"
+    }
+  }
+}
+```
 
 ## Checkpoint in batch mode
 
@@ -90,7 +117,7 @@ When you set `checkpoint.interval` to a value greater than 0 in batch mode, the 
 However, if you do not set `checkpoint.interval` in batch mode, the paimon sink connector will commit the data after all records are written. The written data in paimon that is not visible until the batch task completes.
 
 ## Changelog
-You must configure the `changelog-producer=input` option to enable the changelog producer mode of the paimon table. If you use the auto-create table function of paimon sink, you can configure this property in `paimon.table.write-props`.
+You must configure the `changelog-producer=input` option to enable the changelog producer mode of the paimon table. If you use the auto-create table function of paimon sink, you can configure this property in `paimon.table.write-props` or `table_options`.
 
 The changelog producer mode of the paimon table has [four mode](https://paimon.apache.org/docs/master/primary-key-table/changelog-producer/) which is `none`、`input`、`lookup` and `full-compaction`.
 

--- a/docs/zh/connectors/sink/Paimon.md
+++ b/docs/zh/connectors/sink/Paimon.md
@@ -78,10 +78,38 @@ libfb303-xxx.jar
 | paimon.table.primary-keys    | 字符串  | 否    | -                            | 主键字段列表，联合主键使用逗号分隔(注意：分区字段需要包含在主键字段中)                                                                 |
 | paimon.table.partition-keys  | 字符串  | 否    | -                            | 分区字段列表，多字段使用逗号分隔                                                                                     |
 | paimon.table.write-props     | Map  | 否    | -                            | Paimon表初始化指定的属性, [参考](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions) |
+| table_options                | Map  | 否    | -                            | Sink 侧表属性，在 SaveMode 自动建表时合并进 write-props。详见下文。                                                    |
 | paimon.hadoop.conf           | Map  | 否    | -                            | Hadoop配置文件属性信息                                                                                       |
 | paimon.hadoop.conf-path      | 字符串  | 否    | -                            | Hadoop配置文件目录，用于加载'core-site.xml', 'hdfs-site.xml', 'hive-site.xml'文件配置                               |
 | paimon.table.non-primary-key | Boolean | 否    | false                        | 控制创建主键表或者非主键表. 当为true时,创建非主键表, 为false时,创建主键表                                                         |
 | branch                       | 字符串  | 否    | -                            | 要写入数据的 Paimon 表分支名称。不配置时写入 main 分支。非 main 分支要求 main 表和目标分支已存在，且不支持 `schema_save_mode=RECREATE_SCHEMA` 或 `data_save_mode=DROP_DATA`。 |
+
+### table_options [Map]
+
+Sink 侧表属性，仅在 SaveMode 自动建表时生效（例如 `schema_save_mode` 为 `CREATE_SCHEMA_WHEN_NOT_EXIST` 或 `RECREATE_SCHEMA`）。**不会**对已存在表执行 ALTER。
+
+`table_options` 会合并进建表使用的有效 `paimon.table.write-props`。**键冲突时以 `paimon.table.write-props` 为准**，保证仅配置 write-props 的存量作业行为不变。键名使用 [Paimon CoreOptions](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions)；SeaTunnel 不维护白名单，非法键在 Paimon 建表时失败。空白键与 null 值会在作业提交阶段被拒绝。
+
+示例：
+
+```hocon
+sink {
+  Paimon {
+    warehouse = "file:///tmp/paimon"
+    database = "seatunnel"
+    table = "test"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    table_options = {
+      bucket = "4"
+      file.format = "parquet"
+    }
+    # 同名键时覆盖 table_options
+    paimon.table.write-props = {
+      bucket = "8"
+    }
+  }
+}
+```
 
 ## 批模式下的checkpoint
 
@@ -89,7 +117,7 @@ libfb303-xxx.jar
 但是，如果您没有在批处理模式下设置`checkpoint.interval`，则在写入所有记录之后，paimon sink连接器将提交数据。到批任务完成之前，写入的数据都是不可见的。
 
 ## 更新日志
-你必须配置`changelog-producer=input`来启用paimon表的changelog产生模式。如果你使用了paimon sink的自动建表功能，你可以在`paimon.table.write-props`中指定这个属性。
+你必须配置`changelog-producer=input`来启用paimon表的changelog产生模式。如果你使用了paimon sink的自动建表功能，你可以在`paimon.table.write-props`或`table_options`中指定这个属性。
 
 Paimon表的changelog产生模式有[四种](https://paimon.apache.org/docs/master/primary-key-table/changelog-producer/)，分别是`none`、`input`、`lookup` 和 `full-compaction`。
 

--- a/docs/zh/connectors/sink/Paimon.md
+++ b/docs/zh/connectors/sink/Paimon.md
@@ -78,7 +78,7 @@ libfb303-xxx.jar
 | paimon.table.primary-keys    | 字符串  | 否    | -                            | 主键字段列表，联合主键使用逗号分隔(注意：分区字段需要包含在主键字段中)                                                                 |
 | paimon.table.partition-keys  | 字符串  | 否    | -                            | 分区字段列表，多字段使用逗号分隔                                                                                     |
 | paimon.table.write-props     | Map  | 否    | -                            | Paimon表初始化指定的属性, [参考](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions) |
-| table_options                | Map  | 否    | -                            | Sink 侧表属性，在 SaveMode 自动建表时合并进 write-props。详见下文。                                                    |
+| table_options                | Map  | 否    | -                            | Sink 侧表属性，仅用于 SaveMode 自动建表（不进入运行时 write-props）。详见下文。                                          |
 | paimon.hadoop.conf           | Map  | 否    | -                            | Hadoop配置文件属性信息                                                                                       |
 | paimon.hadoop.conf-path      | 字符串  | 否    | -                            | Hadoop配置文件目录，用于加载'core-site.xml', 'hdfs-site.xml', 'hive-site.xml'文件配置                               |
 | paimon.table.non-primary-key | Boolean | 否    | false                        | 控制创建主键表或者非主键表. 当为true时,创建非主键表, 为false时,创建主键表                                                         |
@@ -86,9 +86,9 @@ libfb303-xxx.jar
 
 ### table_options [Map]
 
-Sink 侧表属性，仅在 SaveMode 自动建表时生效（例如 `schema_save_mode` 为 `CREATE_SCHEMA_WHEN_NOT_EXIST` 或 `RECREATE_SCHEMA`）。**不会**对已存在表执行 ALTER。
+Sink 侧表属性，仅在 SaveMode 自动建表时生效（例如 `schema_save_mode` 为 `CREATE_SCHEMA_WHEN_NOT_EXIST` 或 `RECREATE_SCHEMA`）。**不会**对已存在表执行 ALTER，也**不会**改变由 `paimon.table.write-props` 派生的运行时 writer 设置（例如 `changelog-producer` / `changelog-tmp-path`）。
 
-`table_options` 会合并进建表使用的有效 `paimon.table.write-props`。**键冲突时以 `paimon.table.write-props` 为准**，保证仅配置 write-props 的存量作业行为不变。键名使用 [Paimon CoreOptions](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions)；SeaTunnel 不维护白名单，非法键在 Paimon 建表时失败。空白键与 null 值会在作业提交阶段被拒绝。
+`table_options` 会合并进自动建表使用的 schema options。**键冲突时以 `paimon.table.write-props` 为准**，保证仅配置 write-props 的存量作业行为不变。`paimon.table.write-props` 仍作为运行时 writer 配置。键名使用 [Paimon CoreOptions](https://paimon.apache.org/docs/master/maintenance/configurations/#coreoptions)；SeaTunnel 不维护白名单，非法键在 Paimon 建表时失败。空白键与 null 值会在作业提交阶段被拒绝。
 
 示例：
 

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogFactory.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogFactory.java
@@ -18,12 +18,15 @@
 package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
 import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonTableOptionsConditionExtension;
 
 import com.google.auto.service.AutoService;
 
@@ -61,6 +64,11 @@ public class PaimonCatalogFactory implements CatalogFactory {
                         PaimonSinkOptions.PARTITION_KEYS,
                         PaimonSinkOptions.WRITE_PROPS,
                         PaimonSinkOptions.BRANCH)
+                .optional(
+                        SinkConnectorCommonOptions.TABLE_OPTIONS,
+                        Conditions.extension(
+                                SinkConnectorCommonOptions.TABLE_OPTIONS,
+                                PaimonTableOptionsConditionExtension.INSTANCE))
                 .conditional(
                         PaimonBaseOptions.CATALOG_TYPE,
                         PaimonCatalogEnum.HIVE,

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
@@ -47,7 +47,13 @@ public class PaimonSinkConfig extends PaimonConfig {
     private final Boolean nonPrimaryKey;
     private final List<String> primaryKeys;
     private final List<String> partitionKeys;
+    /** Runtime writer properties from {@code paimon.table.write-props} only. */
     private final Map<String, String> writeProps;
+    /**
+     * SaveMode auto-create options from {@code table_options}. Applied only when building the
+     * Paimon schema for table creation; not merged into runtime {@link #writeProps}.
+     */
+    private final Map<String, String> tableOptions;
 
     public PaimonSinkConfig(ReadonlyConfig readonlyConfig) {
         super(readonlyConfig);
@@ -67,15 +73,13 @@ public class PaimonSinkConfig extends PaimonConfig {
         }
         this.partitionKeys =
                 stringToList(readonlyConfig.get(PaimonSinkOptions.PARTITION_KEYS), ",");
-        // Merge sink table_options into write-props for SaveMode auto-create. write-props wins
-        // on key conflict so existing jobs keep current behavior.
-        Map<String, String> mergedWriteProps = new HashMap<>();
-        mergedWriteProps.putAll(
-                readonlyConfig
-                        .getOptional(SinkConnectorCommonOptions.TABLE_OPTIONS)
-                        .orElse(Collections.emptyMap()));
-        mergedWriteProps.putAll(readonlyConfig.get(PaimonSinkOptions.WRITE_PROPS));
-        this.writeProps = mergedWriteProps;
+        this.tableOptions =
+                new HashMap<>(
+                        readonlyConfig
+                                .getOptional(SinkConnectorCommonOptions.TABLE_OPTIONS)
+                                .orElse(Collections.emptyMap()));
+        // Keep write-props as the runtime writer config only; do not merge table_options here.
+        this.writeProps = new HashMap<>(readonlyConfig.get(PaimonSinkOptions.WRITE_PROPS));
         this.changelogProducer =
                 Stream.of(CoreOptions.ChangelogProducer.values())
                         .filter(
@@ -92,5 +96,24 @@ public class PaimonSinkConfig extends PaimonConfig {
                 writeProps.getOrDefault(
                         PaimonSinkOptions.CHANGELOG_TMP_PATH, System.getProperty("java.io.tmpdir"));
         this.branch = readonlyConfig.get(PaimonSinkOptions.BRANCH);
+    }
+
+    /**
+     * Merge options for SaveMode schema/table creation. {@code writeProps} wins on key conflict.
+     *
+     * @param tableOptions sink {@code table_options}
+     * @param writeProps sink {@code paimon.table.write-props}
+     * @return a new mutable map suitable for {@code Schema.Builder#options}
+     */
+    public static Map<String, String> mergeSchemaCreationOptions(
+            Map<String, String> tableOptions, Map<String, String> writeProps) {
+        Map<String, String> merged = new HashMap<>();
+        if (tableOptions != null && !tableOptions.isEmpty()) {
+            merged.putAll(tableOptions);
+        }
+        if (writeProps != null && !writeProps.isEmpty()) {
+            merged.putAll(writeProps);
+        }
+        return merged;
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfig.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.paimon.config;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.sink.DataSaveMode;
 import org.apache.seatunnel.api.sink.SchemaSaveMode;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorErrorCode;
@@ -28,6 +29,8 @@ import org.apache.paimon.CoreOptions;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -64,7 +67,15 @@ public class PaimonSinkConfig extends PaimonConfig {
         }
         this.partitionKeys =
                 stringToList(readonlyConfig.get(PaimonSinkOptions.PARTITION_KEYS), ",");
-        this.writeProps = readonlyConfig.get(PaimonSinkOptions.WRITE_PROPS);
+        // Merge sink table_options into write-props for SaveMode auto-create. write-props wins
+        // on key conflict so existing jobs keep current behavior.
+        Map<String, String> mergedWriteProps = new HashMap<>();
+        mergedWriteProps.putAll(
+                readonlyConfig
+                        .getOptional(SinkConnectorCommonOptions.TABLE_OPTIONS)
+                        .orElse(Collections.emptyMap()));
+        mergedWriteProps.putAll(readonlyConfig.get(PaimonSinkOptions.WRITE_PROPS));
+        this.writeProps = mergedWriteProps;
         this.changelogProducer =
                 Stream.of(CoreOptions.ChangelogProducer.values())
                         .filter(

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.sink;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -65,6 +66,11 @@ public class PaimonSinkFactory implements TableSinkFactory {
                         PaimonSinkOptions.WRITE_PROPS,
                         PaimonSinkOptions.BRANCH,
                         SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
+                .optional(
+                        SinkConnectorCommonOptions.TABLE_OPTIONS,
+                        Conditions.extension(
+                                SinkConnectorCommonOptions.TABLE_OPTIONS,
+                                PaimonTableOptionsConditionExtension.INSTANCE))
                 .conditional(
                         PaimonSinkOptions.CATALOG_TYPE,
                         PaimonCatalogEnum.HIVE,

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtension.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtension.java
@@ -26,7 +26,8 @@ import java.util.Map;
 
 /**
  * Early validation for Paimon sink {@code table_options}. Delegates to {@link
- * PaimonTableOptionsValidator}.
+ * PaimonTableOptionsValidator}. Options apply only on SaveMode schema auto-create and are not
+ * merged into runtime {@code paimon.table.write-props}.
  */
 public class PaimonTableOptionsConditionExtension
         implements ConditionExtension<Map<String, String>> {
@@ -38,8 +39,9 @@ public class PaimonTableOptionsConditionExtension
 
     @Override
     public String description() {
-        return "must use non-blank keys and non-null values; keys are merged into"
-                + " paimon.table.write-props for SaveMode auto-create (see Paimon connector docs)";
+        return "must use non-blank keys and non-null values; applied only to SaveMode auto-create"
+                + " schema options (not merged into runtime paimon.table.write-props; see Paimon"
+                + " connector docs)";
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtension.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtension.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+import java.util.Map;
+
+/**
+ * Early validation for Paimon sink {@code table_options}. Delegates to {@link
+ * PaimonTableOptionsValidator}.
+ */
+public class PaimonTableOptionsConditionExtension
+        implements ConditionExtension<Map<String, String>> {
+
+    public static final PaimonTableOptionsConditionExtension INSTANCE =
+            new PaimonTableOptionsConditionExtension();
+
+    private PaimonTableOptionsConditionExtension() {}
+
+    @Override
+    public String description() {
+        return "must use non-blank keys and non-null values; keys are merged into"
+                + " paimon.table.write-props for SaveMode auto-create (see Paimon connector docs)";
+    }
+
+    @Override
+    public boolean evaluate(ReadonlyConfig config, Map<String, String> value)
+            throws OptionValidationException {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+        try {
+            PaimonTableOptionsValidator.validate(config, value);
+            return true;
+        } catch (SeaTunnelRuntimeException e) {
+            throw new OptionValidationException(e.getMessage());
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsValidator.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.sink;
+
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Validates Paimon sink {@code table_options} before job submission.
+ *
+ * <p>Paimon accepts open CoreOptions keys; this validator only rejects blank keys or null values.
+ * Unsupported option keys fail later when Paimon creates the table.
+ */
+public final class PaimonTableOptionsValidator {
+
+    private PaimonTableOptionsValidator() {}
+
+    public static void validate(ReadonlyConfig config, Map<String, String> tableOptions) {
+        if (tableOptions == null || tableOptions.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+            if (StringUtils.isBlank(entry.getKey())) {
+                throw new SeaTunnelRuntimeException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        "table_options contains a blank property key for Paimon sink.");
+            }
+            if (entry.getValue() == null) {
+                throw new SeaTunnelRuntimeException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "table_options property '%s' has null value for Paimon sink.",
+                                entry.getKey()));
+            }
+        }
+    }
+
+    public static void validate(ReadonlyConfig config) {
+        validate(
+                config,
+                config.getOptional(SinkConnectorCommonOptions.TABLE_OPTIONS)
+                        .orElse(Collections.emptyMap()));
+    }
+}

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/SchemaUtil.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/utils/SchemaUtil.java
@@ -28,7 +28,6 @@ import org.apache.seatunnel.connectors.seatunnel.paimon.data.PaimonTypeMapper;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.paimon.exception.PaimonConnectorException;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.paimon.types.DataField;
@@ -80,13 +79,13 @@ public class SchemaUtil {
         if (!partitionKeys.isEmpty()) {
             paiSchemaBuilder.partitionKeys(partitionKeys);
         }
-        Map<String, String> writeProps = paimonSinkConfig.getWriteProps();
-        CoreOptions.ChangelogProducer changelogProducer = paimonSinkConfig.getChangelogProducer();
-        if (changelogProducer != null) {
-            writeProps.remove(PaimonSinkOptions.CHANGELOG_TMP_PATH);
-        }
-        if (!writeProps.isEmpty()) {
-            paiSchemaBuilder.options(writeProps);
+        Map<String, String> schemaOptions =
+                PaimonSinkConfig.mergeSchemaCreationOptions(
+                        paimonSinkConfig.getTableOptions(), paimonSinkConfig.getWriteProps());
+        // SeaTunnel-only runtime key; never pass it to Paimon table options.
+        schemaOptions.remove(PaimonSinkOptions.CHANGELOG_TMP_PATH);
+        if (!schemaOptions.isEmpty()) {
+            paiSchemaBuilder.options(schemaOptions);
         }
         if (StringUtils.isNotBlank(comment)) {
             paiSchemaBuilder.comment(comment);

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonOptionRuleTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonOptionRuleTest.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.config;
 
 import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.connectors.seatunnel.paimon.catalog.PaimonCatalogFactory;
 import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.paimon.source.PaimonSourceFactory;
@@ -44,6 +45,18 @@ class PaimonOptionRuleTest {
     void testCatalogOptionRuleDeclaresNonPrimaryKey() {
         assertDeclaredOptions(
                 new PaimonCatalogFactory().optionRule(), PaimonSinkOptions.NON_PRIMARY_KEY);
+    }
+
+    @Test
+    void testSinkOptionRuleDeclaresTableOptions() {
+        assertDeclaredOptions(
+                new PaimonSinkFactory().optionRule(), SinkConnectorCommonOptions.TABLE_OPTIONS);
+    }
+
+    @Test
+    void testCatalogOptionRuleDeclaresTableOptions() {
+        assertDeclaredOptions(
+                new PaimonCatalogFactory().optionRule(), SinkConnectorCommonOptions.TABLE_OPTIONS);
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfigTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfigTableOptionsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class PaimonSinkConfigTableOptionsTest {
+
+    @Test
+    void testTableOptionsMergedIntoWriteProps() {
+        Map<String, Object> config = baseConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("file.format", "parquet");
+        tableOptions.put("bucket", "4");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertEquals("parquet", sinkConfig.getWriteProps().get("file.format"));
+        Assertions.assertEquals("4", sinkConfig.getWriteProps().get("bucket"));
+    }
+
+    @Test
+    void testWritePropsWinsOnKeyConflict() {
+        Map<String, Object> config = baseConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("bucket", "4");
+        tableOptions.put("file.format", "orc");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        Map<String, String> writeProps = new HashMap<>();
+        writeProps.put("bucket", "8");
+        config.put(PaimonSinkOptions.WRITE_PROPS.key(), writeProps);
+
+        PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertEquals("8", sinkConfig.getWriteProps().get("bucket"));
+        Assertions.assertEquals("orc", sinkConfig.getWriteProps().get("file.format"));
+    }
+
+    @Test
+    void testAbsentTableOptionsKeepsWritePropsOnly() {
+        Map<String, Object> config = baseConfig();
+        Map<String, String> writeProps = new HashMap<>();
+        writeProps.put("bucket", "2");
+        config.put(PaimonSinkOptions.WRITE_PROPS.key(), writeProps);
+
+        PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertEquals(1, sinkConfig.getWriteProps().size());
+        Assertions.assertEquals("2", sinkConfig.getWriteProps().get("bucket"));
+    }
+
+    private static Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(PaimonSinkOptions.WAREHOUSE.key(), "file:///tmp/paimon");
+        config.put(PaimonSinkOptions.DATABASE.key(), "db");
+        config.put(PaimonSinkOptions.TABLE.key(), "t");
+        return config;
+    }
+}

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfigTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/config/PaimonSinkConfigTableOptionsTest.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.connectors.seatunnel.paimon.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 
+import org.apache.paimon.CoreOptions;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +31,7 @@ import java.util.Map;
 class PaimonSinkConfigTableOptionsTest {
 
     @Test
-    void testTableOptionsMergedIntoWriteProps() {
+    void testTableOptionsStoredSeparatelyFromWriteProps() {
         Map<String, Object> config = baseConfig();
         Map<String, String> tableOptions = new HashMap<>();
         tableOptions.put("file.format", "parquet");
@@ -38,12 +40,13 @@ class PaimonSinkConfigTableOptionsTest {
 
         PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
 
-        Assertions.assertEquals("parquet", sinkConfig.getWriteProps().get("file.format"));
-        Assertions.assertEquals("4", sinkConfig.getWriteProps().get("bucket"));
+        Assertions.assertTrue(sinkConfig.getWriteProps().isEmpty());
+        Assertions.assertEquals("parquet", sinkConfig.getTableOptions().get("file.format"));
+        Assertions.assertEquals("4", sinkConfig.getTableOptions().get("bucket"));
     }
 
     @Test
-    void testWritePropsWinsOnKeyConflict() {
+    void testWritePropsWinsOnSchemaCreationMerge() {
         Map<String, Object> config = baseConfig();
         Map<String, String> tableOptions = new HashMap<>();
         tableOptions.put("bucket", "4");
@@ -57,7 +60,14 @@ class PaimonSinkConfigTableOptionsTest {
         PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
 
         Assertions.assertEquals("8", sinkConfig.getWriteProps().get("bucket"));
-        Assertions.assertEquals("orc", sinkConfig.getWriteProps().get("file.format"));
+        Assertions.assertNull(sinkConfig.getWriteProps().get("file.format"));
+        Assertions.assertEquals("4", sinkConfig.getTableOptions().get("bucket"));
+
+        Map<String, String> schemaOptions =
+                PaimonSinkConfig.mergeSchemaCreationOptions(
+                        sinkConfig.getTableOptions(), sinkConfig.getWriteProps());
+        Assertions.assertEquals("8", schemaOptions.get("bucket"));
+        Assertions.assertEquals("orc", schemaOptions.get("file.format"));
     }
 
     @Test
@@ -71,6 +81,31 @@ class PaimonSinkConfigTableOptionsTest {
 
         Assertions.assertEquals(1, sinkConfig.getWriteProps().size());
         Assertions.assertEquals("2", sinkConfig.getWriteProps().get("bucket"));
+        Assertions.assertTrue(sinkConfig.getTableOptions().isEmpty());
+    }
+
+    @Test
+    void testTableOptionsChangelogDoesNotAffectRuntimeWriterConfig() {
+        Map<String, Object> config = baseConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(CoreOptions.CHANGELOG_PRODUCER.key(), "lookup");
+        tableOptions.put(PaimonSinkOptions.CHANGELOG_TMP_PATH, "/tmp/from-table-options");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        PaimonSinkConfig sinkConfig = new PaimonSinkConfig(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertNull(
+                sinkConfig.getChangelogProducer(),
+                "table_options changelog-producer must not affect runtime writer config");
+        Assertions.assertEquals(
+                System.getProperty("java.io.tmpdir"),
+                sinkConfig.getChangelogTmpPath(),
+                "table_options changelog-tmp-path must not affect runtime writer config");
+
+        Map<String, String> schemaOptions =
+                PaimonSinkConfig.mergeSchemaCreationOptions(
+                        sinkConfig.getTableOptions(), sinkConfig.getWriteProps());
+        Assertions.assertEquals("lookup", schemaOptions.get(CoreOptions.CHANGELOG_PRODUCER.key()));
     }
 
     private static Map<String, Object> baseConfig() {

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtensionTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonTableOptionsConditionExtensionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class PaimonTableOptionsConditionExtensionTest {
+
+    @Test
+    void testValidTableOptionsPassViaOptionRule() {
+        Map<String, Object> config = paimonSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("bucket", "4");
+        tableOptions.put("file.format", "parquet");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(config));
+    }
+
+    @Test
+    void testBlankKeyRejectedViaOptionRule() {
+        Map<String, Object> config = paimonSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("  ", "4");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSinkOptionRule(config));
+        Assertions.assertTrue(exception.getMessage().contains("blank property key"));
+    }
+
+    @Test
+    void testNullValueRejectedViaOptionRule() {
+        Map<String, Object> config = paimonSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("bucket", null);
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSinkOptionRule(config));
+        Assertions.assertTrue(exception.getMessage().contains("null value"));
+    }
+
+    @Test
+    void testAbsentTableOptionsSkipsExtension() {
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(paimonSinkConfig()));
+    }
+
+    @Test
+    void testEmptyTableOptionsSkipsExtension() {
+        Map<String, Object> config = paimonSinkConfig();
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), new HashMap<>());
+
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(config));
+    }
+
+    private static void validateSinkOptionRule(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                .validate(new PaimonSinkFactory().optionRule());
+    }
+
+    private static Map<String, Object> paimonSinkConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(PaimonSinkOptions.WAREHOUSE.key(), "file:///tmp/paimon");
+        config.put(PaimonSinkOptions.DATABASE.key(), "db");
+        config.put(PaimonSinkOptions.TABLE.key(), "t");
+        return config;
+    }
+}


### PR DESCRIPTION
## Purpose
Add Paimon sink `table_options` for SaveMode auto-create, as a follow-up to #11047 / #11242.

## Changes
- Merge sink `table_options` into effective `paimon.table.write-props` in `PaimonSinkConfig` (write-props wins on key conflict)
- Open-key validation via OptionRule ConditionExtension: reject blank keys / null values at job submission
- Wire `TABLE_OPTIONS` into `PaimonSinkFactory` / `PaimonCatalogFactory`
- Docs (en/zh): merge semantics, precedence, auto-create-only scope
- Unit tests: merge priority, OptionRule, blank-key / null-value reject

## Non-goals
- Key allowlist (Paimon CoreOptions are open; invalid keys fail when Paimon creates the table)
- `ALTER` on existing tables (`table_options` only applies when SaveMode creates the table)
- Changing `SchemaUtil` create path (already consumes `getWriteProps()`)

## Test plan
- [x] `PaimonSinkConfigTableOptionsTest`
- [x] `PaimonTableOptionsConditionExtensionTest`
- [x] `PaimonOptionRuleTest` (declares `table_options`)
- [ ] CI on this PR

## Related
- Issue: #11047
- StarRocks: #11242
- JDBC MySQL: #11101
- TiDB / OceanBase MySQL: #11388
- Oracle: #11416
- PostgreSQL: #11417


Made with [Cursor](https://cursor.com)