### PR TITLE
[Test][E2E] Isolate HTTP binary assert case

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/java/org/apache/seatunnel/e2e/connector/http/HttpIT.java
@@ -365,10 +365,17 @@ public class HttpIT extends TestSuiteBase implements TestResource {
         // http airtable source
         Container.ExecResult execResult22 = container.executeJob("/airtable_json_to_assert.conf");
         Assertions.assertEquals(0, execResult22.getExitCode());
+    }
 
-        // http binary download
-        Container.ExecResult execResult23 = container.executeJob("/http_binary_to_assert.conf");
-        Assertions.assertEquals(0, execResult23.getExitCode());
+    /**
+     * Run the binary download case in a fresh container so the longest HTTP source path does not
+     * inherit accumulated runtime pressure from the broader source-to-assert matrix.
+     */
+    @TestTemplate
+    public void testBinarySourceToAssertSink(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult execResult = container.executeJob("/http_binary_to_assert.conf");
+        Assertions.assertEquals(0, execResult.getExitCode());
     }
 
     @TestTemplate


### PR DESCRIPTION
## What does this PR do?
This PR splits the `/http_binary_to_assert.conf` scenario out of `testSourceToAssertSink` so the longest HTTP binary download path runs in a fresh container instead of at the tail of the full HTTP source-to-assert matrix.

This failure surfaced while re-checking PR #11425. Its old failed `Build` check came from `HttpIT.testSourceToAssertSink` on the binary assert case rather than from the engine-unit-test diff in that PR.

## Why is this needed?
- keeps the same exit-code assertion
- isolates the longest binary download path from accumulated runtime pressure in the broader matrix
- stays scoped to the flaky baseline case only

## Verification
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e -am spotless:apply`
- attempted `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e -am -DskipTests test-compile`, but the local reactor currently hits existing shaded dependency compilation failures in `seatunnel-api` before it reaches this module
- no local Docker run, per current environment constraint; CI will provide the runtime validation