### PR TITLE
[Fix][E2E] Avoid Oracle CDC driver downloads

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/AbstractOracleCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/AbstractOracleCDCIT.java
@@ -19,16 +19,22 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.oracle;
 
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
 
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerLoggerFactory;
+import org.testcontainers.utility.MountableFile;
 
 import lombok.extern.slf4j.Slf4j;
 import oracle.sql.TIMESTAMP;
 import oracle.sql.TIMESTAMPLTZ;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -80,6 +86,8 @@ public class AbstractOracleCDCIT extends TestSuiteBase {
     protected static final String SOURCE_TABLE1 = "FULL_TYPES";
 
     protected static final String SOURCE_TABLE2 = "FULL_TYPES2";
+    private static final String ORACLE_CDC_PLUGIN_LIB = "/tmp/seatunnel/plugins/Oracle-CDC/lib";
+    private static final String JDBC_PLUGIN_LIB = "/tmp/seatunnel/plugins/Jdbc/lib";
 
     protected static final OracleContainer ORACLE_CONTAINER =
             new OracleContainer(getImage())
@@ -102,12 +110,63 @@ public class AbstractOracleCDCIT extends TestSuiteBase {
         }
     }
 
-    protected String oracleDriverUrl() {
-        return "https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/12.2.0.1/ojdbc8-12.2.0.1.jar";
-    }
-
     static {
         System.setProperty("oracle.jdbc.timezoneAsRegion", "false");
+    }
+
+    protected void copyOracleDriverToContainer(GenericContainer<?> container)
+            throws IOException, InterruptedException {
+        copyDriverToContainer(container, ORACLE_CDC_PLUGIN_LIB, oracleDriverJarPath());
+    }
+
+    protected void copyMySQLDriverToJdbcContainer(GenericContainer<?> container)
+            throws IOException, InterruptedException {
+        copyDriverToContainer(container, JDBC_PLUGIN_LIB, mysqlDriverJarPath());
+    }
+
+    private void copyDriverToContainer(
+            GenericContainer<?> container, String pluginLibDir, Path driverJarPath)
+            throws IOException, InterruptedException {
+        Container.ExecResult mkdirResult =
+                container.execInContainer("bash", "-c", "mkdir -p " + pluginLibDir);
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+        container.copyFileToContainer(
+                MountableFile.forHostPath(driverJarPath),
+                pluginLibDir + "/" + driverJarPath.getFileName());
+    }
+
+    private Path oracleDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            oracle.jdbc.driver.OracleDriver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve Oracle JDBC driver jar from the test classpath", e);
+        }
+    }
+
+    private Path mysqlDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            com.mysql.cj.jdbc.Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
+        }
     }
 
     protected static void createAndInitialize(String sqlFile, String username, String password)

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
@@ -63,16 +63,7 @@ public class OracleCDCIT extends AbstractOracleCDCIT implements TestResource {
     private static final String SOURCE_SQL_TEMPLATE = "select * from %s.%s ORDER BY ID";
 
     @TestContainerExtension
-    protected final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Oracle-CDC/lib && cd /tmp/seatunnel/plugins/Oracle-CDC/lib && wget "
-                                        + oracleDriverUrl());
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
+    protected final ContainerExtendedFactory extendedFactory = this::copyOracleDriverToContainer;
 
     @BeforeAll
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCWithSchemaChangeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCWithSchemaChangeIT.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.platform.commons.util.StringUtils;
-import org.testcontainers.containers.Container;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
@@ -121,22 +120,11 @@ public class OracleCDCWithSchemaChangeIT extends AbstractOracleCDCIT implements 
                         new Slf4jLogConsumer(DockerLoggerFactory.getLogger("mysql-docker-image")));
     }
 
-    private String mysqlDriverUrl() {
-        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
-    }
-
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Oracle-CDC/lib && cd /tmp/seatunnel/plugins/Oracle-CDC/lib && wget "
-                                        + oracleDriverUrl()
-                                        + " && mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                                        + mysqlDriverUrl());
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+                copyOracleDriverToContainer(container);
+                copyMySQLDriverToJdbcContainer(container);
             };
 
     @BeforeAll


### PR DESCRIPTION
### Purpose

Remove flaky network dependencies from the Oracle CDC E2E setup. The tests previously downloaded Oracle and MySQL JDBC drivers from Maven Central inside the CI container.

### Changes

- Resolve the Oracle JDBC driver jar from the active test classpath.
- Resolve the MySQL JDBC driver jar from the active test classpath for the schema-change sink test.
- Copy the resolved jars into their plugin lib directories before the E2E jobs run.
- Keep the helper scoped to the Oracle CDC E2E module.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request