### PR TITLE
[Docs][Connector-V2] Complete Chinese file connector options

### DIFF
--- a/docs/zh/connectors/sink/CosFile.md
+++ b/docs/zh/connectors/sink/CosFile.md
@@ -68,6 +68,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 | compress_codec                        | string  | 否  | none                                       |                                                                 |
 | common-options                        | object  | 否  | -                                          |                                                                 |
 | max_rows_in_memory                    | int     | 否  | -                                          | 仅在file_format为excel时使用.                                         |
+| sheet_max_rows                         | int     | 否  | 1048576                                    | 仅在 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否  | Sheet${Random number}                      | 仅在file_format为excel时使用.                                         |
 | csv_string_quote_mode                 | enum    | 否  | MINIMAL                                    | 仅在file_format为csv时使用.                                           |
 | xml_root_tag                          | string  | 否  | RECORDS                                    | 仅在file_format为xml时使用.                                           |
@@ -206,6 +207,10 @@ Tips: excel 类型不支持任何压缩格式
 ### max_rows_in_memory [int]
 
 当文件格式为Excel时，内存中可以缓存的最大数据项数.
+
+### sheet_max_rows [int]
+
+仅在 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name [string]
 

--- a/docs/zh/connectors/sink/FtpFile.md
+++ b/docs/zh/connectors/sink/FtpFile.md
@@ -69,6 +69,7 @@ import ChangeLog from '../changelog/connector-file-ftp.md';
 | compress_codec                        | string  | 否    | none                                       |                                                                           |
 | common-options                        | object  | 否    | -                                          |                                                                           |
 | max_rows_in_memory                    | int     | 否    | -                                          | 仅在 `file_format_type` 为 `excel` 时使用。                                      |
+| sheet_max_rows                         | int     | 否    | 1048576                                    | 仅在 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否    | Sheet${随机数}                                | 仅在 `file_format_type` 为 `excel` 时使用。                                      |
 | csv_string_quote_mode                 | enum    | 否    | MINIMAL                                    | 仅在 `file_format` 为 `csv` 时使用。                                             |
 | xml_root_tag                          | string  | 否    | RECORDS                                    | 仅在 `file_format` 为 `xml` 时使用。                                             |
@@ -236,6 +237,10 @@ Sink 插件的通用参数，请参考[Sink通用选项](../common-options/sink-
 ### max_rows_in_memory [int]
 
 当文件格式为Excel时，可在内存中缓存的数据项的最大数量。 
+
+### sheet_max_rows [int]
+
+仅在 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name [string]
 

--- a/docs/zh/connectors/sink/LocalFile.md
+++ b/docs/zh/connectors/sink/LocalFile.md
@@ -65,6 +65,7 @@ import ChangeLog from '../changelog/connector-file-local.md';
 | compress_codec                        | string  | 否    | none                                       | 压缩编码                                                            |
 | common-options                        | object  | 否    | -                                          | 常见选项                                                            |
 | max_rows_in_memory                    | int     | 否    | -                                          | 仅在 file_format_type 为 excel 时使用                                 |
+| sheet_max_rows                         | int     | 否    | 1048576                                    | 仅在 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否    | Sheet${随机数}                                | 仅在 file_format_type 为 excel 时使用                                 |
 | csv_string_quote_mode                 | enum    | 否    | MINIMAL                                    | 仅在文件格式为 CSV 时使用。                                                |
 | xml_root_tag                          | string  | 否    | RECORDS                                    | 仅在 file_format 为 xml 时使用                                        |
@@ -189,6 +190,10 @@ Sink 插件的常见参数，请参阅 [Sink 常见选项](../common-options/sin
 ### max_rows_in_memory [int]
 
 当文件格式为 Excel 时，内存中可以缓存的数据项最大数量。
+
+### sheet_max_rows [int]
+
+仅在 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name [string]
 

--- a/docs/zh/connectors/sink/OssFile.md
+++ b/docs/zh/connectors/sink/OssFile.md
@@ -121,6 +121,7 @@ import ChangeLog from '../changelog/connector-file-oss.md';
 | compress_codec                        | string  | 否  | none                                       |                                                                   |
 | common-options                        | object  | 否  | -                                          |                                                                   |
 | max_rows_in_memory                    | int     | 否  | -                                          | 仅当file_format_type为excel时使用。                                      |
+| sheet_max_rows                         | int     | 否  | 1048576                                    | 仅当 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否  | Sheet${Random number}                      | 仅当file_format_type为excel时使用。                                      |
 | csv_string_quote_mode                 | enum    | 否  | MINIMAL                                    | 仅在file_format为csv时使用。                                             |
 | xml_root_tag                          | string  | 否  | RECORDS                                    | 仅在file_format为xml时使用。                                             |
@@ -264,6 +265,10 @@ Sink插件常用参数，请参考[Sink common Options](../common-options/sink-c
 ### max_rows_in_memory [int]
 
 当文件格式为Excel时，内存中可以缓存的最大数据项数。
+
+### sheet_max_rows [int]
+
+仅当 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name [string]
 

--- a/docs/zh/connectors/sink/OssJindoFile.md
+++ b/docs/zh/connectors/sink/OssJindoFile.md
@@ -70,6 +70,7 @@ import ChangeLog from '../changelog/connector-file-oss-jindo.md';
 | compress_codec                        | string  | 否  | none                                       |                                                           |
 | common-options                        | object  | 否  | -                                          |                                                           |
 | max_rows_in_memory                    | int     | 否  | -                                          | 仅当file_format_type为excel时使用。                              |
+| sheet_max_rows                         | int     | 否  | 1048576                                    | 仅当 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否  | Sheet${Random number}                      | 仅当file_format_type为excel时使用。                              |
 | csv_string_quote_mode                 | enum    | 否  | MINIMAL                                    | 仅在file_format为csv时使用。                                     |
 | xml_root_tag                          | string  | 否  | RECORDS                                    | 仅在file_format为xml时使用。                                     |
@@ -208,6 +209,10 @@ Sink插件常用参数，请参考[Sink common Options](../common-options/sink-c
 ### max_rows_in_memory [int]
 
 当文件格式为Excel时，内存中可以缓存的最大数据项数。
+
+### sheet_max_rows [int]
+
+仅当 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name [string]
 

--- a/docs/zh/connectors/sink/SftpFile.md
+++ b/docs/zh/connectors/sink/SftpFile.md
@@ -66,6 +66,7 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 | compress_codec                        | string  | 否    | none                                       |                                                           |
 | common-options                        | object  | 否    | -                                          |                                                           |
 | max_rows_in_memory                    | int     | 否    | -                                          | 仅当file_format_type为excel时使用。                              |
+| sheet_max_rows                         | int     | 否    | 1048576                                    | 仅当 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
 | sheet_name                            | string  | 否    | Sheet${Random number}                      | 仅当file_format_type为excel时使用。                              |
 | csv_string_quote_mode                 | enum    | 否    | MINIMAL                                    | 仅当file_format_type为csv时使用。                                |
 | xml_root_tag                          | string  | 否    | RECORDS                                    | 仅当file_format_type为xml时使用                                 |
@@ -211,6 +212,10 @@ Sink插件常用参数，请参考[Sink common Options](../common-options/sink-c
 ### max_rows_in_memory
 
 当文件格式为Excel时，内存中可以缓存的最大数据项数。
+
+### sheet_max_rows [int]
+
+仅当 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
 
 ### sheet_name
 

--- a/docs/zh/connectors/source/CosFile.md
+++ b/docs/zh/connectors/source/CosFile.md
@@ -74,6 +74,7 @@ import ChangeLog from '../changelog/connector-file-cos.md';
 | xml_use_attr_format        | boolean | 否  | -                   |
 | csv_use_header_line        | boolean | 否  | false               |
 | file_filter_pattern        | string  | 否  |                     |
+| filename_extension         | string  | 否  | -                   | 使用指定的文件扩展名筛选文件，例如 `csv`、`.txt`、`json` 或 `.xml`。 |
 | compress_codec             | string  | 否  | none                |
 | archive_compress_codec     | string  | 否  | none                |
 | encoding                   | string  | 否  | UTF-8               |

--- a/docs/zh/connectors/source/FtpFile.md
+++ b/docs/zh/connectors/source/FtpFile.md
@@ -57,6 +57,7 @@ import ChangeLog from '../changelog/connector-file-ftp.md';
 | remote_verification_enabled | boolean | 否    | true                |
 | control_encoding            | string  | 否    | UTF-8               |
 | delimiter/field_delimiter   | string  | 否    | \001                |
+| row_delimiter               | string  | 否    | \n                  | 读取 `text` 文件时使用的行分隔符。默认值为 `\n`。 |
 | read_columns                | list    | 否    | -                   |
 | parse_partition_from_path   | boolean | 否    | true                |
 | date_format                 | string  | 否    | yyyy-MM-dd          |
@@ -69,6 +70,7 @@ import ChangeLog from '../changelog/connector-file-ftp.md';
 | xml_use_attr_format         | boolean | 否    | -                   |
 | csv_use_header_line         | boolean | 否    | false               |
 | file_filter_pattern         | string  | 否    | -                   |
+| filename_extension          | string  | 否    | -                   | 使用指定的文件扩展名筛选文件，例如 `csv`、`.txt`、`json` 或 `.xml`。 |
 | compress_codec              | string  | 否    | none                |
 | archive_compress_codec      | string  | 否    | none                |
 | encoding                    | string  | 否    | UTF-8               |

--- a/docs/zh/connectors/source/ObsFile.md
+++ b/docs/zh/connectors/source/ObsFile.md
@@ -78,6 +78,12 @@ import ChangeLog from '../changelog/connector-file-obs.md';
 | date_format               | string  | 否  | yyyy-MM-dd          | 日期类型格式                                  |
 | datetime_format           | string  | 否  | yyyy-MM-dd HH:mm:ss | 日期时间类型格式                                |
 | time_format               | string  | 否  | HH:mm:ss            | 时间类型格式                                  |
+| filename_extension        | string  | 否  | -                   | 使用指定的文件扩展名筛选文件，例如 `csv`、`.txt`、`json` 或 `.xml`。 |
+| schema                    | config  | 否  | -                   | 读取 JSON、文本等格式时的字段定义。详见 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
+| common-options            |         | 否  | -                   | Source 插件通用参数，详见 [Source Common Options](../common-options/source-common-options.md)。 |
+| sheet_name                | string  | 否  | -                   | 读取 Excel 文件时要读取的工作表名称。 |
+| file_filter_modified_start | string | 否  | -                   | 按文件最后修改时间筛选文件的起始时间（包含该时间），格式为 `yyyy-MM-dd HH:mm:ss`。 |
+| file_filter_modified_end  | string  | 否  | -                   | 按文件最后修改时间筛选文件的结束时间（不包含该时间），格式为 `yyyy-MM-dd HH:mm:ss`。 |
 | quote_char                | string  | 否  | "                   | 用于包裹 CSV 字段的单字符，可保证包含逗号、换行符或引号的字段被正确解析。 |
 | escape_char               | string  | 否  | -                   | 用于在 CSV 字段内转义引号或其他特殊字符，使其不会结束字段。        |
 | recursive_file_scan       | boolean | 否  | true                | 是否递归扫描子目录。 如果设置为 `false`，将忽略子目录，仅扫描指定路径下的文件。 | 

--- a/docs/zh/connectors/source/OssJindoFile.md
+++ b/docs/zh/connectors/source/OssJindoFile.md
@@ -78,6 +78,14 @@ import ChangeLog from '../changelog/connector-file-oss-jindo.md';
 | xml_use_attr_format       | boolean | 否  | -                           | 是否使用 XML 属性格式                                                                 |
 | csv_use_header_line       | boolean | 否  | false                       | 是否使用 CSV 标题行                                                                  |
 | file_filter_pattern       | string  | 否  | -                           | 文件过滤模式                                                                        |
+| filename_extension        | string  | 否  | -                           | 使用指定的文件扩展名筛选文件，例如 `csv`、`.txt`、`json` 或 `.xml`。 |
+| compress_codec            | string  | 否  | none                        | 读取文件时使用的压缩格式。 |
+| archive_compress_codec    | string  | 否  | none                        | 读取归档文件时使用的归档压缩格式。 |
+| encoding                  | string  | 否  | UTF-8                       | 读取 `json`、`text`、`csv` 或 `xml` 文件时使用的字符编码。 |
+| null_format               | string  | 否  | -                           | 仅用于 `text` 格式，指定应解析为 `null` 的字符串。 |
+| common-options            |         | 否  | -                           | Source 插件通用参数，详见 [Source Common Options](../common-options/source-common-options.md)。 |
+| file_filter_modified_start | string | 否  | -                           | 按文件最后修改时间筛选文件的起始时间（包含该时间）。 |
+| file_filter_modified_end  | string  | 否  | -                           | 按文件最后修改时间筛选文件的结束时间（不包含该时间）。 |
 | quote_char                | string  | 否  | "                           | 用于包裹 CSV 字段的单字符，可保证包含逗号、换行符或引号的字段被正确解析。                                       |
 | escape_char               | string  | 否  | -                           | 用于在 CSV 字段内转义引号或其他特殊字符，使其不会结束字段。                                              |
 | recursive_file_scan       | boolean | 否  | true                        | 是否递归扫描子目录。 如果设置为 `false`，将忽略子目录，仅扫描指定路径下的文件。                                  | 


### PR DESCRIPTION
## What documentation issues were found

Several Chinese File connector reference pages omitted configuration options that are implemented in the shared File source/sink option classes and already documented in their English counterparts. This left users unable to discover filename filters, source parsing controls, and the Excel worksheet row limit.

## What changed

- Added missing source options for COS File, FTP File, OBS File, and OSS Jindo File, including filename filtering, row delimiters, parsing/schema settings, compression, encoding, null handling, and modification-time filters where supported.
- Added `sheet_max_rows` to six Chinese File sink pages and explained its Excel-only behavior and default of `1048576`.

## Updated areas

- Chinese source docs: COS File, FTP File, OBS File, OSS Jindo File.
- Chinese sink docs: COS File, FTP File, Local File, OSS File, OSS Jindo File, SFTP File.

English and Chinese pages were both checked. The English pages already documented these options, so this PR updates only the missing Chinese reference content.

## Duplicate PR check

I reviewed Apache SeaTunnel PRs created during the previous seven days (2026-07-09 through 2026-07-16), including all documentation-labelled PRs. Recent work covered S3 credential providers, CDC recipes, transform recipes, and connector feature documentation; none covered these Chinese File connector option gaps.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `npx --yes markdown-link-check@3.8.7 -c .dlc.json -q` for all 10 changed Markdown files
- `git diff --check`