### PR TITLE
[Fix][E2E] Replace flaky waits in E2E tests

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisErrorIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisErrorIT.java
@@ -74,8 +74,13 @@ public class DorisErrorIT extends AbstractDorisIT {
                                 throw new RuntimeException(e);
                             }
                         });
-        // wait for the job to start
-        Thread.sleep(10 * 1000);
+        // Keep the Doris sink job running before stopping Doris so this test exercises the
+        // stream-load failure path instead of an early submission failure.
+        given().pollInterval(1, TimeUnit.SECONDS)
+                .await()
+                .during(10, TimeUnit.SECONDS)
+                .atMost(15, TimeUnit.SECONDS)
+                .until(() -> !future.isDone());
         super.container.stop();
         Assertions.assertNotEquals(0, future.get().getExitCode());
         Assertions.assertTrue(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisSchemaChangeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisSchemaChangeIT.java
@@ -124,7 +124,6 @@ public class DorisSchemaChangeIT extends AbstractDorisIT {
                         throw new RuntimeException(e);
                     }
                 });
-        TimeUnit.SECONDS.sleep(20);
         // waiting for case1 completed
         assertSchemaEvolutionForAddColumns(
                 DATABASE, SOURCE_TABLE, SINK_TABLE, mysqlConnection, jdbcConnection);
@@ -183,7 +182,8 @@ public class DorisSchemaChangeIT extends AbstractDorisIT {
             String sinkTable,
             Connection sourceConnection,
             Connection sinkConnection) {
-        await().atMost(60000, TimeUnit.MILLISECONDS)
+        await().ignoreExceptions()
+                .atMost(60000, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertIterableEquals(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
@@ -387,11 +387,16 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
                                                     SFTP_CONTAINER_HOME
                                                             + "/tmp/seatunnel/continuous/dst/root.bin")));
 
-            Thread.sleep(3000);
-            Assertions.assertFalse(
-                    isSftpFileExists(
-                            SFTP_CONTAINER_HOME
-                                    + "/tmp/seatunnel/continuous/dst/subdir/nested.bin"));
+            Awaitility.await()
+                    .during(3, TimeUnit.SECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(500, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertFalse(
+                                            isSftpFileExists(
+                                                    SFTP_CONTAINER_HOME
+                                                            + "/tmp/seatunnel/continuous/dst/subdir/nested.bin")));
 
             Container.ExecResult cancelResult = container.cancelJob(jobId);
             Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
@@ -1746,8 +1746,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     return null;
                 });
         // wait for data written to kafka
-        given().pollDelay(60, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(5, MINUTES)
                 .untilAsserted(
@@ -1780,8 +1779,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     }
                 });
 
-        given().pollDelay(60, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(10, MINUTES)
                 .untilAsserted(
@@ -1831,8 +1829,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     return null;
                 });
         // wait for data written to kafka
-        given().pollDelay(120, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(5, MINUTES)
                 .untilAsserted(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
@@ -453,9 +453,10 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
 
     private Map<String, RocketMqConsumerMessage> getRocketMqConsumerData(String topicName) {
         Map<String, RocketMqConsumerMessage> data = new HashMap<>();
+        Map<MessageQueue, Long> consumedOffsets = new HashMap<>();
+        DefaultLitePullConsumer consumer = null;
         try {
-            DefaultLitePullConsumer consumer =
-                    RocketMqAdminUtil.initDefaultLitePullConsumer(newConfiguration(), false);
+            consumer = RocketMqAdminUtil.initDefaultLitePullConsumer(newConfiguration(), false);
             consumer.start();
             // assign
             Map<MessageQueue, TopicOffset> queueOffsets =
@@ -490,33 +491,66 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
                     break;
                 }
                 for (MessageExt message : messages) {
+                    MessageQueue messageQueue =
+                            new MessageQueue(
+                                    message.getTopic(),
+                                    message.getBrokerName(),
+                                    message.getQueueId());
                     RocketMqConsumerMessage consumerMessage =
                             new RocketMqConsumerMessage(
                                     new String(message.getBody(), StandardCharsets.UTF_8),
                                     message.getTags());
                     data.put(message.getKeys(), consumerMessage);
+                    consumedOffsets.merge(messageQueue, message.getQueueOffset(), Math::max);
                     consumer.getOffsetStore()
                             .updateConsumeOffsetToBroker(
-                                    new MessageQueue(
-                                            message.getTopic(),
-                                            message.getBrokerName(),
-                                            message.getQueueId()),
-                                    message.getQueueOffset(),
-                                    false);
+                                    messageQueue, message.getQueueOffset(), false);
                 }
                 consumer.commitSync();
             }
+            log.info("Consumer {} data total {}", topicName, data.size());
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
             if (consumer != null) {
                 consumer.shutdown();
             }
-            log.info("Consumer {} data total {}", topicName, data.size());
-            // consumer.commitSync() only submits the offset to the broker, and NameServer scans the
-            // broker to update the offset every 10 seconds
-            Thread.sleep(20 * 1000);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
         }
+        waitConsumedOffsetsSynced(topicName, consumedOffsets);
         return data;
+    }
+
+    private void waitConsumedOffsetsSynced(
+            String topicName, Map<MessageQueue, Long> consumedOffsets) {
+        if (consumedOffsets.isEmpty()) {
+            return;
+        }
+        Awaitility.await()
+                .ignoreExceptions()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Map<MessageQueue, Long> currentOffsets =
+                                    RocketMqAdminUtil.currentOffsets(
+                                            newConfiguration(),
+                                            Lists.newArrayList(topicName),
+                                            consumedOffsets.keySet());
+                            for (Map.Entry<MessageQueue, Long> consumedOffset :
+                                    consumedOffsets.entrySet()) {
+                                Long currentOffset = currentOffsets.get(consumedOffset.getKey());
+                                Assertions.assertNotNull(
+                                        currentOffset,
+                                        "Consume offset should be visible for "
+                                                + consumedOffset.getKey());
+                                Assertions.assertTrue(
+                                        currentOffset >= consumedOffset.getValue(),
+                                        "Consume offset should be synced to broker, currentOffset="
+                                                + currentOffset
+                                                + ", consumedOffset="
+                                                + consumedOffset.getValue());
+                            }
+                        });
     }
 
     private void checkOffsetNoDiff(String topicName, String consumerGroup) {


### PR DESCRIPTION
### Purpose of this pull request

Fix several PR-unrelated flaky E2E waits by replacing fixed sleeps and delayed polling with condition-based waits.

This patch updates:

- RocketMQ E2E: replace a fixed 20s sleep after consumer commit with an Awaitility wait for consumed offsets to become visible from RocketMQ admin APIs, and always shut down the test consumer in finally.
- Kafka E2E: remove fixed 60s/120s initial polling delays from exactly-once streaming assertions. The existing Awaitility assertions already wait for the expected records.
- Doris E2E: remove a fixed 20s schema-change startup sleep by letting the initial table assertion retry through startup-time query failures; replace the error-path startup sleep with a condition that ensures the async job remains running before stopping Doris.
- SFTP E2E: replace the non-recursive scan sleep with an Awaitility window asserting the nested file remains absent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran:

```
./mvnw spotless:apply
```

No E2E tests were run.