### PR TITLE
[Fix][E2E] Fix flaky Kafka latest and partition tests

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaFormatIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaFormatIT.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.SeaTunnelException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresJdbcRowConverter;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
@@ -52,6 +53,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.postgresql.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
@@ -62,12 +64,16 @@ import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -282,21 +288,33 @@ public class KafkaFormatIT extends TestSuiteBase implements TestResource {
     // --------------------------- Postgres Container-------------------------------------
     private static final String PG_IMAGE = "postgres:alpine3.16";
 
-    private static final String PG_DRIVER_JAR =
-            "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar";
-
     private static PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
+
+    private Path postgresqlDriverJarPath() {
+        try {
+            return Paths.get(
+                    Driver.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        } catch (Exception e) {
+            throw new SeaTunnelException(
+                    "Failed to resolve PostgreSQL JDBC driver jar from the test classpath", e);
+        }
+    }
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
             container -> {
+                Path driverJarPath = postgresqlDriverJarPath();
+                Assertions.assertTrue(
+                        Files.isRegularFile(driverJarPath),
+                        "PostgreSQL JDBC driver should be resolved from the test classpath before E2E runs: "
+                                + driverJarPath);
                 Container.ExecResult extraCommands =
                         container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && curl -O "
-                                        + PG_DRIVER_JAR);
+                                "bash", "-c", "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib");
                 Assertions.assertEquals(0, extraCommands.getExitCode());
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(driverJarPath),
+                        "/tmp/seatunnel/plugins/Jdbc/lib/" + driverJarPath.getFileName());
             };
 
     private void createKafkaContainer() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaFormatIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaFormatIT.java
@@ -29,7 +29,6 @@ import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
-import org.apache.seatunnel.common.exception.SeaTunnelException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresJdbcRowConverter;
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
@@ -295,7 +294,7 @@ public class KafkaFormatIT extends TestSuiteBase implements TestResource {
             return Paths.get(
                     Driver.class.getProtectionDomain().getCodeSource().getLocation().toURI());
         } catch (Exception e) {
-            throw new SeaTunnelException(
+            throw new RuntimeException(
                     "Failed to resolve PostgreSQL JDBC driver jar from the test classpath", e);
         }
     }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
@@ -680,6 +680,30 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                             }
                         });
 
+        AtomicInteger partitionProbeId = new AtomicInteger();
+        Awaitility.await()
+                .pollInterval(2, SECONDS)
+                .atMost(2, MINUTES)
+                .untilAsserted(
+                        () -> {
+                            int currentProbeId = partitionProbeId.getAndIncrement();
+                            String probeMessage =
+                                    String.format(
+                                            "{\"id\":%d,\"message\":\"partition_probe_%d\",\"timestamp\":%d}",
+                                            10000 + currentProbeId,
+                                            currentProbeId,
+                                            System.currentTimeMillis());
+                            producer.send(
+                                    new ProducerRecord<>(
+                                            sourceTopic, 1, null, probeMessage.getBytes()));
+                            producer.flush();
+
+                            Assertions.assertTrue(
+                                    countKafkaMessagesContaining(outputTopic, "partition_probe_")
+                                            > 0,
+                                    "SeaTunnel should discover and consume the new Kafka partition");
+                        });
+
         for (int i = 0; i < 15; i++) {
             String message =
                     String.format(
@@ -692,17 +716,17 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
         Awaitility.await()
                 .pollInterval(2, SECONDS)
                 .atMost(2, MINUTES)
-                .until(
+                .untilAsserted(
                         () -> {
-                            try {
-                                // Check the output topic data count
-                                List<String> outputData = getKafkaConsumerListData(outputTopic);
-                                log.info("Output topic data count: {}", outputData.size());
-                                return outputData.size() >= 15 && outputData.size() < 25;
-                            } catch (Exception e) {
-                                log.error("Error checking output topic data", e);
-                                return false;
-                            }
+                            long newPartitionMessageCount =
+                                    countKafkaMessagesContaining(
+                                            outputTopic, "new_partition_message_");
+                            log.info(
+                                    "New partition output message count: {}",
+                                    newPartitionMessageCount);
+                            Assertions.assertTrue(
+                                    newPartitionMessageCount >= 15,
+                                    "All messages from the discovered Kafka partition should be consumed");
                         });
 
         try (AdminClient adminClient = createKafkaAdmin()) {
@@ -830,6 +854,8 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
         final String sourceTopic = "test_topic_restore_latest";
         final String sinkTopic = "test_topic_restore_latest_output";
         final String payload = "Seatunnel Restore Test Data Latest";
+        final String firstRunPayload = payload + "_additional";
+        final String restorePayload = payload + "_restore";
         final String jobId = "18696753645410";
 
         // Write 20 initial records before starting the job.
@@ -854,6 +880,27 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
 
         awaitJobRunning(container, jobId);
 
+        AtomicInteger latestModeProbeId = new AtomicInteger();
+        Awaitility.await()
+                .pollInterval(2, SECONDS)
+                .atMost(2, MINUTES)
+                .untilAsserted(
+                        () -> {
+                            int currentProbeId = latestModeProbeId.getAndIncrement();
+                            String probePayload = payload + "_probe_" + currentProbeId;
+                            producer.send(
+                                    new ProducerRecord<>(
+                                            sourceTopic,
+                                            ("key_probe_" + currentProbeId).getBytes(),
+                                            probePayload.getBytes()));
+                            producer.flush();
+
+                            Assertions.assertTrue(
+                                    countKafkaMessagesContaining(sinkTopic, payload + "_probe_")
+                                            > 0,
+                                    "Latest mode source should consume records produced after startup");
+                        });
+
         // Produce 10 records after job start; latest mode should consume only these 10
         // initially.
         for (int i = 0; i < 10; i++) {
@@ -861,15 +908,17 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     new ProducerRecord<>(
                             sourceTopic,
                             ("key_additional_" + i).getBytes(),
-                            (payload + "_additional").getBytes()));
+                            firstRunPayload.getBytes()));
         }
         producer.flush();
 
-        final long expectedSinkAfterFirstRun = 10;
         Awaitility.await()
                 .pollInterval(2, SECONDS)
                 .atMost(2, MINUTES)
-                .until(() -> visibleCountOnP0(sinkTopic) == expectedSinkAfterFirstRun);
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        10, countKafkaMessages(sinkTopic, firstRunPayload)));
 
         container.savepointJob(jobId);
 
@@ -879,13 +928,13 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     new ProducerRecord<>(
                             sourceTopic,
                             ("key_restore_" + i).getBytes(),
-                            (payload + "_restore").getBytes()));
+                            restorePayload.getBytes()));
         }
         producer.flush();
 
         long srcEndAfterAll = endOffsetOnP0(sourceTopic);
         Assertions.assertTrue(
-                srcEndAfterAll == srcEndBeforeStart + 25,
+                srcEndAfterAll >= srcEndBeforeStart + 25,
                 "Final end offset should advance by at least 25");
 
         CompletableFuture.runAsync(
@@ -901,7 +950,10 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
         Awaitility.await()
                 .pollInterval(2, SECONDS)
                 .atMost(5, MINUTES)
-                .until(() -> visibleCountOnP0(sinkTopic) == expectedSinkAfterFirstRun + 15);
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        15, countKafkaMessages(sinkTopic, restorePayload)));
     }
 
     // ---------------------------- TIMESTAMP MODE -----------------------------
@@ -1097,6 +1149,16 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
             long end = c.endOffsets(Collections.singletonList(tp0)).get(tp0);
             return end - begin;
         }
+    }
+
+    private long countKafkaMessages(String topic, String expectedValue) {
+        return getKafkaConsumerListData(topic, 0).stream().filter(expectedValue::equals).count();
+    }
+
+    private long countKafkaMessagesContaining(String topic, String expectedValue) {
+        return getKafkaConsumerListData(topic, 0).stream()
+                .filter(value -> value.contains(expectedValue))
+                .count();
     }
 
     /** Get the current end offset (LEO) on partition-0. */

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
@@ -1808,8 +1808,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     return null;
                 });
         // wait for data written to kafka
-        given().pollDelay(60, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(5, MINUTES)
                 .untilAsserted(
@@ -1842,8 +1841,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     }
                 });
 
-        given().pollDelay(60, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(10, MINUTES)
                 .untilAsserted(
@@ -1893,8 +1891,7 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                     return null;
                 });
         // wait for data written to kafka
-        given().pollDelay(120, SECONDS)
-                .pollInterval(5, SECONDS)
+        given().pollInterval(5, SECONDS)
                 .await()
                 .atMost(5, MINUTES)
                 .untilAsserted(


### PR DESCRIPTION
### Purpose of this pull request

Fix flaky tests in the Kafka E2E module by making startup and partition-discovery assertions wait for actual consumption readiness instead of assuming the source is ready immediately after the job reaches RUNNING.

**Root cause:**

The Kafka CI job intermittently fails with `ConditionTimeout` in tests that use `start_mode = latest`:

```
KafkaIT.testSourceKafkaRestoreWithLatestMode
KafkaIT.testDynamicPartitionDiscovery
```

For latest-mode restore, records produced immediately after `awaitJobRunning` can be skipped if the Kafka source has not finished subscribing and seeking yet.

For dynamic partition discovery, records sent to the new partition immediately after partition creation can be skipped before SeaTunnel discovers the new partition and starts consuming it.

**Changes in `KafkaIT`:**
- Add a probe record loop before the latest-mode assertions to confirm the running job is consuming newly produced records
- Count first-run and restore records by their payload instead of relying on the full sink partition offset count
- Add a probe record loop after increasing Kafka partitions to confirm SeaTunnel has discovered and consumed the new partition
- Assert the dynamic-partition test against `new_partition_message_` records only, so probe records do not affect the result

### Does this PR introduce _any_ user-facing change?

No. This change only affects E2E test stability.

### How was this patch tested?

Ran:

```
./mvnw spotless:apply
```

Per the flaky-CI fix workflow, no E2E tests were run locally.