### PR TITLE
[Fix][E2E] Avoid EdgeSocket driver downloads

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/AbstractEdgeSocketIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/AbstractEdgeSocketIT.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
+import com.mysql.cj.jdbc.Driver;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.crypto.Cipher;
@@ -42,6 +44,9 @@ import java.io.OutputStreamWriter;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -64,6 +69,7 @@ public abstract class AbstractEdgeSocketIT extends TestSuiteBase implements Test
     protected static final String TRANSFORM_SUFFIX = "_transformed";
     protected static final String EDGE_BATCH_PREFIX = "__BATCH__:";
     protected static final String EDGE_COMMIT_PREFIX = "__COMMIT__:";
+    private static final String JDBC_PLUGIN_LIB = "/tmp/seatunnel/plugins/Jdbc/lib";
 
     protected GenericContainer<?> edgeSocketForwarderContainer;
     private String edgeSocketForwarderTargetHost;
@@ -73,6 +79,35 @@ public abstract class AbstractEdgeSocketIT extends TestSuiteBase implements Test
     protected void stopSinkDependencies() throws Exception {}
 
     protected abstract List<String> querySinkValues() throws Exception;
+
+    protected static void copyMySQLDriverToJdbcContainer(GenericContainer<?> container)
+            throws IOException, InterruptedException {
+        Container.ExecResult mkdirResult =
+                container.execInContainer("bash", "-c", "mkdir -p " + JDBC_PLUGIN_LIB);
+        Assertions.assertEquals(0, mkdirResult.getExitCode(), mkdirResult.getStderr());
+
+        Path driverJarPath = mysqlDriverJarPath();
+        container.copyFileToContainer(
+                MountableFile.forHostPath(driverJarPath),
+                JDBC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
+    }
+
+    private static Path mysqlDriverJarPath() {
+        try {
+            Path driverJarPath =
+                    Paths.get(
+                            Driver.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
+            Assertions.assertTrue(Files.isRegularFile(driverJarPath));
+            return driverJarPath;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
+        }
+    }
 
     @BeforeAll
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/EdgeSocketCheckpointRestoreIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/EdgeSocketCheckpointRestoreIT.java
@@ -65,20 +65,7 @@ public class EdgeSocketCheckpointRestoreIT extends AbstractEdgeSocketIT {
 
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                                        + driverUrl()
-                                        + " --no-check-certificate");
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
-
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
-    }
+            AbstractEdgeSocketIT::copyMySQLDriverToJdbcContainer;
 
     @Override
     protected void startSinkDependencies() throws Exception {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/EdgeSocketMysql8_4IT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-edge-socket-e2e/src/test/java/org/apache/seatunnel/e2e/connector/edgesocket/EdgeSocketMysql8_4IT.java
@@ -66,20 +66,7 @@ public class EdgeSocketMysql8_4IT extends AbstractEdgeSocketIT {
 
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib && cd /tmp/seatunnel/plugins/Jdbc/lib && wget "
-                                        + driverUrl()
-                                        + " --no-check-certificate");
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
-
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
-    }
+            AbstractEdgeSocketIT::copyMySQLDriverToJdbcContainer;
 
     @Override
     protected void startSinkDependencies() throws Exception {


### PR DESCRIPTION
### Purpose

Remove flaky network dependencies from the EdgeSocket E2E setup. The tests previously downloaded the MySQL JDBC driver from Maven Central inside the CI container.

### Changes

- Resolve the MySQL JDBC driver jar from the active test classpath.
- Copy the resolved jar into the JDBC plugin lib directory before the E2E jobs run.
- Keep the helper scoped to the EdgeSocket E2E abstract test class.

### User-facing

No user-facing behavior change. This only stabilizes E2E test setup.

### How tested

- Ran ./mvnw spotless:apply
- Did not run tests per maintainer request