### PR TITLE
[Docs] Document S3File credential provider support for container environments

### DIFF
--- a/docs/en/connectors/sink/S3File.md
+++ b/docs/en/connectors/sink/S3File.md
@@ -110,7 +110,7 @@ If write to `csv`, `text` file type, All column will be string.
 | tmp_path                              | string  | no       | /tmp/seatunnel                                        | The result file will write to a tmp path first and then use `mv` to submit tmp dir to target dir. Need a S3 dir.                                                                |
 | bucket                                | string  | yes      | -                                                     |                                                                                                                                                                                 |
 | fs.s3a.endpoint                       | string  | yes      | -                                                     |                                                                                                                                                                                 |
-| fs.s3a.aws.credentials.provider       | string  | yes      | com.amazonaws.auth.InstanceProfileCredentialsProvider | The way to authenticate s3a. We only support `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` and `com.amazonaws.auth.InstanceProfileCredentialsProvider` now.           |
+| fs.s3a.aws.credentials.provider       | enum    | yes      | com.amazonaws.auth.InstanceProfileCredentialsProvider | The way to authenticate s3a. Only `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` and `com.amazonaws.auth.InstanceProfileCredentialsProvider` are supported. See [Credential Provider in Container Environments](#credential-provider-in-container-environments). |
 | access_key                            | string  | no       | -                                                     | Only used when fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider                                                                          |
 | secret_key                            | string  | no       | -                                                     | Only used when fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider                                                                          |
 | custom_filename                       | boolean | no       | false                                                 | Whether you need custom the filename                                                                                                                                            |
@@ -332,6 +332,47 @@ The encoding of the file to write. This param will be parsed by `Charset.forName
 
 Only used when file_format_type is canal_json,debezium_json or maxwell_json. 
 When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data
+
+### Credential Provider in Container Environments
+
+When running SeaTunnel in container environments such as Kubernetes, ECS, or EKS, users often ask how to configure S3 credentials without embedding long-lived access keys in the job config.
+
+#### Supported credential providers
+
+The `fs.s3a.aws.credentials.provider` option of the S3File connector is a **restricted enum**. Today it accepts only the following two values:
+
+| Value                                                     | Description                                                                                          |
+|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`   | Authenticate with a static `access_key` / `secret_key` pair.                                         |
+| `com.amazonaws.auth.InstanceProfileCredentialsProvider`   | Authenticate with instance/role credentials fetched from the runtime environment (the default value).|
+
+Any other value (for example `com.amazonaws.auth.ContainerCredentialsProvider` or a custom provider class) is **not supported** and will fail the job at startup with an `IllegalArgumentException`. Passing such a provider through `hadoop_s3_properties` does **not** work either: the connector always overwrites the `fs.s3a.aws.credentials.provider` key with the enum value, so the value in `hadoop_s3_properties` is ignored.
+
+#### Container environment support (Kubernetes / ECS / EKS)
+
+The two supported providers only cover part of the common container credential scenarios. Read this carefully — the most common EKS/ECS credential mechanisms are **not** supported today.
+
+- **EC2 instance role (including an EKS worker-node instance role): supported.** Use `InstanceProfileCredentialsProvider`. It reads credentials from the EC2 Instance Metadata Service, so the pod/task inherits the node's EC2 role and no access key is needed in the config:
+
+```hocon
+S3File {
+  bucket = "s3a://seatunnel-test"
+  path = "/seatunnel/text"
+  fs.s3a.endpoint = "s3.us-east-1.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+  file_format_type = "text"
+}
+```
+
+- **EKS IRSA (IAM Roles for Service Accounts) and ECS task role: NOT supported today.** IRSA requires `WebIdentityTokenCredentialsProvider` (STS `AssumeRoleWithWebIdentity`) and an ECS task role requires `ContainerCredentialsProvider`; neither class is part of the enum, so neither can be selected. `InstanceProfileCredentialsProvider` does **not** cover these cases — it only reads EC2 node metadata, which returns the node's role, not the fine-grained service-account or task role.
+
+  Until the connector supports these providers, use one of these workarounds:
+    - Fall back to the EC2 node instance role via `InstanceProfileCredentialsProvider` (coarser-grained permissions than IRSA / task role).
+    - Or use `SimpleAWSCredentialsProvider` with `access_key` / `secret_key` injected from a Kubernetes Secret (for example via environment-variable substitution). Prefer short-lived credentials and avoid hardcoding long-lived keys in the file.
+
+#### Troubleshooting
+
+If the job fails during sink initialization with an error such as `Could not parse value for enum` or a `Factory initialize failed` message referencing `fs.s3a.aws.credentials.provider`, the configured value is outside the supported enum. Set it to one of the two supported values above.
 
 ## Example
 

--- a/docs/en/connectors/source/S3File.md
+++ b/docs/en/connectors/source/S3File.md
@@ -195,7 +195,7 @@ If you assign file type to `parquet` `orc`, schema option not required, connecto
 | file_format_type                | string  | yes      | -                                                     | File type, supported as the following file types: `text` `csv` `parquet` `orc` `json` `excel` `xml` `binary` `markdown`                                                                                                                                                                                                                                                                                    |
 | bucket                          | string  | yes      | -                                                     | The bucket address of s3 file system, for example: `s3n://seatunnel-test`, if you use `s3a` protocol, this parameter should be `s3a://seatunnel-test`.                                                                                                                                                                                                                                                     |
 | fs.s3a.endpoint                 | string  | yes      | -                                                     | fs s3a endpoint                                                                                                                                                                                                                                                                                                                                                                                            |
-| fs.s3a.aws.credentials.provider | string  | yes      | com.amazonaws.auth.InstanceProfileCredentialsProvider | The way to authenticate s3a. We only support `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` and `com.amazonaws.auth.InstanceProfileCredentialsProvider` now. More information about the credential provider you can see [Hadoop AWS Document](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Simple_name.2Fsecret_credentials_with_SimpleAWSCredentialsProvider.2A) |
+| fs.s3a.aws.credentials.provider | enum    | yes      | com.amazonaws.auth.InstanceProfileCredentialsProvider | The way to authenticate s3a. This is a restricted enum and only two values are supported today: `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` and `com.amazonaws.auth.InstanceProfileCredentialsProvider`. Other providers (including container credential providers such as `ContainerCredentialsProvider`) are not accepted, and cannot be injected through `hadoop_s3_properties`. See [Credential Provider in Container Environments](#credential-provider-in-container-environments) for details. |
 | read_columns                    | list    | no       | -                                                     | The read column list of the data source, user can use it to implement field projection. The file type supported column projection as the following shown: `text` `csv` `parquet` `orc` `json` `excel` `xml` . If the user wants to use this feature when reading `text` `json` `csv` files, the "schema" option must be configured.                                                                        |
 | access_key                      | string  | no       | -                                                     | Only used when `fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider `                                                                                                                                                                                                                                                                                                  |
 | secret_key                      | string  | no       | -                                                     | Only used when `fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider `                                                                                                                                                                                                                                                                                                  |
@@ -425,6 +425,47 @@ For more information, please refer to [Metadata SPI](../../introduction/concepts
 
 Whether to scan subdirectories recursively.
 If `false`, subdirectories will be ignored.
+
+### Credential Provider in Container Environments
+
+When running SeaTunnel in container environments such as Kubernetes, ECS, or EKS, users often ask how to configure S3 credentials without embedding long-lived access keys in the job config.
+
+#### Supported credential providers
+
+The `fs.s3a.aws.credentials.provider` option of the S3File connector is a **restricted enum**. Today it accepts only the following two values:
+
+| Value                                                     | Description                                                                                          |
+|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`   | Authenticate with a static `access_key` / `secret_key` pair.                                         |
+| `com.amazonaws.auth.InstanceProfileCredentialsProvider`   | Authenticate with instance/role credentials fetched from the runtime environment (the default value).|
+
+Any other value (for example `com.amazonaws.auth.ContainerCredentialsProvider` or a custom provider class) is **not supported** and will fail the job at startup with an `IllegalArgumentException`. Passing such a provider through `hadoop_s3_properties` does **not** work either: the connector always overwrites the `fs.s3a.aws.credentials.provider` key with the enum value, so the value in `hadoop_s3_properties` is ignored.
+
+#### Container environment support (Kubernetes / ECS / EKS)
+
+The two supported providers only cover part of the common container credential scenarios. Read this carefully — the most common EKS/ECS credential mechanisms are **not** supported today.
+
+- **EC2 instance role (including an EKS worker-node instance role): supported.** Use `InstanceProfileCredentialsProvider`. It reads credentials from the EC2 Instance Metadata Service, so the pod/task inherits the node's EC2 role and no access key is needed in the config:
+
+```hocon
+S3File {
+  path = "/seatunnel/json"
+  bucket = "s3a://seatunnel-test"
+  fs.s3a.endpoint = "s3.us-east-1.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+  file_format_type = "json"
+}
+```
+
+- **EKS IRSA (IAM Roles for Service Accounts) and ECS task role: NOT supported today.** IRSA requires `WebIdentityTokenCredentialsProvider` (STS `AssumeRoleWithWebIdentity`) and an ECS task role requires `ContainerCredentialsProvider`; neither class is part of the enum, so neither can be selected. `InstanceProfileCredentialsProvider` does **not** cover these cases — it only reads EC2 node metadata, which returns the node's role, not the fine-grained service-account or task role.
+
+  Until the connector supports these providers, use one of these workarounds:
+    - Fall back to the EC2 node instance role via `InstanceProfileCredentialsProvider` (coarser-grained permissions than IRSA / task role).
+    - Or use `SimpleAWSCredentialsProvider` with `access_key` / `secret_key` injected from a Kubernetes Secret (for example via environment-variable substitution). Prefer short-lived credentials and avoid hardcoding long-lived keys in the file.
+
+#### Troubleshooting
+
+If the job fails during source initialization with an error such as `Could not parse value for enum` or a `Factory initialize failed` message referencing `fs.s3a.aws.credentials.provider`, the configured value is outside the supported enum. Set it to one of the two supported values above.
 
 ## Example
 

--- a/docs/en/engines/zeta/checkpoint-storage.md
+++ b/docs/en/engines/zeta/checkpoint-storage.md
@@ -187,6 +187,29 @@ seatunnel:
 
 For additional reading on the Hadoop Credential Provider API, you can see: [Credential Provider API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
 
+##### Credential providers in container environments
+
+Unlike the S3File connector, checkpoint storage does **not** restrict `fs.s3a.aws.credentials.provider` to a fixed set of values. Every `fs.s3a.*` option is passed through to the underlying Hadoop `Configuration` unchanged. This means you can use **any** S3A credential provider on the classpath, including container credential providers such as `com.amazonaws.auth.ContainerCredentialsProvider` (ECS/EKS) — as long as the corresponding class is available in `${SEATUNNEL_HOME}/lib`.
+
+For example, to use container credentials in an ECS/EKS deployment without embedding access keys:
+
+```yaml
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          namespace: # checkpoint storage parent path, the default value is /seatunnel/checkpoint/
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.ContainerCredentialsProvider
+```
+
 #### HDFS
 
 if you use HDFS, you can config like this:

--- a/docs/zh/connectors/sink/S3File.md
+++ b/docs/zh/connectors/sink/S3File.md
@@ -109,7 +109,7 @@ import ChangeLog from '../changelog/connector-file-s3.md';
 | tmp_path                              | string  | 否    | /tmp/seatunnel                                        | 结果文件将首先写入临时路径，然后使用 `mv` 将临时目录提交到目标目录。需要一个 S3 目录。                                                                                    |
 | bucket                                | string  | 是    | -                                                     |                                                                                                                                     |
 | fs.s3a.endpoint                       | string  | 是    | -                                                     |                                                                                                                                     |
-| fs.s3a.aws.credentials.provider       | string  | 是    | com.amazonaws.auth.InstanceProfileCredentialsProvider | 认证 s3a 的方式。目前仅支持 `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` 和 `com.amazonaws.auth.InstanceProfileCredentialsProvider`。 |
+| fs.s3a.aws.credentials.provider       | enum    | 是    | com.amazonaws.auth.InstanceProfileCredentialsProvider | 认证 s3a 的方式。这是一个受限枚举，仅支持 `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` 和 `com.amazonaws.auth.InstanceProfileCredentialsProvider` 两个值。容器环境（K8s/ECS/EKS）配置及限制说明请参考[容器环境下的凭证提供方](#容器环境下的凭证提供方)。 |
 | access_key                            | string  | 否    | -                                                     | 仅当 fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider 时使用                                      |
 | secret_key                            | string  | 否    | -                                                     | 仅当 fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider 时使用                                      |
 | custom_filename                       | boolean | 否    | false                                                 | 是否需要自定义文件名                                                                                                                          |
@@ -327,6 +327,47 @@ Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-c
 仅当file_format_type为canal_json、debezium_json、maxwell_json时使用.
 设置成true,序列化数据时,UPDATE_AFTER 和 UPDATE_BEFORE 会合并成 UPDATE;
 设置成false,序列化数据时,UPDATE_AFTER 和 UPDATE_BEFORE 不会合并;
+
+### 容器环境下的凭证提供方
+
+在 Kubernetes、ECS、EKS 等容器环境中运行 SeaTunnel 时，用户常问如何在不把长期 access key 写进作业配置的情况下配置 S3 凭证。
+
+#### 支持的凭证提供方
+
+S3File 连接器的 `fs.s3a.aws.credentials.provider` 选项是一个**受限枚举**，目前仅接受以下两个值：
+
+| 值                                                        | 说明                                                                    |
+|-----------------------------------------------------------|-------------------------------------------------------------------------|
+| `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`   | 使用静态的 `access_key` / `secret_key` 进行认证。                       |
+| `com.amazonaws.auth.InstanceProfileCredentialsProvider`   | 使用从运行时环境获取的实例/角色凭证进行认证（默认值）。                  |
+
+任何其它值（例如 `com.amazonaws.auth.ContainerCredentialsProvider` 或自定义 provider 类）**都不受支持**，作业启动时会抛出 `IllegalArgumentException`。通过 `hadoop_s3_properties` 传入这类 provider 同样**无效**：连接器始终会用枚举值覆盖 `fs.s3a.aws.credentials.provider` 这个 key，因此 `hadoop_s3_properties` 中的对应值会被忽略。
+
+#### 容器环境支持（Kubernetes / ECS / EKS）
+
+目前支持的两个 provider 只覆盖了部分常见的容器凭证场景。请仔细阅读——最常见的 EKS/ECS 凭证机制目前**并不受支持**。
+
+- **EC2 实例角色（包括 EKS 工作节点的实例角色）：支持。** 使用 `InstanceProfileCredentialsProvider`。它从 EC2 实例元数据服务读取凭证，因此 Pod/任务会继承节点的 EC2 角色，配置中无需任何 access key：
+
+```hocon
+S3File {
+  bucket = "s3a://seatunnel-test"
+  path = "/seatunnel/text"
+  fs.s3a.endpoint = "s3.us-east-1.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+  file_format_type = "text"
+}
+```
+
+- **EKS IRSA（IAM Roles for Service Accounts）和 ECS 任务角色：目前不受支持。** IRSA 需要 `WebIdentityTokenCredentialsProvider`（STS `AssumeRoleWithWebIdentity`），ECS 任务角色需要 `ContainerCredentialsProvider`；这两个类都不在枚举中，因此都无法选用。`InstanceProfileCredentialsProvider` **无法**覆盖这两种场景——它只读取 EC2 节点元数据，返回的是节点角色，而不是细粒度的 service account 角色或任务角色。
+
+  在连接器支持这些 provider 之前，请使用以下变通方案之一：
+    - 通过 `InstanceProfileCredentialsProvider` 退回到使用 EC2 节点实例角色（权限粒度比 IRSA / 任务角色更粗）。
+    - 或使用 `SimpleAWSCredentialsProvider`，并通过 Kubernetes Secret（例如借助环境变量替换）注入 `access_key` / `secret_key`。请优先使用短期有效的临时凭证，避免把长期密钥硬编码在文件里。
+
+#### 排查
+
+如果作业在 Sink 初始化阶段失败，并出现类似 `Could not parse value for enum` 或引用 `fs.s3a.aws.credentials.provider` 的 `Factory initialize failed` 错误，说明配置的值不在受支持的枚举范围内。请将其设置为上面两个受支持的值之一。
 
 ## 示例
 

--- a/docs/zh/connectors/source/S3File.md
+++ b/docs/zh/connectors/source/S3File.md
@@ -195,7 +195,7 @@ schema {
 | file_format_type                | string  | 是    | -                                                     | 文件类型，支持以下文件类型：`text` `csv` `parquet` `orc` `json` `excel` `xml` `binary` `markdown`                                                                                                                                                                                                                                   |
 | bucket                          | string  | 是    | -                                                     | s3文件系统的bucket地址，例如：`s3n://seatunnel-test`，如果您使用`s3a`协议，此参数应为`s3a://seatunnel-test`。                                                                                                                                                                                                                                   |
 | fs.s3a.endpoint                 | string  | 是    | -                                                     | fs s3a端点                                                                                                                                                                                                                                                                                                              |
-| fs.s3a.aws.credentials.provider | string  | 是    | com.amazonaws.auth.InstanceProfileCredentialsProvider | s3a的认证方式。我们目前只支持`org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`和`com.amazonaws.auth.InstanceProfileCredentialsProvider`。有关凭据提供程序的更多信息，您可以查看[Hadoop AWS文档](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Simple_name.2Fsecret_credentials_with_SimpleAWSCredentialsProvider.2A) |
+| fs.s3a.aws.credentials.provider | enum    | 是    | com.amazonaws.auth.InstanceProfileCredentialsProvider | s3a 的认证方式。这是一个**受限枚举**，目前只支持 `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` 和 `com.amazonaws.auth.InstanceProfileCredentialsProvider` 两个值。容器环境下的配置方式请参见下方[容器环境下的凭证提供方](#容器环境下的凭证提供方)。有关凭据提供程序的更多信息，您可以查看[Hadoop AWS文档](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Simple_name.2Fsecret_credentials_with_SimpleAWSCredentialsProvider.2A) |
 | read_columns                    | list    | 否    | -                                                     | 数据源的读取列列表，用户可以使用它来实现字段投影。支持列投影的文件类型如下所示：`text` `csv` `parquet` `orc` `json` `excel` `xml`。如果用户想在读取`text` `json` `csv`文件时使用此功能，必须配置"schema"选项。                                                                                                                                                                         |
 | access_key                      | string  | 否    | -                                                     | 仅在`fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`时使用                                                                                                                                                                                                                        |
 | secret_key                      | string  | 否    | -                                                     | 仅在`fs.s3a.aws.credentials.provider = org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`时使用                                                                                                                                                                                                                        |
@@ -424,6 +424,47 @@ markdown 解析器提取各种元素，包括标题、段落、列表、代码�
 > 当使用 Gravitino 作为元数据源时，Gravitino 的列类型会自动转换为 SeaTunnel 数据类型。详细的类型映射信息请参考 [Gravitino 类型映射](../../introduction/concepts/gravitino-type-mapping.md)。
 
 更多信息请参考 [元数据 SPI](../../introduction/concepts/metadata-spi.md)。
+
+### 容器环境下的凭证提供方
+
+在 Kubernetes、ECS、EKS 等容器环境中运行 SeaTunnel 时，用户经常会问：如何在不把长期有效的访问密钥写死在作业配置里的前提下配置 S3 凭证。
+
+#### 支持的凭证提供方
+
+S3File 连接器的 `fs.s3a.aws.credentials.provider` 选项是一个**受限枚举**。目前它只接受以下两个值：
+
+| 值                                                        | 说明                                                             |
+|-----------------------------------------------------------|------------------------------------------------------------------|
+| `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`   | 使用静态的 `access_key` / `secret_key` 进行身份验证。            |
+| `com.amazonaws.auth.InstanceProfileCredentialsProvider`   | 使用运行时环境提供的实例/角色凭证进行身份验证（默认值）。         |
+
+任何其他值（例如 `com.amazonaws.auth.ContainerCredentialsProvider` 或自定义的 provider 类）都**不受支持**，并会在作业启动时抛出 `IllegalArgumentException` 导致失败。通过 `hadoop_s3_properties` 传入这类 provider 也**无效**：连接器总是用枚举值覆盖 `fs.s3a.aws.credentials.provider` 这个 key，因此 `hadoop_s3_properties` 中的值会被忽略。
+
+#### 容器环境支持（Kubernetes / ECS / EKS）
+
+这两个受支持的 provider 只覆盖了部分常见的容器凭证场景。请仔细阅读——最常见的 EKS/ECS 凭证机制目前**并不**受支持。
+
+- **EC2 实例角色（包括 EKS 工作节点的实例角色）：支持。** 使用 `InstanceProfileCredentialsProvider`。它从 EC2 实例元数据服务（IMDS）读取凭证，因此 Pod/Task 继承的是节点的 EC2 角色，配置中无需任何访问密钥：
+
+```hocon
+S3File {
+  path = "/seatunnel/json"
+  bucket = "s3a://seatunnel-test"
+  fs.s3a.endpoint = "s3.us-east-1.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+  file_format_type = "json"
+}
+```
+
+- **EKS IRSA（IAM Roles for Service Accounts）和 ECS Task 角色：目前不受支持。** IRSA 需要 `WebIdentityTokenCredentialsProvider`（STS `AssumeRoleWithWebIdentity`），ECS Task 角色需要 `ContainerCredentialsProvider`；这两个类都不在枚举中，因此都无法选用。`InstanceProfileCredentialsProvider` **无法**覆盖这些场景——它只读取 EC2 节点元数据，返回的是节点角色，而不是细粒度的 service account 角色或 task 角色。
+
+  在连接器支持这些 provider 之前，请使用以下变通方案之一：
+    - 通过 `InstanceProfileCredentialsProvider` 回退到 EC2 节点实例角色（权限粒度比 IRSA / task 角色更粗）。
+    - 或者使用 `SimpleAWSCredentialsProvider`，并通过 Kubernetes Secret（例如借助环境变量替换）注入 `access_key` / `secret_key`。优先使用短期有效的凭证，避免把长期密钥硬编码在文件里。
+
+#### 排查
+
+如果作业在 source 初始化阶段失败，并出现类似 `Could not parse value for enum` 或引用了 `fs.s3a.aws.credentials.provider` 的 `Factory initialize failed` 报错，说明所配置的值不在受支持的枚举范围内。请将其设置为上面两个受支持的值之一。
 
 ## 示例
 

--- a/docs/zh/engines/zeta/checkpoint-storage.md
+++ b/docs/zh/engines/zeta/checkpoint-storage.md
@@ -162,6 +162,29 @@ seatunnel:
 
 有关Hadoop Credential Provider API的更多信息，请参见: [Credential Provider API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
 
+##### 容器环境下的凭证提供方
+
+与 S3File 连接器不同，检查点存储**不会**将 `fs.s3a.aws.credentials.provider` 限制为固定的取值范围。所有 `fs.s3a.*` 选项都会原样透传给底层的 Hadoop `Configuration`。这意味着你可以使用 classpath 上的**任意** S3A 凭证提供方，包括容器凭证提供方，例如 `com.amazonaws.auth.ContainerCredentialsProvider`（ECS/EKS）——只要对应的类位于 `${SEATUNNEL_HOME}/lib` 中即可。
+
+例如，在 ECS/EKS 部署中使用容器凭证、无需嵌入 access key：
+
+```yaml
+seatunnel:
+  engine:
+    checkpoint:
+      interval: 6000
+      timeout: 7000
+      storage:
+        type: hdfs
+        max-retained: 3
+        plugin-config:
+          namespace: # 检查点存储父路径，默认值为/seatunnel/checkpoint/
+          storage.type: s3
+          s3.bucket: s3a://your-bucket
+          fs.s3a.endpoint: your-endpoint
+          fs.s3a.aws.credentials.provider: com.amazonaws.auth.ContainerCredentialsProvider
+```
+
 #### HDFS
 
 如果您使用HDFS，您可以这样配置:


### PR DESCRIPTION
## Purpose of this pull request

Closes #11275.

Clarifies how S3 credentials should be configured for the S3File connector and checkpoint storage in container environments (Kubernetes / ECS / EKS), and documents what is supported and unsupported today. The behavior described is based on the current code:

- The connector option `fs.s3a.aws.credentials.provider` is a restricted enum (`S3aAwsCredentialsProvider`) that only accepts `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` and `com.amazonaws.auth.InstanceProfileCredentialsProvider`. Any other value is rejected at job startup, and it cannot be overridden through `hadoop_s3_properties` (the connector always overwrites that key with the enum value).
- Checkpoint storage uses a different path: all `fs.s3a.*` options are passed through to Hadoop unchanged, so any S3A credential provider (including container credential providers) can be used there.

## What changed

- **Connector docs** (`docs/{en,zh}/connectors/{source,sink}/S3File.md`):
  - Mark `fs.s3a.aws.credentials.provider` as an `enum` in the option tables and describe the restriction.
  - Add a "Credential Provider in Container Environments" section:
    - EC2 instance role (including an EKS worker-node instance role) is supported via `InstanceProfileCredentialsProvider`.
    - EKS IRSA and ECS task role are not supported today, because they require `WebIdentityTokenCredentialsProvider` / `ContainerCredentialsProvider`, which are not part of the enum. Safe workarounds are documented (node instance role, or `SimpleAWSCredentialsProvider` with credentials injected from a Kubernetes Secret).
    - Troubleshooting note for the enum-parse / factory-initialize failure.
- **Checkpoint storage docs** (`docs/{en,zh}/engines/zeta/checkpoint-storage.md`):
  - Note that the S3 checkpoint path passes `fs.s3a.*` through to Hadoop unchanged, so any S3A provider (including container credential providers) can be used, and add a container-environment example.

## Check list

- [x] English and Chinese docs are kept in sync.
- [x] Examples do not contain real credentials.
- [x] Documentation-only change; no code is modified.