### PR TITLE
[Fix][E2E] Fix flaky Databend CDC job startup

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-databend-e2e/src/test/java/org/apache/seatunnel/e2e/connector/databend/DatabendCDCSinkIT.java
@@ -63,6 +63,9 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
     private static final int PORT = 8000;
     private static final int LOCAL_PORT = 8000;
     private static final String DATABASE = "default";
+    private static final String DATABEND_CDC_JOB_CONFIG = "/databend/fake_to_databend_cdc.conf";
+    private static final int MAX_JOB_SUBMIT_ATTEMPTS = 2;
+    private static final int JOB_SUBMIT_RETRY_INTERVAL_SECONDS = 10;
     private DatabendContainer container;
     private GenericContainer<?> minioContainer;
     private Connection connection;
@@ -70,8 +73,7 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
     @TestTemplate
     public void testDatabendSinkCDC(TestContainer container) throws Exception {
         // Run the CDC test job
-        Container.ExecResult execResult =
-                container.executeJob("/databend/fake_to_databend_cdc.conf");
+        Container.ExecResult execResult = executeDatabendCdcJob(container);
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
 
         Awaitility.await()
@@ -162,6 +164,32 @@ public class DatabendCDCSinkIT extends TestSuiteBase implements TestResource {
             }
         }
         clearSinkTable();
+    }
+
+    private Container.ExecResult executeDatabendCdcJob(TestContainer container) throws Exception {
+        Container.ExecResult execResult = null;
+        for (int attempt = 1; attempt <= MAX_JOB_SUBMIT_ATTEMPTS; attempt++) {
+            execResult = container.executeJob(DATABEND_CDC_JOB_CONFIG);
+            if (execResult.getExitCode() == 0 || !isFlinkResourceNotReady(execResult)) {
+                return execResult;
+            }
+            if (attempt < MAX_JOB_SUBMIT_ATTEMPTS) {
+                LOG.warn(
+                        "Databend CDC job failed because Flink resources were not ready,"
+                                + " retrying job submission ({}/{})",
+                        attempt,
+                        MAX_JOB_SUBMIT_ATTEMPTS);
+                TimeUnit.SECONDS.sleep(JOB_SUBMIT_RETRY_INTERVAL_SECONDS);
+            }
+        }
+        return execResult;
+    }
+
+    private boolean isFlinkResourceNotReady(Container.ExecResult execResult) {
+        String stderr = execResult.getStderr();
+        return stderr != null
+                && (stderr.contains("NoResourceAvailableException")
+                        || stderr.contains("Could not acquire the minimum required resources"));
     }
 
     private void clearSinkTable() throws SQLException {


### PR DESCRIPTION
### Purpose of this pull request

Fix a flaky Databend CDC E2E failure that is unrelated to PR code changes.

The failed CI log shows one TestTemplate invocation failing during Flink job submission with:

```
NoResourceAvailableException: Could not acquire the minimum required resources
Current slot pool status: Registered TMs: 0, registered slots: 0 free slots: 0
```

Other invocations in the same job pass, so this is a transient Flink resource readiness race rather than a Databend result mismatch.

### Changes

- Retry the Databend CDC job submission once when the failed execution matches the narrow Flink resource-not-ready error.
- Keep all Databend result assertions unchanged.
- Return non-resource failures immediately so real failures are still reported.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply`
- E2E tests were not run per request.