### PR TITLE
[Fix][Connector-V2] Parse ClickhouseFile node_pass with documented snake_case keys

### DIFF
--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/NodePassConfig.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/NodePassConfig.java
@@ -17,6 +17,9 @@
 
 package org.apache.seatunnel.connectors.seatunnel.clickhouse.config;
 
+import org.apache.seatunnel.shade.com.fasterxml.jackson.annotation.JsonAlias;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.apache.seatunnel.api.configuration.util.OptionMark;
 
 import lombok.Data;
@@ -24,8 +27,18 @@ import lombok.Data;
 @Data
 public class NodePassConfig {
 
+    // The documented config key is snake_case ("node_pass.node_address"), while
+    // ReadonlyConfig converts the value with a plain ObjectMapper that has no
+    // snake_case naming strategy. Without the explicit mapping the conversion
+    // fails with an UnrecognizedPropertyException and the sink cannot be
+    // created (issue #9889).
     @OptionMark(description = "The address of Clickhouse server node")
+    @JsonProperty("node_address")
+    @JsonAlias("nodeAddress")
     private String nodeAddress;
+
+    @OptionMark(description = "Clickhouse server linux username")
+    private String username;
 
     @OptionMark(description = "Clickhouse server linux password")
     private String password;

--- a/seatunnel-connectors-v2/connector-clickhouse/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/NodePassConfigTest.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/test/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/config/NodePassConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.clickhouse.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NodePassConfigTest {
+
+    @Test
+    public void testNodePassConfigParsesDocumentedSnakeCaseKeys() {
+        // The documented node_pass entries use snake_case keys
+        // (node_pass.node_address / node_pass.username / node_pass.password).
+        // ReadonlyConfig.get(NODE_PASS) must convert them into NodePassConfig;
+        // before the fix the plain ObjectMapper conversion failed with
+        // UnrecognizedPropertyException and the sink could not be created
+        // (issue #9889).
+        Map<String, Object> nodePass = new HashMap<>();
+        nodePass.put("node_address", "10.0.0.1:8123");
+        nodePass.put("username", "default");
+        nodePass.put("password", "secret");
+
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        Collections.singletonMap(
+                                ClickhouseFileSinkOptions.NODE_PASS.key(),
+                                Collections.singletonList(nodePass)));
+
+        List<NodePassConfig> parsed = config.get(ClickhouseFileSinkOptions.NODE_PASS);
+        Assertions.assertEquals(1, parsed.size());
+        Assertions.assertEquals("10.0.0.1:8123", parsed.get(0).getNodeAddress());
+        Assertions.assertEquals("default", parsed.get(0).getUsername());
+        Assertions.assertEquals("secret", parsed.get(0).getPassword());
+    }
+
+    @Test
+    public void testNodePassConfigAcceptsCamelCaseAlias() {
+        Map<String, Object> nodePass = new HashMap<>();
+        nodePass.put("nodeAddress", "10.0.0.2:8123");
+        nodePass.put("password", "secret2");
+
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        Collections.singletonMap(
+                                ClickhouseFileSinkOptions.NODE_PASS.key(),
+                                Collections.singletonList(nodePass)));
+
+        List<NodePassConfig> parsed = config.get(ClickhouseFileSinkOptions.NODE_PASS);
+        Assertions.assertEquals(1, parsed.size());
+        Assertions.assertEquals("10.0.0.2:8123", parsed.get(0).getNodeAddress());
+        Assertions.assertEquals("secret2", parsed.get(0).getPassword());
+    }
+}


### PR DESCRIPTION
## Purpose of the change

Fixes #9889.

Configuring the ClickhouseFile sink exactly as documented fails at startup:

```
FactoryException: Unable to create a sink for identifier 'ClickhouseFile'
```

## Root cause

The documentation describes `node_pass` entries with snake_case keys:

```hocon
node_pass = [{
    node_address = "xxx"
    password = "xxx"
}]
```

but `NodePassConfig` declares the field `nodeAddress` with no Jackson mapping. `ReadonlyConfig` converts option values with a **plain `ObjectMapper`** (no snake_case naming strategy), so deserializing the documented configuration throws:

```
UnrecognizedPropertyException: Unrecognized field "node_address"
(class ...NodePassConfig), not marked as ignorable
(2 known properties: "nodeAddress", "password"])
```

## Changes

- **`NodePassConfig`**
  - `@JsonProperty("node_address")` on `nodeAddress`, with `@JsonAlias("nodeAddress")` so users who already write the camelCase form keep working.
  - Added the documented `username` field (`node_pass.username`, per the docs table), so entries containing it no longer fail deserialization either.
- **`NodePassConfigTest`** (new)
  - `testNodePassConfigParsesDocumentedSnakeCaseKeys` — goes through the real `ReadonlyConfig.get(NODE_PASS)` conversion path with `node_address`/`username`/`password` and asserts all fields. Without the fix it reproduces the exact `UnrecognizedPropertyException` from the issue (verified by running the test against the unfixed class).
  - `testNodePassConfigAcceptsCamelCaseAlias` — `nodeAddress` keeps working.

## Verification

- `./mvnw -pl seatunnel-connectors-v2/connector-clickhouse test` — full module suite passes.
- Behavioral repro confirmed: with the fix stashed, the snake_case test fails with `Unrecognized field "node_address"`; with the fix, both tests pass.