### PR TITLE
[Fix][CI] Avoid flaky approve label workflow failures

### DIFF
--- a/.github/workflows/approve-label.yml
+++ b/.github/workflows/approve-label.yml
@@ -20,7 +20,7 @@ name: "Label when approved workflow run"
 on:
   workflow_run:
     workflows: [Label-when-reviewed]
-    types: [requested]
+    types: [completed]
 permissions:
   # All other permissions are set to none
   checks: write
@@ -42,10 +42,12 @@ jobs:
       - name: "Get information about the original trigger of the run"
         uses: ./.github/actions/get-workflow-origin
         id: source-run-info
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
       - name: Label when approved by commiters
+        if: steps.source-run-info.outcome == 'success' && steps.source-run-info.outputs.pullRequestNumber != ''
         uses: ./.github/actions/label-when-approved-action
         id: label-when-approved-by-commiters
         with:
@@ -55,6 +57,7 @@ jobs:
           remove_label_when_approval_missing: 'true'
           pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
       - name: Label when approved by anyone
+        if: steps.source-run-info.outcome == 'success' && steps.source-run-info.outputs.pullRequestNumber != ''
         uses: ./.github/actions/label-when-approved-action
         id: label-when-approved-by-anyone
         with:


### PR DESCRIPTION
### Purpose of this pull request

Fix flaky failures in the `Label when approved` workflow by avoiding a best-effort label automation failure turning CI red.

**Root cause:**

The workflow currently runs on the `requested` event of the `Label-when-reviewed` workflow and immediately calls the GitHub Actions API to resolve the source run:

```
Getting workflow id for source run id: 29387900060, owner: apache, repo: seatunnel
Error: Not Found
```

This source-run lookup can return `404 Not Found` when the workflow run is not yet visible or cannot be resolved by the token at that moment. The failure is unrelated to the PR code but marks the CI job as failed.

**Changes:**
- Trigger the label workflow after the source workflow is `completed` instead of `requested`
- Allow the source-run lookup step to fail without failing the whole workflow
- Skip label update steps when no pull request number is resolved

### Does this PR introduce _any_ user-facing change?

No. This only affects GitHub Actions label automation stability.

### How was this patch tested?

- `./mvnw spotless:apply`

Per request, no tests were run locally.
