### PR TITLE
[Fix][E2E] Avoid TiDB CDC driver downloads

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/pom.xml
@@ -29,6 +29,18 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.seatunnel</groupId>
+                <artifactId>connector-jdbc</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- SeaTunnel connectors -->
         <dependency>
@@ -53,6 +65,11 @@
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-jdbc</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.tikv</groupId>
+            <artifactId>tikv-client-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-tidb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tidb/TiDBCDCIT.java
@@ -31,10 +31,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+import org.tikv.common.TiSession;
 
+import com.mysql.cj.jdbc.Driver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -76,36 +83,58 @@ public class TiDBCDCIT extends TiDBTestBase implements TestResource {
                     + " f_text, f_tinytext, f_varchar, f_date, f_datetime, f_timestamp, f_bit1, f_bit64, f_char,"
                     + " f_enum, f_mediumblob, f_long_varchar, f_real, f_time, f_tinyint, f_tinyint_unsigned,"
                     + " f_json, cast(f_year as year) from %s.%s";
-
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
-    }
-
-    private String tiKVUrl() {
-        return "https://repo1.maven.org/maven2/org/tikv/tikv-client-java/3.2.0/tikv-client-java-3.2.0.jar";
-    }
+    private static final String TIDB_CDC_PLUGIN_LIB = "/tmp/seatunnel/plugins/TiDB-CDC/lib";
 
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
                 Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/TiDB-CDC/lib && cd "
-                                        + "/tmp/seatunnel/plugins/TiDB-CDC/lib && wget "
-                                        + driverUrl());
+                        container.execInContainer("bash", "-c", "mkdir -p " + TIDB_CDC_PLUGIN_LIB);
                 Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-                Container.ExecResult extraCommands2 =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/TiDB-CDC/lib && cd "
-                                        + "/tmp/seatunnel/plugins/TiDB-CDC/lib && wget "
-                                        + tiKVUrl());
-                Assertions.assertEquals(
-                        0, extraCommands2.getExitCode(), extraCommands2.getStderr());
+
+                copyDriverToContainer(container, mysqlDriverJarPath());
+                copyDriverToContainer(container, tiKVClientJarPath());
             };
+
+    private void copyDriverToContainer(GenericContainer<?> container, Path driverJarPath) {
+        container.copyFileToContainer(
+                MountableFile.forHostPath(driverJarPath),
+                TIDB_CDC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
+    }
+
+    private Path mysqlDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
+        }
+    }
+
+    private Path tiKVClientJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            TiSession.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve TiKV client jar from the test classpath", e);
+        }
+    }
 
     @BeforeAll
     @Override


### PR DESCRIPTION
### Purpose

Remove flaky network dependencies from the TiDB CDC E2E setup. The test previously downloaded MySQL JDBC and TiKV client jars from Maven Central inside the CI container.

### Changes

- Resolve the MySQL JDBC driver jar from the active test classpath.
- Add TiKV client as an E2E test dependency through the existing connector-jdbc dependency management.
- Resolve the TiKV client jar from the active test classpath.
- Copy the resolved jars into the TiDB CDC plugin lib directory before the E2E job runs.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request