### PR TITLE
[Docs] Fill in env config overview

### DIFF
--- a/docs/en/introduction/concepts/config.md
+++ b/docs/en/introduction/concepts/config.md
@@ -70,7 +70,17 @@ Use `env` for job-level and engine-level settings such as `job.mode`, `paralleli
 
 Common parameters are shared across engines. Engine-specific parameters are separated by prefix. For Flink and Spark, see [JobEnvConfig](../configuration/JobEnvConfig.md).
 
-<!-- TODO add supported env parameters -->
+The most common `env` parameters are:
+
+- `job.mode`: chooses `BATCH` or `STREAMING`
+- `job.name`: sets the job name shown by the engine and UI
+- `parallelism`: controls how many parallel readers and writers SeaTunnel uses
+- `checkpoint.interval`: enables periodic checkpoints in streaming jobs
+- `checkpoint.timeout`: limits how long a checkpoint can run before the job fails
+- `jars`: loads extra third-party JARs needed by the job
+- `shade.identifier`: selects the config encryption or decryption strategy
+
+For the full parameter list, engine-specific prefixes, and more examples, see [JobEnvConfig](../configuration/JobEnvConfig.md).
 
 ### source
 

--- a/docs/zh/introduction/concepts/config.md
+++ b/docs/zh/introduction/concepts/config.md
@@ -70,7 +70,17 @@ sink {
 
 公共参数可以直接配置；引擎专属参数则按前缀区分。Flink 和 Spark 的具体写法请参考 [JobEnvConfig](../configuration/JobEnvConfig.md)。
 
-<!-- TODO add supported env parameters -->
+`env` 里最常用的参数包括：
+
+- `job.mode`：指定任务运行在 `BATCH` 或 `STREAMING` 模式
+- `job.name`：设置任务名称，方便在引擎和界面里识别
+- `parallelism`：控制 SeaTunnel 读取和写入时使用的并行度
+- `checkpoint.interval`：为流式任务开启周期性 checkpoint
+- `checkpoint.timeout`：限制单次 checkpoint 最长允许执行多久
+- `jars`：加载任务依赖的额外第三方 JAR 包
+- `shade.identifier`：指定配置加密或解密所使用的方式
+
+如果您想查看完整参数列表、引擎专属前缀和更多示例，请继续阅读 [JobEnvConfig](../configuration/JobEnvConfig.md)。
 
 ### `source`：数据读取入口
 


### PR DESCRIPTION
## What does this PR do?

This PR fills in the missing `env` parameter overview in the config introduction docs. The previous page still contained a TODO placeholder, so readers could not quickly see which job-level settings are most commonly used.

## Why is this change needed?

The config introduction page is meant to help first-time users understand the four main sections of a SeaTunnel job. Leaving the `env` section unfinished makes that page less useful and forces readers to jump away before they understand the basics.

## What is changed?

- Replace the TODO placeholder in `docs/en/introduction/concepts/config.md` with a short list of commonly used `env` parameters
- Add the same explanation to `docs/zh/introduction/concepts/config.md`
- Keep the detailed reference in `JobEnvConfig` as the next step for readers who need full parameter coverage

## Verification

- `./mvnw spotless:apply`
  - Failed in the local environment with `java.lang.UnsatisfiedLinkError: no nio in java.library.path` from the Spotless Maven plugin
- `./mvnw -q -DskipTests verify`
  - Failed for the same Spotless plugin environment issue
- `git diff --check`
  - Passed

Because this PR only updates documentation text, no code paths were changed.