### PR TITLE
[Fix][Connector-V2] Prevent silent StarRocks batch data loss

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/HttpHelper.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/HttpHelper.java
@@ -105,9 +105,30 @@ public class HttpHelper {
 
     public Map<String, Object> doHttpGet(String getUrl, Map<String, String> header)
             throws IOException {
+        return doHttpGet(getUrl, header, 0);
+    }
+
+    /**
+     * Executes a JSON GET request with a caller-provided deadline for connection and response I/O.
+     *
+     * @param getUrl target URL
+     * @param header request headers
+     * @param timeoutMs timeout in milliseconds, or zero to preserve the client default
+     * @return parsed JSON response, or null when the response has no usable entity
+     */
+    Map<String, Object> doHttpGet(String getUrl, Map<String, String> header, int timeoutMs)
+            throws IOException {
         log.info("Executing GET from {}.", getUrl);
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(getUrl);
+            if (timeoutMs > 0) {
+                httpGet.setConfig(
+                        RequestConfig.custom()
+                                .setConnectTimeout(timeoutMs)
+                                .setConnectionRequestTimeout(timeoutMs)
+                                .setSocketTimeout(timeoutMs)
+                                .build());
+            }
             if (null != header) {
                 for (Map.Entry<String, String> entry : header.entrySet()) {
                     httpGet.setHeader(entry.getKey(), String.valueOf(entry.getValue()));

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManager.java
@@ -20,7 +20,6 @@ package org.apache.seatunnel.connectors.seatunnel.starrocks.client;
 import org.apache.seatunnel.shade.com.google.common.base.Strings;
 
 import org.apache.seatunnel.api.table.catalog.TableSchema;
-import org.apache.seatunnel.common.utils.ExceptionUtils;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SinkConfig;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorException;
@@ -40,6 +39,13 @@ public class StarRocksSinkManager {
     private final List<byte[]> batchList;
 
     private final StarRocksStreamLoadVisitor starrocksStreamLoadVisitor;
+
+    /**
+     * Snapshot whose outcome is not confirmed yet. Its rows and label must survive failed flush
+     * calls so a later retry cannot bypass StarRocks label-based idempotency.
+     */
+    private StarRocksFlushTuple pendingFlush;
+
     private volatile boolean initialize;
     private volatile Exception flushException;
     private int batchRowCount = 0;
@@ -65,9 +71,18 @@ public class StarRocksSinkManager {
         initialize = true;
     }
 
+    /**
+     * Buffers a record after resolving any previously failed flush.
+     *
+     * <p>A new record cannot join a pending snapshot because clearing that snapshot after a retry
+     * would otherwise clear a record that was never sent.
+     */
     public synchronized void write(String record) throws IOException {
         tryInit();
         checkFlushException();
+        if (pendingFlush != null) {
+            flush();
+        }
         byte[] bts = record.getBytes(StandardCharsets.UTF_8);
         batchList.add(bts);
         batchRowCount++;
@@ -82,29 +97,39 @@ public class StarRocksSinkManager {
         flush();
     }
 
+    /**
+     * Flushes buffered rows and releases them only after StarRocks confirms success or commit.
+     *
+     * <p>Failed or unknown outcomes retain both the batch snapshot and its label across calls. The
+     * label changes only when StarRocks explicitly reports that the previous transaction aborted.
+     */
     public synchronized void flush() throws IOException {
         checkFlushException();
-        if (batchList.isEmpty()) {
-            return;
+        if (pendingFlush == null) {
+            if (batchList.isEmpty()) {
+                return;
+            }
+            pendingFlush =
+                    new StarRocksFlushTuple(
+                            createBatchLabel(), batchBytesSize, new ArrayList<>(batchList));
         }
-        String label = createBatchLabel();
-        StarRocksFlushTuple tuple =
-                new StarRocksFlushTuple(label, batchBytesSize, new ArrayList<>(batchList));
+        StarRocksFlushTuple tuple = pendingFlush;
+        boolean loadSucceeded = false;
         for (int i = 0; i <= sinkConfig.getMaxRetries(); i++) {
             try {
                 Boolean successFlag = starrocksStreamLoadVisitor.doStreamLoad(tuple);
-                if (successFlag) {
+                if (Boolean.TRUE.equals(successFlag)) {
+                    loadSucceeded = true;
                     break;
                 }
+                throw new StarRocksConnectorException(
+                        StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                        String.format(
+                                "Stream Load returned a non-success result for %s.%s with label [%s].",
+                                sinkConfig.getDatabase(), sinkConfig.getTable(), tuple.getLabel()));
             } catch (Exception e) {
                 log.warn("Writing records to StarRocks failed, retry times = {}", i, e);
 
-                String labelAlreadyMessage =
-                        String.format("Label [%s] has already been used", label);
-                if (ExceptionUtils.getMessage(e).contains(labelAlreadyMessage)) {
-                    log.warn("Label [{}] has already been used, Skipping this batch", label);
-                    break;
-                }
                 if (i >= sinkConfig.getMaxRetries()) {
                     throw new StarRocksConnectorException(
                             StarRocksConnectorErrorCode.WRITE_RECORDS_FAILED,
@@ -131,10 +156,20 @@ public class StarRocksSinkManager {
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
                     throw new StarRocksConnectorException(
-                            StarRocksConnectorErrorCode.FLUSH_DATA_FAILED, e);
+                            StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                            "Interrupted while waiting to retry Stream Load.",
+                            ex);
                 }
             }
         }
+        if (!loadSucceeded) {
+            throw new StarRocksConnectorException(
+                    StarRocksConnectorErrorCode.WRITE_RECORDS_FAILED,
+                    "Stream Load did not complete successfully; buffered records were retained.");
+        }
+        // Buffered rows can only be released after StarRocks confirms a successful or committed
+        // load.
+        pendingFlush = null;
         batchList.clear();
         batchRowCount = 0;
         batchBytesSize = 0;

--- a/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/main/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitor.java
@@ -46,11 +46,13 @@ public class StarRocksStreamLoadVisitor {
 
     private final HttpHelper httpHelper;
     private static final int MAX_SLEEP_TIME = 5;
+    private static final long DEFAULT_LABEL_STATE_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(3);
 
     private final SinkConfig sinkConfig;
     private long pos;
     private static final String RESULT_FAILED = "Fail";
     private static final String RESULT_SUCCESS = "Success";
+    private static final String RESULT_PUBLISH_TIMEOUT = "Publish Timeout";
     private static final String RESULT_LABEL_EXISTED = "Label Already Exists";
     private static final String LABEL_STATE_VISIBLE = "VISIBLE";
     private static final String LABEL_STATE_COMMITTED = "COMMITTED";
@@ -60,10 +62,38 @@ public class StarRocksStreamLoadVisitor {
 
     private final TableSchema tableSchema;
 
+    /**
+     * Maximum total time spent waiting for one reused label to leave the PREPARE state. The bound
+     * prevents a checkpoint flush from waiting forever on an unresolved transaction.
+     */
+    private final long labelStateTimeoutMs;
+
     public StarRocksStreamLoadVisitor(SinkConfig sinkConfig, TableSchema tableSchema) {
+        this(sinkConfig, tableSchema, new HttpHelper(sinkConfig), DEFAULT_LABEL_STATE_TIMEOUT_MS);
+    }
+
+    /**
+     * Creates a visitor with an explicit HTTP helper so response handling can be verified without a
+     * live StarRocks cluster.
+     */
+    StarRocksStreamLoadVisitor(
+            SinkConfig sinkConfig, TableSchema tableSchema, HttpHelper httpHelper) {
+        this(sinkConfig, tableSchema, httpHelper, DEFAULT_LABEL_STATE_TIMEOUT_MS);
+    }
+
+    /**
+     * Creates a visitor with explicit HTTP transport and label-state timeout for deterministic
+     * boundary tests.
+     */
+    StarRocksStreamLoadVisitor(
+            SinkConfig sinkConfig,
+            TableSchema tableSchema,
+            HttpHelper httpHelper,
+            long labelStateTimeoutMs) {
         this.sinkConfig = sinkConfig;
         this.tableSchema = tableSchema;
-        this.httpHelper = new HttpHelper(sinkConfig);
+        this.httpHelper = httpHelper;
+        this.labelStateTimeoutMs = Math.max(1, labelStateTimeoutMs);
         checkBatchMaxBytes(sinkConfig.getBatchMaxBytes(), sinkConfig.getBatchMaxSize());
     }
 
@@ -105,7 +135,22 @@ public class StarRocksStreamLoadVisitor {
         if (LOG.isDebugEnabled()) {
             LOG.debug("StreamLoad response:\n" + JsonUtils.toJsonString(loadResult));
         }
-        if (RESULT_FAILED.equals(loadResult.get(keyStatus))) {
+        Object resultStatus = loadResult.get(keyStatus);
+        if (RESULT_SUCCESS.equals(resultStatus) || RESULT_PUBLISH_TIMEOUT.equals(resultStatus)) {
+            return true;
+        }
+        if (RESULT_LABEL_EXISTED.equals(resultStatus)) {
+            LOG.debug("StreamLoad response:\n" + JsonUtils.toJsonString(loadResult));
+            // The original request may already be committed, so never resend it under a new label
+            // until StarRocks reports the final state of the existing label.
+            checkLabelState(host, flushData.getLabel());
+            return true;
+        }
+        if (RESULT_FAILED.equals(resultStatus)) {
+            if (isLabelAlreadyUsed(loadResult, flushData.getLabel())) {
+                checkLabelState(host, flushData.getLabel());
+                return true;
+            }
             StringBuilder errorBuilder = new StringBuilder("Failed to flush data to StarRocks \n");
             errorBuilder
                     .append(sinkConfig.getDatabase())
@@ -131,12 +176,11 @@ public class StarRocksStreamLoadVisitor {
             }
             throw new StarRocksConnectorException(
                     StarRocksConnectorErrorCode.FLUSH_DATA_FAILED, errorBuilder.toString());
-        } else if (RESULT_LABEL_EXISTED.equals(loadResult.get(keyStatus))) {
-            LOG.debug("StreamLoad response:\n" + JsonUtils.toJsonString(loadResult));
-            // has to block-checking the state to get the final result
-            checkLabelState(host, flushData.getLabel());
         }
-        return RESULT_SUCCESS.equals(loadResult.get(keyStatus));
+        throw new StarRocksConnectorException(
+                StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                "Unable to flush data to StarRocks: unexpected result status. "
+                        + JsonUtils.toJsonString(loadResult));
     }
 
     private String getAvailableHost() {
@@ -192,12 +236,8 @@ public class StarRocksStreamLoadVisitor {
     @SuppressWarnings("unchecked")
     private void checkLabelState(String host, String label) throws IOException {
         int idx = 0;
-        while (true) {
-            try {
-                TimeUnit.SECONDS.sleep(Math.min(++idx, MAX_SLEEP_TIME));
-            } catch (InterruptedException ex) {
-                break;
-            }
+        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(labelStateTimeoutMs);
+        while (System.nanoTime() < deadlineNanos) {
             try {
                 String queryLoadStateUrl =
                         new StringBuilder(host)
@@ -207,7 +247,10 @@ public class StarRocksStreamLoadVisitor {
                                 .append(label)
                                 .toString();
                 Map<String, Object> result =
-                        httpHelper.doHttpGet(queryLoadStateUrl, getLoadStateHttpHeader(label));
+                        httpHelper.doHttpGet(
+                                queryLoadStateUrl,
+                                getLoadStateHttpHeader(label),
+                                remainingTimeoutMs(deadlineNanos));
                 if (result == null) {
                     throw new StarRocksConnectorException(
                             StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
@@ -233,6 +276,7 @@ public class StarRocksStreamLoadVisitor {
                     case LABEL_STATE_COMMITTED:
                         return;
                     case RESULT_LABEL_PREPARE:
+                        sleepBeforeNextLabelCheck(++idx, deadlineNanos, label);
                         continue;
                     case RESULT_LABEL_ABORTED:
                         throw new StarRocksConnectorException(
@@ -256,6 +300,62 @@ public class StarRocksStreamLoadVisitor {
                         StarRocksConnectorErrorCode.FLUSH_DATA_FAILED, e);
             }
         }
+        throw new StarRocksConnectorException(
+                StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                String.format(
+                        "Timed out after %d ms while checking the final state of label[%s].",
+                        labelStateTimeoutMs, label));
+    }
+
+    /**
+     * Converts the remaining label-state deadline into a positive HTTP timeout.
+     *
+     * @param deadlineNanos absolute deadline based on {@link System#nanoTime()}
+     * @return bounded timeout accepted by the Apache HTTP client
+     */
+    private int remainingTimeoutMs(long deadlineNanos) {
+        long remainingNanos = Math.max(1, deadlineNanos - System.nanoTime());
+        long remainingMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(remainingNanos));
+        return (int) Math.min(Integer.MAX_VALUE, remainingMillis);
+    }
+
+    /**
+     * Waits before polling a PREPARE label again without exceeding the total state deadline. An
+     * interrupted wait fails the flush while preserving the thread interruption signal.
+     */
+    private void sleepBeforeNextLabelCheck(int attempt, long deadlineNanos, String label) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+            return;
+        }
+        long sleepNanos =
+                Math.min(
+                        TimeUnit.SECONDS.toNanos(Math.min(attempt, MAX_SLEEP_TIME)),
+                        remainingNanos);
+        try {
+            TimeUnit.NANOSECONDS.sleep(sleepNanos);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new StarRocksConnectorException(
+                    StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                    String.format(
+                            "Interrupted while checking the final state of label[%s].", label),
+                    ex);
+        }
+    }
+
+    /**
+     * Detects the legacy failure response used by some StarRocks versions for a reused label.
+     *
+     * @param loadResult Stream Load response body
+     * @param label label used by the current batch
+     * @return true when the message identifies the current label as already used
+     */
+    private boolean isLabelAlreadyUsed(Map<String, Object> loadResult, String label) {
+        Object message = loadResult.get("Message");
+        return message != null
+                && message.toString()
+                        .contains(String.format("Label [%s] has already been used", label));
     }
 
     private String getBasicAuthHeader(String username, String password) {

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManagerTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksSinkManagerTest.java
@@ -18,14 +18,22 @@
 package org.apache.seatunnel.connectors.seatunnel.starrocks.client;
 
 import org.apache.seatunnel.connectors.seatunnel.starrocks.config.SinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksConnectorException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -38,6 +46,12 @@ public class StarRocksSinkManagerTest {
     private StarRocksStreamLoadVisitor mockStreamLoadVisitor;
     private StarRocksSinkManager sinkManager;
 
+    /**
+     * Counts labels created by the production lifecycle so tests can detect unintended
+     * regeneration.
+     */
+    private AtomicInteger labelSequence;
+
     @BeforeEach
     void setUp() {
         mockSinkConfig = mock(SinkConfig.class);
@@ -45,29 +59,37 @@ public class StarRocksSinkManagerTest {
         when(mockSinkConfig.getBatchMaxSize()).thenReturn(10);
         when(mockSinkConfig.getBatchMaxBytes()).thenReturn(1024 * 1024 * 1024L);
         when(mockSinkConfig.getMaxRetries()).thenReturn(3);
-        when(mockSinkConfig.getRetryBackoffMultiplierMs()).thenReturn(100);
+        when(mockSinkConfig.getRetryBackoffMultiplierMs()).thenReturn(0);
         when(mockSinkConfig.getMaxRetryBackoffMs()).thenReturn(1000);
+        labelSequence = new AtomicInteger();
         this.sinkManager =
                 new StarRocksSinkManager(mockSinkConfig, null, mockStreamLoadVisitor) {
                     public String createBatchLabel() {
-                        return "test-label";
+                        return "test-label-" + labelSequence.incrementAndGet();
                     }
                 };
     }
 
+    /**
+     * Verifies that a reused-label exception can no longer silently discard buffered rows.
+     *
+     * <p>A later successful flush must still send the record retained after retries are exhausted.
+     */
     @Test
-    void testLabelAlreadyMessageHandledCorrectly() throws Exception {
-        // Mock behavior for label already used
-        doThrow(new RuntimeException("Label [test-label] has already been used"))
+    void testLabelAlreadyMessageDoesNotDiscardBufferedRecords() throws Exception {
+        doThrow(new RuntimeException("Label [test-label-1] has already been used"))
                 .when(mockStreamLoadVisitor)
                 .doStreamLoad(any());
 
-        // Add a record to trigger flush
         sinkManager.write("test-record");
 
-        // Verify that the exception is caught and the batch is skipped
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(4)).doStreamLoad(any());
+
+        doReturn(true).when(mockStreamLoadVisitor).doStreamLoad(any());
         assertDoesNotThrow(() -> sinkManager.flush());
-        verify(mockStreamLoadVisitor, times(1)).doStreamLoad(any());
+        verify(mockStreamLoadVisitor, times(5)).doStreamLoad(any());
+        assertEquals(1, labelSequence.get());
     }
 
     @Test
@@ -84,5 +106,181 @@ public class StarRocksSinkManagerTest {
         assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
         verify(mockStreamLoadVisitor, times(4))
                 .doStreamLoad(any()); // 3 retries + 1 initial attempt
+    }
+
+    /**
+     * Verifies that a false visitor response retains the batch until a later successful flush.
+     *
+     * <p>The second flush proves that the first failed flush did not clear the internal batch.
+     */
+    @Test
+    void testFalseResponseDoesNotDiscardBufferedRecords() throws Exception {
+        List<String> attemptedLabels = new ArrayList<>();
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            attemptedLabels.add(
+                                    ((StarRocksFlushTuple) invocation.getArgument(0)).getLabel());
+                            return attemptedLabels.size() >= 5;
+                        });
+        sinkManager.write("test-record");
+
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(4)).doStreamLoad(any());
+
+        assertDoesNotThrow(() -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(5)).doStreamLoad(any());
+        assertEquals(5, attemptedLabels.size());
+        for (String attemptedLabel : attemptedLabels) {
+            assertEquals("test-label-1", attemptedLabel);
+        }
+        assertEquals(1, labelSequence.get());
+    }
+
+    /**
+     * Verifies that a confirmed successful response releases the buffered rows exactly once.
+     *
+     * <p>An immediate second flush must not issue another Stream Load request.
+     */
+    @Test
+    void testSuccessfulResponseClearsBufferedRecords() throws Exception {
+        when(mockStreamLoadVisitor.doStreamLoad(any())).thenReturn(true);
+        sinkManager.write("test-record");
+
+        assertDoesNotThrow(() -> sinkManager.flush());
+        assertDoesNotThrow(() -> sinkManager.flush());
+        verify(mockStreamLoadVisitor, times(1)).doStreamLoad(any());
+        assertEquals(1, labelSequence.get());
+    }
+
+    /**
+     * Verifies that an aborted transaction receives a new label before its batch is retried.
+     *
+     * <p>The captured labels prevent a retry from reusing the transaction known to be aborted.
+     */
+    @Test
+    void testAbortedLabelIsRecreatedBeforeRetry() throws Exception {
+        AtomicInteger labelSequence = new AtomicInteger();
+        List<String> attemptedLabels = new ArrayList<>();
+        StarRocksConnectorException abortedLabel =
+                new StarRocksConnectorException(
+                        StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                        "The prior transaction was aborted.",
+                        true);
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            attemptedLabels.add(tuple.getLabel());
+                            if (attemptedLabels.size() == 1) {
+                                throw abortedLabel;
+                            }
+                            return true;
+                        });
+        StarRocksSinkManager manager =
+                new StarRocksSinkManager(mockSinkConfig, null, mockStreamLoadVisitor) {
+                    @Override
+                    public String createBatchLabel() {
+                        return "test-label-" + labelSequence.incrementAndGet();
+                    }
+                };
+
+        manager.write("test-record");
+        assertDoesNotThrow(() -> manager.flush());
+
+        assertEquals(2, attemptedLabels.size());
+        assertEquals("test-label-1", attemptedLabels.get(0));
+        assertEquals("test-label-2", attemptedLabels.get(1));
+    }
+
+    /**
+     * Verifies that a null response follows the same fail-closed path as an explicit false result.
+     */
+    @Test
+    void testNullResponseDoesNotDiscardBufferedRecordsOrLabel() throws Exception {
+        when(mockStreamLoadVisitor.doStreamLoad(any())).thenReturn(null);
+        sinkManager.write("test-record");
+
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        assertEquals(1, labelSequence.get());
+
+        doReturn(true).when(mockStreamLoadVisitor).doStreamLoad(any());
+        assertDoesNotThrow(() -> sinkManager.flush());
+        assertEquals(1, labelSequence.get());
+    }
+
+    /**
+     * Verifies that a pending snapshot is resolved before a new record enters the active batch. New
+     * records must never be cleared as part of an older successful flush.
+     */
+    @Test
+    void testPendingSnapshotIsFlushedBeforeAcceptingNewRecord() throws Exception {
+        when(mockSinkConfig.getMaxRetries()).thenReturn(0);
+        List<String> attemptedLabels = new ArrayList<>();
+        List<Integer> attemptedRows = new ArrayList<>();
+        AtomicInteger attempts = new AtomicInteger();
+        when(mockStreamLoadVisitor.doStreamLoad(any()))
+                .thenAnswer(
+                        invocation -> {
+                            StarRocksFlushTuple tuple = invocation.getArgument(0);
+                            attemptedLabels.add(tuple.getLabel());
+                            attemptedRows.add(tuple.getRows().size());
+                            return attempts.incrementAndGet() > 1;
+                        });
+
+        sinkManager.write("first-record");
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        sinkManager.write("second-record");
+        assertDoesNotThrow(() -> sinkManager.flush());
+
+        assertEquals(3, attemptedLabels.size());
+        assertEquals("test-label-1", attemptedLabels.get(0));
+        assertEquals("test-label-1", attemptedLabels.get(1));
+        assertEquals("test-label-2", attemptedLabels.get(2));
+        assertEquals(1, attemptedRows.get(0));
+        assertEquals(1, attemptedRows.get(1));
+        assertEquals(1, attemptedRows.get(2));
+    }
+
+    /**
+     * Verifies that retry exhaustion cannot create one more label after the final aborted attempt.
+     */
+    @Test
+    void testRecreatedLabelExhaustionRetainsLastAttemptedLabel() throws Exception {
+        StarRocksConnectorException abortedLabel =
+                new StarRocksConnectorException(
+                        StarRocksConnectorErrorCode.FLUSH_DATA_FAILED,
+                        "The prior transaction was aborted.",
+                        true);
+        doThrow(abortedLabel).when(mockStreamLoadVisitor).doStreamLoad(any());
+        sinkManager.write("test-record");
+
+        assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+        assertEquals(4, labelSequence.get());
+
+        doReturn(true).when(mockStreamLoadVisitor).doStreamLoad(any());
+        assertDoesNotThrow(() -> sinkManager.flush());
+        assertEquals(4, labelSequence.get());
+    }
+
+    /**
+     * Verifies that an interrupted retry preserves the pending snapshot, label, and interrupt flag.
+     */
+    @Test
+    void testInterruptedRetryRetainsBufferedRecordsAndLabel() throws Exception {
+        when(mockStreamLoadVisitor.doStreamLoad(any())).thenReturn(false);
+        try {
+            Thread.currentThread().interrupt();
+            sinkManager.write("test-record");
+            assertThrows(StarRocksConnectorException.class, () -> sinkManager.flush());
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertEquals(1, labelSequence.get());
+        } finally {
+            Thread.interrupted();
+        }
+
+        doReturn(true).when(mockStreamLoadVisitor).doStreamLoad(any());
+        assertDoesNotThrow(() -> sinkManager.flush());
+        assertEquals(1, labelSequence.get());
     }
 }

--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
@@ -23,12 +23,22 @@ import org.apache.seatunnel.connectors.seatunnel.starrocks.exception.StarRocksCo
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class StarRocksStreamLoadVisitorTest {
@@ -109,5 +119,320 @@ public class StarRocksStreamLoadVisitorTest {
                             new StarRocksStreamLoadVisitor(sinkConfig, mock(TableSchema.class));
                     visitor.checkBatchMaxBytes(1024, 10);
                 });
+    }
+
+    /**
+     * Verifies that a successful load awaiting publication is not submitted a second time.
+     *
+     * <p>StarRocks documents Publish Timeout as loaded successfully and requiring no retry.
+     */
+    @Test
+    void returnsSuccessForPublishTimeout() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Publish Timeout"));
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper, never()).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Verifies that an existing visible label confirms the original batch was loaded.
+     *
+     * <p>The visitor must query the label state instead of resending the batch under a new label.
+     */
+    @Test
+    void returnsSuccessWhenExistingLabelIsVisible() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> labelState = new HashMap<>();
+        labelState.put("state", "VISIBLE");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(labelState);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Verifies that a new label is allowed only after StarRocks reports the old one aborted.
+     *
+     * <p>The recreation flag is the manager's proof that retrying cannot duplicate a committed
+     * load.
+     */
+    @Test
+    void recreatesLabelOnlyAfterExistingLabelIsAborted() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        Map<String, Object> loadResult = createLoadResult("Fail");
+        loadResult.put("Message", "Label [test-label] has already been used");
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any())).thenReturn(loadResult);
+        Map<String, Object> labelState = new HashMap<>();
+        labelState.put("state", "ABORTED");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(labelState);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        StarRocksConnectorException exception =
+                assertThrows(
+                        StarRocksConnectorException.class,
+                        () -> visitor.doStreamLoad(createFlushTuple()));
+        assertTrue(exception.needReCreateLabel());
+    }
+
+    /**
+     * Verifies that interruption fails the flush without treating the label check as success.
+     *
+     * <p>The interrupt flag must remain set so the engine can preserve cancellation semantics.
+     */
+    @Test
+    void failsWithoutDiscardingStateWhenLabelCheckIsInterrupted() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> labelState = new HashMap<>();
+        labelState.put("state", "PREPARE");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(labelState);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        try {
+            Thread.currentThread().interrupt();
+            assertThrows(
+                    StarRocksConnectorException.class,
+                    () -> visitor.doStreamLoad(createFlushTuple()));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    /**
+     * Verifies that the normal Stream Load success response is accepted without a label query. A
+     * committed request must complete through the shortest response path.
+     */
+    @Test
+    void returnsSuccessForNormalSuccessStatus() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Success"));
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper, never()).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Verifies that an existing committed label confirms the original batch without resubmission.
+     */
+    @Test
+    void returnsSuccessWhenExistingLabelIsCommitted() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> labelState = new HashMap<>();
+        labelState.put("state", "COMMITTED");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(labelState);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+    }
+
+    /**
+     * Verifies that an unknown label state fails closed without authorizing a replacement label.
+     */
+    @Test
+    void failsWhenExistingLabelStateIsUnknown() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> labelState = new HashMap<>();
+        labelState.put("state", "UNKNOWN");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(labelState);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        StarRocksConnectorException exception =
+                assertThrows(
+                        StarRocksConnectorException.class,
+                        () -> visitor.doStreamLoad(createFlushTuple()));
+        assertFalse(exception.needReCreateLabel());
+    }
+
+    /**
+     * Verifies that an unrecognized response status cannot be converted into a successful flush.
+     */
+    @Test
+    void failsForUnexpectedStreamLoadStatus() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Mystery"));
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        assertThrows(
+                StarRocksConnectorException.class, () -> visitor.doStreamLoad(createFlushTuple()));
+    }
+
+    /**
+     * Verifies that an ordinary failed load does not authorize a new idempotency label. Only an
+     * explicitly aborted transaction may release the pending batch for a replacement label.
+     */
+    @Test
+    void failsOrdinaryLoadFailureWithoutRecreatingLabel() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        Map<String, Object> loadResult = createLoadResult("Fail");
+        loadResult.put("Message", "Invalid row format");
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any())).thenReturn(loadResult);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper);
+
+        StarRocksConnectorException exception =
+                assertThrows(
+                        StarRocksConnectorException.class,
+                        () -> visitor.doStreamLoad(createFlushTuple()));
+        assertFalse(exception.needReCreateLabel());
+    }
+
+    /**
+     * Verifies that a PREPARE transaction can become visible before the bounded wait expires. The
+     * original label must be accepted without submitting the batch again.
+     */
+    @Test
+    void returnsSuccessWhenPrepareStateBecomesVisible() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> preparing = new HashMap<>();
+        preparing.put("state", "PREPARE");
+        Map<String, Object> visible = new HashMap<>();
+        visible.put("state", "VISIBLE");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(preparing, visible);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper, 2000);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper, org.mockito.Mockito.times(2)).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Verifies that a PREPARE transaction can become committed before the bounded wait expires. A
+     * committed label is a terminal success even before the data becomes visible.
+     */
+    @Test
+    void returnsSuccessWhenPrepareStateBecomesCommitted() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> preparing = new HashMap<>();
+        preparing.put("state", "PREPARE");
+        Map<String, Object> committed = new HashMap<>();
+        committed.put("state", "COMMITTED");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(preparing, committed);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper, 2000);
+
+        assertTrue(visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper, org.mockito.Mockito.times(2)).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Verifies that a label permanently in PREPARE fails when the total wait deadline expires. The
+     * caller can then retry the same pending batch without losing its idempotency label.
+     */
+    @Test
+    void failsWhenPrepareStateExceedsDeadline() throws Exception {
+        SinkConfig sinkConfig = createSinkConfig();
+        HttpHelper httpHelper = mock(HttpHelper.class);
+        when(httpHelper.tryHttpConnection("http://localhost:8030")).thenReturn(true);
+        when(httpHelper.doHttpPut(anyString(), any(byte[].class), any()))
+                .thenReturn(createLoadResult("Label Already Exists"));
+        Map<String, Object> preparing = new HashMap<>();
+        preparing.put("state", "PREPARE");
+        when(httpHelper.doHttpGet(anyString(), any(), anyInt())).thenReturn(preparing);
+        StarRocksStreamLoadVisitor visitor =
+                new StarRocksStreamLoadVisitor(sinkConfig, createTableSchema(), httpHelper, 10);
+
+        assertThrows(
+                StarRocksConnectorException.class, () -> visitor.doStreamLoad(createFlushTuple()));
+        verify(httpHelper).doHttpGet(anyString(), any(), anyInt());
+    }
+
+    /**
+     * Creates the minimal deterministic sink configuration needed by response-handling tests.
+     *
+     * @return mocked sink configuration for one JSON Stream Load target
+     */
+    private SinkConfig createSinkConfig() {
+        SinkConfig sinkConfig = mock(SinkConfig.class);
+        when(sinkConfig.getLoadFormat()).thenReturn(SinkConfig.StreamLoadFormat.JSON);
+        when(sinkConfig.getBatchMaxBytes()).thenReturn(1024L);
+        when(sinkConfig.getBatchMaxSize()).thenReturn(10);
+        when(sinkConfig.getNodeUrls()).thenReturn(Collections.singletonList("localhost:8030"));
+        when(sinkConfig.getDatabase()).thenReturn("test_db");
+        when(sinkConfig.getTable()).thenReturn("test_table");
+        when(sinkConfig.getUsername()).thenReturn("test_user");
+        when(sinkConfig.getPassword()).thenReturn("test_password");
+        when(sinkConfig.getStreamLoadProps()).thenReturn(Collections.emptyMap());
+        return sinkConfig;
+    }
+
+    /**
+     * Creates a schema without columns because JSON response tests do not require column headers.
+     */
+    private TableSchema createTableSchema() {
+        TableSchema tableSchema = mock(TableSchema.class);
+        when(tableSchema.getColumns()).thenReturn(Collections.emptyList());
+        return tableSchema;
+    }
+
+    /**
+     * Creates one stable JSON row with a fixed label for Stream Load response tests.
+     *
+     * @return flush tuple whose label can be matched against StarRocks responses
+     */
+    private StarRocksFlushTuple createFlushTuple() {
+        byte[] row = "{}".getBytes(StandardCharsets.UTF_8);
+        List<byte[]> rows = Collections.singletonList(row);
+        return new StarRocksFlushTuple("test-label", (long) row.length, rows);
+    }
+
+    /**
+     * Creates a Stream Load response map containing the supplied StarRocks status.
+     *
+     * @param status response status returned by StarRocks
+     * @return mutable response map for test-specific fields
+     */
+    private Map<String, Object> createLoadResult(String status) {
+        Map<String, Object> loadResult = new HashMap<>();
+        loadResult.put("Status", status);
+        return loadResult;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

StarRocks Stream Load failures could previously exhaust retries and still clear the in-memory batch. The sink also treated a reused label as a reason to skip the batch, even though StarRocks may have committed the original transaction. Both paths can silently lose records.

This patch makes the sink fail closed:

- Retain the pending rows and their Stream Load label across failed `flush()` calls.
- Release buffered rows only after `Success`, `Publish Timeout`, `VISIBLE`, or `COMMITTED`.
- Query the existing label before deciding the outcome of `Label Already Exists`.
- Create a replacement label only when StarRocks explicitly reports `ABORTED`.
- Bound `PREPARE` polling to three minutes, apply the remaining deadline to HTTP I/O, and preserve thread interruption.
- Reject false, null, failed, and unknown responses without clearing the batch.

Related to #10680. Thanks to @xyueji for identifying the label-reuse failure mode. This PR keeps the pending batch and original label until the transaction state is known; immediately retrying an unknown outcome with a new label can duplicate data that StarRocks already committed.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, a StarRocks Stream Load failure could be logged while the buffered records were cleared, allowing the job to continue with missing rows. A reused label was also skipped without confirming whether its transaction was committed.

After this change, unresolved outcomes fail the write and retain the pending batch and label. The sink does not claim exactly-once across process restarts; it preserves the existing at-least-once contract while preventing silent batch loss in one writer lifecycle.

No configuration, default value, public API, SPI, serialization format, or connector registration changes are introduced.

### How was this patch tested?

Unit and module verification on JDK 8:

```bash
mvn -T 3C -f seatunnel-connectors-v2/connector-starrocks/pom.xml spotless:apply -nsu -Dmaven.gitcommitid.skip=true
mvn -T 3C -f seatunnel-connectors-v2/connector-starrocks/pom.xml test -nsu -Dmaven.gitcommitid.skip=true
mvn -T 3C -f seatunnel-connectors-v2/connector-starrocks/pom.xml -q -DskipTests verify -nsu -Dmaven.gitcommitid.skip=true
```

Result: 88 tests, 0 failures, 0 errors, 0 skipped. The new regression matrix covers false/null results, retry exhaustion, pending-batch and label retention, new records arriving after a failed flush, interrupted retries, final-attempt label handling, `Success`, `Publish Timeout`, reused-label `VISIBLE`/`COMMITTED`/`ABORTED`/`UNKNOWN`, ordinary failures, unexpected statuses, bounded `PREPARE` polling, and interruption.

The Stream Load protocol was also verified against a real `starrocks/allin1-ubuntu:3.3.4` FE/BE instance:

1. The first request with a fixed label returned `Success`.
2. A second request with the same label returned `Label Already Exists`.
3. `get_load_state` returned `VISIBLE`.
4. The target table contained only the first row, proving that the reused label did not insert a duplicate row.
5. An invalid load returned `Fail`; `get_load_state` returned `ABORTED`; a later valid retry succeeded.

A full MySQL CDC to StarRocks E2E job was not run. This patch does not modify the MySQL source, CDC deserialization, checkpoint state, schema handling, connector registration, or packaging; the real validation targets the Stream Load transaction protocol where this defect occurs. `seatunnel-engine-ui` was skipped because it is outside the affected module.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because no configuration or public contract changes.
* [x] `incompatible-changes.md` is not required because this change is backward compatible.
* [x] Connector registration and packaging files are not changed because this is an internal StarRocks sink correctness fix.