### PR TITLE
[Fix][seatunnel-common,seatunnel-core] Fix comma-containing plain variable parsing

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/PlaceholderUtils.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/PlaceholderUtils.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.common.utils;
 
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,7 +39,7 @@ public class PlaceholderUtils {
         while (matcher.find()) {
             String replacement =
                     value != null && !value.isEmpty()
-                            ? value
+                            ? StringUtils.unwrap(value, "\"")
                             : (matcher.group(1) != null
                                     ? matcher.group(1).substring(1).trim()
                                     : defaultValue);

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-console-seatunnel-e2e/src/test/java/org/apache/seatunnel/engine/e2e/console/FakeSourceToConsoleIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-console-seatunnel-e2e/src/test/java/org/apache/seatunnel/engine/e2e/console/FakeSourceToConsoleIT.java
@@ -24,12 +24,33 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FakeSourceToConsoleIT extends SeaTunnelEngineContainer {
 
     @Test
     public void testFakeSourceToConsoleSink() throws IOException, InterruptedException {
         Container.ExecResult execResult = executeSeaTunnelJob("/fakesource_to_console.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
+    }
+
+    @Test
+    public void testCommaParams() {
+        List<String> variables = new ArrayList<>();
+        variables.add("date=2026-07-13");
+        variables.add("cols=\"addr1,addr2\"");
+        variables.add("required_cols=[date,id,name,addr1]");
+        Container.ExecResult execResult = null;
+        try {
+            execResult =
+                    executeSeaTunnelJob("/fakesource_to_console_with_comma_params.conf", variables);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         Assertions.assertEquals(0, execResult.getExitCode());
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-console-seatunnel-e2e/src/test/resources/fakesource_to_console_with_comma_params.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-console-seatunnel-e2e/src/test/resources/fakesource_to_console_with_comma_params.conf
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### This config file is a demonstration of streaming processing in seatunnel config
+######
+
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  # This is a example source plugin **only for test and demonstrate the feature source plugin**
+  FakeSource {
+    plugin_output = "fake"
+    schema {
+      fields {
+        id = "int"
+        name = "string"
+        age = "int"
+        addr1 = "string"
+        addr2 = "string"
+      }
+    }
+  }
+}
+
+transform {
+    SQL {
+        plugin_input = "fake"
+        plugin_output = "sql"
+        query = "SELECT id, name, age, '${date}' as date, ${cols} FROM fake"
+    }
+    filter{
+        plugin_input = "sql"
+        plugin_output = "filter"
+        include_fields = ${required_cols}
+    }
+}
+
+
+sink {
+  console {
+    plugin_input = "filter"
+  }
+
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SeaTunnelEngineContainer.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SeaTunnelEngineContainer.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.Container;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -49,5 +50,10 @@ public abstract class SeaTunnelEngineContainer extends SeaTunnelContainer {
     public Container.ExecResult executeSeaTunnelJob(String confFile)
             throws IOException, InterruptedException {
         return executeJob(confFile);
+    }
+
+    public Container.ExecResult executeSeaTunnelJob(String confFile, List<String> variables)
+            throws IOException, InterruptedException {
+        return executeJob(confFile, variables);
     }
 }


### PR DESCRIPTION
    ### Problem
    When using a plain variable containing commas (e.g., passing a list of required columns for database table reading), the parser only accepted the text before the first comma, or threw an error.
    ### Investigation
    I first tried the approach shown in the source code(AbstractCommandArgs) below, but it didn't work as expected. After tracing through ConfigBuilder, I discovered that the issue was in PlaceholderUtils: the escaped quotes (\") wrapping the variable value were not being properly unwrapped.
    ### Fix
    I fixed the unwrapping logic in PlaceholderUtils so that comma-containing values are parsed correctly.
    Verification
    I tested the fix by running SeaTunnelEngineLocalExample locally after recompiling the seatunnel-common and seatunnel-core/seatunnel-core-starter modules. After that, I replaced the original jars in my local SeaTunnel installation ($SEATUNNEL_HOME/starter) with the newly recompiled related starter jars (e.g., seatunnel-starter,spark-starter,flink-starter), and verified the fix by running [ $SEATUNNEL_HOME//bin/seatunnel.sh   -c config/fake_to_console.conf   -m local]. It now works as expected.

<img width="1071" height="263" alt="image" src="https://github.com/user-attachments/assets/0820fac5-93bc-4999-9a26-c1a57ecdf30a" />
