### PR TITLE
[Improve][Connector-V2] Add declarative Console sink delay validation

### DIFF
--- a/docs/en/connectors/sink/Console.md
+++ b/docs/en/connectors/sink/Console.md
@@ -35,7 +35,7 @@ Console can receive rows from multiple upstream tables and can apply schema chan
 |--------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
 | common-options           |         | No       | -       | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md) for details. |
 | log.print.data           | boolean | No       | true    | Whether to print row data to the task log. Set it to `false` when you only want to keep the sink in the job graph without printing every row. |
-| log.print.delay.ms       | int     | No       | 0       | Delay in milliseconds after each row is processed. It can slow down printing during debugging.                |
+| log.print.delay.ms       | int     | No       | 0       | Non-negative delay in milliseconds after each row is processed. It can slow down printing during debugging.   |
 | multi_table_sink_replica | int     | No       | 1       | Writer replica count for each table in a multi-table sink job.                                                |
 
 ## Output Format

--- a/docs/zh/connectors/sink/Console.md
+++ b/docs/zh/connectors/sink/Console.md
@@ -35,7 +35,7 @@ Console 可以接收多个上游表的数据，也可以处理 Schema 变更事�
 |--------------------------|---------|------|------|--------------------------------------------------------------------|
 | common-options           |         | 否    | -    | Sink 插件通用参数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。 |
 | log.print.data           | boolean | 否    | true | 是否将行数据打印到任务日志。如果只想保留 Console 节点但不打印每行数据，可以设置为 `false`。       |
-| log.print.delay.ms       | int     | 否    | 0    | 每处理一行后的等待时间，单位为毫秒。调试时可以用它放慢打印速度。                              |
+| log.print.delay.ms       | int     | 否    | 0    | 每处理一行后的非负等待时间，单位为毫秒。调试时可以用它放慢打印速度。                           |
 | multi_table_sink_replica | int     | 否    | 1    | 多表写入时每张表对应的 Sink Writer 副本数。                                  |
 
 ## 输出格式

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.console.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -37,10 +38,11 @@ public class ConsoleSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
+                .optional(ConsoleSinkOptions.LOG_PRINT_DATA)
                 .optional(
-                        ConsoleSinkOptions.LOG_PRINT_DATA,
                         ConsoleSinkOptions.LOG_PRINT_DELAY,
-                        ConsoleSinkOptions.MULTI_TABLE_SINK_REPLICA)
+                        Conditions.greaterOrEqual(ConsoleSinkOptions.LOG_PRINT_DELAY, 0))
+                .optional(ConsoleSinkOptions.MULTI_TABLE_SINK_REPLICA)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-console/src/main/java/org/apache/seatunnel/connectors/seatunnel/console/sink/ConsoleSinkOptions.java
@@ -35,5 +35,6 @@ public class ConsoleSinkOptions extends SinkConnectorCommonOptions {
                     .intType()
                     .defaultValue(0)
                     .withDescription(
-                            "Delay in milliseconds between printing each data item to the logs.");
+                            "Non-negative delay in milliseconds between printing each data item "
+                                    + "to the logs.");
 }

--- a/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/ConsoleFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-console/src/test/java/org/apache/seatunnel/connectors/seatunnel/console/ConsoleFactoryTest.java
@@ -17,14 +17,53 @@
 
 package org.apache.seatunnel.connectors.seatunnel.console;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkFactory;
+import org.apache.seatunnel.connectors.seatunnel.console.sink.ConsoleSinkOptions;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class ConsoleFactoryTest {
+
+    private OptionRule sinkRule;
+
+    @BeforeEach
+    void setUp() {
+        sinkRule = new ConsoleSinkFactory().optionRule();
+    }
+
     @Test
     public void testOptionRule() {
-        Assertions.assertNotNull((new ConsoleSinkFactory()).optionRule());
+        Assertions.assertNotNull(sinkRule);
+    }
+
+    @Test
+    void testNonNegativeLogPrintDelay() {
+        Assertions.assertDoesNotThrow(() -> validateLogPrintDelay(0));
+        Assertions.assertDoesNotThrow(() -> validateLogPrintDelay(100));
+    }
+
+    @Test
+    void testNegativeLogPrintDelayFails() {
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateLogPrintDelay(-1));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains(ConsoleSinkOptions.LOG_PRINT_DELAY.key()));
+    }
+
+    private void validateLogPrintDelay(int delayMs) {
+        Map<String, Object> config =
+                Collections.singletonMap(ConsoleSinkOptions.LOG_PRINT_DELAY.key(), delayMs);
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(sinkRule);
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007.

Adds a declarative `OptionRule` constraint for the Console sink so `log.print.delay.ms` must be non-negative and invalid values are rejected during configuration validation. It also adds focused unit coverage and aligns the English and Chinese connector documentation.

### Does this PR introduce _any_ user-facing change?

Yes. A negative `log.print.delay.ms` value was previously accepted and effectively treated as no delay. It is now rejected during option validation with an `OptionValidationException`. Zero and positive values retain their existing behavior.

### How was this patch tested?

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-console -am -DskipIT=true -Dskip.spotless=true verify`
  - Console tests: 7 passed, 0 failed
- `git diff --check`

The repository-wide `./mvnw -q -DskipTests verify` progressed beyond the focused connector but could not complete locally because the corporate TLS proxy prevented Maven from validating the certificate chain for the external Mulesoft repository used by the Druid connector. The focused Console reactor completed successfully.

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese Console connector documentation are updated.
* [x] No incompatible API or SPI change is introduced.
* [x] No new connector registration or distribution change is required.