### PR TITLE
[Fix][E2E] Fix flaky engine cluster cancel wait

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFaultToleranceIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFaultToleranceIT.java
@@ -918,7 +918,7 @@ public class ClusterFaultToleranceIT {
             newClientJobProxy.cancelJob();
             Awaitility.await()
                     .pollDelay(2000, TimeUnit.MILLISECONDS)
-                    .atMost(60000, TimeUnit.MILLISECONDS)
+                    .atMost(300000, TimeUnit.MILLISECONDS)
                     .pollInterval(2000, TimeUnit.MILLISECONDS)
                     .untilAsserted(
                             () -> {


### PR DESCRIPTION
### Purpose of this pull request

Fix a flaky engine E2E failure in `ClusterFaultToleranceIT.testStreamJobRestoreInAllNodeDown`.

The failed CI log shows the recovered streaming job reached the cancel phase, but the test only allowed 60 seconds for the final state transition:

```
expected: <CANCELED> but was: <CANCELING> within 1 minutes
```

This is unrelated to PR code changes and can happen after the all-node-down restore path while job cleanup is still in progress.

### Changes

- Align the cancel wait timeout in `testStreamJobRestoreInAllNodeDown` with the other all-node-down restore scenario in the same test class.
- Keep the final `CANCELED` and `waitForJobComplete` assertions unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply`
- Tests were not run per request.