### PR TITLE
[Feature][Connector-V2] Support JDBC sink table_options for Kingbase

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -271,6 +271,7 @@ Current support:
 | TiDB | Yes | `engine`, `charset`, `collate` (via MySQL JDBC protocol and `jdbc:mysql://`) |
 | OceanBase (MySQL mode) | Yes | `engine`, `charset`, `collate` |
 | PostgreSQL | Yes | `tablespace`, `fillfactor` |
+| Kingbase | Yes | `tablespace`, `fillfactor` |
 | Other JDBC dialects | No | Non-empty `table_options` fails validation at job submission |
 
 Invalid or unsupported keys are validated early via `JdbcSinkFactory` option rules (`--check` and job submission), not only at runtime DDL.
@@ -281,8 +282,9 @@ Invalid or unsupported keys are validated early via `JdbcSinkFactory` option rul
 - **TiDB**: When connected via `jdbc:mysql://` with a MySQL JDBC driver, TiDB shares the same key whitelist and DDL merge path as MySQL. `charset` and `collate` take effect; `engine` is accepted for MySQL syntax compatibility but is **ignored** by TiDB (storage engine is not configurable).
 - **OceanBase (MySQL mode)**: Supported for `jdbc:oceanbase://` when not using Oracle-compatible mode. `charset` and `collate` must be values supported by your OceanBase version (typically a MySQL-compatible subset; use `SHOW CHARSET` / `SHOW COLLATION` on the target). Unsupported values fail when `CREATE TABLE` runs, not at job submission. OceanBase **Oracle-compatible mode** does not support `table_options`; a non-empty map fails at job submission.
 - **PostgreSQL**: `fillfactor` is emitted as `WITH (fillfactor=<n>)` and must be an integer in `[10, 100]`; `tablespace` is emitted as `TABLESPACE "..."` using the configured name literally (not rewritten by `fieldIde`). Blank values and illegal characters in `tablespace` (for example `"`) are rejected at job submission. Only these curated keys are accepted (arbitrary `WITH` parameters are not supported). OpenGauss and HighGo inherit the same validation and DDL path via Postgres catalog/dialect.
+- **Kingbase**: `fillfactor` is emitted as `WITH (fillfactor=<n>)` and must be an integer in `[10, 100]` (PostgreSQL-compatible); `tablespace` is emitted as `TABLESPACE "..."` using the configured name literally (not rewritten by `fieldIde`). Blank values and illegal characters in `tablespace` (for example `"`) are rejected at job submission. Only these curated keys are accepted (arbitrary `WITH (...)` parameters are not supported). The tablespace must already exist on the target.
 
-SeaTunnel validates the **key whitelist** at submission time for all dialects that support `table_options`. For PostgreSQL (and OpenGauss / HighGo via the same path), it also validates blank values and the `fillfactor` numeric range. Other dialects (for example MySQL) do not verify whether each value is supported by the target database beyond the key whitelist.
+SeaTunnel validates the **key whitelist** at submission time for all dialects that support `table_options`. For PostgreSQL (and OpenGauss / HighGo via the same path), and Kingbase, it also validates blank values and the `fillfactor` numeric range. Other dialects (for example MySQL) do not verify whether each value is supported by the target database beyond the key whitelist.
 
 Example (MySQL auto-create with engine and charset):
 
@@ -330,6 +332,30 @@ sink {
   }
 }
 ```
+
+Example (Kingbase auto-create with tablespace and fillfactor):
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:kingbase8://localhost:54321/test"
+    driver = "com.kingbase8.Driver"
+    username = "SYSTEM"
+    password = "123456"
+    database = "test"
+    table = "orders"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table_options = {
+      "tablespace" = "pg_default"
+      "fillfactor" = "70"
+    }
+  }
+}
+```
+
+The generated `CREATE TABLE` statement appends `WITH (fillfactor=70)` and `TABLESPACE "pg_default"`.
 
 ### enable_upsert [boolean]
 

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -259,6 +259,7 @@ Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_
 | TiDB | 是 | `engine`、`charset`、`collate`（通过 MySQL JDBC 协议与 `jdbc:mysql://` 连接） |
 | OceanBase（MySQL 模式） | 是 | `engine`、`charset`、`collate` |
 | PostgreSQL | 是 | `tablespace`、`fillfactor` |
+| Kingbase | 是 | `tablespace`、`fillfactor` |
 | 其他 JDBC 方言 | 否 | 配置非空 `table_options` 时任务启动即校验失败 |
 
 非法或不支持的 key 会在 `JdbcSinkFactory` 的 option 规则阶段提前校验（`--check` 与作业提交），而非仅在运行时 DDL 阶段失败。
@@ -269,8 +270,9 @@ Sink 在自动建表（SaveMode DDL）时附加的表级选项。仅在 `schema_
 - **TiDB**：通过 `jdbc:mysql://` 与 MySQL JDBC 驱动连接时，与 MySQL 使用相同的 key 白名单与 DDL 拼接方式。`charset`、`collate` 会生效；`engine` 仅为 MySQL 兼容语法，TiDB 会解析但**忽略**存储引擎设置。
 - **OceanBase（MySQL 模式）**：`jdbc:oceanbase://` 且非 Oracle 兼容模式时支持上述三个 key。`charset`、`collate` 须为 OceanBase 当前版本支持的字符集与排序规则（通常为 MySQL 兼容子集，请以目标库 `SHOW CHARSET` / `SHOW COLLATION` 为准）；不支持的取值会在执行 `CREATE TABLE` 时报错，而非在作业提交阶段校验。OceanBase **Oracle 兼容模式**不支持 `table_options`，配置非空时任务启动即失败。
 - **PostgreSQL**：`fillfactor` 会生成 `WITH (fillfactor=<n>)`，取值须为 `[10, 100]` 的整数；`tablespace` 会生成 `TABLESPACE "..."`，按配置字面量引用（**不受** `fieldIde` 大小写改写）。空白值，以及 `tablespace` 中的非法字符（例如 `"`）会在作业提交阶段被拒绝。仅接受上述 curated key（不支持任意 `WITH` 参数）。OpenGauss、HighGo 通过 Postgres catalog/dialect 继承同一套校验与 DDL。
+- **Kingbase**：`fillfactor` 会写入 `WITH (fillfactor=<n>)`，取值须为 `[10, 100]` 的整数（PostgreSQL 兼容）；`tablespace` 会写入 `TABLESPACE "..."`，按配置字面量引用（**不受** `fieldIde` 大小写改写）。空白值，以及 `tablespace` 中的非法字符（例如 `"`）会在作业提交阶段被拒绝。仅接受上述 curated key（不支持透传任意 `WITH (...)` 参数）。表空间须已在目标库存在。
 
-SeaTunnel 在提交时会对所有支持 `table_options` 的方言校验 **key 白名单**。对 PostgreSQL（以及 OpenGauss / HighGo 同源路径），还会校验空白值与 `fillfactor` 数值区间。其他方言（例如 MySQL）在白名单之外不额外校验具体取值是否被目标库支持。
+SeaTunnel 在提交时会对所有支持 `table_options` 的方言校验 **key 白名单**。对 PostgreSQL（以及 OpenGauss / HighGo 同源路径）与 Kingbase，还会校验空白值与 `fillfactor` 数值区间。其他方言（例如 MySQL）在白名单之外不额外校验具体取值是否被目标库支持。
 
 示例（MySQL 自动建表时指定存储引擎与字符集）：
 
@@ -318,6 +320,30 @@ sink {
   }
 }
 ```
+
+示例（Kingbase 自动建表时指定表空间与 fillfactor）：
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:kingbase8://localhost:54321/test"
+    driver = "com.kingbase8.Driver"
+    username = "SYSTEM"
+    password = "123456"
+    database = "test"
+    table = "orders"
+    generate_sink_sql = true
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    primary_keys = ["id"]
+    table_options = {
+      "tablespace" = "pg_default"
+      "fillfactor" = "70"
+    }
+  }
+}
+```
+
+生成的 DDL 会追加 `WITH (fillfactor=70)` 与 `TABLESPACE "pg_default"`。
 
 ### custom_sql [String]
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCatalog.java
@@ -48,6 +48,12 @@ import static org.apache.seatunnel.common.exception.CommonErrorCode.UNSUPPORTED_
 @Slf4j
 public class KingbaseCatalog extends AbstractJdbcCatalog {
 
+    /** Sink {@code table_options} key for Kingbase table tablespace. */
+    public static final String TABLE_OPTION_TABLESPACE = "tablespace";
+
+    /** Sink {@code table_options} key for Kingbase fillfactor ({@code WITH (fillfactor=...)}). */
+    public static final String TABLE_OPTION_FILLFACTOR = "fillfactor";
+
     protected static List<String> EXCLUDED_SCHEMAS =
             Collections.unmodifiableList(
                     Arrays.asList(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilder.java
@@ -37,6 +37,8 @@ public class KingbaseCreateTableSqlBuilder {
     private PrimaryKey primaryKey;
     private String sourceCatalogName;
     private String fieldIde;
+    private String tablespace;
+    private String fillfactor;
     private boolean createIndex;
 
     public KingbaseCreateTableSqlBuilder(CatalogTable catalogTable, boolean createIndex) {
@@ -44,6 +46,8 @@ public class KingbaseCreateTableSqlBuilder {
         this.primaryKey = catalogTable.getTableSchema().getPrimaryKey();
         this.sourceCatalogName = catalogTable.getCatalogName();
         this.fieldIde = catalogTable.getOptions().get("fieldIde");
+        this.tablespace = catalogTable.getOptions().get(KingbaseCatalog.TABLE_OPTION_TABLESPACE);
+        this.fillfactor = catalogTable.getOptions().get(KingbaseCatalog.TABLE_OPTION_FILLFACTOR);
         this.createIndex = createIndex;
     }
 
@@ -69,6 +73,14 @@ public class KingbaseCreateTableSqlBuilder {
 
         createTableSql.append(String.join(",\n", columnSqls));
         createTableSql.append("\n)");
+        if (StringUtils.isNotBlank(fillfactor)) {
+            createTableSql.append("\nWITH (fillfactor=").append(fillfactor).append(")");
+        }
+        if (StringUtils.isNotBlank(tablespace)) {
+            createTableSql
+                    .append("\nTABLESPACE ")
+                    .append(CatalogUtils.quoteIdentifier(tablespace, fieldIde, "\""));
+        }
 
         List<String> commentSqls =
                 columns.stream()

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilder.java
@@ -74,12 +74,13 @@ public class KingbaseCreateTableSqlBuilder {
         createTableSql.append(String.join(",\n", columnSqls));
         createTableSql.append("\n)");
         if (StringUtils.isNotBlank(fillfactor)) {
-            createTableSql.append("\nWITH (fillfactor=").append(fillfactor).append(")");
+            // Value is validated as 10-100 by KingbaseDialect.validateTableOptions.
+            createTableSql.append("\nWITH (fillfactor=").append(fillfactor.trim()).append(")");
         }
         if (StringUtils.isNotBlank(tablespace)) {
-            createTableSql
-                    .append("\nTABLESPACE ")
-                    .append(CatalogUtils.quoteIdentifier(tablespace, fieldIde, "\""));
+            // Tablespace is a storage object name: quote literally, do NOT apply fieldIde
+            // case rewriting (that policy is only for table/column identifiers).
+            createTableSql.append("\nTABLESPACE \"").append(tablespace.trim()).append("\"");
         }
 
         List<String> commentSqls =

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialect.java
@@ -17,7 +17,10 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.kingbase;
 
+import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.kingbase.KingbaseCatalog;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
@@ -25,10 +28,21 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDiale
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class KingbaseDialect implements JdbcDialect {
+
+    private static final Set<String> SUPPORTED_TABLE_OPTIONS =
+            Collections.unmodifiableSet(
+                    new LinkedHashSet<>(
+                            Arrays.asList(
+                                    KingbaseCatalog.TABLE_OPTION_TABLESPACE,
+                                    KingbaseCatalog.TABLE_OPTION_FILLFACTOR)));
 
     public String fieldIde = FieldIdeEnum.ORIGINAL.getValue();
 
@@ -106,5 +120,24 @@ public class KingbaseDialect implements JdbcDialect {
     @Override
     public String quoteDatabaseIdentifier(String identifier) {
         return "\"" + identifier + "\"";
+    }
+
+    @Override
+    public void validateTableOptions(Map<String, String> tableOptions) {
+        if (tableOptions == null || tableOptions.isEmpty()) {
+            return;
+        }
+
+        Set<String> unsupportedOptions = new LinkedHashSet<>(tableOptions.keySet());
+        unsupportedOptions.removeAll(SUPPORTED_TABLE_OPTIONS);
+        if (!unsupportedOptions.isEmpty()) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Unsupported JDBC table_options for dialect '%s': %s. Supported keys: %s",
+                            dialectName(),
+                            String.join(", ", unsupportedOptions),
+                            String.join(", ", SUPPORTED_TABLE_OPTIONS)));
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialect.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.kingbase;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.kingbase.KingbaseCatalog;
@@ -36,6 +38,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class KingbaseDialect implements JdbcDialect {
+
+    /** Kingbase (PostgreSQL-compatible) FILLFACTOR legal range (inclusive): 10-100. */
+    private static final int FILLFACTOR_MIN = 10;
+
+    private static final int FILLFACTOR_MAX = 100;
 
     private static final Set<String> SUPPORTED_TABLE_OPTIONS =
             Collections.unmodifiableSet(
@@ -138,6 +145,66 @@ public class KingbaseDialect implements JdbcDialect {
                             dialectName(),
                             String.join(", ", unsupportedOptions),
                             String.join(", ", SUPPORTED_TABLE_OPTIONS)));
+        }
+
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (StringUtils.isBlank(value)) {
+                throw new JdbcConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "Invalid JDBC table_options for dialect '%s': key '%s' must not be blank",
+                                dialectName(), key));
+            }
+            String trimmed = value.trim();
+            if (KingbaseCatalog.TABLE_OPTION_FILLFACTOR.equals(key)) {
+                validateFillfactor(trimmed);
+            } else if (KingbaseCatalog.TABLE_OPTION_TABLESPACE.equals(key)) {
+                validateTablespace(trimmed);
+            }
+        }
+    }
+
+    private void validateFillfactor(String value) {
+        int fillfactor;
+        try {
+            fillfactor = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' must be an integer between %d and %d, but got '%s'",
+                            dialectName(),
+                            KingbaseCatalog.TABLE_OPTION_FILLFACTOR,
+                            FILLFACTOR_MIN,
+                            FILLFACTOR_MAX,
+                            value));
+        }
+        if (fillfactor < FILLFACTOR_MIN || fillfactor > FILLFACTOR_MAX) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' must be an integer between %d and %d, but got '%s'",
+                            dialectName(),
+                            KingbaseCatalog.TABLE_OPTION_FILLFACTOR,
+                            FILLFACTOR_MIN,
+                            FILLFACTOR_MAX,
+                            value));
+        }
+    }
+
+    private void validateTablespace(String value) {
+        // Always emitted as TABLESPACE "...", so reject quote / control chars that break DDL.
+        if (value.indexOf('"') >= 0
+                || value.indexOf('\n') >= 0
+                || value.indexOf('\r') >= 0
+                || value.indexOf(';') >= 0) {
+            throw new JdbcConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "Invalid JDBC table_options for dialect '%s': key '%s' contains illegal characters: '%s'",
+                            dialectName(), KingbaseCatalog.TABLE_OPTION_TABLESPACE, value));
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilderTest.java
@@ -79,6 +79,38 @@ class KingbaseCreateTableSqlBuilderTest {
         Assertions.assertEquals(expectedSqlSkipIndex, createTableSqlSkipIndex);
     }
 
+    @Test
+    void testBuildWithTableOptions() {
+        TablePath tablePath = TablePath.of("test", "public", "test_table");
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, null))
+                        .primaryKey(PrimaryKey.of("pk_id", Lists.newArrayList("id")))
+                        .build();
+
+        HashMap<String, String> options = new HashMap<>();
+        options.put(KingbaseCatalog.TABLE_OPTION_TABLESPACE, "pg_default");
+        options.put(KingbaseCatalog.TABLE_OPTION_FILLFACTOR, "70");
+
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(DatabaseIdentifier.KINGBASE, tablePath),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with options");
+
+        String createTableSql =
+                new KingbaseCreateTableSqlBuilder(catalogTable, false).build(tablePath);
+
+        Assertions.assertTrue(
+                createTableSql.contains("WITH (fillfactor=70)"),
+                "CREATE TABLE should contain fillfactor: " + createTableSql);
+        Assertions.assertTrue(
+                createTableSql.contains("TABLESPACE \"pg_default\""),
+                "CREATE TABLE should contain tablespace: " + createTableSql);
+    }
+
     private CatalogTable kingbaseCatalogTable(TablePath tablePath) {
         List<Column> columns =
                 Lists.newArrayList(

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/kingbase/KingbaseCreateTableSqlBuilderTest.java
@@ -111,6 +111,40 @@ class KingbaseCreateTableSqlBuilderTest {
                 "CREATE TABLE should contain tablespace: " + createTableSql);
     }
 
+    @Test
+    void testBuildWithTableOptionsIgnoresFieldIde() {
+        TablePath tablePath = TablePath.of("test", "public", "test_table");
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, null))
+                        .primaryKey(PrimaryKey.of("pk_id", Lists.newArrayList("id")))
+                        .build();
+
+        HashMap<String, String> options = new HashMap<>();
+        options.put("fieldIde", "UPPERCASE");
+        options.put(KingbaseCatalog.TABLE_OPTION_TABLESPACE, "pg_default");
+        options.put(KingbaseCatalog.TABLE_OPTION_FILLFACTOR, "70");
+
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(DatabaseIdentifier.KINGBASE, tablePath),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with options");
+
+        String createTableSql =
+                new KingbaseCreateTableSqlBuilder(catalogTable, false).build(tablePath);
+
+        Assertions.assertTrue(
+                createTableSql.contains("WITH (fillfactor=70)"),
+                "CREATE TABLE should contain fillfactor: " + createTableSql);
+        Assertions.assertTrue(
+                createTableSql.contains("TABLESPACE \"pg_default\""),
+                "tablespace must not be rewritten by fieldIde; got: " + createTableSql);
+        Assertions.assertFalse(createTableSql.contains("TABLESPACE \"PG_DEFAULT\""));
+    }
+
     private CatalogTable kingbaseCatalogTable(TablePath tablePath) {
         List<Column> columns =
                 Lists.newArrayList(

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialectTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialectTableOptionsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.kingbase;
+
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class KingbaseDialectTableOptionsTest {
+
+    @Test
+    void testValidateTableOptionsAcceptsSupportedKeys() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("tablespace", "pg_default");
+        tableOptions.put("fillfactor", "70");
+        Assertions.assertDoesNotThrow(() -> dialect.validateTableOptions(tableOptions));
+    }
+
+    @Test
+    void testValidateTableOptionsRejectsUnsupportedKeys() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("engine", "InnoDB");
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () -> dialect.validateTableOptions(tableOptions));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
+        Assertions.assertTrue(exception.getMessage().contains("KingBase"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialectTableOptionsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/kingbase/KingbaseDialectTableOptionsTest.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialecten
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,6 +39,15 @@ class KingbaseDialectTableOptionsTest {
     }
 
     @Test
+    void testValidateTableOptionsFillfactorBoundary() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+        Assertions.assertDoesNotThrow(
+                () -> dialect.validateTableOptions(Collections.singletonMap("fillfactor", "10")));
+        Assertions.assertDoesNotThrow(
+                () -> dialect.validateTableOptions(Collections.singletonMap("fillfactor", "100")));
+    }
+
+    @Test
     void testValidateTableOptionsRejectsUnsupportedKeys() {
         KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
         Map<String, String> tableOptions = new HashMap<>();
@@ -48,5 +58,68 @@ class KingbaseDialectTableOptionsTest {
                         () -> dialect.validateTableOptions(tableOptions));
         Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
         Assertions.assertTrue(exception.getMessage().contains("KingBase"));
+    }
+
+    @Test
+    void testValidateTableOptionsRejectBlankValues() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+
+        JdbcConnectorException blankTablespace =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("tablespace", " ")));
+        Assertions.assertTrue(blankTablespace.getMessage().contains("must not be blank"));
+
+        JdbcConnectorException blankFillfactor =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("fillfactor", " ")));
+        Assertions.assertTrue(blankFillfactor.getMessage().contains("must not be blank"));
+    }
+
+    @Test
+    void testValidateTableOptionsRejectInvalidFillfactor() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+
+        JdbcConnectorException nonNumeric =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("fillfactor", "abc")));
+        Assertions.assertTrue(nonNumeric.getMessage().contains("must be an integer between"));
+
+        JdbcConnectorException tooLow =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("fillfactor", "9")));
+        Assertions.assertTrue(tooLow.getMessage().contains("must be an integer between"));
+
+        JdbcConnectorException tooHigh =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("fillfactor", "101")));
+        Assertions.assertTrue(tooHigh.getMessage().contains("must be an integer between"));
+    }
+
+    @Test
+    void testValidateTableOptionsRejectIllegalTablespace() {
+        KingbaseDialect dialect = new KingbaseDialect(FieldIdeEnum.ORIGINAL.getValue());
+
+        JdbcConnectorException exception =
+                Assertions.assertThrows(
+                        JdbcConnectorException.class,
+                        () ->
+                                dialect.validateTableOptions(
+                                        Collections.singletonMap("tablespace", "pg_\"default\"")));
+        Assertions.assertTrue(exception.getMessage().contains("illegal characters"));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcTableOptionsConditionExtensionTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcTableOptionsConditionExtensionTest.java
@@ -123,6 +123,31 @@ class JdbcTableOptionsConditionExtensionTest {
                 exception.getMessage().contains("not supported for dialect 'Oracle'"));
     }
 
+    @Test
+    void testKingbaseTableOptionsPassViaOptionRule() {
+        Map<String, Object> config = kingbaseSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("tablespace", "pg_default");
+        tableOptions.put("fillfactor", "70");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        Assertions.assertDoesNotThrow(() -> validateSinkOptionRule(config));
+    }
+
+    @Test
+    void testKingbaseRejectsUnknownTableOptionsViaOptionRule() {
+        Map<String, Object> config = kingbaseSinkConfig();
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("engine", "InnoDB");
+        config.put(SinkConnectorCommonOptions.TABLE_OPTIONS.key(), tableOptions);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSinkOptionRule(config));
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported JDBC table_options"));
+        Assertions.assertTrue(exception.getMessage().contains("KingBase"));
+    }
+
     private static void validateSinkOptionRule(Map<String, Object> config) {
         ConfigValidator.of(ReadonlyConfig.fromMap(config))
                 .validate(new JdbcSinkFactory().optionRule());
@@ -165,6 +190,14 @@ class JdbcTableOptionsConditionExtensionTest {
         config.put("url", "jdbc:oceanbase://127.0.0.1:2881/test");
         config.put("driver", "com.oceanbase.jdbc.Driver");
         config.put("compatible_mode", "oracle");
+        config.put("query", "INSERT INTO test_table VALUES (?)");
+        return config;
+    }
+
+    private static Map<String, Object> kingbaseSinkConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("url", "jdbc:kingbase8://127.0.0.1:54321/test");
+        config.put("driver", "com.kingbase8.Driver");
         config.put("query", "INSERT INTO test_table VALUES (?)");
         return config;
     }


### PR DESCRIPTION
## Purpose
Extend JDBC sink `table_options` (SaveMode auto-create) to Kingbase, as a follow-up to #11047 / #11101 / #11388.

## Changes
- Add Kingbase curated key whitelist: `tablespace`, `fillfactor`
- Wire `KingbaseDialect.validateTableOptions` and apply options in `KingbaseCreateTableSqlBuilder` DDL (`WITH (fillfactor=...)` / `TABLESPACE "..."`)
- Docs (en/zh): support matrix + dialect notes + Kingbase example
- Unit tests: dialect / DDL / OptionRule coverage

## Non-goals
- Arbitrary `WITH (...)` parameters
- Reusing Postgres Builder/Dialect inheritance (Kingbase has an independent catalog path)
- `ALTER TABLE` on existing tables (`table_options` only applies when SaveMode creates the table)
- E2E (`JdbcKingbaseIT` requires a local license and is `@Disabled` by default)

## Test plan
- [x] `KingbaseDialectTableOptionsTest`
- [x] `KingbaseCreateTableSqlBuilderTest#testBuildWithTableOptions`
- [x] `JdbcTableOptionsConditionExtensionTest` (Kingbase pass / unknown-key reject)
- [ ] CI on this PR

## Related
- Issue: #11047
- MySQL: #11101
- TiDB / OceanBase MySQL: #11388
- Oracle: #11416
- PostgreSQL: #11417
- Paimon: #11418
- Dameng: #11419


Made with [Cursor](https://cursor.com)