### PR TITLE
[Fix][E2E] Avoid MongoDB CDC driver downloads

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MongodbCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MongodbCDCIT.java
@@ -124,9 +124,6 @@ public class MongodbCDCIT extends TestSuiteBase implements TestResource {
     private static final String SINK_SQL_ORDERS =
             "select order_number,order_date,quantity,product_id from orders order by order_number asc";
 
-    private static final String MYSQL_DRIVER_JAR =
-            "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar";
-
     private final UniqueDatabase inventoryDatabase =
             new UniqueDatabase(MYSQL_CONTAINER, MYSQL_DATABASE);
 
@@ -146,15 +143,7 @@ public class MongodbCDCIT extends TestSuiteBase implements TestResource {
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                                        + MYSQL_DRIVER_JAR);
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
+            MysqlDriverResolver::copyMySQLDriverToJdbcContainer;
 
     @BeforeAll
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MongodbCDCMultiSourceIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MongodbCDCMultiSourceIT.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
-import org.testcontainers.containers.Container;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
@@ -77,9 +76,6 @@ public class MongodbCDCMultiSourceIT extends TestSuiteBase implements TestResour
     private static final String MYSQL_USER_NAME = "st_user";
     private static final String MYSQL_USER_PASSWORD = "seatunnel";
     private static final String MYSQL_DATABASE = "mongodb_cdc";
-    private static final String MYSQL_DRIVER_JAR =
-            "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar";
-
     private static final MySqlContainer MYSQL_CONTAINER = createMySqlContainer();
     private final UniqueDatabase database = new UniqueDatabase(MYSQL_CONTAINER, MYSQL_DATABASE);
 
@@ -98,15 +94,7 @@ public class MongodbCDCMultiSourceIT extends TestSuiteBase implements TestResour
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                                        + MYSQL_DRIVER_JAR);
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
+            MysqlDriverResolver::copyMySQLDriverToJdbcContainer;
 
     @BeforeAll
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MysqlDriverResolver.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mongodb-e2e/src/test/java/mongodb/MysqlDriverResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongodb;
+
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+
+import com.mysql.cj.jdbc.Driver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+final class MysqlDriverResolver {
+
+    private static final String JDBC_PLUGIN_LIB = "/tmp/seatunnel/plugins/Jdbc/lib";
+
+    private MysqlDriverResolver() {}
+
+    static void copyMySQLDriverToJdbcContainer(GenericContainer<?> container)
+            throws IOException, InterruptedException {
+        Container.ExecResult mkdirResult =
+                container.execInContainer("bash", "-c", "mkdir -p " + JDBC_PLUGIN_LIB);
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+
+        Path driverJarPath = mysqlDriverJarPath();
+        container.copyFileToContainer(
+                MountableFile.forHostPath(driverJarPath),
+                JDBC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
+    }
+
+    private static Path mysqlDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Remove flaky network dependencies from the MongoDB CDC E2E setup. The tests previously downloaded the MySQL JDBC driver from Maven Central inside the CI container.

### Changes

- Resolve the MySQL JDBC driver jar from the active test classpath.
- Copy the resolved jar into the JDBC plugin lib directory before the E2E jobs run.
- Keep the helper scoped to the MongoDB CDC E2E module.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request