### PR TITLE
[Feature][Connector-V2] Add NATS JetStream sink connector

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -354,3 +354,13 @@ bigquery:
       - changed-files:
           - any-glob-to-any-file: seatunnel-connectors-v2/connector-bigquery/**
           - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(bigquery)/**'
+
+nats-jetstream:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - seatunnel-connectors-v2/connector-nats-jetstream/**
+              - seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/**
+          - all-globs-to-all-files:
+              - '!seatunnel-connectors-v2/connector-!(nats-jetstream)/**'
+              - '!seatunnel-e2e/seatunnel-connector-v2-e2e/connector-!(nats-jetstream)-e2e/**'

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -105,3 +105,4 @@ connector-hugegraph
 connector-lance
 connector-mqtt
 connector-bigquery
+connector-nats-jetstream

--- a/docs/en/connectors/changelog/connector-nats-jetstream.md
+++ b/docs/en/connectors/changelog/connector-nats-jetstream.md
@@ -1,0 +1,26 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+# Changelog
+
+## next version
+
+### Sink
+
+- Add NATS JetStream Sink Connector

--- a/docs/en/connectors/sink/NatsJetStream.md
+++ b/docs/en/connectors/sink/NatsJetStream.md
@@ -1,0 +1,340 @@
+import ChangeLog from '../changelog/connector-nats-jetstream.md';
+
+# NatsJetStream
+
+> NATS JetStream sink connector
+
+## Description
+
+NatsJetStream is a **JetStream sink**, not a core NATS publish connector. It writes SeaTunnel rows to a JetStream-enabled NATS Server by using the `io.nats:jnats` client and waiting for the synchronous JetStream publish acknowledgement for each record.
+
+The current implementation targets JetStream-enabled **NATS Server 2.x** with the `jnats` **2.24.0** client used by this connector. The connector documentation only claims compatibility proven by the current implementation and E2E coverage.
+
+The sink does **not** create streams or manage JetStream resources. You must pre-provision a JetStream stream and bind it to the subject, or subject pattern, used by the sink.
+
+## Key features
+
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+:::caution Delivery semantics
+
+This sink provides **at-least-once** delivery.
+
+A successful synchronous JetStream publish acknowledgement means JetStream accepted that publish request, but it does **not** prove exactly-once delivery across retries, task restarts, failover, or ambiguous acknowledgement loss.
+
+Duplicates can still happen when SeaTunnel retries after a publish succeeded but the acknowledgement was lost, delayed, or surfaced ambiguously to the writer.
+
+Native-mode message IDs are only a **broker-side duplicate-mitigation hint**. JetStream duplicate suppression works only when:
+
+1. the target stream is configured with a duplicate window, and
+2. the sink writes stable message IDs.
+
+Even with that setup, the connector must still be treated as **at-least-once**.
+
+:::
+
+## Supported Engines
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
+## Connector contract
+
+- Scope: sink only; no NATS source support is included.
+- Compatibility target: JetStream-enabled NATS Server 2.x with `io.nats:jnats:2.24.0`.
+- Stream lifecycle: publish-only. The connector does not create, update, or delete streams, consumers, or subjects.
+- Delivery guarantee: writer-only at-least-once.
+- Duplicate handling: duplicates are possible on retry, restart, checkpoint recovery, or ambiguous acknowledgement loss.
+- JSON mode: one configured subject, JSON payload, no per-record headers or message ID.
+- Native mode: maps row fields to `subject`, `id`, `headers`, and `data`; `data` is required and must be `bytes`.
+- Row kinds: all SeaTunnel row kinds are published as ordinary sink messages; no CDC-aware update/delete behavior is provided.
+- Authentication: use either no credentials, `username` + `password`, or `token`; `token` is mutually exclusive with `username` / `password`.
+- Initial limitations: synchronous per-record publish only; batching and connector-managed retry controls are out of scope.
+- Non-goals: stream administration, exactly-once, source support, schema evolution handling beyond incoming rows, and formats beyond documented JSON/native mode.
+
+## Broker setup
+
+Before running a SeaTunnel job:
+
+1. Start a JetStream-enabled NATS Server.
+2. Create the target stream yourself.
+3. Bind the stream to the configured subject or subject pattern.
+4. Ensure the subject used by JSON mode or the final subject produced by native mode is covered by that stream binding.
+
+If the stream does not exist, JetStream is disabled, or the subject is not bound to a stream, the sink can fail when the first publish reaches JetStream.
+
+## Options
+
+| name | type | required | default value |
+|------|------|----------|---------------|
+| url | string | yes | - |
+| username | string | no | - |
+| password | string | no | - |
+| token | string | no | - |
+| subject | string | conditional | - |
+| format | enum (`json`, `native`) | no | json |
+| native_format_fields | map<string,string> | no | `{id:id, subject:subject, headers:headers, data:data}` |
+| include_row_kind_header | boolean | no | true |
+| common-options | - | no | - |
+
+### Authentication rules
+
+- Configure `username` and `password` together, or configure `token`.
+- Do not configure `token` together with `username` / `password`.
+- Treat `password` and `token` as sensitive options and do not expose them in shared configs or logs.
+
+### subject [string]
+
+- Required in `json` format.
+- Optional in `native` format only when `native_format_fields.subject` is mapped to a nonblank row field.
+- In `native` format, it is used as the fallback subject when the mapped subject field is `null`, empty, or blank.
+
+### native_format_fields [map<string,string>]
+
+Used only when `format = "native"`.
+
+Supported mapping keys:
+
+- `data`: required mapping, must point to a `bytes` field
+- `subject`: optional mapping, must point to a `string` field when present in the schema
+- `id`: optional mapping, must point to a `string` field when present in the schema
+- `headers`: optional mapping, must point to a `map<string,string>` field when present in the schema
+
+Unsupported mapping keys are rejected.
+
+When an optional mapping (`subject`, `id`, `headers`) points to a field that does not exist in the input schema, the connector silently skips that mapping. For example, with the default mapping `{id:id, subject:subject, headers:headers, data:data}`, a schema that only contains a `data` field will still be accepted; `id`, `subject`, and `headers` are simply not set on the published message.
+
+### include_row_kind_header [boolean]
+
+Used only when `format = "native"`.
+
+- Default is `true`.
+- When enabled, the connector adds JetStream header `x-seatunnel-row-kind` with the SeaTunnel row kind name.
+- When disabled, the connector does not add that generated header.
+- Mapped `headers` are still written normally.
+
+### common options
+
+Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Data contract
+
+### JSON mode
+
+When `format = "json"`:
+
+- every incoming row is serialized as one JSON payload;
+- the payload is written to the fixed sink `subject`;
+- no per-record headers or message ID are produced by the connector, and row kind metadata is not added to the JSON payload.
+
+### Native mode
+
+When `format = "native"`, each row is mapped to a JetStream publish request:
+
+- `data` -> message payload, required, `bytes`
+- `subject` -> per-record subject, optional, `string`
+- `id` -> JetStream message ID, optional, `string`
+- `headers` -> JetStream headers, optional, `map<string,string>`
+- when `include_row_kind_header = true`, the connector also adds JetStream header `x-seatunnel-row-kind` with the SeaTunnel row kind name
+
+Final subject resolution order:
+
+1. use the mapped native `subject` field when it is nonblank;
+2. otherwise use the sink `subject` option;
+3. if neither exists, validation fails before the writer starts.
+
+If native `id` is `null`, empty, or blank, the message is published without a JetStream message ID.
+
+If native `headers` is `null`, the connector sends only the generated `x-seatunnel-row-kind` header when `include_row_kind_header = true`.
+
+## Row kind handling
+
+The sink accepts all SeaTunnel row kinds.
+
+It does not interpret `INSERT`, `UPDATE_BEFORE`, `UPDATE_AFTER`, or `DELETE` as CDC operations. Each row is published as an ordinary message according to the configured JSON or native format.
+
+In native format, the connector can expose the row kind as JetStream header `x-seatunnel-row-kind` when `include_row_kind_header = true`. JSON format does not include row kind metadata in the payload.
+
+## Examples
+
+### Minimal JSON example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          id = 101
+          name = "alice"
+          score = 9.5
+        }
+      }
+    ]
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
+      }
+    }
+    plugin_output = "json_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "json_fake"
+    url = "nats://127.0.0.1:4222"
+    subject = "orders.json"
+    format = "json"
+  }
+}
+```
+
+Produced payload:
+
+```json
+{"id":101,"name":"alice","score":9.5}
+```
+
+All rows are published to the fixed subject `orders.json`.
+
+### Native-mode example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.alpha"
+          message_id = "msg-1"
+          attributes = {
+            tenant = "acme"
+            trace = "trace-1"
+          }
+          payload = [1, 35, -1]
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.beta"
+          message_id = "msg-2"
+          attributes = {
+            tenant = "beta"
+            trace = "trace-2"
+          }
+          payload = [112, 97, 121, 108, 111, 97, 100, 45, 50]
+        }
+      }
+    ]
+    schema = {
+      fields {
+        dynamic_subject = string
+        message_id = string
+        attributes = "map<string,string>"
+        payload = bytes
+      }
+    }
+    plugin_output = "native_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "native_fake"
+    url = "nats://127.0.0.1:4222"
+    subject = "events.native.default"
+    format = "native"
+    native_format_fields = {
+      subject = dynamic_subject
+      id = message_id
+      headers = attributes
+      data = payload
+    }
+  }
+}
+```
+
+Native mapping result for the first row:
+
+- subject: `events.native.alpha`
+- message ID: `msg-1`
+- headers: `tenant=acme`, `trace=trace-1`
+- payload bytes: `[1, 35, -1]`
+
+If `dynamic_subject` is blank or `null`, the connector falls back to `subject = "events.native.default"`.
+
+### Native mode with explicit default field mapping
+
+When the input schema already contains `subject`, `id`, `headers`, and `data`, you can use the default mapping values below.
+
+```hocon
+native_format_fields = {
+  subject = subject
+  id = id
+  headers = headers
+  data = data
+}
+```
+
+`native_format_fields` still needs to provide the `data` mapping in native mode.
+
+Input schema contract:
+
+```text
+subject : string
+id      : string
+headers : map<string,string>
+data    : bytes
+```
+
+## Errors and operational notes
+
+- Connection failures fail writer startup.
+- Publish failures fail the task with the target subject in the error message.
+- Missing stream bindings, wrong subjects, or JetStream API errors can appear on the first publish.
+- The writer uses synchronous per-record publish calls, so throughput depends on JetStream acknowledgement latency.
+
+## Unsupported features and limitations
+
+- No exactly-once guarantee.
+- No core NATS publish mode without JetStream.
+- No stream creation, update, or deletion.
+- No connector-managed deduplication window configuration.
+- No native payload conversion from non-`bytes` columns.
+- No CDC-aware update/delete semantics based on row kind.
+
+## FAQ
+
+### Is this a core NATS publisher?
+
+No. It publishes through the JetStream API and expects JetStream-enabled server-side resources.
+
+### Can the connector create the stream automatically?
+
+No. The stream must be created and bound to the publish subject before the job starts.
+
+### Can message IDs make delivery exactly-once?
+
+No. Message IDs only help JetStream duplicate suppression when the target stream has a duplicate window and producers resend the same stable ID.
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-nats-jetstream.md
+++ b/docs/zh/connectors/changelog/connector-nats-jetstream.md
@@ -1,0 +1,26 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+# Changelog
+
+## next version
+
+### Sink
+
+- Add NATS JetStream Sink Connector

--- a/docs/zh/connectors/sink/NatsJetStream.md
+++ b/docs/zh/connectors/sink/NatsJetStream.md
@@ -1,0 +1,340 @@
+import ChangeLog from '../changelog/connector-nats-jetstream.md';
+
+# NatsJetStream
+
+> NATS JetStream Sink 连接器
+
+## 描述
+
+NatsJetStream 是一个 **JetStream sink**，不是 core NATS publish 连接器。它使用 `io.nats:jnats` 客户端把 SeaTunnel 行数据写入启用了 JetStream 的 NATS Server，并且对每条记录等待同步的 JetStream publish acknowledgement。
+
+当前实现面向启用了 JetStream 的 **NATS Server 2.x**，以及该连接器当前使用的 `jnats` **2.24.0** 客户端版本。本文档只声明当前实现和 E2E 测试已经证明的兼容范围。
+
+该 Sink **不会**创建 stream，也不会管理 JetStream 资源。你必须预先创建目标 JetStream stream，并把它绑定到该 Sink 使用的 subject 或 subject pattern。
+
+## 主要特性
+
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+:::caution 投递语义
+
+该 Sink 提供 **至少一次** 投递。
+
+同步的 JetStream publish acknowledgement 只能说明 JetStream 已经接受了这次 publish 请求，但**不能**证明在重试、任务重启、故障切换或 acknowledgement 歧义丢失场景下实现 exactly-once。
+
+如果 SeaTunnel 在消息实际上已写入成功后，因为 acknowledgement 丢失、延迟或返回结果不明确而触发重试，仍然可能产生重复消息。
+
+native 模式中的 message ID 只能作为 **broker 侧的重复缓解提示**。JetStream 的重复抑制只有在以下两个条件同时满足时才会生效：
+
+1. 目标 stream 配置了 duplicate window；
+2. Sink 写出了稳定的 message ID。
+
+即使满足以上条件，这个连接器仍然只能按 **至少一次** 理解。
+
+:::
+
+## 支持引擎
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
+## Connector contract
+
+- 范围：仅支持 sink；本次贡献不包含 NATS source。
+- 兼容性目标：启用 JetStream 的 NATS Server 2.x，客户端版本为 `io.nats:jnats:2.24.0`。
+- Stream 生命周期：仅发布。连接器不会创建、更新或删除 stream、consumer 或 subject。
+- 交付语义：writer-only at-least-once。
+- 重复消息：在重试、重启、checkpoint 恢复或 acknowledgement 模糊丢失时，可能产生重复。
+- JSON 模式：单个已配置 subject、JSON payload，不支持逐条消息 headers 或 message ID。
+- Native 模式：把行字段映射为 `subject`、`id`、`headers` 和 `data`；其中 `data` 必填且必须是 `bytes`。
+- Row kind：所有 SeaTunnel row kind 都作为普通 sink 消息发布；不提供 CDC 感知的 update/delete 语义。
+- 认证：只能使用无认证、`username` + `password`，或单独 `token`；`token` 与 `username` / `password` 互斥。
+- 初始限制：仅支持同步逐条发布；batching 和连接器自管 retry 不在范围内。
+- 非目标：stream 管理、exactly-once、source 支持、超出输入行模式的 schema evolution，以及文档之外的格式。
+
+## Broker 准备
+
+运行 SeaTunnel 作业前，请先完成以下准备：
+
+1. 启动启用了 JetStream 的 NATS Server。
+2. 自行创建目标 stream。
+3. 把该 stream 绑定到配置的 subject 或 subject pattern。
+4. 确保 JSON 模式使用的 subject，或 native 模式最终解析出的 subject，已经被该 stream 覆盖。
+
+如果 stream 不存在、JetStream 未启用、或者 subject 没有绑定到 stream，Sink 可能会在第一条消息 publish 到 JetStream 时失败。
+
+## 选项
+
+| 名称 | 类型 | 是否必填 | 默认值 |
+|------|------|----------|--------|
+| url | string | 是 | - |
+| username | string | 否 | - |
+| password | string | 否 | - |
+| token | string | 否 | - |
+| subject | string | 条件必填 | - |
+| format | 枚举（`json`、`native`） | 否 | json |
+| native_format_fields | map<string,string> | 否 | `{id:id, subject:subject, headers:headers, data:data}` |
+| include_row_kind_header | boolean | 否 | true |
+| common-options | - | 否 | - |
+
+### 认证规则
+
+- 配置 `username` 时必须同时配置 `password`，或者只配置 `token`。
+- `token` 不能与 `username` / `password` 同时配置。
+- `password` 和 `token` 都属于敏感配置，不应出现在共享配置文件或日志中。
+
+### subject [string]
+
+- 在 `json` 格式下必须配置。
+- 在 `native` 格式下，只有当 `native_format_fields.subject` 映射到了非空白字段时才可以省略。
+- 在 `native` 格式下，当映射的 subject 字段为 `null`、空字符串或空白字符串时，会回退到该 `subject` 配置。
+
+### native_format_fields [map<string,string>]
+
+仅在 `format = "native"` 时使用。
+
+支持的映射键：
+
+- `data`：必填映射，必须指向 `bytes` 字段
+- `subject`：可选映射，当字段存在于 schema 中时必须指向 `string` 字段
+- `id`：可选映射，当字段存在于 schema 中时必须指向 `string` 字段
+- `headers`：可选映射，当字段存在于 schema 中时必须指向 `map<string,string>` 字段
+
+不支持的映射键会直接校验失败。
+
+当可选映射（`subject`、`id`、`headers`）指向的字段不存在于输入 schema 时，连接器会静默跳过该映射。例如，使用默认映射 `{id:id, subject:subject, headers:headers, data:data}` 时，如果 schema 只包含 `data` 字段，仍然会被接受；`id`、`subject` 和 `headers` 只是不会设置到发布的消息上。
+
+### include_row_kind_header [boolean]
+
+仅在 `format = "native"` 时生效。
+
+- 默认值为 `true`。
+- 启用后，连接器会额外写入 JetStream header `x-seatunnel-row-kind`，值为 SeaTunnel RowKind 名称。
+- 禁用后，连接器不会再自动写入这个生成的 header。
+- 通过 `headers` 映射得到的 headers 仍会正常写入。
+
+### common options
+
+Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
+
+## 数据契约
+
+### JSON 模式
+
+当 `format = "json"` 时：
+
+- 每条输入行都会被序列化为一个 JSON payload；
+- payload 会写入固定的 sink `subject`；
+- 连接器不会为每条记录额外生成 headers 或 message ID，也不会把 RowKind 元数据写进 JSON payload。
+
+### Native 模式
+
+当 `format = "native"` 时，每一行都会映射成一个 JetStream publish 请求：
+
+- `data` -> 消息 payload，必填，类型必须为 `bytes`
+- `subject` -> 每条记录的 subject，可选，类型必须为 `string`
+- `id` -> JetStream message ID，可选，类型必须为 `string`
+- `headers` -> JetStream headers，可选，类型必须为 `map<string,string>`
+- 当 `include_row_kind_header = true` 时，连接器还会额外写入 JetStream header `x-seatunnel-row-kind`，值为 SeaTunnel RowKind 名称
+
+最终 subject 的解析顺序如下：
+
+1. 如果映射后的 native `subject` 字段为非空白值，则优先使用该值；
+2. 否则使用 sink 的 `subject` 配置；
+3. 如果两者都没有，writer 启动前校验失败。
+
+如果 native `id` 为 `null`、空字符串或空白字符串，则该消息不会带 JetStream message ID。
+
+如果 native `headers` 为 `null`，那么只有在 `include_row_kind_header = true` 时，连接器才会发送自动生成的 `x-seatunnel-row-kind` header。
+
+## RowKind 处理方式
+
+该 Sink 接受所有 SeaTunnel RowKind。
+
+它不会把 `INSERT`、`UPDATE_BEFORE`、`UPDATE_AFTER` 或 `DELETE` 按 CDC 语义解释。每一行都会按照配置的 JSON 或 native 格式作为普通消息发布出去。
+
+在 native 格式下，当 `include_row_kind_header = true` 时，连接器会通过 JetStream header `x-seatunnel-row-kind` 暴露该行的 RowKind。JSON 格式不会在 payload 中包含 RowKind 元数据。
+
+## 示例
+
+### 最小 JSON 示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          id = 101
+          name = "alice"
+          score = 9.5
+        }
+      }
+    ]
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
+      }
+    }
+    plugin_output = "json_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "json_fake"
+    url = "nats://127.0.0.1:4222"
+    subject = "orders.json"
+    format = "json"
+  }
+}
+```
+
+产出的 payload：
+
+```json
+{"id":101,"name":"alice","score":9.5}
+```
+
+所有行都会被发布到固定 subject `orders.json`。
+
+### Native 模式示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.alpha"
+          message_id = "msg-1"
+          attributes = {
+            tenant = "acme"
+            trace = "trace-1"
+          }
+          payload = [1, 35, -1]
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.beta"
+          message_id = "msg-2"
+          attributes = {
+            tenant = "beta"
+            trace = "trace-2"
+          }
+          payload = [112, 97, 121, 108, 111, 97, 100, 45, 50]
+        }
+      }
+    ]
+    schema = {
+      fields {
+        dynamic_subject = string
+        message_id = string
+        attributes = "map<string,string>"
+        payload = bytes
+      }
+    }
+    plugin_output = "native_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "native_fake"
+    url = "nats://127.0.0.1:4222"
+    subject = "events.native.default"
+    format = "native"
+    native_format_fields = {
+      subject = dynamic_subject
+      id = message_id
+      headers = attributes
+      data = payload
+    }
+  }
+}
+```
+
+第一条记录映射后的结果：
+
+- subject: `events.native.alpha`
+- message ID: `msg-1`
+- headers: `tenant=acme`、`trace=trace-1`
+- payload bytes: `[1, 35, -1]`
+
+如果 `dynamic_subject` 是空白值或 `null`，连接器会回退到 `subject = "events.native.default"`。
+
+### 使用显式默认字段映射的 Native 模式
+
+如果输入 schema 已经直接包含 `subject`、`id`、`headers` 和 `data` 字段，可以使用下面这组默认映射值。
+
+```hocon
+native_format_fields = {
+  subject = subject
+  id = id
+  headers = headers
+  data = data
+}
+```
+
+在 native 模式下，`native_format_fields` 仍然需要提供 `data` 映射。
+
+输入 schema 契约：
+
+```text
+subject : string
+id      : string
+headers : map<string,string>
+data    : bytes
+```
+
+## 错误与运维说明
+
+- 连接失败会导致 writer 启动失败。
+- publish 失败会让任务失败，错误信息中会包含目标 subject。
+- stream 绑定缺失、subject 配置错误或 JetStream API 返回异常，通常会在第一条消息 publish 时暴露。
+- writer 采用逐条同步 publish，因此吞吐受 JetStream acknowledgement 延迟影响明显。
+
+## 不支持的能力与限制
+
+- 不提供 exactly-once。
+- 不支持脱离 JetStream 的 core NATS publish 模式。
+- 不支持自动创建、更新或删除 stream。
+- 不支持由连接器配置 JetStream deduplication window。
+- 不支持把非 `bytes` 列自动转换成 native payload。
+- 不支持基于 RowKind 的 CDC 更新/删除语义。
+
+## FAQ
+
+### 这是一个 core NATS publisher 吗？
+
+不是。它通过 JetStream API 发布消息，并依赖服务端已经准备好的 JetStream 资源。
+
+### 连接器会自动创建 stream 吗？
+
+不会。作业启动前必须先创建 stream，并把它绑定到发布 subject。
+
+### message ID 能让投递变成 exactly-once 吗？
+
+不能。message ID 只能在目标 stream 已配置 duplicate window，且生产端重复发送相同稳定 ID 时，帮助 JetStream 做重复抑制。
+
+## 变更日志
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -165,6 +165,7 @@ seatunnel.source.Fluss = connector-fluss
 seatunnel.sink.Fluss = connector-fluss
 seatunnel.sink.Lance = connector-lance
 seatunnel.sink.BigQuery = connector-bigquery
+seatunnel.sink.NatsJetStream = connector-nats-jetstream
 
 # For custom transforms, make sure to use the seatunnel.transform.[PluginIdentifier]=[JarPerfix] naming convention. For example:
 # seatunnel.transform.Sql = seatunnel-transforms-v2

--- a/seatunnel-connectors-v2/connector-nats-jetstream/pom.xml
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-nats-jetstream</artifactId>
+    <name>SeaTunnel : Connectors V2 : NATS Jetstream</name>
+
+    <properties>
+        <nats.client.version>2.24.0</nats.client.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- TODO add to dependency management after version unify-->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.nats</groupId>
+            <artifactId>jnats</artifactId>
+            <version>${nats.client.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/config/NatsJetStreamMessageFormat.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/config/NatsJetStreamMessageFormat.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.config;
+
+public enum NatsJetStreamMessageFormat {
+    JSON,
+    NATIVE
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/config/NatsJetStreamSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/config/NatsJetStreamSinkOptions.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NatsJetStreamSinkOptions {
+    public static final String CONNECTOR_IDENTITY = "NatsJetStream";
+
+    public static final String NATIVE_MAPPING_ID = "id";
+    public static final String NATIVE_MAPPING_SUBJECT = "subject";
+    public static final String NATIVE_MAPPING_HEADERS = "headers";
+    public static final String NATIVE_MAPPING_DATA = "data";
+
+    public static final Option<String> URL =
+            Options.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "NATS server address used by the sink, for example `nats://127.0.0.1:4222`."
+                                    + " Keep credentials out of the URL and configure `username`/`password` or `token` separately.");
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Username for NATS authentication. This option must be configured together with `password`"
+                                    + " and must not be combined with `token`.");
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Password for NATS authentication. This option must be configured together with `username`"
+                                    + " and must not be combined with `token`.");
+
+    public static final Option<String> TOKEN =
+            Options.key("token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Authentication token for NATS. Configure either `token` or the `username`/`password` pair.");
+
+    public static final Option<String> SUBJECT =
+            Options.key("subject")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Default JetStream subject used for published messages. This option is required in `json` format"
+                                    + " and is used as the fallback subject in `native` format when the mapped subject field is null.");
+
+    public static final Option<NatsJetStreamMessageFormat> FORMAT =
+            Options.key("format")
+                    .enumType(NatsJetStreamMessageFormat.class)
+                    .defaultValue(NatsJetStreamMessageFormat.JSON)
+                    .withDescription(
+                            "Message format written to JetStream. Supported values are `json` and `native`.");
+
+    public static final Option<Map<String, String>> NATIVE_FIELDS =
+            Options.key("native_format_fields")
+                    .mapType()
+                    .defaultValue(getDefaultNativeFields())
+                    .withDescription(
+                            "Field mapping used only when `format = native`. Supported mapping keys are `id`, `subject`, `headers`, and `data`."
+                                    + " Values are SeaTunnel field names. The default mapping is "
+                                    + "`{\"id\":\"id\",\"subject\":\"subject\",\"headers\":\"headers\",\"data\":\"data\"}`."
+                                    + " Optional mappings (`id`, `subject`, `headers`) are silently skipped when the mapped field"
+                                    + " does not exist in the input schema. `data` must map to a BYTES field,"
+                                    + " `subject` and `id` must map to STRING fields when present,"
+                                    + " and `headers` must map to MAP<STRING, STRING> when present.");
+
+    public static final Option<Boolean> INCLUDE_ROW_KIND_HEADER =
+            Options.key("include_row_kind_header")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to add JetStream header `x-seatunnel-row-kind` in `native` format."
+                                    + " When enabled, the header value is the SeaTunnel row kind name."
+                                    + " This option has no effect in `json` format.");
+
+    public static Map<String, String> getDefaultNativeFields() {
+        Map<String, String> map = new HashMap<>();
+        map.put(NATIVE_MAPPING_ID, NATIVE_MAPPING_ID);
+        map.put(NATIVE_MAPPING_SUBJECT, NATIVE_MAPPING_SUBJECT);
+        map.put(NATIVE_MAPPING_HEADERS, NATIVE_MAPPING_HEADERS);
+        map.put(NATIVE_MAPPING_DATA, NATIVE_MAPPING_DATA);
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/exception/NatsJetStreamConnectorException.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/exception/NatsJetStreamConnectorException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class NatsJetStreamConnectorException extends SeaTunnelRuntimeException {
+
+    public NatsJetStreamConnectorException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage) {
+        super(seaTunnelErrorCode, errorMessage);
+    }
+
+    public NatsJetStreamConnectorException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage, Throwable cause) {
+        super(seaTunnelErrorCode, errorMessage, cause);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamRequestSerializer.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamRequestSerializer.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.serialization.SerializationSchema;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink.NatsJetStreamSinkWriter.NativeFieldMapping;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink.NatsJetStreamSinkWriter.PublishRequest;
+
+import io.nats.client.impl.Headers;
+
+import java.util.Map;
+
+final class NatsJetStreamRequestSerializer {
+
+    static final String ROW_KIND_HEADER = "x-seatunnel-row-kind";
+
+    private final String defaultSubject;
+    private final SerializationSchema serializationSchema;
+    private final boolean includeRowKindHeader;
+    private final NativeFieldMapping nativeFieldMapping;
+
+    private NatsJetStreamRequestSerializer(
+            String defaultSubject,
+            SerializationSchema serializationSchema,
+            boolean includeRowKindHeader,
+            NativeFieldMapping nativeFieldMapping) {
+        this.defaultSubject = defaultSubject;
+        this.serializationSchema = serializationSchema;
+        this.includeRowKindHeader = includeRowKindHeader;
+        this.nativeFieldMapping = nativeFieldMapping;
+    }
+
+    static NatsJetStreamRequestSerializer forJson(
+            String defaultSubject, SerializationSchema serializationSchema) {
+        return new NatsJetStreamRequestSerializer(defaultSubject, serializationSchema, false, null);
+    }
+
+    static NatsJetStreamRequestSerializer forNative(
+            String defaultSubject,
+            boolean includeRowKindHeader,
+            NativeFieldMapping nativeFieldMapping) {
+        return new NatsJetStreamRequestSerializer(
+                defaultSubject, null, includeRowKindHeader, nativeFieldMapping);
+    }
+
+    PublishRequest serialize(SeaTunnelRow element) {
+        if (nativeFieldMapping == null) {
+            return new PublishRequest(
+                    defaultSubject, null, null, serializationSchema.serialize(element));
+        }
+        String subject = defaultSubject;
+        if (nativeFieldMapping.subjectFieldIndex >= 0) {
+            subject = resolveSubjectField(element, nativeFieldMapping.subjectFieldIndex, subject);
+        }
+        if (subject == null || subject.isEmpty()) {
+            throw NatsJetStreamSinkWriter.invalidRecord("subject", "must not be null or blank");
+        }
+
+        String messageId = null;
+        if (nativeFieldMapping.messageIdFieldIndex >= 0) {
+            messageId =
+                    resolveOptionalStringField(
+                            element, nativeFieldMapping.messageIdFieldIndex, "id");
+        }
+
+        Headers headers = null;
+        if (includeRowKindHeader) {
+            headers = withRowKindHeader(element);
+        }
+        if (nativeFieldMapping.headersFieldIndex >= 0) {
+            headers = requireHeaders(element, nativeFieldMapping.headersFieldIndex, headers);
+        }
+
+        byte[] data = requireBinaryPayload(element, nativeFieldMapping.dataFieldIndex);
+        return new PublishRequest(subject, messageId, headers, data);
+    }
+
+    private static Headers requireHeaders(SeaTunnelRow element, int fieldIndex, Headers headers) {
+        Object headersValue = element.getField(fieldIndex);
+        if (headersValue == null) {
+            return headers;
+        }
+        if (headers == null) {
+            headers = new Headers();
+        }
+        if (!(headersValue instanceof Map)) {
+            throw NatsJetStreamSinkWriter.invalidRecord(
+                    "headers", "must be a map of string keys and values");
+        }
+        Map<?, ?> rawHeaders = (Map<?, ?>) headersValue;
+        for (Map.Entry<?, ?> entry : rawHeaders.entrySet()) {
+            if (!(entry.getKey() instanceof String)) {
+                throw NatsJetStreamSinkWriter.invalidRecord("headers", "contains a non-string key");
+            }
+            if (!(entry.getValue() instanceof String)) {
+                throw NatsJetStreamSinkWriter.invalidRecord(
+                        "headers", "contains a non-string value");
+            }
+            headers.add((String) entry.getKey(), (String) entry.getValue());
+        }
+        return headers;
+    }
+
+    private static byte[] requireBinaryPayload(SeaTunnelRow element, int fieldIndex) {
+        Object value = element.getField(fieldIndex);
+        if (!(value instanceof byte[])) {
+            throw NatsJetStreamSinkWriter.invalidRecord("data", "must be a non-null BYTES value");
+        }
+        return (byte[]) value;
+    }
+
+    private static Headers withRowKindHeader(SeaTunnelRow element) {
+        Headers headers = new Headers();
+        headers.add(ROW_KIND_HEADER, element.getRowKind().name());
+        return headers;
+    }
+
+    private static String resolveSubjectField(
+            SeaTunnelRow element, int fieldIndex, String fallbackSubject) {
+        Object value = element.getField(fieldIndex);
+        if (value == null) {
+            return fallbackSubject;
+        }
+        if (!(value instanceof String)) {
+            throw NatsJetStreamSinkWriter.invalidRecord("subject", "must be a STRING value");
+        }
+        String subject = ((String) value).trim();
+        if (subject.isEmpty()) {
+            return fallbackSubject;
+        }
+        return subject;
+    }
+
+    private static String resolveOptionalStringField(
+            SeaTunnelRow element, int fieldIndex, String fieldName) {
+        Object value = element.getField(fieldIndex);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String)) {
+            throw NatsJetStreamSinkWriter.invalidRecord(fieldName, "must be a STRING value");
+        }
+        String stringValue = ((String) value).trim();
+        if (stringValue.isEmpty()) {
+            return null;
+        }
+        return stringValue;
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSink.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSink.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SinkWriter.Context;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class NatsJetStreamSink implements SeaTunnelSink<SeaTunnelRow, Void, Void, Void> {
+
+    private final ReadonlyConfig pluginConfig;
+    private final SeaTunnelRowType seaTunnelRowType;
+    private final CatalogTable catalogTable;
+
+    public NatsJetStreamSink(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
+        NatsJetStreamSinkValidator.validate(pluginConfig, catalogTable);
+        this.pluginConfig = pluginConfig;
+        this.catalogTable = catalogTable;
+        this.seaTunnelRowType = catalogTable.getTableSchema().toPhysicalRowDataType();
+    }
+
+    @Override
+    public String getPluginName() {
+        return NatsJetStreamSinkOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public SinkWriter<SeaTunnelRow, Void, Void> createWriter(Context arg0) throws IOException {
+        return new NatsJetStreamSinkWriter(arg0, seaTunnelRowType, pluginConfig, catalogTable);
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.ofNullable(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(Factory.class)
+public class NatsJetStreamSinkFactory implements TableSinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return NatsJetStreamSinkOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(NatsJetStreamSinkOptions.URL)
+                .optional(
+                        NatsJetStreamSinkOptions.USERNAME,
+                        NatsJetStreamSinkOptions.PASSWORD,
+                        NatsJetStreamSinkOptions.TOKEN,
+                        NatsJetStreamSinkOptions.SUBJECT,
+                        NatsJetStreamSinkOptions.FORMAT,
+                        NatsJetStreamSinkOptions.NATIVE_FIELDS,
+                        NatsJetStreamSinkOptions.INCLUDE_ROW_KIND_HEADER)
+                .build();
+    }
+
+    @Override
+    public TableSink createSink(TableSinkFactoryContext context) {
+        ReadonlyConfig options = context.getOptions();
+        CatalogTable catalogTable = context.getCatalogTable();
+        NatsJetStreamSinkValidator.validate(options, catalogTable);
+        return () -> new NatsJetStreamSink(options, catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkValidator.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkValidator.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
+import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamMessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.exception.NatsJetStreamConnectorException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+final class NatsJetStreamSinkValidator {
+
+    private static final Set<String> SUPPORTED_NATIVE_MAPPING_KEYS =
+            new HashSet<>(
+                    Arrays.asList(
+                            NatsJetStreamSinkOptions.NATIVE_MAPPING_ID,
+                            NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT,
+                            NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS,
+                            NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA));
+
+    private NatsJetStreamSinkValidator() {}
+
+    static void validate(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
+        requireNonBlank(pluginConfig, NatsJetStreamSinkOptions.URL);
+        validateAuthentication(pluginConfig);
+        NatsJetStreamMessageFormat format = pluginConfig.get(NatsJetStreamSinkOptions.FORMAT);
+        if (format == null) {
+            throw invalidOption("format", "must be one of: json, native");
+        }
+        if (format == NatsJetStreamMessageFormat.JSON) {
+            requireNonBlank(pluginConfig, NatsJetStreamSinkOptions.SUBJECT);
+            return;
+        }
+        validateNativeMapping(pluginConfig, catalogTable);
+    }
+
+    private static void validateAuthentication(ReadonlyConfig pluginConfig) {
+        Optional<String> username = pluginConfig.getOptional(NatsJetStreamSinkOptions.USERNAME);
+        Optional<String> password = pluginConfig.getOptional(NatsJetStreamSinkOptions.PASSWORD);
+        Optional<String> token = pluginConfig.getOptional(NatsJetStreamSinkOptions.TOKEN);
+
+        boolean hasUsername = username.map(NatsJetStreamSinkValidator::isNotBlank).orElse(false);
+        boolean hasPassword = password.map(NatsJetStreamSinkValidator::isNotBlank).orElse(false);
+        boolean hasToken = token.map(NatsJetStreamSinkValidator::isNotBlank).orElse(false);
+
+        if (hasUsername != hasPassword) {
+            throw invalidOption(
+                    hasUsername
+                            ? NatsJetStreamSinkOptions.PASSWORD.key()
+                            : NatsJetStreamSinkOptions.USERNAME.key(),
+                    "must be configured together with `"
+                            + (hasUsername
+                                    ? NatsJetStreamSinkOptions.USERNAME.key()
+                                    : NatsJetStreamSinkOptions.PASSWORD.key())
+                            + "`");
+        }
+        if (hasToken && hasUsername) {
+            throw invalidOption(
+                    NatsJetStreamSinkOptions.TOKEN.key(),
+                    "cannot be configured together with `username` and `password`");
+        }
+    }
+
+    private static void validateNativeMapping(
+            ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
+        Map<String, String> nativeFields = pluginConfig.get(NatsJetStreamSinkOptions.NATIVE_FIELDS);
+        if (nativeFields == null || nativeFields.isEmpty()) {
+            throw invalidOption(
+                    NatsJetStreamSinkOptions.NATIVE_FIELDS.key(),
+                    "must define at least the `data` field mapping in native format");
+        }
+
+        for (String mappingKey : nativeFields.keySet()) {
+            if (!SUPPORTED_NATIVE_MAPPING_KEYS.contains(mappingKey)) {
+                throw invalidOption(
+                        NatsJetStreamSinkOptions.NATIVE_FIELDS.key(),
+                        "contains unsupported mapping key `" + mappingKey + "`");
+            }
+        }
+
+        String dataField = nativeFields.get(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA);
+        if (!isNotBlank(dataField)) {
+            throw invalidOption(
+                    NatsJetStreamSinkOptions.NATIVE_FIELDS.key(),
+                    "must define a non-empty mapping for `data`");
+        }
+
+        SeaTunnelRowType rowType = catalogTable.getSeaTunnelRowType();
+        validateMappedFieldType(
+                rowType, NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, dataField, SqlType.BYTES);
+
+        validateOptionalStringField(
+                rowType, nativeFields, NatsJetStreamSinkOptions.NATIVE_MAPPING_ID);
+        validateOptionalHeadersField(rowType, nativeFields);
+
+        String subject = pluginConfig.getOptional(NatsJetStreamSinkOptions.SUBJECT).orElse(null);
+        boolean hasSubjectFallback = isNotBlank(subject);
+        boolean hasSubjectField =
+                isNotBlank(nativeFields.get(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT));
+        if (!hasSubjectFallback && !hasSubjectField) {
+            throw invalidOption(
+                    NatsJetStreamSinkOptions.SUBJECT.key(),
+                    "or `native_format_fields.subject` must be configured in native format");
+        }
+        validateSubjectField(rowType, nativeFields, hasSubjectFallback);
+    }
+
+    /**
+     * Validates the native {@code subject} field mapping. Unlike other optional mappings, the
+     * subject mapping is required to resolve to an existing {@code STRING} field whenever no
+     * sink-level {@code subject} fallback is configured. Without this check, a subject mapping that
+     * points to a non-existent field silently resolves to {@code null} at runtime and every row is
+     * rejected by the serializer.
+     */
+    private static void validateSubjectField(
+            SeaTunnelRowType rowType,
+            Map<String, String> nativeFields,
+            boolean hasSubjectFallback) {
+        String fieldName = nativeFields.get(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT);
+        if (!isNotBlank(fieldName)) {
+            return;
+        }
+        int fieldIndex = rowType.indexOf(fieldName, false);
+        if (fieldIndex < 0) {
+            if (!hasSubjectFallback) {
+                throw invalidField(
+                        fieldName,
+                        "mapped from `"
+                                + NatsJetStreamSinkOptions.NATIVE_FIELDS.key()
+                                + ".subject` does not exist in table schema");
+            }
+            return;
+        }
+        SeaTunnelDataType<?> fieldType = rowType.getFieldType(fieldIndex);
+        if (fieldType.getSqlType() != SqlType.STRING) {
+            throw invalidField(fieldName, "must use `STRING` type for native mapping `subject`");
+        }
+    }
+
+    private static void validateOptionalStringField(
+            SeaTunnelRowType rowType, Map<String, String> nativeFields, String mappingKey) {
+        String fieldName = nativeFields.get(mappingKey);
+        if (!isNotBlank(fieldName)) {
+            return;
+        }
+        int fieldIndex = rowType.indexOf(fieldName, false);
+        if (fieldIndex < 0) {
+            return;
+        }
+        SeaTunnelDataType<?> fieldType = rowType.getFieldType(fieldIndex);
+        if (fieldType.getSqlType() != SqlType.STRING) {
+            throw invalidField(
+                    fieldName, "must use `STRING` type for native mapping `" + mappingKey + "`");
+        }
+    }
+
+    private static void validateOptionalHeadersField(
+            SeaTunnelRowType rowType, Map<String, String> nativeFields) {
+        String fieldName = nativeFields.get(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS);
+        if (!isNotBlank(fieldName)) {
+            return;
+        }
+        int fieldIndex = rowType.indexOf(fieldName, false);
+        if (fieldIndex < 0) {
+            return;
+        }
+        SeaTunnelDataType<?> fieldType = rowType.getFieldType(fieldIndex);
+        if (!(fieldType instanceof MapType)) {
+            throw invalidField(fieldName, "must use MAP<STRING, STRING> type");
+        }
+        MapType<?, ?> mapType = (MapType<?, ?>) fieldType;
+        if (mapType.getKeyType().getSqlType() != SqlType.STRING
+                || mapType.getValueType().getSqlType() != SqlType.STRING) {
+            throw invalidField(fieldName, "must use MAP<STRING, STRING> type");
+        }
+    }
+
+    private static void validateMappedFieldType(
+            SeaTunnelRowType rowType, String mappingKey, String fieldName, SqlType expectedType) {
+        int fieldIndex = rowType.indexOf(fieldName, false);
+        if (fieldIndex < 0) {
+            throw invalidField(
+                    fieldName,
+                    "mapped from `"
+                            + NatsJetStreamSinkOptions.NATIVE_FIELDS.key()
+                            + "."
+                            + mappingKey
+                            + "` does not exist in table schema");
+        }
+        SeaTunnelDataType<?> fieldType = rowType.getFieldType(fieldIndex);
+        if (fieldType.getSqlType() != expectedType) {
+            throw invalidField(
+                    fieldName,
+                    "must use `" + expectedType + "` type for native mapping `" + mappingKey + "`");
+        }
+    }
+
+    private static void requireNonBlank(
+            ReadonlyConfig pluginConfig,
+            org.apache.seatunnel.api.configuration.Option<String> option) {
+        String value = pluginConfig.getOptional(option).orElse(null);
+        if (!isNotBlank(value)) {
+            throw invalidOption(option.key(), "must not be blank");
+        }
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static NatsJetStreamConnectorException invalidOption(
+            String optionName, String message) {
+        return new NatsJetStreamConnectorException(
+                CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                "Invalid NATS JetStream sink option `" + optionName + "`: " + message);
+    }
+
+    private static NatsJetStreamConnectorException invalidField(String fieldName, String message) {
+        return new NatsJetStreamConnectorException(
+                CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                "Invalid NATS JetStream sink field `" + fieldName + "`: " + message);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/main/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkWriter.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamMessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.exception.NatsJetStreamConnectorException;
+import org.apache.seatunnel.format.json.JsonSerializationSchema;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStream;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.PublishOptions;
+import io.nats.client.impl.Headers;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+public class NatsJetStreamSinkWriter implements SinkWriter<SeaTunnelRow, Void, Void> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NatsJetStreamSinkWriter.class);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration PUBLISH_TIMEOUT = Duration.ofSeconds(30);
+
+    private final int subtaskIndex;
+    private final NatsJetStreamRequestSerializer requestSerializer;
+
+    private Connection connection;
+    private JetStream jetStream;
+
+    public NatsJetStreamSinkWriter(
+            Context context,
+            SeaTunnelRowType seaTunnelRowType,
+            ReadonlyConfig pluginConfig,
+            CatalogTable catalogTable)
+            throws IOException {
+
+        NatsJetStreamSinkValidator.validate(pluginConfig, catalogTable);
+        this.subtaskIndex = context.getIndexOfSubtask();
+        this.requestSerializer = createRequestSerializer(seaTunnelRowType, pluginConfig);
+        connect(pluginConfig);
+        LOG.info("Opened NATS JetStream sink writer for subtask {}", subtaskIndex);
+    }
+
+    @Override
+    public void abortPrepare() {}
+
+    @Override
+    public void close() throws IOException {
+        IOException closeException = null;
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                closeException = new IOException("Interrupted while closing NATS connection", e);
+            } finally {
+                jetStream = null;
+                connection = null;
+            }
+        }
+        if (closeException == null) {
+            LOG.info("Closed NATS JetStream sink writer for subtask {}", subtaskIndex);
+            return;
+        }
+        throw closeException;
+    }
+
+    @Override
+    public Optional<Void> prepareCommit() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void write(SeaTunnelRow element) throws IOException {
+        publish(requestSerializer.serialize(element));
+    }
+
+    static NatsJetStreamRequestSerializer createRequestSerializer(
+            SeaTunnelRowType seaTunnelRowType, ReadonlyConfig pluginConfig) {
+        String defaultSubject =
+                normalizeSubject(pluginConfig.getOptional(NatsJetStreamSinkOptions.SUBJECT));
+        NatsJetStreamMessageFormat format = pluginConfig.get(NatsJetStreamSinkOptions.FORMAT);
+        if (format == NatsJetStreamMessageFormat.JSON) {
+            return NatsJetStreamRequestSerializer.forJson(
+                    defaultSubject, new JsonSerializationSchema(seaTunnelRowType));
+        }
+        return NatsJetStreamRequestSerializer.forNative(
+                defaultSubject,
+                pluginConfig.get(NatsJetStreamSinkOptions.INCLUDE_ROW_KIND_HEADER),
+                NativeFieldMapping.of(
+                        seaTunnelRowType,
+                        pluginConfig.get(NatsJetStreamSinkOptions.NATIVE_FIELDS)));
+    }
+
+    static String normalizeSubject(Optional<String> subject) {
+        return subject.map(String::trim).filter(value -> !value.isEmpty()).orElse(null);
+    }
+
+    private void connect(ReadonlyConfig pluginConfig) throws IOException {
+        Options.Builder builder =
+                Options.builder()
+                        .server(pluginConfig.get(NatsJetStreamSinkOptions.URL))
+                        .connectionTimeout(CONNECT_TIMEOUT);
+
+        Optional<String> username = pluginConfig.getOptional(NatsJetStreamSinkOptions.USERNAME);
+        Optional<String> password = pluginConfig.getOptional(NatsJetStreamSinkOptions.PASSWORD);
+        Optional<String> token = pluginConfig.getOptional(NatsJetStreamSinkOptions.TOKEN);
+        boolean hasUsername = username.map(NatsJetStreamSinkWriter::isNotBlank).orElse(false);
+        boolean hasPassword = password.map(NatsJetStreamSinkWriter::isNotBlank).orElse(false);
+        boolean hasToken = token.map(NatsJetStreamSinkWriter::isNotBlank).orElse(false);
+        if (hasUsername && hasPassword) {
+            builder.userInfo(username.get().trim(), password.get());
+        } else if (hasToken) {
+            builder.token(token.get().toCharArray());
+        }
+
+        try {
+            connection = Nats.connect(builder.build());
+            jetStream = connection.jetStream();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while connecting to NATS JetStream", e);
+        } catch (IOException | RuntimeException e) {
+            IOException failure =
+                    new IOException(
+                            String.format(
+                                    "Failed to connect NATS JetStream sink writer for subtask %d",
+                                    subtaskIndex),
+                            e);
+            closeConnectionQuietly(connection, failure);
+            throw failure;
+        }
+    }
+
+    /**
+     * Best-effort close of a connection that could not be fully initialized. Preserves the current
+     * thread's interrupt status and attaches any close failure as a suppressed exception on the
+     * provided primary failure so the original initialization error remains visible.
+     */
+    private static void closeConnectionQuietly(Connection toClose, IOException primaryFailure) {
+        if (toClose == null) {
+            return;
+        }
+        try {
+            toClose.close();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            primaryFailure.addSuppressed(
+                    new IOException("Interrupted while closing NATS connection", e));
+        } catch (Exception e) {
+            primaryFailure.addSuppressed(new IOException("Failed to close NATS connection", e));
+        }
+    }
+
+    private void publish(PublishRequest publishRequest) throws IOException {
+        PublishOptions.Builder optionsBuilder =
+                PublishOptions.builder().streamTimeout(PUBLISH_TIMEOUT);
+        if (publishRequest.messageId != null) {
+            optionsBuilder.messageId(publishRequest.messageId);
+        }
+        try {
+            jetStream.publish(
+                    publishRequest.subject,
+                    publishRequest.headers,
+                    publishRequest.payload,
+                    optionsBuilder.build());
+        } catch (JetStreamApiException e) {
+            throw publishFailure(publishRequest.subject, e);
+        } catch (IOException | RuntimeException e) {
+            throw publishFailure(publishRequest.subject, e);
+        }
+    }
+
+    private IOException publishFailure(String subject, Exception cause) {
+        return new IOException(
+                String.format(
+                        "Failed to publish NATS JetStream message for subtask %d to subject '%s'",
+                        subtaskIndex, subject),
+                cause);
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    static NatsJetStreamConnectorException invalidRecord(String fieldName, String message) {
+        return new NatsJetStreamConnectorException(
+                CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                "Invalid NATS JetStream record field `" + fieldName + "`: " + message);
+    }
+
+    static final class PublishRequest {
+        private final String subject;
+        private final String messageId;
+        private final Headers headers;
+        private final byte[] payload;
+
+        PublishRequest(String subject, String messageId, Headers headers, byte[] payload) {
+            this.subject = subject;
+            this.messageId = messageId;
+            this.headers = headers;
+            this.payload = payload;
+        }
+
+        String getSubject() {
+            return subject;
+        }
+
+        String getMessageId() {
+            return messageId;
+        }
+
+        Headers getHeaders() {
+            return headers;
+        }
+
+        byte[] getPayload() {
+            return payload;
+        }
+    }
+
+    static final class NativeFieldMapping {
+        final int messageIdFieldIndex;
+        final int subjectFieldIndex;
+        final int headersFieldIndex;
+        final int dataFieldIndex;
+
+        private NativeFieldMapping(
+                int messageIdFieldIndex,
+                int subjectFieldIndex,
+                int headersFieldIndex,
+                int dataFieldIndex) {
+            this.messageIdFieldIndex = messageIdFieldIndex;
+            this.subjectFieldIndex = subjectFieldIndex;
+            this.headersFieldIndex = headersFieldIndex;
+            this.dataFieldIndex = dataFieldIndex;
+        }
+
+        static NativeFieldMapping of(SeaTunnelRowType rowType, Map<String, String> nativeFields) {
+            return new NativeFieldMapping(
+                    resolveFieldIndex(
+                            rowType, nativeFields, NatsJetStreamSinkOptions.NATIVE_MAPPING_ID),
+                    resolveFieldIndex(
+                            rowType, nativeFields, NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT),
+                    resolveFieldIndex(
+                            rowType, nativeFields, NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS),
+                    requireFieldIndex(
+                            rowType, nativeFields, NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA));
+        }
+
+        private static int resolveFieldIndex(
+                SeaTunnelRowType rowType, Map<String, String> nativeFields, String mappingKey) {
+            String fieldName = nativeFields.get(mappingKey);
+            if (fieldName == null || fieldName.trim().isEmpty()) {
+                return -1;
+            }
+            return rowType.indexOf(fieldName, false);
+        }
+
+        private static int requireFieldIndex(
+                SeaTunnelRowType rowType, Map<String, String> nativeFields, String mappingKey) {
+            return rowType.indexOf(nativeFields.get(mappingKey), false);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamRequestSerializerTest.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamRequestSerializerTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamMessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.exception.NatsJetStreamConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class NatsJetStreamRequestSerializerTest {
+
+    private static final SeaTunnelRowType JSON_ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"id", "name", "active"},
+                    new SeaTunnelDataType<?>[] {
+                        BasicType.INT_TYPE, BasicType.STRING_TYPE, BasicType.BOOLEAN_TYPE
+                    });
+
+    static final SeaTunnelRowType NATIVE_ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"dynamic_subject", "message_id", "attributes", "payload"},
+                    new SeaTunnelDataType<?>[] {
+                        BasicType.STRING_TYPE,
+                        BasicType.STRING_TYPE,
+                        new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE),
+                        PrimitiveByteArrayType.INSTANCE
+                    });
+
+    @Test
+    void createJsonSerializerGeneratesRepresentativeJsonPayload() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        JSON_ROW_TYPE, ReadonlyConfig.fromMap(validJsonConfig()));
+
+        NatsJetStreamSinkWriter.PublishRequest request =
+                serializer.serialize(new SeaTunnelRow(new Object[] {7, "alice", true}));
+
+        Assertions.assertEquals("orders.events", request.getSubject());
+        Assertions.assertNull(request.getHeaders());
+        Assertions.assertNull(request.getMessageId());
+        Assertions.assertEquals(
+                "{\"id\":7,\"name\":\"alice\",\"active\":true}",
+                new String(request.getPayload(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void createNativeSerializerBuildsSubjectHeadersPayloadAndMessageId() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(validNativeConfig()));
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("tenant", "acme");
+        headers.put("trace", "t-1");
+        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+        SeaTunnelRow row =
+                new SeaTunnelRow(new Object[] {"payments.created", "msg-1", headers, payload});
+
+        NatsJetStreamSinkWriter.PublishRequest request = serializer.serialize(row);
+
+        Assertions.assertEquals("payments.created", request.getSubject());
+        Assertions.assertEquals("msg-1", request.getMessageId());
+        Assertions.assertArrayEquals(payload, request.getPayload());
+        Assertions.assertNotNull(request.getHeaders());
+        Assertions.assertEquals("acme", request.getHeaders().getFirst("tenant"));
+        Assertions.assertEquals("t-1", request.getHeaders().getFirst("trace"));
+        Assertions.assertEquals(
+                "INSERT",
+                request.getHeaders().getFirst(NatsJetStreamRequestSerializer.ROW_KIND_HEADER));
+    }
+
+    @Test
+    void createNativeSerializerFallsBackToConfiguredSubjectAndOptionalFields() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(config));
+
+        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+        NatsJetStreamSinkWriter.PublishRequest request =
+                serializer.serialize(new SeaTunnelRow(new Object[] {null, null, null, payload}));
+
+        Assertions.assertEquals("orders.events", request.getSubject());
+        Assertions.assertNull(request.getMessageId());
+        Assertions.assertNotNull(request.getHeaders());
+        Assertions.assertEquals(
+                "INSERT",
+                request.getHeaders().getFirst(NatsJetStreamRequestSerializer.ROW_KIND_HEADER));
+        Assertions.assertArrayEquals(payload, request.getPayload());
+    }
+
+    @Test
+    void createNativeSerializerSkipsRowKindHeaderWhenDisabled() {
+        Map<String, Object> config = validNativeConfig();
+        config.put(NatsJetStreamSinkOptions.INCLUDE_ROW_KIND_HEADER.key(), false);
+
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(config));
+
+        NatsJetStreamSinkWriter.PublishRequest request =
+                serializer.serialize(
+                        new SeaTunnelRow(
+                                new Object[] {"payments.created", null, null, bytes("hello")}));
+
+        Assertions.assertNull(request.getHeaders());
+    }
+
+    @Test
+    void createNativeSerializerRejectsBlankSubjectWithoutFallback() {
+        Map<String, Object> config = validNativeConfig();
+        config.remove(NatsJetStreamSinkOptions.SUBJECT.key());
+
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(config));
+
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () ->
+                                serializer.serialize(
+                                        new SeaTunnelRow(
+                                                new Object[] {"   ", null, null, bytes("x")})));
+
+        Assertions.assertTrue(exception.getMessage().contains("field `subject`"));
+        Assertions.assertTrue(exception.getMessage().contains("must not be null or blank"));
+    }
+
+    @Test
+    void createNativeSerializerRejectsWrongSubjectType() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(validNativeConfig()));
+
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () ->
+                                serializer.serialize(
+                                        new SeaTunnelRow(
+                                                new Object[] {1, null, null, bytes("x")})));
+
+        Assertions.assertTrue(exception.getMessage().contains("field `subject`"));
+        Assertions.assertTrue(exception.getMessage().contains("STRING value"));
+    }
+
+    @Test
+    void createNativeSerializerRejectsWrongMessageIdType() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(validNativeConfig()));
+
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () ->
+                                serializer.serialize(
+                                        new SeaTunnelRow(
+                                                new Object[] {
+                                                    "payments.created", 12, null, bytes("x")
+                                                })));
+
+        Assertions.assertTrue(exception.getMessage().contains("field `id`"));
+        Assertions.assertTrue(exception.getMessage().contains("STRING value"));
+    }
+
+    @Test
+    void createNativeSerializerRejectsWrongHeadersValueType() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(validNativeConfig()));
+
+        Map<String, Object> headers = new LinkedHashMap<>();
+        headers.put("tenant", 1);
+
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () ->
+                                serializer.serialize(
+                                        new SeaTunnelRow(
+                                                new Object[] {
+                                                    "payments.created", "msg-1", headers, bytes("x")
+                                                })));
+
+        Assertions.assertTrue(exception.getMessage().contains("field `headers`"));
+        Assertions.assertTrue(exception.getMessage().contains("non-string value"));
+    }
+
+    @Test
+    void createNativeSerializerRejectsWrongPayloadType() {
+        NatsJetStreamRequestSerializer serializer =
+                NatsJetStreamSinkWriter.createRequestSerializer(
+                        NATIVE_ROW_TYPE, ReadonlyConfig.fromMap(validNativeConfig()));
+
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () ->
+                                serializer.serialize(
+                                        new SeaTunnelRow(
+                                                new Object[] {
+                                                    "payments.created", "msg-1", null, "text"
+                                                })));
+
+        Assertions.assertTrue(exception.getMessage().contains("field `data`"));
+        Assertions.assertTrue(exception.getMessage().contains("non-null BYTES value"));
+    }
+
+    private Map<String, Object> validJsonConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(NatsJetStreamSinkOptions.URL.key(), "nats://127.0.0.1:4222");
+        config.put(NatsJetStreamSinkOptions.SUBJECT.key(), "orders.events");
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), NatsJetStreamMessageFormat.JSON.name());
+        return config;
+    }
+
+    private Map<String, Object> validNativeConfig() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), NatsJetStreamMessageFormat.NATIVE.name());
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "dynamic_subject");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_ID, "message_id");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS, "attributes");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+        return config;
+    }
+
+    private byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkFactoryTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamMessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.exception.NatsJetStreamConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class NatsJetStreamSinkFactoryTest {
+
+    private final NatsJetStreamSinkFactory factory = new NatsJetStreamSinkFactory();
+
+    @Test
+    void optionRuleAndFactoryIdentifier() {
+        Assertions.assertNotNull(factory.optionRule());
+        Assertions.assertEquals(
+                NatsJetStreamSinkOptions.CONNECTOR_IDENTITY, factory.factoryIdentifier());
+    }
+
+    @Test
+    void createSinkRejectsBlankUrl() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.URL.key(), "   ");
+
+        assertInvalidOption(config, defaultCatalogTable(), "url", "must not be blank");
+    }
+
+    @Test
+    void createSinkRejectsBlankJsonSubject() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.SUBJECT.key(), "   ");
+
+        assertInvalidOption(config, defaultCatalogTable(), "subject", "must not be blank");
+    }
+
+    @Test
+    void createSinkAcceptsValidJsonConfig() {
+        Assertions.assertDoesNotThrow(() -> createSink(validJsonConfig(), defaultCatalogTable()));
+    }
+
+    @Test
+    void createSinkRejectsMissingUrl() {
+        Map<String, Object> config = validJsonConfig();
+        config.remove(NatsJetStreamSinkOptions.URL.key());
+
+        assertInvalidOption(config, defaultCatalogTable(), "url", "must not be blank");
+    }
+
+    @Test
+    void createSinkRejectsMissingJsonSubject() {
+        Map<String, Object> config = validJsonConfig();
+        config.remove(NatsJetStreamSinkOptions.SUBJECT.key());
+
+        assertInvalidOption(config, defaultCatalogTable(), "subject", "must not be blank");
+    }
+
+    @Test
+    void createSinkRejectsIncompleteUsernamePasswordPair() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.USERNAME.key(), "alice");
+
+        assertInvalidOption(
+                config, defaultCatalogTable(), "password", "must be configured together");
+    }
+
+    @Test
+    void createSinkRejectsConflictingAuthentication() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.USERNAME.key(), "alice");
+        config.put(NatsJetStreamSinkOptions.PASSWORD.key(), "secret");
+        config.put(NatsJetStreamSinkOptions.TOKEN.key(), "token");
+
+        assertInvalidOption(
+                config, defaultCatalogTable(), "token", "cannot be configured together");
+    }
+
+    @Test
+    void createSinkRejectsUnknownFormatValue() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), "yaml");
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> createSink(config, defaultCatalogTable()));
+    }
+
+    @Test
+    void createSinkRejectsNativeWithoutDataMapping() {
+        Map<String, Object> config = validNativeConfig();
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), new HashMap<String, String>());
+
+        assertInvalidOption(
+                config,
+                defaultCatalogTable(),
+                NatsJetStreamSinkOptions.NATIVE_FIELDS.key(),
+                "must define at least the `data` field mapping");
+    }
+
+    @Test
+    void createSinkRejectsNativeWithoutSubjectFallbackOrMapping() {
+        Map<String, Object> config = validNativeConfig();
+        config.remove(NatsJetStreamSinkOptions.SUBJECT.key());
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidOption(config, defaultCatalogTable(), "subject", "must be configured");
+    }
+
+    @Test
+    void createSinkRejectsNativeSubjectMappingToMissingFieldWithoutFallback() {
+        Map<String, Object> config = validNativeConfig();
+        config.remove(NatsJetStreamSinkOptions.SUBJECT.key());
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "missing_subject");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidField(
+                config, defaultCatalogTable(), "missing_subject", "does not exist in table schema");
+    }
+
+    @Test
+    void createSinkAcceptsNativeSubjectMappingToMissingFieldWithFallback() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "missing_subject");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        Assertions.assertDoesNotThrow(() -> createSink(config, defaultCatalogTable()));
+    }
+
+    @Test
+    void createSinkRejectsNativeMissingMappedPayloadField() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "missing_payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "dynamic_subject");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidField(
+                config, defaultCatalogTable(), "missing_payload", "does not exist in table schema");
+    }
+
+    @Test
+    void createSinkRejectsNativeWrongPayloadType() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "dynamic_subject");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidField(
+                config, defaultCatalogTable(), "dynamic_subject", "must use `BYTES` type");
+    }
+
+    @Test
+    void createSinkRejectsNativeWrongSubjectType() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "payload");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidFieldOrOption(
+                config, defaultCatalogTable(), "payload", "native mapping `subject`");
+    }
+
+    @Test
+    void createSinkRejectsNativeWrongHeadersType() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS, "dynamic_subject");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        assertInvalidField(config, defaultCatalogTable(), "dynamic_subject", "MAP<STRING, STRING>");
+    }
+
+    @Test
+    void createSinkAcceptsNativeCustomFieldMapping() {
+        Map<String, Object> config = validNativeConfig();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "dynamic_subject");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS, "attributes");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_ID, "message_id");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+
+        Assertions.assertDoesNotThrow(() -> createSink(config, defaultCatalogTable()));
+    }
+
+    @Test
+    void createSinkAcceptsNativeDefaultMappingWithOnlyDataField() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), NatsJetStreamMessageFormat.NATIVE.name());
+        Assertions.assertDoesNotThrow(() -> createSink(config, dataOnlyCatalogTable()));
+    }
+
+    private void assertInvalidOption(
+            Map<String, Object> config,
+            CatalogTable catalogTable,
+            String optionKey,
+            String fragment) {
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () -> createSink(config, catalogTable));
+        Assertions.assertTrue(exception.getMessage().contains("option `" + optionKey + "`"));
+        Assertions.assertTrue(exception.getMessage().contains(fragment));
+    }
+
+    private void assertInvalidField(
+            Map<String, Object> config,
+            CatalogTable catalogTable,
+            String fieldName,
+            String fragment) {
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () -> createSink(config, catalogTable));
+        Assertions.assertTrue(exception.getMessage().contains("field `" + fieldName + "`"));
+        Assertions.assertTrue(exception.getMessage().contains(fragment));
+    }
+
+    private void assertInvalidFieldOrOption(
+            Map<String, Object> config,
+            CatalogTable catalogTable,
+            String fieldOrOptionName,
+            String fragment) {
+        NatsJetStreamConnectorException exception =
+                Assertions.assertThrows(
+                        NatsJetStreamConnectorException.class,
+                        () -> createSink(config, catalogTable));
+        Assertions.assertTrue(
+                exception.getMessage().contains("field `" + fieldOrOptionName + "`")
+                        || exception.getMessage().contains("option `" + fieldOrOptionName + "`"));
+        Assertions.assertTrue(exception.getMessage().contains(fragment));
+    }
+
+    private void createSink(Map<String, Object> config, CatalogTable catalogTable) {
+        factory.createSink(
+                new TableSinkFactoryContext(
+                        catalogTable, ReadonlyConfig.fromMap(config), getClass().getClassLoader()));
+    }
+
+    private Map<String, Object> validJsonConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(NatsJetStreamSinkOptions.URL.key(), "nats://127.0.0.1:4222");
+        config.put(NatsJetStreamSinkOptions.SUBJECT.key(), "orders.events");
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), NatsJetStreamMessageFormat.JSON.name());
+        return config;
+    }
+
+    private Map<String, Object> validNativeConfig() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), NatsJetStreamMessageFormat.NATIVE.name());
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "dynamic_subject");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS, "attributes");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_ID, "message_id");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+        return config;
+    }
+
+    private CatalogTable dataOnlyCatalogTable() {
+        List<Column> columns = new ArrayList<>();
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("data")
+                        .dataType(PrimitiveByteArrayType.INSTANCE)
+                        .nullable(false)
+                        .build());
+        TableSchema tableSchema = TableSchema.builder().columns(columns).build();
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "nats_jetstream_data_only_sink"),
+                tableSchema,
+                new HashMap<>(),
+                new ArrayList<>(),
+                "nats jetstream data only sink test table");
+    }
+
+    private CatalogTable defaultCatalogTable() {
+        List<Column> columns = new ArrayList<>();
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("dynamic_subject")
+                        .dataType(BasicType.STRING_TYPE)
+                        .nullable(true)
+                        .build());
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("message_id")
+                        .dataType(BasicType.STRING_TYPE)
+                        .nullable(true)
+                        .build());
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("attributes")
+                        .dataType(new MapType<>(BasicType.STRING_TYPE, BasicType.STRING_TYPE))
+                        .nullable(true)
+                        .build());
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("payload")
+                        .dataType(PrimitiveByteArrayType.INSTANCE)
+                        .nullable(false)
+                        .build());
+        TableSchema tableSchema = TableSchema.builder().columns(columns).build();
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "nats_jetstream_sink"),
+                tableSchema,
+                new HashMap<>(),
+                new ArrayList<>(),
+                "nats jetstream sink test table");
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/NatsJetStreamSinkWriterTest.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.natsjetstream.config.NatsJetStreamSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.PublishOptions;
+import io.nats.client.impl.Headers;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+class NatsJetStreamSinkWriterTest {
+
+    private static final SeaTunnelRowType JSON_ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"id", "name"},
+                    new SeaTunnelDataType<?>[] {BasicType.INT_TYPE, BasicType.STRING_TYPE});
+
+    @Test
+    void writePublishesJsonPayload() throws Exception {
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            JSON_ROW_TYPE,
+                            ReadonlyConfig.fromMap(validJsonConfig()),
+                            TestWriterResources.catalogTable(JSON_ROW_TYPE));
+
+            writer.write(new SeaTunnelRow(new Object[] {1, "alice"}));
+
+            ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+            ArgumentCaptor<PublishOptions> optionsCaptor =
+                    ArgumentCaptor.forClass(PublishOptions.class);
+            Mockito.verify(resources.getJetStream())
+                    .publish(
+                            Mockito.eq("orders.events"),
+                            Mockito.isNull(),
+                            payloadCaptor.capture(),
+                            optionsCaptor.capture());
+            Assertions.assertEquals(
+                    "{\"id\":1,\"name\":\"alice\"}",
+                    new String(payloadCaptor.getValue(), StandardCharsets.UTF_8));
+            Assertions.assertNull(optionsCaptor.getValue().getMessageId());
+        }
+    }
+
+    @Test
+    void writeTranslatesJetStreamPublishFailure() throws Exception {
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            Mockito.doThrow(Mockito.mock(JetStreamApiException.class))
+                    .when(resources.getJetStream())
+                    .publish(
+                            Mockito.anyString(),
+                            Mockito.any(),
+                            Mockito.any(byte[].class),
+                            Mockito.any(PublishOptions.class));
+
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            JSON_ROW_TYPE,
+                            ReadonlyConfig.fromMap(validJsonConfig()),
+                            TestWriterResources.catalogTable(JSON_ROW_TYPE));
+
+            IOException exception =
+                    Assertions.assertThrows(
+                            IOException.class,
+                            () -> writer.write(new SeaTunnelRow(new Object[] {1, "alice"})));
+
+            Assertions.assertTrue(
+                    exception.getMessage().contains("Failed to publish NATS JetStream message"));
+            Assertions.assertTrue(exception.getMessage().contains("orders.events"));
+        }
+    }
+
+    @Test
+    void closeTranslatesInterruptedExceptionAndPreservesInterrupt() throws Exception {
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            Mockito.doThrow(new InterruptedException("stop"))
+                    .when(resources.getConnection())
+                    .close();
+
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            JSON_ROW_TYPE,
+                            ReadonlyConfig.fromMap(validJsonConfig()),
+                            TestWriterResources.catalogTable(JSON_ROW_TYPE));
+
+            IOException exception = Assertions.assertThrows(IOException.class, writer::close);
+
+            Assertions.assertTrue(
+                    exception.getMessage().contains("Interrupted while closing NATS connection"));
+            Assertions.assertTrue(Thread.currentThread().isInterrupted());
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void writePublishesDeleteRowKindAsRegularMessage() throws Exception {
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            JSON_ROW_TYPE,
+                            ReadonlyConfig.fromMap(validJsonConfig()),
+                            TestWriterResources.catalogTable(JSON_ROW_TYPE));
+            SeaTunnelRow row = new SeaTunnelRow(new Object[] {1, "alice"});
+            row.setRowKind(org.apache.seatunnel.api.table.type.RowKind.DELETE);
+
+            writer.write(row);
+
+            Mockito.verify(resources.getJetStream())
+                    .publish(
+                            Mockito.eq("orders.events"),
+                            Mockito.isNull(),
+                            Mockito.any(byte[].class),
+                            Mockito.any(PublishOptions.class));
+        }
+    }
+
+    @Test
+    void writePublishesNativeDataOnlyMessageUsingConfiguredSubjectFallback() throws Exception {
+        SeaTunnelRowType dataOnlyRowType =
+                new SeaTunnelRowType(
+                        new String[] {"data"},
+                        new SeaTunnelDataType<?>[] {PrimitiveByteArrayType.INSTANCE});
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            dataOnlyRowType,
+                            ReadonlyConfig.fromMap(validNativeFallbackConfig()),
+                            TestWriterResources.catalogTable(dataOnlyRowType));
+            byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+
+            writer.write(new SeaTunnelRow(new Object[] {payload}));
+
+            ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+            ArgumentCaptor<Headers> headersCaptor = ArgumentCaptor.forClass(Headers.class);
+            Mockito.verify(resources.getJetStream())
+                    .publish(
+                            Mockito.eq("orders.events"),
+                            headersCaptor.capture(),
+                            payloadCaptor.capture(),
+                            Mockito.any(PublishOptions.class));
+            Assertions.assertArrayEquals(payload, payloadCaptor.getValue());
+            Assertions.assertEquals(
+                    "INSERT",
+                    headersCaptor
+                            .getValue()
+                            .getFirst(NatsJetStreamRequestSerializer.ROW_KIND_HEADER));
+        }
+    }
+
+    @Test
+    void writePublishesNativeMessageIdAndHeaders() throws Exception {
+        SeaTunnelRowType nativeRowType = NatsJetStreamRequestSerializerTest.NATIVE_ROW_TYPE;
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            nativeRowType,
+                            ReadonlyConfig.fromMap(validNativeConfig()),
+                            TestWriterResources.catalogTable(nativeRowType));
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("tenant", "acme");
+            headers.put("trace", "t-1");
+            writer.write(
+                    new SeaTunnelRow(
+                            new Object[] {
+                                "payments.created",
+                                "message-9",
+                                headers,
+                                "payload".getBytes(StandardCharsets.UTF_8)
+                            }));
+
+            ArgumentCaptor<Headers> headersCaptor = ArgumentCaptor.forClass(Headers.class);
+            ArgumentCaptor<PublishOptions> optionsCaptor =
+                    ArgumentCaptor.forClass(PublishOptions.class);
+            Mockito.verify(resources.getJetStream())
+                    .publish(
+                            Mockito.eq("payments.created"),
+                            headersCaptor.capture(),
+                            Mockito.any(byte[].class),
+                            optionsCaptor.capture());
+            Assertions.assertEquals("acme", headersCaptor.getValue().getFirst("tenant"));
+            Assertions.assertEquals("message-9", optionsCaptor.getValue().getMessageId());
+            Assertions.assertEquals(
+                    "INSERT",
+                    headersCaptor
+                            .getValue()
+                            .getFirst(NatsJetStreamRequestSerializer.ROW_KIND_HEADER));
+        }
+    }
+
+    @Test
+    void writeSkipsRowKindHeaderWhenDisabled() throws Exception {
+        SeaTunnelRowType nativeRowType = NatsJetStreamRequestSerializerTest.NATIVE_ROW_TYPE;
+        TestContext context = new TestContext();
+        try (TestWriterResources resources = TestWriterResources.open(context)) {
+            Map<String, Object> config = validNativeConfig();
+            config.put(NatsJetStreamSinkOptions.INCLUDE_ROW_KIND_HEADER.key(), false);
+            NatsJetStreamSinkWriter writer =
+                    new NatsJetStreamSinkWriter(
+                            context,
+                            nativeRowType,
+                            ReadonlyConfig.fromMap(config),
+                            TestWriterResources.catalogTable(nativeRowType));
+
+            writer.write(
+                    new SeaTunnelRow(
+                            new Object[] {
+                                "payments.created",
+                                "message-9",
+                                null,
+                                "payload".getBytes(StandardCharsets.UTF_8)
+                            }));
+
+            Mockito.verify(resources.getJetStream())
+                    .publish(
+                            Mockito.eq("payments.created"),
+                            Mockito.isNull(),
+                            Mockito.any(byte[].class),
+                            Mockito.any(PublishOptions.class));
+        }
+    }
+
+    @Test
+    void constructorClosesConnectionWhenJetStreamAcquisitionFails() throws Exception {
+        TestContext context = new TestContext();
+        Connection connection = Mockito.mock(Connection.class);
+        Mockito.when(connection.jetStream())
+                .thenThrow(new RuntimeException("jetStream unavailable"));
+        try (MockedStatic<Nats> mockedNats = Mockito.mockStatic(Nats.class)) {
+            mockedNats
+                    .when(() -> Nats.connect(Mockito.any(io.nats.client.Options.class)))
+                    .thenReturn(connection);
+
+            IOException exception =
+                    Assertions.assertThrows(
+                            IOException.class,
+                            () ->
+                                    new NatsJetStreamSinkWriter(
+                                            context,
+                                            JSON_ROW_TYPE,
+                                            ReadonlyConfig.fromMap(validJsonConfig()),
+                                            TestWriterResources.catalogTable(JSON_ROW_TYPE)));
+
+            Assertions.assertTrue(
+                    exception
+                            .getMessage()
+                            .contains("Failed to connect NATS JetStream sink writer"));
+        }
+        Mockito.verify(connection, Mockito.times(1)).close();
+    }
+
+    private Map<String, Object> validJsonConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(NatsJetStreamSinkOptions.URL.key(), "nats://127.0.0.1:4222");
+        config.put(NatsJetStreamSinkOptions.SUBJECT.key(), "orders.events");
+        return config;
+    }
+
+    private Map<String, Object> validNativeFallbackConfig() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), "NATIVE");
+        return config;
+    }
+
+    private Map<String, Object> validNativeConfig() {
+        Map<String, Object> config = validJsonConfig();
+        config.put(NatsJetStreamSinkOptions.FORMAT.key(), "NATIVE");
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_SUBJECT, "dynamic_subject");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_ID, "message_id");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_HEADERS, "attributes");
+        mappings.put(NatsJetStreamSinkOptions.NATIVE_MAPPING_DATA, "payload");
+        config.put(NatsJetStreamSinkOptions.NATIVE_FIELDS.key(), mappings);
+        return config;
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/TestContext.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/TestContext.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.sink.SinkWriter;
+
+final class TestContext implements SinkWriter.Context {
+
+    @Override
+    public int getIndexOfSubtask() {
+        return 2;
+    }
+
+    @Override
+    public MetricsContext getMetricsContext() {
+        return null;
+    }
+
+    @Override
+    public EventListener getEventListener() {
+        return null;
+    }
+}

--- a/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/TestWriterResources.java
+++ b/seatunnel-connectors-v2/connector-nats-jetstream/src/test/java/org/apache/seatunnel/connectors/seatunnel/natsjetstream/sink/TestWriterResources.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.natsjetstream.sink;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStream;
+import io.nats.client.Nats;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+final class TestWriterResources implements AutoCloseable {
+
+    private final MockedStatic<Nats> mockedNats;
+    private final Connection connection;
+    private final JetStream jetStream;
+
+    private TestWriterResources(
+            MockedStatic<Nats> mockedNats, Connection connection, JetStream jetStream) {
+        this.mockedNats = mockedNats;
+        this.connection = connection;
+        this.jetStream = jetStream;
+    }
+
+    static TestWriterResources open(TestContext context) throws Exception {
+        Connection connection = Mockito.mock(Connection.class);
+        JetStream jetStream = Mockito.mock(JetStream.class);
+        Mockito.when(connection.jetStream()).thenReturn(jetStream);
+        MockedStatic<Nats> mockedNats = Mockito.mockStatic(Nats.class);
+        mockedNats
+                .when(() -> Nats.connect(Mockito.any(io.nats.client.Options.class)))
+                .thenReturn(connection);
+        return new TestWriterResources(mockedNats, connection, jetStream);
+    }
+
+    static CatalogTable catalogTable(SeaTunnelRowType rowType) {
+        List<Column> columns = new ArrayList<>();
+        for (int i = 0; i < rowType.getTotalFields(); i++) {
+            SeaTunnelDataType<?> fieldType = rowType.getFieldType(i);
+            columns.add(
+                    PhysicalColumn.builder()
+                            .name(rowType.getFieldName(i))
+                            .dataType(fieldType)
+                            .nullable(true)
+                            .build());
+        }
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "nats_test"),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                "nats test table");
+    }
+
+    Connection getConnection() {
+        return connection;
+    }
+
+    JetStream getJetStream() {
+        return jetStream;
+    }
+
+    @Override
+    public void close() {
+        mockedNats.close();
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -96,6 +96,7 @@
         <module>connector-lance</module>
         <module>connector-bigquery</module>
         <module>connector-edge-socket</module>
+        <module>connector-nats-jetstream</module>
     </modules>
 
     <dependencyManagement>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -781,6 +781,13 @@
 
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-nats-jetstream</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-bigquery</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-dist/release-docs/LICENSE
+++ b/seatunnel-dist/release-docs/LICENSE
@@ -338,7 +338,10 @@ The text of each license is the standard Apache 2.0 license.
      (The Apache Software License, Version 2.0) Prometheus Java Span Context Supplier - OpenTelemetry (io.prometheus:simpleclient_tracer_otel:0.16.0 - https://mvnrepository.com/artifact/io.prometheus/simpleclient_tracer_otel/0.16.0)
      (The Apache Software License, Version 2.0) Prometheus Java Span Context Supplier - OpenTelemetry Agent (io.prometheus:simpleclient_tracer_otel_agent:0.16.0 - https://mvnrepository.com/artifact/io.prometheus/simpleclient_tracer_otel_agent/0.16.0)
      (Apache-2.0) hugegraph-client (org.apache.hugegraph:hugegraph-client:1.5.0 - https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-client)
-     (Apache-2.0) hugegraph-common (org.apache.hugegraph:hugegraph-common:1.5.0 - https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common)
+      (Apache-2.0) hugegraph-common (org.apache.hugegraph:hugegraph-common:1.5.0 - https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common)
+      (Apache-2.0) jnats (io.nats:jnats:2.24.0 - https://github.com/nats-io/nats.java)
+      (Apache-2.0) jspecify (org.jspecify:jspecify:1.0.0 - https://github.com/jspecify/jspecify)
+
 
 ========================================================================
 MOZILLA PUBLIC LICENSE License
@@ -403,7 +406,9 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
      (MIT License) jcl-over-slf4j (org.slf4j:jcl-over-slf4j:1.7.25 - http://www.slf4j.org)
      (MIT License) animal-sniffer-annotations (org.codehaus.mojo:animal-sniffer-annotations:1.17 - https://mvnrepository.com/artifact/org.codehaus.mojo/animal-sniffer-annotations/1.17)
      (MIT License) checker-qual (org.checkerframework:checker-qual:3.10.0 - https://mvnrepository.com/)
-     (MIT License) oshi-core (com.github.oshi:oshi-core:6.6.5 - https://github.com/oshi/oshi)
+      (MIT License) oshi-core (com.github.oshi:oshi-core:6.6.5 - https://github.com/oshi/oshi)
+      (MIT License) Bouncy Castle Provider (LTS Distribution) (org.bouncycastle:bcprov-lts8on:2.73.9 - https://www.bouncycastle.org/lts-java)
+
 
 ========================================================================
 EPL-1.0 and Apache-2.0 licenses

--- a/seatunnel-dist/release-docs/NOTICE
+++ b/seatunnel-dist/release-docs/NOTICE
@@ -1,6 +1,10 @@
 Apache SeaTunnel
 Copyright 2021-2024 The Apache Software Foundation
 
+This product includes Bouncy Castle Provider (LTS Distribution), developed by
+The Legion of the Bouncy Castle Inc. and distributed under the Bouncy Castle
+License. The license text is provided in licenses/LICENSE-bcprov-lts8on.txt.
+
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 

--- a/seatunnel-dist/release-docs/licenses/LICENSE-bcprov-lts8on.txt
+++ b/seatunnel-dist/release-docs/licenses/LICENSE-bcprov-lts8on.txt
@@ -1,0 +1,21 @@
+Bouncy Castle License
+
+Copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/seatunnel-dist/release-docs/licenses/LICENSE-jnats.txt
+++ b/seatunnel-dist/release-docs/licenses/LICENSE-jnats.txt
@@ -1,0 +1,1 @@
+License: {Name: The Apache License, Version 2.0, URL: http://www.apache.org/licenses/LICENSE-2.0.txt, Distribution: repo, Comments: , }

--- a/seatunnel-dist/release-docs/licenses/LICENSE-jspecify.txt
+++ b/seatunnel-dist/release-docs/licenses/LICENSE-jspecify.txt
@@ -1,0 +1,1 @@
+License: {Name: The Apache License, Version 2.0, URL: http://www.apache.org/licenses/LICENSE-2.0.txt, Distribution: repo, Comments: , }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connector-v2-e2e</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-nats-jetstream-e2e</artifactId>
+    <name>SeaTunnel : E2E : Connector V2 : NATS JetStream</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-starter</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-jackson</artifactId>
+            <version>${project.version}</version>
+            <classifier>optional</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-nats-jetstream</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-fake</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-console</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-assert</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/java/org/apache/seatunnel/e2e/connector/natsjetstream/NatsJetStreamIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/java/org/apache/seatunnel/e2e/connector/natsjetstream/NatsJetStreamIT.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.natsjetstream;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.JetStreamSubscription;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.PullSubscribeOptions;
+import io.nats.client.api.RetentionPolicy;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+import io.nats.client.impl.Headers;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+public class NatsJetStreamIT extends TestSuiteBase implements TestResource {
+
+    private static final String IMAGE = "nats:2.10.14-alpine";
+    private static final String NATS_HOST = "nats-jetstream-e2e";
+    private static final int NATS_PORT = 4222;
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final String JSON_STREAM = "json_stream";
+    private static final String JSON_SUBJECT = "orders.json";
+    private static final String NATIVE_STREAM = "native_stream";
+    private static final String NATIVE_SUBJECT_ONE = "events.native.alpha";
+    private static final String NATIVE_SUBJECT_TWO = "events.native.beta";
+    private static final String DEFAULT_STREAM = "default_stream";
+    private static final String DEFAULT_SUBJECT = "events.default";
+
+    private static final List<String> EXPECTED_JSON_PAYLOADS =
+            Arrays.asList(
+                    "{\"id\":101,\"name\":\"alice\",\"score\":9.5}",
+                    "{\"id\":102,\"name\":\"bob\",\"score\":7.25}",
+                    "{\"id\":103,\"name\":\"carol\",\"score\":8.75}");
+
+    private static final List<NativeExpectedMessage> EXPECTED_NATIVE_MESSAGES =
+            Arrays.asList(
+                    new NativeExpectedMessage(
+                            NATIVE_SUBJECT_ONE,
+                            "msg-1",
+                            mapOf("tenant", "acme", "trace", "trace-1"),
+                            "payload-1".getBytes(StandardCharsets.UTF_8)),
+                    new NativeExpectedMessage(
+                            NATIVE_SUBJECT_TWO,
+                            "msg-2",
+                            mapOf("tenant", "beta", "trace", "trace-2"),
+                            "payload-2".getBytes(StandardCharsets.UTF_8)),
+                    new NativeExpectedMessage(
+                            NATIVE_SUBJECT_ONE,
+                            "msg-3",
+                            mapOf("tenant", "acme", "trace", "trace-3"),
+                            "payload-3".getBytes(StandardCharsets.UTF_8)));
+
+    private static final List<String> EXPECTED_DEFAULT_PAYLOADS =
+            Arrays.asList(
+                    "{\"id\":201,\"status\":\"queued\",\"enabled\":true}",
+                    "{\"id\":202,\"status\":\"done\",\"enabled\":false}");
+
+    private GenericContainer<?> natsContainer;
+    private Connection adminConnection;
+
+    @BeforeAll
+    @Override
+    public void startUp() throws Exception {
+        natsContainer =
+                new GenericContainer<>(DockerImageName.parse(IMAGE))
+                        .withCommand("--jetstream")
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(NATS_HOST)
+                        .withExposedPorts(NATS_PORT)
+                        .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(IMAGE)))
+                        .waitingFor(new HostPortWaitStrategy().withStartupTimeout(STARTUP_TIMEOUT));
+        Startables.deepStart(Stream.of(natsContainer)).join();
+        adminConnection = createClientConnection();
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() throws Exception {
+        if (adminConnection != null) {
+            adminConnection.close();
+            adminConnection = null;
+        }
+        if (natsContainer != null) {
+            natsContainer.close();
+            natsContainer = null;
+        }
+    }
+
+    @TestTemplate
+    public void testJsonSink(TestContainer container) throws Exception {
+        recreateStream(JSON_STREAM, JSON_SUBJECT);
+        try (VerificationConsumer consumer =
+                createVerificationConsumer(JSON_STREAM, JSON_SUBJECT)) {
+            Container.ExecResult execResult =
+                    container.executeJob("/fake_to_nats_jetstream_json.conf");
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+
+            List<Message> messages = consumer.awaitMessages(EXPECTED_JSON_PAYLOADS.size());
+            List<String> actualPayloads =
+                    messages.stream()
+                            .map(message -> new String(message.getData(), StandardCharsets.UTF_8))
+                            .collect(Collectors.toList());
+            Assertions.assertEquals(EXPECTED_JSON_PAYLOADS, actualPayloads);
+            Assertions.assertTrue(
+                    messages.stream()
+                            .allMatch(message -> JSON_SUBJECT.equals(message.getSubject())));
+        }
+    }
+
+    @TestTemplate
+    public void testNativeSink(TestContainer container) throws Exception {
+        recreateStream(NATIVE_STREAM, NATIVE_SUBJECT_ONE, NATIVE_SUBJECT_TWO);
+        try (VerificationConsumer consumer =
+                createVerificationConsumer(NATIVE_STREAM, "events.native.*")) {
+            Container.ExecResult execResult =
+                    container.executeJob("/fake_to_nats_jetstream_native.conf");
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+
+            List<Message> messages = consumer.awaitMessages(EXPECTED_NATIVE_MESSAGES.size());
+            List<NativeActualMessage> actualMessages =
+                    messages.stream()
+                            .map(NativeActualMessage::fromMessage)
+                            .collect(Collectors.toList());
+            List<NativeActualMessage> expectedMessages =
+                    EXPECTED_NATIVE_MESSAGES.stream()
+                            .map(NativeExpectedMessage::toActualMessage)
+                            .sorted(NativeActualMessage::compareByContent)
+                            .collect(Collectors.toList());
+            actualMessages.sort(NativeActualMessage::compareByContent);
+            Assertions.assertEquals(expectedMessages, actualMessages);
+        }
+    }
+
+    @TestTemplate
+    public void testNativeSinkWithDefaultFieldMapping(TestContainer container) throws Exception {
+        recreateStream(DEFAULT_STREAM, DEFAULT_SUBJECT);
+        try (VerificationConsumer consumer =
+                createVerificationConsumer(DEFAULT_STREAM, DEFAULT_SUBJECT)) {
+            Container.ExecResult execResult =
+                    container.executeJob("/fake_to_nats_jetstream_native_defaults.conf");
+            Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+
+            List<Message> messages = consumer.awaitMessages(EXPECTED_DEFAULT_PAYLOADS.size());
+            List<String> actualPayloads =
+                    messages.stream()
+                            .map(message -> new String(message.getData(), StandardCharsets.UTF_8))
+                            .collect(Collectors.toList());
+            Assertions.assertEquals(EXPECTED_DEFAULT_PAYLOADS, actualPayloads);
+            Assertions.assertTrue(
+                    messages.stream()
+                            .allMatch(message -> DEFAULT_SUBJECT.equals(message.getSubject())));
+            Assertions.assertTrue(
+                    messages.stream()
+                            .allMatch(
+                                    message -> {
+                                        Headers headers = message.getHeaders();
+                                        return headers == null || headers.isEmpty();
+                                    }));
+        }
+    }
+
+    private Connection createClientConnection() throws IOException, InterruptedException {
+        Options options =
+                new Options.Builder()
+                        .server(getMappedNatsUrl())
+                        .connectionTimeout(Duration.ofSeconds(30))
+                        .build();
+        return Nats.connect(options);
+    }
+
+    private String getMappedNatsUrl() {
+        return "nats://" + natsContainer.getHost() + ":" + natsContainer.getMappedPort(NATS_PORT);
+    }
+
+    private void recreateStream(String streamName, String... subjects)
+            throws IOException, JetStreamApiException {
+        JetStreamManagement management = adminConnection.jetStreamManagement();
+        try {
+            management.deleteStream(streamName);
+        } catch (JetStreamApiException e) {
+            if (e.getErrorCode() != 404) {
+                throw e;
+            }
+        }
+        management.addStream(
+                StreamConfiguration.builder()
+                        .name(streamName)
+                        .storageType(StorageType.Memory)
+                        .retentionPolicy(RetentionPolicy.Limits)
+                        .subjects(subjects)
+                        .build());
+    }
+
+    private VerificationConsumer createVerificationConsumer(
+            String streamName, String subscriptionSubject)
+            throws IOException, InterruptedException, JetStreamApiException {
+        Connection connection = createClientConnection();
+        PullSubscribeOptions subscribeOptions =
+                PullSubscribeOptions.builder().stream(streamName)
+                        .durable("consumer-" + UUID.randomUUID())
+                        .build();
+        JetStreamSubscription subscription =
+                connection.jetStream().subscribe(subscriptionSubject, subscribeOptions);
+        return new VerificationConsumer(connection, subscription);
+    }
+
+    private static Map<String, String> mapOf(String... keyValues) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put(keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    private static final class VerificationConsumer implements AutoCloseable {
+        private final Connection connection;
+        private final JetStreamSubscription subscription;
+
+        private VerificationConsumer(Connection connection, JetStreamSubscription subscription) {
+            this.connection = connection;
+            this.subscription = subscription;
+        }
+
+        private List<Message> awaitMessages(int expectedCount) {
+            List<Message> receivedMessages = new ArrayList<>(expectedCount);
+            Awaitility.await()
+                    .atMost(TEST_TIMEOUT)
+                    .pollInterval(200, TimeUnit.MILLISECONDS)
+                    .until(
+                            () -> {
+                                subscription.pull(expectedCount - receivedMessages.size());
+                                while (receivedMessages.size() < expectedCount) {
+                                    Message message =
+                                            subscription.nextMessage(Duration.ofMillis(200));
+                                    if (message == null) {
+                                        break;
+                                    }
+                                    receivedMessages.add(message);
+                                    message.ack();
+                                }
+                                return receivedMessages.size() >= expectedCount;
+                            });
+            return receivedMessages;
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private static final class NativeExpectedMessage {
+        private final String subject;
+        private final String messageId;
+        private final Map<String, String> headers;
+        private final byte[] payload;
+
+        private NativeExpectedMessage(
+                String subject, String messageId, Map<String, String> headers, byte[] payload) {
+            this.subject = subject;
+            this.messageId = messageId;
+            this.headers = headers;
+            this.payload = payload;
+        }
+
+        private NativeActualMessage toActualMessage() {
+            return new NativeActualMessage(subject, messageId, headers, payload);
+        }
+    }
+
+    private static final class NativeActualMessage {
+        private final String subject;
+        private final String messageId;
+        private final Map<String, String> headers;
+        private final byte[] payload;
+
+        private NativeActualMessage(
+                String subject, String messageId, Map<String, String> headers, byte[] payload) {
+            this.subject = subject;
+            this.messageId = messageId;
+            this.headers = headers;
+            this.payload = payload;
+        }
+
+        private static NativeActualMessage fromMessage(Message message) {
+            Headers headers = message.getHeaders();
+            Map<String, String> headerMap = new LinkedHashMap<>();
+            String messageId = null;
+            if (headers != null) {
+                for (String key : headers.keySet()) {
+                    if (!"Nats-Msg-Id".equals(key)) {
+                        headerMap.put(key, headers.getFirst(key));
+                    }
+                }
+                messageId = headers.getFirst("Nats-Msg-Id");
+            }
+            return new NativeActualMessage(
+                    message.getSubject(), messageId, headerMap, message.getData());
+        }
+
+        private static int compareByContent(NativeActualMessage left, NativeActualMessage right) {
+            int subjectComparison = left.subject.compareTo(right.subject);
+            if (subjectComparison != 0) {
+                return subjectComparison;
+            }
+            int messageIdComparison =
+                    java.util.Objects.toString(left.messageId, "")
+                            .compareTo(java.util.Objects.toString(right.messageId, ""));
+            if (messageIdComparison != 0) {
+                return messageIdComparison;
+            }
+            return comparePayloads(left.payload, right.payload);
+        }
+
+        private static int comparePayloads(byte[] left, byte[] right) {
+            int length = Math.min(left.length, right.length);
+            for (int i = 0; i < length; i++) {
+                int comparison = Byte.compare(left[i], right[i]);
+                if (comparison != 0) {
+                    return comparison;
+                }
+            }
+            return Integer.compare(left.length, right.length);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof NativeActualMessage)) {
+                return false;
+            }
+            NativeActualMessage that = (NativeActualMessage) obj;
+            return subject.equals(that.subject)
+                    && java.util.Objects.equals(messageId, that.messageId)
+                    && headers.equals(that.headers)
+                    && Arrays.equals(payload, that.payload);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = java.util.Objects.hash(subject, messageId, headers);
+            result = 31 * result + Arrays.hashCode(payload);
+            return result;
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_json.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_json.conf
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  job.name = "SeaTunnel_NatsJetStream_Json_E2E"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          id = 101
+          name = "alice"
+          score = 9.5
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          id = 102
+          name = "bob"
+          score = 7.25
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          id = 103
+          name = "carol"
+          score = 8.75
+        }
+      }
+    ]
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
+      }
+    }
+    plugin_output = "json_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "json_fake"
+    url = "nats://nats-jetstream-e2e:4222"
+    subject = "orders.json"
+    format = "json"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_native.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_native.conf
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  job.name = "SeaTunnel_NatsJetStream_Native_E2E"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.alpha"
+          message_id = "msg-1"
+          attributes = {
+            tenant = "acme"
+            trace = "trace-1"
+          }
+          payload = "cGF5bG9hZC0x"
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.beta"
+          message_id = "msg-2"
+          attributes = {
+            tenant = "beta"
+            trace = "trace-2"
+          }
+          payload = "cGF5bG9hZC0y"
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          dynamic_subject = "events.native.alpha"
+          message_id = "msg-3"
+          attributes = {
+            tenant = "acme"
+            trace = "trace-3"
+          }
+          payload = "cGF5bG9hZC0z"
+        }
+      }
+    ]
+    schema = {
+      fields {
+        dynamic_subject = string
+        message_id = string
+        attributes = "map<string,string>"
+        payload = bytes
+      }
+    }
+    plugin_output = "native_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "native_fake"
+    url = "nats://nats-jetstream-e2e:4222"
+    subject = "events.native.default"
+     format = "native"
+     include_row_kind_header = false
+     native_format_fields = {
+      subject = dynamic_subject
+      id = message_id
+      headers = attributes
+      data = payload
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_native_defaults.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e/src/test/resources/fake_to_nats_jetstream_native_defaults.conf
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  job.name = "SeaTunnel_NatsJetStream_Native_Defaults_E2E"
+}
+
+source {
+  FakeSource {
+    rows = [
+      {
+        kind = INSERT
+        fields = {
+          subject = null
+          id = null
+          headers = null
+          data = "eyJpZCI6MjAxLCJzdGF0dXMiOiJxdWV1ZWQiLCJlbmFibGVkIjp0cnVlfQ=="
+        }
+      },
+      {
+        kind = INSERT
+        fields = {
+          subject = "   "
+          id = ""
+          headers = null
+          data = "eyJpZCI6MjAyLCJzdGF0dXMiOiJkb25lIiwiZW5hYmxlZCI6ZmFsc2V9"
+        }
+      }
+    ]
+    schema = {
+      fields {
+        subject = string
+        id = string
+        headers = "map<string,string>"
+        data = bytes
+      }
+    }
+    plugin_output = "default_native_fake"
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "default_native_fake"
+    url = "nats://nats-jetstream-e2e:4222"
+    subject = "events.default"
+     format = "native"
+     include_row_kind_header = false
+   }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
@@ -96,6 +96,7 @@
         <module>connector-fluss-e2e</module>
         <module>connector-lance-e2e</module>
         <module>connector-bigquery-e2e</module>
+        <module>connector-nats-jetstream-e2e</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
[Feature] [Connector-V2] Add NATS JetStream sink connector

### Purpose of this pull request

This pull request implements the sink portion of #10101 by adding a publish-only NATS JetStream Connector V2 sink.

The connector supports:

- JSON and native message formats
- NATS username/password and token authentication
- Configurable subjects
- Configurable native field mappings for message ID, subject, headers, and payload
- Optional SeaTunnel row-kind headers
- Configuration and schema validation
- At-least-once writer semantics without checkpoint state or transactional commit support
- Pre-provisioned JetStream streams

The NATS source connector and stream-management functionality are intentionally out of scope.

### Does this PR introduce _any_ user-facing change?

Yes. This PR adds a new `NatsJetStream` sink connector and its documentation in English and Chinese.

Example configuration:

```hocon
sink {
  NatsJetStream {
    url = "nats://localhost:4222"
    subject = "events"
    format = "json"
  }
}
```

The connector also supports native messages with configurable field mappings:

```hocon
sink {
  NatsJetStream {
    url = "nats://localhost:4222"
    format = "native"
    subject = "events"
    native_format_fields {
      id = "message_id"
      subject = "event_subject"
      headers = "attributes"
      data = "payload"
    }
  }
}
```

This is a new connector and does not change the behavior of existing connectors or configurations.

### How was this patch tested?

Added unit tests covering:

- Sink factory creation and option rules
- Authentication validation
- JSON and native format validation
- Native field mapping validation
- Subject fallback and resolution
- Message ID and header serialization
- Payload type validation
- Row-kind header behavior
- Invalid record handling

Executed successfully with Java 11:

```bash
./mvnw -B \
  -pl seatunnel-connectors-v2/connector-nats-jetstream \
  -Dtest='*NatsJetStream*Test' test
```

Result: 31 tests passed, 0 failures, 0 errors.

Executed the NATS JetStream E2E test suite with Testcontainers and NATS `2.10.14-alpine`:

```bash
./mvnw -B \
  -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-nats-jetstream-e2e \
  -am \
  -DskipUT \
  -DskipIT=false \
  -Dit.test=NatsJetStreamIT \
  -DfailIfNoTests=false \
  verify
```

Result: 21 tests passed, 0 failures, 0 errors.

Also verified:

- Java 11 Spotless formatting
- Connector module compilation and verification
- Distribution packaging
- Connector registration checks
- CI module detection for the connector and E2E module
- No whitespace errors

The repository-wide license check was attempted but could not complete because of the unrelated unresolved dependency `connector-http-airtable:3.0.0-SNAPSHOT`.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according to the [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Updated `plugin-mapping.properties` with the NATS JetStream connector.
  2. Updated `seatunnel-dist/pom.xml`.
  3. Added the NATS JetStream CI label scope in `label-scope-conf.yml`.
  4. Added the NATS JetStream E2E module and test cases.
  5. Updated `config/plugin_config`.