### PR TITLE
[Fix][E2E] Avoid Pulsar JDBC driver download

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/CanalToPulsarIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-pulsar-e2e/src/test/java/org/apache/seatunnel/e2e/connector/pulsar/CanalToPulsarIT.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.postgresql.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
@@ -59,6 +60,9 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -116,8 +120,7 @@ public class CanalToPulsarIT extends TestSuiteBase implements TestResource {
     // postgres
     private static final String PG_IMAGE = "postgres:alpine3.16";
 
-    private static final String PG_DRIVER_JAR =
-            "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar";
+    private static final String SEATUNNEL_JDBC_PLUGIN_LIB = "/tmp/seatunnel/plugins/Jdbc/lib";
 
     private static PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
 
@@ -126,13 +129,32 @@ public class CanalToPulsarIT extends TestSuiteBase implements TestResource {
             container -> {
                 Container.ExecResult extraCommands =
                         container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && curl -O "
-                                        + PG_DRIVER_JAR);
+                                "bash", "-c", "mkdir -p " + SEATUNNEL_JDBC_PLUGIN_LIB);
 
                 Assertions.assertEquals(0, extraCommands.getExitCode());
+
+                Path driverJarPath = postgresDriverJarPath();
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(driverJarPath),
+                        SEATUNNEL_JDBC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
             };
+
+    private Path postgresDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve PostgreSQL JDBC driver jar from the test classpath", e);
+        }
+    }
 
     private void createPostgreSQLContainer() throws ClassNotFoundException {
         POSTGRESQL_CONTAINER =


### PR DESCRIPTION
### Purpose

Remove a flaky network dependency from the Pulsar E2E setup. The test previously downloaded the PostgreSQL JDBC driver from Maven Central inside the CI container.

### Changes

- Resolve the PostgreSQL JDBC driver jar from the active test classpath.
- Copy the resolved jar into the SeaTunnel JDBC plugin lib directory before the E2E job runs.
- Keep the helper local to the Pulsar E2E test module.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request