### PR TITLE
[Fix][Zeta] Prevent negative intermediate queue metrics

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/TaskGroupWithIntermediateBlockingQueue.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/TaskGroupWithIntermediateBlockingQueue.java
@@ -57,6 +57,7 @@ public class TaskGroupWithIntermediateBlockingQueue extends AbstractTaskGroupWit
         private final Counter putBlockedNs;
         private final Counter flushSignalQueueSuccessTotal;
         private final Counter flushSignalQueueFailureTotal;
+        private final IntermediateBlockingQueue.QueueSizeTracker queueSizeTracker;
 
         private QueueWithMetrics(
                 BlockingQueue<Record<?>> queue,
@@ -64,13 +65,15 @@ public class TaskGroupWithIntermediateBlockingQueue extends AbstractTaskGroupWit
                 Counter queueSize,
                 Counter putBlockedNs,
                 Counter flushSignalQueueSuccessTotal,
-                Counter flushSignalQueueFailureTotal) {
+                Counter flushSignalQueueFailureTotal,
+                IntermediateBlockingQueue.QueueSizeTracker queueSizeTracker) {
             this.queue = queue;
             this.totalQueueSize = totalQueueSize;
             this.queueSize = queueSize;
             this.putBlockedNs = putBlockedNs;
             this.flushSignalQueueSuccessTotal = flushSignalQueueSuccessTotal;
             this.flushSignalQueueFailureTotal = flushSignalQueueFailureTotal;
+            this.queueSizeTracker = queueSizeTracker;
         }
     }
 
@@ -107,7 +110,8 @@ public class TaskGroupWithIntermediateBlockingQueue extends AbstractTaskGroupWit
                             queueSize,
                             putBlockedNs,
                             flushSignalQueueSuccessTotal,
-                            flushSignalQueueFailureTotal);
+                            flushSignalQueueFailureTotal,
+                            new IntermediateBlockingQueue.QueueSizeTracker());
                 });
         QueueWithMetrics cache = blockingQueueCache.get(id);
         return new IntermediateBlockingQueue(
@@ -116,7 +120,8 @@ public class TaskGroupWithIntermediateBlockingQueue extends AbstractTaskGroupWit
                 cache.queueSize,
                 cache.putBlockedNs,
                 cache.flushSignalQueueSuccessTotal,
-                cache.flushSignalQueueFailureTotal);
+                cache.flushSignalQueueFailureTotal,
+                cache.queueSizeTracker);
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueue.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueue.java
@@ -44,6 +44,7 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
     private final Counter putBlockedNs;
     private final Counter flushSignalQueueSuccessTotal;
     private final Counter flushSignalQueueFailureTotal;
+    private final QueueSizeTracker queueSizeTracker;
 
     public IntermediateBlockingQueue(
             BlockingQueue<Record<?>> queue,
@@ -52,12 +53,31 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
             Counter putBlockedNs,
             Counter flushSignalQueueSuccessTotal,
             Counter flushSignalQueueFailureTotal) {
+        this(
+                queue,
+                totalIntermediateQueueSize,
+                intermediateQueueSize,
+                putBlockedNs,
+                flushSignalQueueSuccessTotal,
+                flushSignalQueueFailureTotal,
+                new QueueSizeTracker());
+    }
+
+    public IntermediateBlockingQueue(
+            BlockingQueue<Record<?>> queue,
+            Counter totalIntermediateQueueSize,
+            Counter intermediateQueueSize,
+            Counter putBlockedNs,
+            Counter flushSignalQueueSuccessTotal,
+            Counter flushSignalQueueFailureTotal,
+            QueueSizeTracker queueSizeTracker) {
         super(queue);
         this.totalIntermediateQueueSize = totalIntermediateQueueSize;
         this.intermediateQueueSize = intermediateQueueSize;
         this.putBlockedNs = putBlockedNs;
         this.flushSignalQueueSuccessTotal = flushSignalQueueSuccessTotal;
         this.flushSignalQueueFailureTotal = flushSignalQueueFailureTotal;
+        this.queueSizeTracker = queueSizeTracker;
     }
 
     @Override
@@ -86,10 +106,7 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
                                 StainTraceStage.QUEUE_IN);
             }
             if (result) {
-                totalIntermediateQueueSize.inc();
-                if (metricsEnabled) {
-                    intermediateQueueSize.set(getIntermediateQueue().size());
-                }
+                recordEnqueued(metricsEnabled);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -105,13 +122,8 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
             if (record == null) {
                 break;
             }
-            boolean result = handleRecord(record, collector::collect, StainTraceStage.QUEUE_OUT);
-            if (result) {
-                totalIntermediateQueueSize.dec();
-                if (metricsEnabled) {
-                    intermediateQueueSize.set(getIntermediateQueue().size());
-                }
-            }
+            recordDequeued(metricsEnabled);
+            handleRecord(record, collector::collect, StainTraceStage.QUEUE_OUT);
         }
     }
 
@@ -171,5 +183,43 @@ public class IntermediateBlockingQueue extends AbstractIntermediateQueue<Blockin
             flushSignalQueueFailureTotal.inc();
         }
         return offered;
+    }
+
+    private void recordEnqueued(boolean metricsEnabled) {
+        synchronized (queueSizeTracker) {
+            if (queueSizeTracker.pendingDequeues > 0) {
+                queueSizeTracker.pendingDequeues--;
+            } else {
+                queueSizeTracker.accountedQueueSize++;
+                totalIntermediateQueueSize.inc();
+            }
+        }
+        if (metricsEnabled) {
+            intermediateQueueSize.set(getIntermediateQueue().size());
+        }
+    }
+
+    private void recordDequeued(boolean metricsEnabled) {
+        synchronized (queueSizeTracker) {
+            if (queueSizeTracker.accountedQueueSize > 0) {
+                queueSizeTracker.accountedQueueSize--;
+                totalIntermediateQueueSize.dec();
+            } else {
+                queueSizeTracker.pendingDequeues++;
+            }
+        }
+        if (metricsEnabled) {
+            intermediateQueueSize.set(getIntermediateQueue().size());
+        }
+    }
+
+    /**
+     * Metric state shared by all wrappers for one queue. A consumer can report a dequeue before the
+     * producer returns from {@code put}; pending dequeues pair those reordered notifications
+     * without decrementing the total counter below zero.
+     */
+    public static final class QueueSizeTracker {
+        private long accountedQueueSize;
+        private long pendingDequeues;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueueSignalTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/group/queue/IntermediateBlockingQueueSignalTest.java
@@ -39,6 +39,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 class IntermediateBlockingQueueSignalTest {
 
@@ -46,6 +49,7 @@ class IntermediateBlockingQueueSignalTest {
             new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 1L, 1);
 
     private BlockingQueue<Record<?>> backing;
+    private ThreadSafeCounter totalSizeCounter;
     private ThreadSafeCounter sizeCounter;
     private IntermediateBlockingQueue queue;
     private IntermediateQueueFlowLifeCycle<?> flow;
@@ -53,11 +57,12 @@ class IntermediateBlockingQueueSignalTest {
     @BeforeEach
     void setUp() {
         backing = new ArrayBlockingQueue<>(4);
+        totalSizeCounter = new ThreadSafeCounter("totalQueueSize");
         sizeCounter = new ThreadSafeCounter("intermediateQueueSize");
         queue =
                 new IntermediateBlockingQueue(
                         backing,
-                        new ThreadSafeCounter("totalQueueSize"),
+                        totalSizeCounter,
                         sizeCounter,
                         new ThreadSafeCounter("putBlockedNs"),
                         new ThreadSafeCounter("flushSignalQueueSuccess"),
@@ -87,12 +92,14 @@ class IntermediateBlockingQueueSignalTest {
         queue.received(new Record<>(FlushSignal.of(1L, 42L)));
 
         Assertions.assertEquals(1, backing.size());
+        Assertions.assertEquals(1L, totalSizeCounter.getCount());
         Assertions.assertEquals(1L, sizeCounter.getCount());
 
         RecordingCollector downstream = new RecordingCollector();
         queue.collect(downstream);
 
         Assertions.assertEquals(0, backing.size(), "queue should be drained after collect");
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
         Assertions.assertEquals(
                 0L, sizeCounter.getCount(), "size counter should return to zero after drain");
         Assertions.assertEquals(1, downstream.collected.size(), "signal must reach downstream");
@@ -156,6 +163,194 @@ class IntermediateBlockingQueueSignalTest {
 
         Assertions.assertEquals(1, backing.size(), "only the barrier should remain in queue");
         Assertions.assertEquals(1L, sizeCounter.getCount());
+    }
+
+    @Test
+    void totalSizeDoesNotBecomeNegativeWhenDequeuePrecedesEnqueueMetricUpdate() throws Exception {
+        DelayedPutQueue delayedBacking = new DelayedPutQueue(4);
+        totalSizeCounter = new ThreadSafeCounter("totalQueueSize");
+        sizeCounter = new ThreadSafeCounter("intermediateQueueSize");
+        IntermediateBlockingQueue.QueueSizeTracker queueSizeTracker =
+                new IntermediateBlockingQueue.QueueSizeTracker();
+        IntermediateBlockingQueue producerQueue =
+                new IntermediateBlockingQueue(
+                        delayedBacking,
+                        totalSizeCounter,
+                        sizeCounter,
+                        new ThreadSafeCounter("putBlockedNs"),
+                        new ThreadSafeCounter("flushSignalQueueSuccess"),
+                        new ThreadSafeCounter("flushSignalQueueFailure"),
+                        queueSizeTracker);
+        queue =
+                new IntermediateBlockingQueue(
+                        delayedBacking,
+                        totalSizeCounter,
+                        sizeCounter,
+                        new ThreadSafeCounter("putBlockedNs"),
+                        new ThreadSafeCounter("flushSignalQueueSuccess"),
+                        new ThreadSafeCounter("flushSignalQueueFailure"),
+                        queueSizeTracker);
+        SeaTunnelTask task = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(task.isObservabilityEnabled()).thenReturn(false);
+        producerQueue.setRunningTask(task);
+        producerQueue.setIntermediateQueueFlowLifeCycle(flow);
+        queue.setRunningTask(task);
+        queue.setIntermediateQueueFlowLifeCycle(flow);
+
+        AtomicReference<Throwable> producerFailure = new AtomicReference<>();
+        Thread producer =
+                new Thread(
+                        () -> {
+                            try {
+                                producerQueue.received(
+                                        new Record<>(new SeaTunnelRow(new Object[] {"value"})));
+                            } catch (Throwable e) {
+                                producerFailure.set(e);
+                            }
+                        });
+        producer.start();
+
+        try {
+            Assertions.assertTrue(delayedBacking.awaitPublished());
+            queue.collect(new RecordingCollector());
+
+            Assertions.assertEquals(0L, totalSizeCounter.getCount());
+        } finally {
+            delayedBacking.releasePut();
+            producer.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        Assertions.assertFalse(producer.isAlive());
+        Assertions.assertNull(producerFailure.get());
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
+    }
+
+    @Test
+    void dequeuedRecordUpdatesSizeWhenPrepareCloseDropsIt() throws Exception {
+        queue.received(new Record<>(new SeaTunnelRow(new Object[] {"value"})));
+        flow.setPrepareClose(true);
+
+        RecordingCollector downstream = new RecordingCollector();
+        queue.collect(downstream);
+
+        Assertions.assertTrue(downstream.collected.isEmpty());
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
+        Assertions.assertEquals(0L, sizeCounter.getCount());
+    }
+
+    @Test
+    void interruptedPutDoesNotChangeQueueMetrics() {
+        BlockingQueue<Record<?>> interruptedBacking = new InterruptingPutQueue(1);
+        queue =
+                new IntermediateBlockingQueue(
+                        interruptedBacking,
+                        totalSizeCounter,
+                        sizeCounter,
+                        new ThreadSafeCounter("putBlockedNs"),
+                        new ThreadSafeCounter("flushSignalQueueSuccess"),
+                        new ThreadSafeCounter("flushSignalQueueFailure"));
+        SeaTunnelTask task = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(task.isObservabilityEnabled()).thenReturn(false);
+        queue.setRunningTask(task);
+        queue.setIntermediateQueueFlowLifeCycle(flow);
+
+        RuntimeException failure =
+                Assertions.assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                queue.received(
+                                        new Record<>(
+                                                new SeaTunnelRow(new Object[] {"interrupted"}))));
+
+        Assertions.assertInstanceOf(InterruptedException.class, failure.getCause());
+        Assertions.assertTrue(interruptedBacking.isEmpty());
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
+        Assertions.assertEquals(0L, sizeCounter.getCount());
+    }
+
+    @Test
+    void collectorFailureStillUpdatesQueueMetrics() throws Exception {
+        queue.received(new Record<>(new SeaTunnelRow(new Object[] {"value"})));
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () ->
+                        queue.collect(
+                                new Collector<Record<?>>() {
+                                    @Override
+                                    public void collect(Record<?> record) {
+                                        throw new IllegalStateException("collector failure");
+                                    }
+
+                                    @Override
+                                    public void close() {}
+                                }));
+
+        Assertions.assertTrue(backing.isEmpty());
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
+        Assertions.assertEquals(0L, sizeCounter.getCount());
+    }
+
+    @Test
+    void independentQueuesCanShareTotalSizeCounter() throws Exception {
+        BlockingQueue<Record<?>> secondBacking = new ArrayBlockingQueue<>(4);
+        ThreadSafeCounter secondSizeCounter = new ThreadSafeCounter("secondQueueSize");
+        IntermediateBlockingQueue secondQueue =
+                new IntermediateBlockingQueue(
+                        secondBacking,
+                        totalSizeCounter,
+                        secondSizeCounter,
+                        new ThreadSafeCounter("secondPutBlockedNs"),
+                        new ThreadSafeCounter("flushSignalQueueSuccess"),
+                        new ThreadSafeCounter("flushSignalQueueFailure"));
+        secondQueue.setRunningTask(queue.getRunningTask());
+        secondQueue.setIntermediateQueueFlowLifeCycle(flow);
+
+        queue.received(new Record<>(new SeaTunnelRow(new Object[] {"first"})));
+        secondQueue.received(new Record<>(new SeaTunnelRow(new Object[] {"second"})));
+
+        Assertions.assertEquals(2L, totalSizeCounter.getCount());
+        queue.collect(new RecordingCollector());
+        Assertions.assertEquals(1L, totalSizeCounter.getCount());
+        secondQueue.collect(new RecordingCollector());
+        Assertions.assertEquals(0L, totalSizeCounter.getCount());
+        Assertions.assertEquals(0L, sizeCounter.getCount());
+        Assertions.assertEquals(0L, secondSizeCounter.getCount());
+    }
+
+    private static class DelayedPutQueue extends ArrayBlockingQueue<Record<?>> {
+        private final CountDownLatch published = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+
+        private DelayedPutQueue(int capacity) {
+            super(capacity);
+        }
+
+        @Override
+        public void put(Record<?> record) throws InterruptedException {
+            super.put(record);
+            published.countDown();
+            release.await();
+        }
+
+        private boolean awaitPublished() throws InterruptedException {
+            return published.await(5, TimeUnit.SECONDS);
+        }
+
+        private void releasePut() {
+            release.countDown();
+        }
+    }
+
+    private static class InterruptingPutQueue extends ArrayBlockingQueue<Record<?>> {
+        private InterruptingPutQueue(int capacity) {
+            super(capacity);
+        }
+
+        @Override
+        public void put(Record<?> record) throws InterruptedException {
+            throw new InterruptedException("test interruption");
+        }
     }
 
     private static class RecordingCollector implements Collector<Record<?>> {


### PR DESCRIPTION
### Purpose of this pull request

Closes #11497.

`IntermediateBlockingQueue` publishes a record before the producer can update `IntermediateQueueSize`. A concurrent consumer can therefore dequeue the record and decrement the shared total first, temporarily exposing a negative value through the REST metrics API.

This patch shares queue metric ordering state across all wrappers for the same blocking queue. If a dequeue metric notification arrives before its enqueue notification, the tracker pairs the two events without decrementing the total below zero. Queue occupancy is also updated immediately after polling, so records dropped by `prepareClose` or followed by a collector failure do not leave stale counts.

### Does this PR introduce _any_ user-facing change?

Yes. Zeta REST job metrics no longer report a negative `IntermediateQueueSize` during concurrent enqueue and dequeue. There are no configuration or API changes.

### How was this patch tested?

Added deterministic unit coverage that pauses a producer after `put()` publishes a record, drains it through a separate consumer wrapper, and verifies the shared total never becomes negative. Added coverage for dequeued records dropped during `prepareClose`, interrupted `put()`, collector failures after polling, and independent queues sharing the total counter.

```shell
./mvnw -pl seatunnel-engine/seatunnel-engine-server -Dtest=IntermediateBlockingQueueSignalTest test
```

Result: 10 tests passed.

An adjacent regression run covering `IntermediateBlockingQueueSignalTest`, `FlushSignalMetricsFlowTest`, and `RecordEventProducerTest` passed 19 tests. The server module also passed:

```shell
./mvnw -pl seatunnel-engine/seatunnel-engine-server -DskipTests verify
```

The repository-level `./mvnw -q -DskipTests verify` completed the Zeta modules and later failed in the unrelated `connector-jdbc` module on existing source compilation errors.

### Check list

* [x] No new Jar binary package is added.
* [x] No documentation update is required for this metrics correctness fix.
* [x] No incompatible change is introduced.
* [x] This PR does not change connector code.