### PR TITLE
[Fix][Zeta][E2E] Fix CI failures and flaky connector tests

### DIFF
--- a/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
+++ b/seatunnel-connectors-v2/connector-starrocks/src/test/java/org/apache/seatunnel/connectors/seatunnel/starrocks/client/StarRocksStreamLoadVisitorTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -382,7 +383,7 @@ public class StarRocksStreamLoadVisitorTest {
 
         assertThrows(
                 StarRocksConnectorException.class, () -> visitor.doStreamLoad(createFlushTuple()));
-        verify(httpHelper).doHttpGet(anyString(), any(), anyInt());
+        verify(httpHelper, atLeastOnce()).doHttpGet(anyString(), any(), anyInt());
     }
 
     /**

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/MysqlCDCSpecificStartingOffsetIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/MysqlCDCSpecificStartingOffsetIT.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/java/org/apache/seatunnel/e2e/connector/elasticsearch/ElasticsearchTimerFlushIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/java/org/apache/seatunnel/e2e/connector/elasticsearch/ElasticsearchTimerFlushIT.java
@@ -70,7 +70,7 @@ import static org.awaitility.Awaitility.await;
 public class ElasticsearchTimerFlushIT extends TestSuiteBase implements TestResource {
 
     private static final MySqlContainer MYSQL_CONTAINER = createMySqlContainer(MySqlVersion.V8_0);
-    private static final String MYSQL_HOST = "mysql_cdc_e2e";
+    private static final String MYSQL_HOST = "mysql_cdc_timer_flush_e2e";
     private static final String MYSQL_USER_NAME = "mysqluser";
     private static final String MYSQL_USER_PASSWORD = "mysqlpw";
     private static final String DATABASE = "shop";

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/resources/elasticsearch/mysqlcdc_to_elasticsearch_timer_flush.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/resources/elasticsearch/mysqlcdc_to_elasticsearch_timer_flush.conf
@@ -28,7 +28,7 @@ source {
     username = "st_user_source"
     password = "mysqlpw"
     table-names = ["shop.products"]
-    url = "jdbc:mysql://mysql_cdc_e2e:3306/shop"
+    url = "jdbc:mysql://mysql_cdc_timer_flush_e2e:3306/shop"
     table-names-config = [{"table": "shop.products", "primaryKeys": ["id"]}]
   }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServicePipelineCleanupTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServicePipelineCleanupTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server;
 
 import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
@@ -36,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;


### PR DESCRIPTION
## Purpose

Fix deterministic CI failures and reduce timing-related flakiness in the Zeta and connector test suites.

## Root causes

- `CoordinatorServicePipelineCleanupTest` used the JDK `CompletableFuture`, while SeaTunnel's import check requires the engine-specific implementation.
- `MysqlCDCSpecificStartingOffsetIT` referenced `Container.ExecResult` without importing Testcontainers' `Container` class, causing test compilation to fail.
- `ElasticsearchTimerFlushIT` reused the generic `mysql_cdc_e2e` network alias. Concurrent E2E jobs could connect to the wrong MySQL container, resulting in authentication failures or unexpected row counts.
- `StarRocksStreamLoadVisitorTest` expected exactly one state query even though deadline-based polling may legally perform more than one query on slower CI runners.

## Changes

- Use SeaTunnel's `CompletableFuture` in the coordinator cleanup test.
- Add the missing Testcontainers import to the MySQL CDC E2E test.
- Give the Elasticsearch timer-flush E2E test a dedicated MySQL network alias and update its job configuration.
- Verify that StarRocks state polling occurs at least once instead of requiring exactly one invocation.

## Validation

- `./mvnw spotless:apply`
- `./mvnw -B -T 1 clean test -Dlicense.skipAddThirdParty=true -pl seatunnel-ci-tools -am --no-snapshot-updates`
- `./mvnw -pl seatunnel-connectors-v2/connector-starrocks -DskipIT -Dskip.spotless=true -Dtest=StarRocksStreamLoadVisitorTest test` (17 tests passed)
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e,seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e -DskipUT -DskipIT -Dskip.spotless=true test-compile`

Kafka exactly-once timing failures are not changed by this PR because addressing them correctly requires a production-code fix rather than weakening the E2E assertion.
