### PR TITLE
[Docs][Connector-V2] Fix StarRocks CREATE TABLE link

### DIFF
--- a/docs/en/connectors/sink/StarRocks.md
+++ b/docs/en/connectors/sink/StarRocks.md
@@ -145,7 +145,7 @@ When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL
 
 Sink-specific table options applied when SaveMode auto-creates the target table (DDL phase). They take effect only when `schema_save_mode` triggers table creation, such as `CREATE_SCHEMA_WHEN_NOT_EXIST` or `RECREATE_SCHEMA`. They do **not** affect Stream Load writes at runtime and do **not** run `ALTER TABLE` on existing tables.
 
-When used with the default `save_mode_create_template` (option omitted, or configured with the same content as the built-in default), `table_options` are merged into the template `PROPERTIES` clause. **Duplicate keys are overridden by `table_options`.** Use property names from the [StarRocks CREATE TABLE documentation](https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket/partition/CREATE_TABLE/#properties); SeaTunnel does not maintain an allowlist—invalid properties fail when StarRocks executes the CREATE TABLE statement.
+When used with the default `save_mode_create_template` (option omitted, or configured with the same content as the built-in default), `table_options` are merged into the template `PROPERTIES` clause. **Duplicate keys are overridden by `table_options`.** Use property names from the [StarRocks CREATE TABLE documentation](https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE/#properties); SeaTunnel does not maintain an allowlist—invalid properties fail when StarRocks executes the CREATE TABLE statement.
 
 If you configure a `save_mode_create_template` that **differs from the built-in default**, `table_options` cannot be used together (validation fails at job submission). Put properties directly in the template instead.
 

--- a/docs/zh/connectors/sink/StarRocks.md
+++ b/docs/zh/connectors/sink/StarRocks.md
@@ -139,7 +139,7 @@ table选项参数可以填入一任意表名，这个名字最终会被用作目
 
 Sink 在 SaveMode 自动建表（DDL）时附加的表级属性。仅在 `schema_save_mode` 触发建表时生效，例如 `CREATE_SCHEMA_WHEN_NOT_EXIST`、`RECREATE_SCHEMA`；**不影响** Stream Load 写入，也**不会**对已存在表执行 `ALTER TABLE`。
 
-在默认 `save_mode_create_template`（未配置或与内置默认值相同）下，`table_options` 会合并进模板 `PROPERTIES` 子句；**同名 key 以 `table_options` 为准**。属性名请参考 [StarRocks CREATE TABLE 文档](https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket/partition/CREATE_TABLE/#properties)；SeaTunnel 不做白名单，非法属性由 StarRocks 执行 DDL 时报错。
+在默认 `save_mode_create_template`（未配置或与内置默认值相同）下，`table_options` 会合并进模板 `PROPERTIES` 子句；**同名 key 以 `table_options` 为准**。属性名请参考 [StarRocks CREATE TABLE 文档](https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE/#properties)；SeaTunnel 不做白名单，非法属性由 StarRocks 执行 DDL 时报错。
 
 若配置了**与内置默认值不同**的 `save_mode_create_template`，则不能与 `table_options` 同时使用（任务提交时校验失败）；此时请将属性直接写入模板。
 


### PR DESCRIPTION
## Purpose

Fix the dead StarRocks CREATE TABLE documentation link that currently causes the repository Dead links check to fail. This baseline issue was exposed while checking #11517 and is intentionally isolated from that Zeta change.

## Changes

- Update the English StarRocks sink documentation to the current official CREATE TABLE page.
- Update the Chinese StarRocks sink documentation with the same URL.
- Preserve the properties anchor so the link still targets the relevant section.

## Validation

- The old URL returns HTTP 404.
- The replacement official StarRocks URL returns HTTP 200 and contains the properties anchor.
- markdown-link-check 3.8.7 with the repository .dlc.json passes for both changed files.
- Scoped Spotless apply for connector-starrocks passed.
- git diff --check passed.
- Independent QA review: PASS.
- Independent Maintainer review: PASS.

## Impact

Documentation only. No runtime behavior, configuration, API, dependency, or compatibility changes.