### PR TITLE
[Improve][CI] Keep required Build without strict sync on dev

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,7 +53,7 @@ github:
   protected_branches:
     dev:
       required_status_checks:
-        strict: true
+        strict: false
         checks:
           - context: Build
             app_id: 15368


### PR DESCRIPTION
## Why
The previous branch protection change made `Build` required and also set `required_status_checks.strict: true`.

That enforces an extra gate beyond required CI: every PR branch must be updated to the latest `dev` and re-run checks before merge. In practice, an approved PR with a successful `Build` can still be blocked only because it is behind `dev`.

PR #11525 is one concrete example: it had approval plus successful `Build`, but GitHub still blocked merge because the branch was behind `dev`.

## What changed
- keep `Build` as the required status check
- change `required_status_checks.strict` from `true` to `false`

This preserves the intended gate of "CI must pass before merge" without forcing every PR to sync with the latest `dev` before merge.