### PR TITLE
[Fix][E2E] Avoid Opengauss CDC driver download

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-opengauss-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/OpengaussCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-opengauss-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/OpengaussCDCIT.java
@@ -38,6 +38,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -93,6 +95,7 @@ public class OpengaussCDCIT extends TestSuiteBase implements TestResource {
     protected static final DockerImageName OPENGAUSS_IMAGE =
             DockerImageName.parse("opengauss/opengauss:5.0.0")
                     .asCompatibleSubstituteFor("postgres");
+    private static final String JDBC_PLUGIN_LIB = "/tmp/seatunnel/plugins/JDBC/lib";
 
     private static final String SOURCE_SQL_TEMPLATE = "select * from %s.%s order by id";
 
@@ -103,21 +106,35 @@ public class OpengaussCDCIT extends TestSuiteBase implements TestResource {
                     .withEnv("GS_PASSWORD", PASSWORD)
                     .withLogConsumer(new Slf4jLogConsumer(log));
 
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.1/postgresql-42.5.1.jar";
-    }
-
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
                 Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/JDBC/lib && cd /tmp/seatunnel/plugins/JDBC/lib && wget "
-                                        + driverUrl());
+                        container.execInContainer("bash", "-c", "mkdir -p " + JDBC_PLUGIN_LIB);
                 Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+
+                Path driverJarPath = postgresDriverJarPath();
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(driverJarPath),
+                        JDBC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
             };
+
+    private Path postgresDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            org.postgresql.Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve PostgreSQL JDBC driver jar from the test classpath", e);
+        }
+    }
 
     @BeforeAll
     @Override


### PR DESCRIPTION
### Purpose

Remove a flaky network dependency from the Opengauss CDC E2E setup. The test previously downloaded the PostgreSQL JDBC driver from Maven Central inside the CI container.

### Changes

- Resolve the PostgreSQL JDBC driver jar from the active test classpath.
- Copy the resolved jar into the JDBC plugin lib directory before the E2E job runs.
- Keep the change scoped to the Opengauss CDC E2E test.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request