### PR TITLE
[Fix][Connector-V2] Fix NPE when reading Parquet source on Spark (missing tableId)

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategy.java
@@ -94,7 +94,7 @@ public class ParquetReadStrategy extends AbstractReadStrategy {
     @Override
     public void read(String path, String tableId, Collector<SeaTunnelRow> output)
             throws FileConnectorException, IOException {
-        this.read(new FileSourceSplit(path), output);
+        this.read(new FileSourceSplit(tableId, path), output);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategyTest.java
@@ -101,9 +101,6 @@ public class ParquetReadStrategyTest {
 
     @Test
     public void testParquetReadPreservesTableId() throws Exception {
-        // Regression for https://github.com/apache/seatunnel/issues/11499
-        // ParquetReadStrategy previously dropped the tableId when building the split, which
-        // surfaced as an NPE in the Spark translation layer (UTF8String.fromString(null)).
         URL resource = ParquetReadStrategyTest.class.getResource("/timestamp_as_int64.parquet");
         Assertions.assertNotNull(resource);
         String path = Paths.get(resource.toURI()).toString();

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/ParquetReadStrategyTest.java
@@ -100,6 +100,28 @@ public class ParquetReadStrategyTest {
     }
 
     @Test
+    public void testParquetReadPreservesTableId() throws Exception {
+        // Regression for https://github.com/apache/seatunnel/issues/11499
+        // ParquetReadStrategy previously dropped the tableId when building the split, which
+        // surfaced as an NPE in the Spark translation layer (UTF8String.fromString(null)).
+        URL resource = ParquetReadStrategyTest.class.getResource("/timestamp_as_int64.parquet");
+        Assertions.assertNotNull(resource);
+        String path = Paths.get(resource.toURI()).toString();
+        ParquetReadStrategy parquetReadStrategy = new ParquetReadStrategy();
+        LocalFileSystemConf.LocalConf localConf =
+                new LocalFileSystemConf.LocalConf(FS_DEFAULT_NAME_DEFAULT);
+        parquetReadStrategy.init(localConf);
+        SeaTunnelRowType seaTunnelRowTypeInfo = parquetReadStrategy.getSeaTunnelRowTypeInfo(path);
+        Assertions.assertNotNull(seaTunnelRowTypeInfo);
+        String tableId = "my_db.my_table";
+        TestCollector testCollector = new TestCollector();
+        parquetReadStrategy.read(path, tableId, testCollector);
+        List<SeaTunnelRow> rows = testCollector.getRows();
+        Assertions.assertFalse(rows.isEmpty());
+        rows.forEach(row -> Assertions.assertEquals(tableId, row.getTableId()));
+    }
+
+    @Test
     public void testParquetRead2() throws Exception {
         URL resource = ParquetReadStrategyTest.class.getResource("/hive.parquet");
         Assertions.assertNotNull(resource);

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/serialization/InternalRowConverter.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/main/java/org/apache/seatunnel/translation/spark/serialization/InternalRowConverter.java
@@ -178,7 +178,11 @@ public final class InternalRowConverter extends RowConverter<InternalRow> {
         values[0] = new MutableByte();
         values[0].update(seaTunnelRow.getRowKind().toByteValue());
         values[1] = new MutableAny();
-        values[1].update(UTF8String.fromString(seaTunnelRow.getTableId()));
+        // Defensive guard: tableId is expected to be non-null (SeaTunnelRow defaults it to ""),
+        // but a misbehaving source may leave it null. Normalize to "" so we never pass null to
+        // UTF8String.fromString, which would otherwise throw NPE in the generated Spark writer.
+        String tableId = seaTunnelRow.getTableId();
+        values[1].update(UTF8String.fromString(tableId == null ? "" : tableId));
         // Fill any remaining null values with MutableAny
         for (int i = 0; i < values.length; i++) {
             if (values[i] == null) {

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
@@ -292,6 +292,29 @@ public class MultiTableManagerTest {
         }
     }
 
+    @Test
+    public void testConvertRowWithNullTableIdDoesNotThrow() throws IOException {
+        // Regression for https://github.com/apache/seatunnel/issues/11499
+        // A misbehaving source (e.g. the pre-fix ParquetReadStrategy) may leave tableId null.
+        // The Spark translation reserves an internal field for the table id, so a null value
+        // used to reach UTF8String.fromString(null) and throw NPE in the generated writer.
+        // The converter must normalize null to "" and keep the internal table-id field non-null.
+        initSchema();
+        initData();
+        MultiTableManager multiTableManager =
+                new MultiTableManager(new CatalogTable[] {catalogTable1});
+        InternalRowConverter rowSerialization =
+                multiTableManager.getInternalRowCollector(null, null, null).getRowSerialization();
+
+        seaTunnelRow1.setTableId(null);
+
+        InternalRow internalRow =
+                Assertions.assertDoesNotThrow(() -> rowSerialization.convert(seaTunnelRow1));
+        // index 1 is the reserved table-id field (index 0 is row kind)
+        Assertions.assertFalse(internalRow.isNullAt(1));
+        Assertions.assertEquals("", internalRow.getString(1));
+    }
+
     public void initSchema() {
         this.rowType1 =
                 new SeaTunnelRowType(

--- a/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
+++ b/seatunnel-translation/seatunnel-translation-spark/seatunnel-translation-spark-common/src/test/java/org/apache/seatunnel/translation/spark/execution/MultiTableManagerTest.java
@@ -294,11 +294,6 @@ public class MultiTableManagerTest {
 
     @Test
     public void testConvertRowWithNullTableIdDoesNotThrow() throws IOException {
-        // Regression for https://github.com/apache/seatunnel/issues/11499
-        // A misbehaving source (e.g. the pre-fix ParquetReadStrategy) may leave tableId null.
-        // The Spark translation reserves an internal field for the table id, so a null value
-        // used to reach UTF8String.fromString(null) and throw NPE in the generated writer.
-        // The converter must normalize null to "" and keep the internal table-id field non-null.
         initSchema();
         initData();
         MultiTableManager multiTableManager =


### PR DESCRIPTION
### Purpose of this pull request

Fix #11499: NPE is thrown when reading a single-table Parquet source under the Spark engine.

### Reproduction Scenarios

- Engine: Spark
- Source: `LocalFile` / any `File` series connector, `file_format_type = parquet`, single table
- Phenomenon: `NullPointerException` is thrown immediately after the job starts, and no data can be read

```
java.lang.NullPointerException
    at org.apache.spark.unsafe.types.UTF8String.fromString(...)
    at org.apache.seatunnel.translation.spark.serialization.InternalRowConverter.parcel(InternalRowConverter.java:181)
    ...
```

### Root cause

`ParquetReadStrategy#read(String path, String tableId, Collector output)` constructs a split using the single-argument constructor and discards the input parameter `tableId`:

```java
// Before fix
this.read(new FileSourceSplit(path), output);   // tableId -> null
```

`FileSourceSplit(String)` sets `tableId` to `null` (this constructor is only retained for compatibility with split-id before upgrade). Afterwards, `seaTunnelRow.setTableId(split.getTableId())` is executed for each row, resulting in `null` `tableId` for all rows.

Under the Spark engine, this null value is passed to `InternalRowConverter#parcel` in the translation layer:

```java
values[1].update(UTF8String.fromString(seaTunnelRow.getTableId())); // NPE
```

`UTF8String.fromString(null)` throws an NPE. Zeta / Flink do not go through this path, so this issue is specific to Spark.

Among all read strategies, Parquet is the only one that discards tableId:

| Strategy | Construction Method | Carries tableId |
|---|---|---|
| Json / Text / Csv / Xml / Excel | `new FileSourceSplit(tableId, path)` | ✅ |
| Orc | Directly call `setTableId(tableId)` | ✅ |
| **Parquet (Before fix)** | `new FileSourceSplit(path)` | ❌ |

### Fix

Transmit tableId truthfully to align Parquet with other strategies:

```java
// After fix
this.read(new FileSourceSplit(tableId, path), output);
```

This is a minimal change targeting the root cause. No configuration options, default values or public APIs are modified, and the checkpoint compatibility contract of `FileSourceSplit(String)` remains unchanged, so there is no backward compatibility risk.

### Does this PR introduce any user-visible change?

No. Only the behavior is corrected: in the single-table Parquet scenario, rows no longer carry a null tableId, but carry the tableId passed by the caller (`""` under single-table path), thus eliminating the NPE on the Spark side.

### How was this patch tested?

Added regression unit test `ParquetReadStrategyTest#testParquetReadPreservesTableId`: read Parquet files with non-empty tableId, assert that each row retains the tableId to precisely lock the regression point.

```
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
```

Verified by `./mvnw spotless:apply` (no code formatting changes) and the above module tests.

**Regarding E2E coverage:** This bug only occurs under the Spark engine. The existing `LocalFileIT` covering Parquet has been annotated with `@DisabledOnContainer(value = {SPARK_2_4})` entirely due to apache-compress / apache-poi conflicts. Therefore, there is currently no E2E coverage for the Spark + Parquet path — which is why this issue was not detected by E2E tests for a long time. Adding Spark-only Parquet E2E tests requires setting up a separate IT environment without poi, which is beyond the scope of this fix. The unit test at the read-strategy layer can reliably cover this regression point. If maintainers prefer to add Spark E2E tests, I can create another issue to follow up.

### Checklist

- [x] Code has been formatted with `./mvnw spotless:apply`
- [x] Added regression unit test
- [x] No config option / default value / public API changed
- [x] No backward-compatibility impact

Closes #11499