### PR TITLE
[Test][Zeta] Stabilize coordinator retryable operation test

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -71,6 +71,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.ClusterProperty;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Field;
@@ -596,26 +597,45 @@ public class CoordinatorServiceTest {
     @Test
     public void testSeaTunnelEngineRetryableExceptionOperationCanBeRetryByHazelcast() {
 
-        HazelcastInstanceImpl instance =
-                SeaTunnelServerStarter.createHazelcastInstance(
+        int maxRetryCount = 3;
+        ReturnRetryTimesOperation.resetRetryTimes();
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setClusterName(
                         TestUtils.getClusterName(
                                 "CoordinatorServiceTest_testSeaTunnelEngineRetryableExceptionOperationCanBeRetryByHazelcast"));
+        // Keep the production retry contract intact while using a small test-only budget so CI
+        // can still verify terminal exception propagation without waiting for 250 retries.
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setProperty(
+                        ClusterProperty.INVOCATION_MAX_RETRY_COUNT.getName(),
+                        String.valueOf(maxRetryCount));
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setProperty(ClusterProperty.INVOCATION_RETRY_PAUSE.getName(), "1");
+        HazelcastInstanceImpl instance =
+                SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
         try {
             CompletionException exception =
                     Assertions.assertThrows(
                             CompletionException.class,
-                            () -> {
-                                NodeEngineUtil.sendOperationToMemberNode(
-                                                instance.node.getNodeEngine(),
-                                                new ReturnRetryTimesOperation(),
-                                                instance.getCluster().getLocalMember().getAddress())
-                                        .join();
-                            });
+                            () ->
+                                    NodeEngineUtil.sendOperationToMemberNode(
+                                                    instance.node.getNodeEngine(),
+                                                    new ReturnRetryTimesOperation(),
+                                                    instance.getCluster()
+                                                            .getLocalMember()
+                                                            .getAddress())
+                                            .join());
             Assertions.assertTrue(
                     exception
                             .getCause()
                             .getMessage()
-                            .contains("Retryable exception occurred, retry times: 250"));
+                            .contains(
+                                    "Retryable exception occurred, retry times: " + maxRetryCount));
+            Assertions.assertEquals(maxRetryCount, ReturnRetryTimesOperation.getRetryTimes());
         } finally {
             instance.shutdown();
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/operation/ReturnRetryTimesOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/operation/ReturnRetryTimesOperation.java
@@ -30,6 +30,24 @@ public class ReturnRetryTimesOperation extends Operation
 
     private static final AtomicInteger retryTimes = new AtomicInteger(0);
 
+    /**
+     * Reset the static retry counter before starting a new retry-focused test.
+     *
+     * <p>The operation is reused across Hazelcast retries in the same test JVM.
+     */
+    public static void resetRetryTimes() {
+        retryTimes.set(0);
+    }
+
+    /**
+     * Return the number of operation attempts observed by the current test.
+     *
+     * <p>The terminal assertion uses this value to verify retry exhaustion.
+     */
+    public static int getRetryTimes() {
+        return retryTimes.get();
+    }
+
     @Override
     public void run() {
         retryTimes.getAndIncrement();


### PR DESCRIPTION
## Purpose

The coordinator retry test depended on Hazelcast's production default retry budget and pause. Exercising the full default budget makes an otherwise deterministic unit test unnecessarily slow and vulnerable to CI timing variation.

## Changes

- Configure a test-only maximum of three invocation attempts with a one-millisecond retry pause.
- Reset and expose the test operation attempt counter for an exact terminal assertion.
- Preserve the original contract by waiting for the terminal `CompletionException`, checking its retry message, and asserting the exact attempt count.
- Always shut down the test Hazelcast instance in `finally`.

## Validation

- `CoordinatorServiceTest#testSeaTunnelEngineRetryableExceptionOperationCanBeRetryByHazelcast`: 1 test, 0 failures, 0 errors
- `verify -DskipTests` for `seatunnel-engine-server` (includes test compilation and Spotless check)
- Two independent code reviews passed with no blocking findings

`seatunnel-engine-ui` was excluded because this change does not touch the UI.
