### PR TITLE
[Fix][E2E] Replace flaky SFTP continuous wait

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-file-sftp-e2e/src/test/java/org/apache/seatunnel/e2e/connector/file/fstp/SftpFileIT.java
@@ -387,11 +387,16 @@ public class SftpFileIT extends TestSuiteBase implements TestResource {
                                                     SFTP_CONTAINER_HOME
                                                             + "/tmp/seatunnel/continuous/dst/root.bin")));
 
-            Thread.sleep(3000);
-            Assertions.assertFalse(
-                    isSftpFileExists(
-                            SFTP_CONTAINER_HOME
-                                    + "/tmp/seatunnel/continuous/dst/subdir/nested.bin"));
+            Awaitility.await()
+                    .during(3, TimeUnit.SECONDS)
+                    .atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(500, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertFalse(
+                                            isSftpFileExists(
+                                                    SFTP_CONTAINER_HOME
+                                                            + "/tmp/seatunnel/continuous/dst/subdir/nested.bin")));
 
             Container.ExecResult cancelResult = container.cancelJob(jobId);
             Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());


### PR DESCRIPTION
### Purpose of this pull request

Fix a flaky SFTP E2E assertion that used a fixed sleep before checking that nested files are not synchronized by the continuous job.

### Changes

- Replace the fixed sleep with an Awaitility assertion that requires the nested file to remain absent for the expected duration.
- Keep the change limited to the SFTP E2E test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- ./mvnw spotless:apply
- Tests were not run per request.