### PR TITLE
[Feature][Connector-V2][Fluss] Support Fluss source connector

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -143,6 +143,11 @@ file:
       - changed-files:
           - any-glob-to-any-file: seatunnel-connectors-v2/connector-file/**
           - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(file)/**'
+fluss:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: seatunnel-connectors-v2/connector-fluss/**
+          - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(fluss)/**'
 google-firestore:
   - all:
       - changed-files:

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -46,6 +46,7 @@ connector-file-jindo-oss
 connector-file-s3
 connector-file-sftp
 connector-file-obs
+connector-fluss
 connector-google-sheets
 connector-google-firestore
 connector-google-bigtable

--- a/docs/en/connectors/source/Fluss.md
+++ b/docs/en/connectors/source/Fluss.md
@@ -1,0 +1,179 @@
+import ChangeLog from '../changelog/connector-fluss.md';
+
+# Fluss
+
+> Fluss source connector
+
+## Supported Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+
+## Description
+
+The Fluss source reads rows from an existing Fluss table in batch or streaming jobs.
+
+The connector reads the table through the Fluss log scanner, one split per table bucket, so the
+read parallelism follows the number of buckets. Each record's change type (`INSERT`,
+`UPDATE_BEFORE`, `UPDATE_AFTER`, `DELETE`) is mapped to the corresponding SeaTunnel `RowKind`, so a
+log table is read as append-only inserts and a primary-key table is read as its changelog.
+
+:::caution Primary-key tables
+
+For a primary-key table the connector reads only the table's **changelog**, starting from the
+earliest available log offset; it does **not** read the KV snapshot first. It therefore captures
+ongoing changes (insert / update / delete) with the correct `RowKind`, but it does **not** guarantee
+a complete initial load of rows that already exist: any record that has aged out of the changelog
+through log retention or compaction will be missing. A full "snapshot + incremental" sync of a
+primary-key table is not supported yet. If you need the complete current state, prefer a **log
+(append-only) table**, which the log scanner always reads in full.
+
+:::
+
+Boundedness follows the job mode:
+
+- In `BATCH` mode the source is bounded: each bucket is read up to the latest log offset captured
+  when the job starts, then the split finishes.
+- In `STREAMING` mode the source is unbounded: it keeps reading new log records. The read position
+  of every bucket is stored in the checkpoint state, so the job resumes from where it stopped.
+
+Use `start_mode` to choose the offset each bucket starts from:
+
+- `earliest` (default): read the whole log from its earliest available offset.
+- `latest`: read only records appended after the job starts.
+
+`start_mode=latest` is only meaningful for a streaming job.
+
+The Fluss database and table must already exist before the job starts. The source does not create
+Fluss databases or tables. The table schema is read automatically from the Fluss cluster, so no
+`schema` option is required.
+
+## Limitations
+
+- **Single table only.** Each source reads exactly one table, configured with `database` + `table`.
+  Reading multiple tables in a single source is not supported.
+- **No arbitrary start offset.** The start position is chosen with `start_mode` (`earliest` or
+  `latest`) only. Starting from a specific log offset is not supported.
+- **Partitioned tables are not supported.** Pointing the source at a partitioned Fluss table fails
+  fast at job startup with an error. Use a non-partitioned table.
+- **Primary-key tables are read as changelog only.** The connector reads the table's changelog, not
+  a KV snapshot, so it does not perform a full initial load ("snapshot + incremental"). See the
+  primary-key caution above for details.
+
+## Dependency
+
+```xml
+<dependency>
+    <groupId>com.alibaba.fluss</groupId>
+    <artifactId>fluss-client</artifactId>
+    <version>0.7.0</version>
+</dependency>
+```
+
+## Source Options
+
+| Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| bootstrap.servers | string | yes | - | Fluss coordinator address, for example `fluss-coordinator:9123`. |
+| database | string | yes | - | The Fluss database to read from. |
+| table | string | yes | - | The Fluss table to read from. |
+| client.config | map | no | - | Extra Fluss client options passed to the Fluss connection. |
+| start_mode | string | no | earliest | The offset each bucket starts reading from: `earliest` (whole log) or `latest` (only records appended after the job starts). `latest` is rejected in `BATCH` mode. |
+| poll.timeout.ms | long | no | 10000 | The maximum time, in milliseconds, to block in a single Fluss log scanner poll. |
+| common-options | - | no | - | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
+
+### client.config
+
+Use `client.config` to pass additional Fluss client settings.
+
+```hocon
+client.config = {
+  request.timeout = "30s"
+}
+```
+
+Refer to the Fluss client documentation for supported keys.
+
+## Data Type Mapping
+
+| Fluss Data Type | SeaTunnel Data Type |
+|---|---|
+| BOOLEAN | BOOLEAN |
+| TINYINT | TINYINT |
+| SMALLINT | SMALLINT |
+| INT | INT |
+| BIGINT | BIGINT |
+| FLOAT | FLOAT |
+| DOUBLE | DOUBLE |
+| DECIMAL | DECIMAL |
+| CHAR | STRING |
+| STRING | STRING |
+| BINARY | BYTES |
+| BYTES | BYTES |
+| DATE | DATE |
+| TIME | TIME |
+| TIMESTAMP | TIMESTAMP |
+| TIMESTAMP_LTZ | TIMESTAMP_TZ |
+
+## Task Examples
+
+### Batch read
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_db"
+    table = "fluss_table"
+    plugin_output = "fluss_source"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fluss_source"
+  }
+}
+```
+
+### Streaming read
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_db"
+    table = "fluss_table"
+    start_mode = "latest"
+  }
+}
+
+sink {
+  Console {
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/source/Fluss.md
+++ b/docs/zh/connectors/source/Fluss.md
@@ -1,0 +1,161 @@
+import ChangeLog from '../changelog/connector-fluss.md';
+
+# Fluss
+
+> Fluss Source 连接器
+
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 主要特性
+
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
+
+## 描述
+
+Fluss Source 用于在批处理或流处理作业中，从已有的 Fluss 表读取数据。
+
+连接器通过 Fluss 的 log scanner 读取数据，每个表 bucket 对应一个分片（split），因此读取并行度与 bucket 数量一致。每条记录的变更类型（`INSERT`、`UPDATE_BEFORE`、`UPDATE_AFTER`、`DELETE`）会映射为对应的 SeaTunnel `RowKind`，因此日志表以仅追加（append-only）的 `INSERT` 形式读取，主键表则以其变更日志（changelog）的形式读取。
+
+:::caution 主键表
+
+对于主键表，连接器只从最早可用的 log offset 开始读取表的 **changelog**，**不会**先读取 KV 快照。因此它能捕获持续发生的变更（插入/更新/删除）并带上正确的 `RowKind`，但**不保证**对已存在数据的完整初始加载：任何因日志保留（retention）或压缩（compaction）而从 changelog 中被清除的记录都会缺失。目前**尚不支持**主键表的“快照 + 增量”完整同步。如果需要完整的当前状态，请优先使用**日志表（append-only）**，log scanner 总能将其完整读取。
+
+:::
+
+有界性由作业模式决定：
+
+- 在 `BATCH` 模式下，Source 是有界的：每个 bucket 读取到作业启动时捕获的最新 log offset 后，分片结束。
+- 在 `STREAMING` 模式下，Source 是无界的：会持续读取新的 log 记录。每个 bucket 的读取位置会保存在 checkpoint 状态中，作业可从中断处恢复。
+
+使用 `start_mode` 选择每个 bucket 的起始读取位点：
+
+- `earliest`（默认）：从最早可用的 offset 开始读取整个 log。
+- `latest`：只读取作业启动之后新追加的记录。
+
+`start_mode=latest` 仅对流处理作业有意义。
+
+运行作业前，Fluss database 和 table 必须已经存在。Source 不会自动创建 Fluss database 或 table。表结构会自动从 Fluss 集群读取，因此不需要配置 `schema` 选项。
+
+## 限制
+
+- **仅支持单表。** 每个 source 只读取一张表，通过 `database` + `table` 配置。不支持在一个 source 中读取多张表。
+- **不支持指定任意起始位点。** 起始位置只能通过 `start_mode`（`earliest` 或 `latest`）选择；不支持从指定的 log offset 开始读取。
+- **不支持分区表。** 将 source 指向分区 Fluss 表会在作业启动时直接失败（fail-fast）并给出错误。请使用非分区表。
+- **主键表仅按 changelog 读取。** 连接器读取表的 changelog，而非 KV 快照，因此不做完整初始加载（“快照 + 增量”）。详见上方主键表 caution。
+
+## 依赖
+
+```xml
+<dependency>
+    <groupId>com.alibaba.fluss</groupId>
+    <artifactId>fluss-client</artifactId>
+    <version>0.7.0</version>
+</dependency>
+```
+
+## Source 选项
+
+| 名称 | 类型 | 是否必填 | 默认值 | 描述 |
+|---|---|---|---|---|
+| bootstrap.servers | string | 是 | - | Fluss coordinator 地址，例如 `fluss-coordinator:9123`。 |
+| database | string | 是 | - | 要读取的 Fluss database。 |
+| table | string | 是 | - | 要读取的 Fluss table。 |
+| client.config | map | 否 | - | 传递给 Fluss 连接的额外 Fluss 客户端选项。 |
+| start_mode | string | 否 | earliest | 每个 bucket 的起始读取位点：`earliest`（整个 log）或 `latest`（仅作业启动后新追加的记录）。`latest` 在 `BATCH` 模式下会被拒绝。 |
+| poll.timeout.ms | long | 否 | 10000 | 单次 Fluss log scanner poll 的最大阻塞时间，单位毫秒。 |
+| common-options | - | 否 | - | Source 通用选项，详见 [Source 通用选项](../common-options/source-common-options.md)。 |
+
+### client.config
+
+使用 `client.config` 传递额外的 Fluss 客户端配置。
+
+```hocon
+client.config = {
+  request.timeout = "30s"
+}
+```
+
+支持的配置项请参考 Fluss 客户端文档。
+
+## 数据类型映射
+
+| Fluss 数据类型 | SeaTunnel 数据类型 |
+|---|---|
+| BOOLEAN | BOOLEAN |
+| TINYINT | TINYINT |
+| SMALLINT | SMALLINT |
+| INT | INT |
+| BIGINT | BIGINT |
+| FLOAT | FLOAT |
+| DOUBLE | DOUBLE |
+| DECIMAL | DECIMAL |
+| CHAR | STRING |
+| STRING | STRING |
+| BINARY | BYTES |
+| BYTES | BYTES |
+| DATE | DATE |
+| TIME | TIME |
+| TIMESTAMP | TIMESTAMP |
+| TIMESTAMP_LTZ | TIMESTAMP_TZ |
+
+## 任务示例
+
+### 批处理读取
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_db"
+    table = "fluss_table"
+    plugin_output = "fluss_source"
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "fluss_source"
+  }
+}
+```
+
+### 流处理读取
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_db"
+    table = "fluss_table"
+    start_mode = "latest"
+  }
+}
+
+sink {
+  Console {
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -160,6 +160,7 @@ seatunnel.sink.GraphQL = connector-graphql
 seatunnel.sink.Aerospike = connector-aerospike
 seatunnel.sink.SensorsData = connector-sensorsdata
 seatunnel.sink.HugeGraph = connector-hugegraph
+seatunnel.source.Fluss = connector-fluss
 seatunnel.sink.Fluss = connector-fluss
 seatunnel.sink.Lance = connector-lance
 seatunnel.sink.BigQuery = connector-bigquery

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/config/FlussSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/config/FlussSourceOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.time.Duration;
+
+public class FlussSourceOptions extends FlussBaseOptions {
+
+    public static final Option<Long> POLL_TIMEOUT_MS =
+            Options.key("poll.timeout.ms")
+                    .longType()
+                    .defaultValue(Duration.ofSeconds(10).toMillis())
+                    .withDescription(
+                            "The maximum time to block in the Fluss log scanner poll when "
+                                    + "fetching records");
+
+    public static final Option<StartMode> START_MODE =
+            Options.key("start_mode")
+                    .enumType(StartMode.class)
+                    .defaultValue(StartMode.EARLIEST)
+                    .withDescription(
+                            "The offset each bucket starts reading from: [earliest] reads the "
+                                    + "whole log from its earliest available offset; [latest] reads "
+                                    + "only records appended after the job starts. [latest] is only "
+                                    + "meaningful for streaming jobs and is rejected in BATCH mode.");
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/config/StartMode.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/config/StartMode.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.fluss.config;
+
+import lombok.Getter;
+
+@Getter
+public enum StartMode {
+    EARLIEST("earliest"),
+
+    LATEST("latest");
+
+    private final String mode;
+
+    StartMode(String mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public String toString() {
+        return mode;
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussAdminClient.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussAdminClient.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.common.utils.TemporaryClassLoaderContext;
+
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.client.admin.OffsetSpec;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TableInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+class FlussAdminClient implements AutoCloseable {
+
+    private final Connection connection;
+    private final Admin admin;
+    private final String description;
+
+    FlussAdminClient(Configuration flussConfig, String description) {
+        this.description = description;
+        Connection conn = createConnection(flussConfig);
+        try {
+            this.admin = conn.getAdmin();
+        } catch (RuntimeException e) {
+            try {
+                conn.close();
+            } catch (Exception closeError) {
+                e.addSuppressed(closeError);
+            }
+            throw e;
+        }
+        this.connection = conn;
+    }
+
+    /**
+     * Creates the Fluss connection with the connector classloader pinned as the thread context
+     * classloader. Fluss authenticates by loading its 'PLAINTEXT' protocol plugin via {@code
+     * ServiceLoader} off the context classloader (AuthenticationFactory); a reader creates this
+     * client on the framework's SplitFetcher thread, whose context classloader is not the
+     * connector's. The connection's authenticator is loaded once here and reused by every later
+     * admin / scan call, so pinning only the connection setup is enough.
+     */
+    private static Connection createConnection(Configuration flussConfig) {
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(FlussAdminClient.class.getClassLoader())) {
+            return ConnectionFactory.createConnection(flussConfig);
+        }
+    }
+
+    Connection connection() {
+        return connection;
+    }
+
+    TableInfo getTableInfo(TablePath tablePath) {
+        try {
+            return admin.getTableInfo(toFlussTablePath(tablePath)).get();
+        } catch (Exception e) {
+            throw wrap(
+                    String.format(
+                            "Failed to read Fluss table info for %s", tablePath.getFullName()),
+                    e);
+        }
+    }
+
+    Map<Integer, Long> earliestOffsets(TablePath tablePath, List<Integer> buckets) {
+        CompletableFuture<Map<Integer, Long>> earliest =
+                listOffsetsAsync(tablePath, buckets, new OffsetSpec.EarliestSpec());
+        return awaitOffsets(earliest, tablePath, buckets);
+    }
+
+    Map<Integer, Long> latestOffsets(TablePath tablePath, List<Integer> buckets) {
+        CompletableFuture<Map<Integer, Long>> latest =
+                listOffsetsAsync(tablePath, buckets, new OffsetSpec.LatestSpec());
+        return awaitOffsets(latest, tablePath, buckets);
+    }
+
+    BucketBounds bucketBounds(TablePath tablePath, List<Integer> buckets) {
+        CompletableFuture<Map<Integer, Long>> earliest =
+                listOffsetsAsync(tablePath, buckets, new OffsetSpec.EarliestSpec());
+        CompletableFuture<Map<Integer, Long>> latest =
+                listOffsetsAsync(tablePath, buckets, new OffsetSpec.LatestSpec());
+        return new BucketBounds(
+                awaitOffsets(earliest, tablePath, buckets),
+                awaitOffsets(latest, tablePath, buckets));
+    }
+
+    private CompletableFuture<Map<Integer, Long>> listOffsetsAsync(
+            TablePath tablePath, List<Integer> buckets, OffsetSpec spec) {
+        return admin.listOffsets(toFlussTablePath(tablePath), buckets, spec).all();
+    }
+
+    private Map<Integer, Long> awaitOffsets(
+            CompletableFuture<Map<Integer, Long>> future,
+            TablePath tablePath,
+            List<Integer> buckets) {
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw wrap(
+                    String.format(
+                            "Failed to list offsets for table %s buckets %s",
+                            tablePath.getFullName(), buckets),
+                    e);
+        }
+    }
+
+    static final class BucketBounds {
+        final Map<Integer, Long> earliest;
+        final Map<Integer, Long> latest;
+
+        BucketBounds(Map<Integer, Long> earliest, Map<Integer, Long> latest) {
+            this.earliest = earliest;
+            this.latest = latest;
+        }
+    }
+
+    private static IllegalStateException wrap(String message, Exception e) {
+        // Restore the interrupt status so an interrupt during a blocking get() (e.g. job
+        // cancellation) is not swallowed by wrapping it in an unchecked exception.
+        if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        return new IllegalStateException(message, e);
+    }
+
+    private static com.alibaba.fluss.metadata.TablePath toFlussTablePath(TablePath tablePath) {
+        return com.alibaba.fluss.metadata.TablePath.of(
+                tablePath.getDatabaseName(), tablePath.getTableName());
+    }
+
+    @Override
+    public void close() {
+        // Best-effort: this client only backs short-lived schema/offset discovery, so a failure to
+        // release it must not fail a job (or a discovery) whose data was already fetched. Both the
+        // admin and the connection are always attempted; failures are logged, not thrown.
+        // Pin the connector classloader (see createConnection): teardown may run on a framework
+        // thread whose context classloader is not the connector's, and Fluss can lazily load
+        // classes while closing.
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(FlussAdminClient.class.getClassLoader())) {
+            try {
+                admin.close();
+            } catch (Exception e) {
+                log.warn("Failed to close Fluss admin for {}", description, e);
+            }
+            try {
+                connection.close();
+            } catch (Exception e) {
+                log.warn("Failed to close Fluss connection for {}", description, e);
+            }
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussRecord.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import lombok.Getter;
+
+@Getter
+public class FlussRecord {
+
+    private final SeaTunnelRow row;
+    private final long logOffset;
+
+    public FlussRecord(SeaTunnelRow row, long logOffset) {
+        this.row = row;
+        this.logOffset = logOffset;
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussRecordEmitter.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussRecordEmitter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordEmitter;
+
+public class FlussRecordEmitter
+        implements RecordEmitter<FlussRecord, SeaTunnelRow, FlussSourceSplitState> {
+
+    @Override
+    public void emitRecord(
+            FlussRecord element,
+            Collector<SeaTunnelRow> collector,
+            FlussSourceSplitState splitState) {
+        collector.collect(element.getRow());
+        splitState.setCurrentOffset(element.getLogOffset() + 1);
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSource.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSource.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.source.SupportParallelism;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SourceReaderOptions;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitReader;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.StartMode;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class FlussSource
+        implements SeaTunnelSource<SeaTunnelRow, FlussSourceSplit, FlussSourceState>,
+                SupportParallelism {
+
+    private final ReadonlyConfig readonlyConfig;
+    private final FlussSourceConfig sourceConfig;
+    private JobContext jobContext;
+
+    public FlussSource(ReadonlyConfig readonlyConfig) {
+        this.readonlyConfig = readonlyConfig;
+        this.sourceConfig = new FlussSourceConfig(readonlyConfig);
+    }
+
+    @Override
+    public String getPluginName() {
+        return FlussSourceOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return jobContext != null && JobMode.BATCH.equals(jobContext.getJobMode())
+                ? Boundedness.BOUNDED
+                : Boundedness.UNBOUNDED;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return sourceConfig.getProducedCatalogTables();
+    }
+
+    @Override
+    public SourceReader<SeaTunnelRow, FlussSourceSplit> createReader(
+            SourceReader.Context readerContext) {
+        Supplier<SplitReader<FlussRecord, FlussSourceSplit>> splitReaderSupplier =
+                () -> new FlussSourceSplitReader(sourceConfig);
+        return new FlussSourceReader(
+                splitReaderSupplier,
+                new FlussRecordEmitter(),
+                new SourceReaderOptions(readonlyConfig),
+                readerContext);
+    }
+
+    @Override
+    public SourceSplitEnumerator<FlussSourceSplit, FlussSourceState> createEnumerator(
+            SourceSplitEnumerator.Context<FlussSourceSplit> enumeratorContext) {
+        return new FlussSourceSplitEnumerator(sourceConfig, enumeratorContext, null, isStreaming());
+    }
+
+    @Override
+    public SourceSplitEnumerator<FlussSourceSplit, FlussSourceState> restoreEnumerator(
+            SourceSplitEnumerator.Context<FlussSourceSplit> enumeratorContext,
+            FlussSourceState checkpointState) {
+        return new FlussSourceSplitEnumerator(
+                sourceConfig, enumeratorContext, checkpointState, isStreaming());
+    }
+
+    private boolean isStreaming() {
+        return getBoundedness() == Boundedness.UNBOUNDED;
+    }
+
+    @Override
+    public void setJobContext(JobContext jobContext) {
+        checkStartMode(jobContext.getJobMode(), sourceConfig.getStartMode());
+        this.jobContext = jobContext;
+    }
+
+    static void checkStartMode(JobMode jobMode, StartMode startMode) {
+        if (JobMode.BATCH.equals(jobMode) && StartMode.LATEST.equals(startMode)) {
+            throw new IllegalArgumentException(
+                    "Fluss source option '"
+                            + FlussSourceOptions.START_MODE.key()
+                            + "=latest' is not supported in BATCH mode.");
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceConfig.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.StartMode;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TableInfo;
+import com.alibaba.fluss.types.DataField;
+import com.alibaba.fluss.types.DataType;
+import com.alibaba.fluss.types.RowType;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FlussSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ReadonlyConfig readonlyConfig;
+    @Getter private final String database;
+    @Getter private final String table;
+    @Getter private final long pollTimeoutMs;
+    @Getter private final StartMode startMode;
+    private final CatalogTable catalogTable;
+    @Getter private final RowType flussRowType;
+
+    public FlussSourceConfig(ReadonlyConfig readonlyConfig) {
+        this.readonlyConfig = readonlyConfig;
+        this.database = readonlyConfig.get(FlussSourceOptions.DATABASE);
+        this.table = readonlyConfig.get(FlussSourceOptions.TABLE);
+        this.pollTimeoutMs = readonlyConfig.get(FlussSourceOptions.POLL_TIMEOUT_MS);
+        this.startMode = readonlyConfig.get(FlussSourceOptions.START_MODE);
+        TableInfo tableInfo = loadTableInfo();
+        this.catalogTable = toCatalogTable(tableInfo);
+        this.flussRowType = tableInfo.getRowType();
+    }
+
+    private TableInfo loadTableInfo() {
+        try (FlussAdminClient adminClient =
+                new FlussAdminClient(buildFlussConfig(), getTablePath().getFullName())) {
+            return adminClient.getTableInfo(getTablePath());
+        }
+    }
+
+    private CatalogTable toCatalogTable(TableInfo tableInfo) {
+        if (tableInfo.isPartitioned()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Fluss source does not support partitioned tables yet: %s.%s",
+                            database, table));
+        }
+        RowType rowType = tableInfo.getRowType();
+        TableSchema.Builder schemaBuilder = TableSchema.builder();
+        for (DataField field : rowType.getFields()) {
+            DataType fieldType = field.getType();
+            schemaBuilder.column(
+                    PhysicalColumn.of(
+                            field.getName(),
+                            FlussTypeConverter.toSeaTunnelType(field.getName(), fieldType),
+                            FlussTypeConverter.columnLength(fieldType),
+                            FlussTypeConverter.columnScale(fieldType),
+                            fieldType.isNullable(),
+                            null,
+                            field.getDescription().orElse(null)));
+        }
+        if (tableInfo.hasPrimaryKey()) {
+            schemaBuilder.primaryKey(PrimaryKey.of(table + "_pk", tableInfo.getPrimaryKeys()));
+        }
+        TableIdentifier tableIdentifier =
+                TableIdentifier.of(FlussSourceOptions.CONNECTOR_IDENTITY, database, table);
+        return CatalogTable.of(
+                tableIdentifier,
+                schemaBuilder.build(),
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                tableInfo.getComment().orElse(null));
+    }
+
+    public Configuration buildFlussConfig() {
+        Configuration flussConfig = new Configuration();
+        flussConfig.setString(
+                FlussSourceOptions.BOOTSTRAP_SERVERS.key(),
+                readonlyConfig.get(FlussSourceOptions.BOOTSTRAP_SERVERS));
+        Optional<Map<String, String>> clientConfig =
+                readonlyConfig.getOptional(FlussSourceOptions.CLIENT_CONFIG);
+        clientConfig.ifPresent(m -> m.forEach(flussConfig::setString));
+        return flussConfig;
+    }
+
+    public TablePath getTablePath() {
+        return TablePath.of(database, table);
+    }
+
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussSourceOptions;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterThan;
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
+@AutoService(Factory.class)
+public class FlussSourceFactory implements TableSourceFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return FlussSourceOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        FlussSourceOptions.BOOTSTRAP_SERVERS,
+                        notBlank(FlussSourceOptions.BOOTSTRAP_SERVERS))
+                .required(FlussSourceOptions.DATABASE, notBlank(FlussSourceOptions.DATABASE))
+                .required(FlussSourceOptions.TABLE, notBlank(FlussSourceOptions.TABLE))
+                .optional(FlussSourceOptions.CLIENT_CONFIG)
+                .optional(FlussSourceOptions.START_MODE)
+                .optional(
+                        FlussSourceOptions.POLL_TIMEOUT_MS,
+                        greaterThan(FlussSourceOptions.POLL_TIMEOUT_MS, 0L))
+                .build();
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return FlussSource.class;
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        return () -> (SeaTunnelSource<T, SplitT, StateT>) new FlussSource(context.getOptions());
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceReader.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceReader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordEmitter;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.SourceReaderOptions;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitReader;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class FlussSourceReader
+        extends SingleThreadMultiplexSourceReaderBase<
+                FlussRecord, SeaTunnelRow, FlussSourceSplit, FlussSourceSplitState> {
+
+    public FlussSourceReader(
+            Supplier<SplitReader<FlussRecord, FlussSourceSplit>> splitReaderSupplier,
+            RecordEmitter<FlussRecord, SeaTunnelRow, FlussSourceSplitState> recordEmitter,
+            SourceReaderOptions options,
+            SourceReader.Context context) {
+        super(splitReaderSupplier, recordEmitter, options, context);
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, FlussSourceSplitState> finishedSplitIds) {
+        // no external offset commit required; positions are held in the checkpoint state
+    }
+
+    @Override
+    protected FlussSourceSplitState initializedState(FlussSourceSplit split) {
+        return new FlussSourceSplitState(split);
+    }
+
+    @Override
+    protected FlussSourceSplit toSplitType(String splitId, FlussSourceSplitState splitState) {
+        return splitState.toFlussSourceSplit();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // no external offset commit required; positions are held in the checkpoint state
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplit.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class FlussSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final long tableId;
+    private final int bucketId;
+    private final long startOffset;
+    private final long endOffset;
+
+    public FlussSourceSplit(
+            TablePath tablePath, long tableId, int bucketId, long startOffset, long endOffset) {
+        this.tablePath = tablePath;
+        this.tableId = tableId;
+        this.bucketId = bucketId;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    @Override
+    public String splitId() {
+        return tablePath.getFullName() + "-" + bucketId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FlussSourceSplit that = (FlussSourceSplit) o;
+        return tableId == that.tableId && bucketId == that.bucketId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, bucketId);
+    }
+
+    @Override
+    public String toString() {
+        return "FlussSourceSplit{"
+                + "tablePath="
+                + tablePath.getFullName()
+                + ", bucketId="
+                + bucketId
+                + ", startOffset="
+                + startOffset
+                + ", endOffset="
+                + endOffset
+                + '}';
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.StartMode;
+
+import com.alibaba.fluss.client.table.scanner.log.LogScanner;
+import com.alibaba.fluss.metadata.TableInfo;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
+public class FlussSourceSplitEnumerator
+        implements SourceSplitEnumerator<FlussSourceSplit, FlussSourceState> {
+
+    private final FlussSourceConfig config;
+    private final Context<FlussSourceSplit> context;
+    private final boolean streaming;
+
+    private final Object lock = new Object();
+    private final Set<FlussSourceSplit> pendingSplits = new HashSet<>();
+    private final boolean restored;
+
+    private boolean initialized = false;
+    private final Set<Integer> noMoreSplitsSignaled = new HashSet<>();
+
+    public FlussSourceSplitEnumerator(
+            FlussSourceConfig config,
+            Context<FlussSourceSplit> context,
+            FlussSourceState restoreState,
+            boolean streaming) {
+        this.config = config;
+        this.context = context;
+        this.streaming = streaming;
+        this.restored = restoreState != null;
+        if (restored) {
+            pendingSplits.addAll(restoreState.getPendingSplits());
+        }
+    }
+
+    @Override
+    public void open() {
+        // No-op: discovery opens its own short-lived admin client; a restored enumerator skips it.
+    }
+
+    @Override
+    public void run() throws Exception {
+        synchronized (lock) {
+            if (!initialized) {
+                if (!restored) {
+                    pendingSplits.addAll(discoverSplits());
+                }
+                initialized = true;
+            }
+        }
+        assignSplits();
+    }
+
+    private List<FlussSourceSplit> discoverSplits() {
+        try (FlussAdminClient adminClient =
+                new FlussAdminClient(
+                        config.buildFlussConfig(), config.getTablePath().getFullName())) {
+            TablePath tablePath = config.getTablePath();
+            TableInfo tableInfo = adminClient.getTableInfo(tablePath);
+            int numBuckets = tableInfo.getNumBuckets();
+            long tableId = tableInfo.getTableId();
+            List<Integer> buckets =
+                    IntStream.range(0, numBuckets).boxed().collect(Collectors.toList());
+
+            if (streaming) {
+                Map<Integer, Long> latestOffsets =
+                        config.getStartMode() == StartMode.LATEST
+                                ? adminClient.latestOffsets(tablePath, buckets)
+                                : null;
+                List<FlussSourceSplit> splits = new ArrayList<>(numBuckets);
+                for (int bucket : buckets) {
+                    long startOffset =
+                            latestOffsets != null
+                                    ? latestOffsets.get(bucket)
+                                    : LogScanner.EARLIEST_OFFSET;
+                    splits.add(
+                            new FlussSourceSplit(
+                                    tablePath, tableId, bucket, startOffset, Long.MAX_VALUE));
+                }
+                log.info(
+                        "Discovered {} bucket split(s) for table {} (streaming, start_mode={})",
+                        splits.size(),
+                        tablePath.getFullName(),
+                        config.getStartMode());
+                return splits;
+            }
+
+            FlussAdminClient.BucketBounds bounds = adminClient.bucketBounds(tablePath, buckets);
+            List<FlussSourceSplit> splits = new ArrayList<>(numBuckets);
+            int emptyBuckets = 0;
+            for (int bucket : buckets) {
+                long earliest = bounds.earliest.get(bucket);
+                long latest = bounds.latest.get(bucket);
+                if (earliest == latest) {
+                    emptyBuckets++;
+                    continue;
+                }
+                splits.add(
+                        new FlussSourceSplit(
+                                tablePath, tableId, bucket, LogScanner.EARLIEST_OFFSET, latest));
+            }
+            log.info(
+                    "Discovered {} bucket split(s) for table {} (batch, {} empty bucket(s) skipped)",
+                    splits.size(),
+                    tablePath.getFullName(),
+                    emptyBuckets);
+            return splits;
+        }
+    }
+
+    private void assignSplits() {
+        synchronized (lock) {
+            if (!initialized) {
+                return;
+            }
+            int parallelism = context.currentParallelism();
+            Set<Integer> registeredReaders = context.registeredReaders();
+            Map<Integer, List<FlussSourceSplit>> assignment = new HashMap<>();
+            for (FlussSourceSplit split : pendingSplits) {
+                int owner = getSplitOwner(split, parallelism);
+                if (registeredReaders.contains(owner)) {
+                    assignment.computeIfAbsent(owner, k -> new ArrayList<>()).add(split);
+                }
+            }
+            assignment.forEach(
+                    (subtaskId, splits) -> {
+                        context.assignSplit(subtaskId, splits);
+                        splits.forEach(pendingSplits::remove);
+                    });
+            if (!streaming) {
+                for (int subtaskId : registeredReaders) {
+                    if (noMoreSplitsSignaled.add(subtaskId)) {
+                        context.signalNoMoreSplits(subtaskId);
+                    }
+                }
+            }
+        }
+    }
+
+    private static int getSplitOwner(FlussSourceSplit split, int parallelism) {
+        int hash = split.getTablePath().getFullName().hashCode() * 31 + split.getBucketId();
+        return (hash & Integer.MAX_VALUE) % parallelism;
+    }
+
+    @Override
+    public void addSplitsBack(List<FlussSourceSplit> splits, int subtaskId) {
+        synchronized (lock) {
+            if (splits == null || splits.isEmpty()) {
+                return;
+            }
+            splits.forEach(pendingSplits::remove);
+            pendingSplits.addAll(splits);
+            if (context.registeredReaders().contains(subtaskId)) {
+                assignSplits();
+            }
+        }
+    }
+
+    @Override
+    public int currentUnassignedSplitSize() {
+        return pendingSplits.size();
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId) {
+        throw new UnsupportedOperationException(
+                "Does not support split requests: subtask " + subtaskId);
+    }
+
+    @Override
+    public void registerReader(int subtaskId) {
+        assignSplits();
+    }
+
+    @Override
+    public FlussSourceState snapshotState(long checkpointId) {
+        synchronized (lock) {
+            return new FlussSourceState(new HashSet<>(pendingSplits));
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // no-op: read positions are persisted in the split state
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No-op: the admin client used for discovery is short-lived and closed there.
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReader.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReader.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsBySplits;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsAddition;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsChange;
+
+import com.alibaba.fluss.client.table.Table;
+import com.alibaba.fluss.client.table.scanner.ScanRecord;
+import com.alibaba.fluss.client.table.scanner.log.LogScanner;
+import com.alibaba.fluss.client.table.scanner.log.ScanRecords;
+import com.alibaba.fluss.exception.FetchException;
+import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.record.ChangeType;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.types.DataType;
+import com.alibaba.fluss.types.RowType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Reads the configured Fluss table's buckets through a single {@link LogScanner}, created lazily on
+ * the first split assignment. This is a single-table connector: every split a reader receives
+ * belongs to {@code config.getTablePath()} and is decoded with that table's row type. In bounded
+ * mode a bucket is finished once its read position reaches the captured {@code endOffset}.
+ *
+ * <p>An {@code earliest} fresh split (batch or streaming) carries {@link
+ * LogScanner#EARLIEST_OFFSET} (-2), which Fluss re-resolves server-side to the live log start on
+ * every poll, so it is always in range and never overruns. A {@code latest} fresh split (tail
+ * captured by the enumerator) and a restored split carry a concrete resume position; if retention
+ * has discarded it — before it is subscribed or while a slow reader falls behind mid-stream — the
+ * next {@link LogScanner#poll} throws an out-of-range {@link FetchException} (Fluss has no
+ * client-side auto-reset). The reader resets any bucket now behind its earliest to the current
+ * earliest (Kafka's {@code auto.offset.reset=earliest}); best-effort, since retention may advance
+ * again before the next poll. If that pass resets nothing the out-of-range is not a recoverable
+ * front-side truncation (e.g. a position beyond latest after a table recreate / rollback / dirty
+ * offset), so the reader rethrows to fail the job rather than re-poll the same exception forever.
+ *
+ * <p>A bounded bucket that retention truncates empty is the one case the reset cannot see: the -2
+ * sentinel it subscribes at never overruns, so no exception fires, yet the bucket yields no record
+ * and its {@code nextOffset} never reaches {@code endOffset}. {@link
+ * #completeDrainedSentinelBuckets(TableScan)} covers it by finishing a still-sentinel bounded
+ * bucket whose current earliest has reached its end. Empty bounded buckets are also filtered out by
+ * the enumerator at discovery.
+ */
+@Slf4j
+public class FlussSourceSplitReader implements SplitReader<FlussRecord, FlussSourceSplit> {
+
+    private final FlussSourceConfig config;
+    private final Duration pollTimeout;
+
+    private FlussAdminClient adminClient;
+
+    /** The configured table's scan state, created lazily on the first split assignment. */
+    private volatile TableScan tableScan;
+
+    /** Used to detect bounded completion and to spot positions a retention reset has to recover. */
+    private final Map<TableBucket, BucketReader> assigned = new HashMap<>();
+
+    private final Set<String> drainedSplits = new HashSet<>();
+
+    public FlussSourceSplitReader(FlussSourceConfig config) {
+        this.config = config;
+        this.pollTimeout = Duration.ofMillis(config.getPollTimeoutMs());
+    }
+
+    private FlussAdminClient adminClient() {
+        if (adminClient == null) {
+            adminClient =
+                    new FlussAdminClient(
+                            config.buildFlussConfig(), config.getTablePath().getFullName());
+        }
+        return adminClient;
+    }
+
+    @Override
+    public RecordsWithSplitIds<FlussRecord> fetch() throws IOException {
+        Map<String, Collection<FlussRecord>> recordsBySplit = new HashMap<>();
+        Set<String> finishedSplits = new HashSet<>();
+
+        TableScan scan = tableScan;
+        if (scan != null) {
+            ScanRecords scanRecords = null;
+            try {
+                scanRecords = scan.logScanner.poll(pollTimeout);
+            } catch (FetchException e) {
+                if (!(e.getCause() instanceof LogOffsetOutOfRangeException)) {
+                    throw e;
+                }
+                // A subscribed offset was discarded by retention. Reset the bucket(s) now behind
+                // their earliest and retry on the next fetch().
+                log.warn(
+                        "Out-of-range offset while polling table {}; resetting truncated buckets to earliest",
+                        scan.tablePath.getFullName(),
+                        e);
+                if (!resetTruncatedBuckets(scan)) {
+                    // Nothing was behind its earliest, so this out-of-range is not a recoverable
+                    // front-side retention truncation. Fail with the original cause
+                    // instead of re-polling and throwing the same exception forever.
+                    throw e;
+                }
+            }
+            if (scanRecords != null) {
+                for (TableBucket bucket : scanRecords.buckets()) {
+                    BucketReader reader = assigned.get(bucket);
+                    if (reader == null || reader.done) {
+                        // Unknown bucket, or a bucket already finished but still subscribed.
+                        continue;
+                    }
+                    FlussSourceSplit split = reader.split;
+                    Collection<FlussRecord> out = null;
+                    for (ScanRecord record : scanRecords.records(bucket)) {
+                        long offset = record.logOffset();
+                        if (isBounded(split.getEndOffset()) && offset >= split.getEndOffset()) {
+                            reader.nextOffset = offset;
+                            break;
+                        }
+                        if (out == null) {
+                            out =
+                                    recordsBySplit.computeIfAbsent(
+                                            split.splitId(), k -> new ArrayList<>());
+                        }
+                        out.add(new FlussRecord(convert(scan, record), offset));
+                        reader.nextOffset = offset + 1;
+                    }
+                }
+            }
+            // Finish any bounded bucket retention truncated empty while still on the sentinel
+            completeDrainedSentinelBuckets(scan);
+        }
+
+        if (!drainedSplits.isEmpty()) {
+            finishedSplits.addAll(drainedSplits);
+            drainedSplits.clear();
+        }
+
+        for (BucketReader reader : assigned.values()) {
+            FlussSourceSplit split = reader.split;
+            if (!reader.done
+                    && isBounded(split.getEndOffset())
+                    && reader.nextOffset >= split.getEndOffset()) {
+                finishedSplits.add(split.splitId());
+                // Mark finished but keep it tracked. Its records are
+                // dropped by the done check above, and finishedSplits is only added once.
+                reader.done = true;
+            }
+        }
+
+        return new RecordsBySplits<>(recordsBySplit, finishedSplits);
+    }
+
+    static boolean isBounded(long endOffset) {
+        return endOffset != Long.MAX_VALUE;
+    }
+
+    /**
+     * Assignment-time drained check, needing no earliest lookup: a bounded split whose recorded
+     * start already reaches its captured end offset has nothing left to read.
+     *
+     * <p>That a fully consumed ("finished") split can be handed back on restore looks impossible,
+     * but {@code SourceReaderBase} removes a finished split's state <em>lazily</em>: the reader
+     * reports the split in {@code finishedSplits}, yet the base only drops its state one {@code
+     * pollNext} later (in {@code finishCurrentFetch}), after the split's last record has already
+     * advanced {@code currentOffset} to the end. A checkpoint landing in that window persists a
+     * just-completed split, and restoring it hands us back {@code start == end}. Finishing it here
+     * skips a pointless subscribe + poll and avoids a misleading out-of-range warning should
+     * retention have meanwhile passed that end.
+     *
+     * <p>The {@link LogScanner#EARLIEST_OFFSET} (-2) sentinel of a fresh split floors to 0, so a
+     * fresh split is only drained when its end offset is 0 — an empty bucket, which the enumerator
+     * already filters out, leaving that a defensive fallback.
+     */
+    static boolean isDrainedAtAssignment(long startOffset, long endOffset) {
+        return isBounded(endOffset) && Math.max(startOffset, 0L) >= endOffset;
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<FlussSourceSplit> splitsChanges) {
+        if (!(splitsChanges instanceof SplitsAddition)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SplitChange type of %s is not supported.",
+                            splitsChanges.getClass()));
+        }
+        for (FlussSourceSplit split : splitsChanges.splits()) {
+            long startOffset = split.getStartOffset();
+            long endOffset = split.getEndOffset();
+            if (isDrainedAtAssignment(startOffset, endOffset)) {
+                drainedSplits.add(split.splitId());
+                log.info(
+                        "Split {} has nothing to read (startOffset={}, endOffset={}); marking finished without subscribing",
+                        split.splitId(),
+                        startOffset,
+                        endOffset);
+                continue;
+            }
+            if (tableScan == null) {
+                tableScan = createTableScan();
+            }
+            TableBucket bucket = new TableBucket(split.getTableId(), split.getBucketId());
+            tableScan.logScanner.subscribe(split.getBucketId(), startOffset);
+            assigned.put(bucket, new BucketReader(split, startOffset));
+            log.info("Subscribed to {} at offset {}", split, startOffset);
+        }
+    }
+
+    /**
+     * Resets buckets whose subscribed position retention discarded from the front, after a poll
+     * threw out-of-range.
+     *
+     * @return whether any bucket was reset. {@code false} means no subscribed position was behind
+     *     its earliest, so the out-of-range was not a recoverable front-side truncation.
+     */
+    private boolean resetTruncatedBuckets(TableScan scan) {
+        List<BucketReader> candidates =
+                assigned.values().stream()
+                        .filter(reader -> reader.nextOffset >= 0)
+                        .collect(Collectors.toList());
+        if (candidates.isEmpty()) {
+            return false;
+        }
+        Map<Integer, Long> earliestByBucket = earliestOffsets(scan.tablePath, candidates);
+        boolean reset = false;
+        for (BucketReader reader : candidates) {
+            long earliest = earliestByBucket.get(reader.split.getBucketId());
+            if (reader.nextOffset >= earliest) {
+                continue;
+            }
+            scan.logScanner.subscribe(reader.split.getBucketId(), earliest);
+            reader.nextOffset = earliest;
+            reset = true;
+        }
+        return reset;
+    }
+
+    private void completeDrainedSentinelBuckets(TableScan scan) {
+        List<BucketReader> sentinelBounded =
+                assigned.values().stream()
+                        .filter(
+                                reader ->
+                                        !reader.done
+                                                && reader.nextOffset < 0
+                                                && isBounded(reader.split.getEndOffset()))
+                        .collect(Collectors.toList());
+        if (sentinelBounded.isEmpty()) {
+            return;
+        }
+        Map<Integer, Long> earliestByBucket = earliestOffsets(scan.tablePath, sentinelBounded);
+        for (BucketReader reader : sentinelBounded) {
+            long earliest = earliestByBucket.get(reader.split.getBucketId());
+            if (earliest >= reader.split.getEndOffset()) {
+                reader.nextOffset = earliest;
+            }
+        }
+    }
+
+    @SuppressWarnings("resource")
+    private Map<Integer, Long> earliestOffsets(
+            TablePath tablePath, Collection<BucketReader> readers) {
+        List<Integer> buckets =
+                readers.stream()
+                        .map(r -> r.split.getBucketId())
+                        .distinct()
+                        .collect(Collectors.toList());
+        return adminClient().earliestOffsets(tablePath, buckets);
+    }
+
+    @SuppressWarnings("resource")
+    private TableScan createTableScan() {
+        TablePath tablePath = config.getTablePath();
+        com.alibaba.fluss.metadata.TablePath flussTablePath =
+                com.alibaba.fluss.metadata.TablePath.of(
+                        tablePath.getDatabaseName(), tablePath.getTableName());
+        Table table = adminClient().connection().getTable(flussTablePath);
+        try {
+            LogScanner logScanner = table.newScan().createLogScanner();
+            return new TableScan(tablePath, table, logScanner, config.getFlussRowType());
+        } catch (RuntimeException e) {
+            try {
+                table.close();
+            } catch (Exception closeError) {
+                e.addSuppressed(closeError);
+            }
+            throw e;
+        }
+    }
+
+    private SeaTunnelRow convert(TableScan tableScan, ScanRecord record) {
+        InternalRow internalRow = record.getRow();
+        int arity = tableScan.fieldGetters.length;
+        Object[] fields = new Object[arity];
+        for (int i = 0; i < arity; i++) {
+            fields[i] =
+                    FlussTypeConverter.toSeaTunnelValue(
+                            tableScan.fieldNames[i],
+                            tableScan.fieldTypes[i],
+                            tableScan.fieldGetters[i].getFieldOrNull(internalRow));
+        }
+        SeaTunnelRow row = new SeaTunnelRow(fields);
+        row.setRowKind(toRowKind(record.getChangeType()));
+        return row;
+    }
+
+    private static RowKind toRowKind(ChangeType changeType) {
+        switch (changeType) {
+            case UPDATE_BEFORE:
+                return RowKind.UPDATE_BEFORE;
+            case UPDATE_AFTER:
+                return RowKind.UPDATE_AFTER;
+            case DELETE:
+                return RowKind.DELETE;
+            case APPEND_ONLY:
+            case INSERT:
+            default:
+                return RowKind.INSERT;
+        }
+    }
+
+    @Override
+    public void wakeUp() {
+        TableScan scan = tableScan;
+        if (scan != null) {
+            scan.logScanner.wakeup();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        TableScan scan = tableScan;
+        tableScan = null;
+        try {
+            if (scan != null) {
+                scan.close();
+            }
+        } finally {
+            if (adminClient != null) {
+                adminClient.close();
+            }
+        }
+    }
+
+    /** The mutable per-bucket read cursor. */
+    private static final class BucketReader {
+        private final FlussSourceSplit split;
+        private long nextOffset;
+
+        /**
+         * True once this bounded bucket has reached its end offset. The reader stays tracked (not
+         * removed) because {@code com.alibaba.fluss:fluss-client:0.7.0} can't per-bucket
+         * unsubscribe a non-partitioned table: keeping it lets {@link
+         * #resetTruncatedBuckets(TableScan)} clear a later retention truncation instead of spinning
+         * on an out-of-range poll no one owns. Records from a done bucket are dropped in {@link
+         * #fetch()}.
+         */
+        private boolean done;
+
+        private BucketReader(FlussSourceSplit split, long nextOffset) {
+            this.split = split;
+            this.nextOffset = nextOffset;
+        }
+    }
+
+    /** The configured table's scanning resources. */
+    private static class TableScan {
+        private final TablePath tablePath;
+        private final Table table;
+        private final LogScanner logScanner;
+        private final String[] fieldNames;
+        private final DataType[] fieldTypes;
+        private final InternalRow.FieldGetter[] fieldGetters;
+
+        private TableScan(
+                TablePath tablePath, Table table, LogScanner logScanner, RowType rowType) {
+            this.tablePath = tablePath;
+            this.table = table;
+            this.logScanner = logScanner;
+            List<String> names = rowType.getFieldNames();
+            int fieldCount = rowType.getFieldCount();
+            this.fieldNames = new String[fieldCount];
+            this.fieldTypes = new DataType[fieldCount];
+            for (int i = 0; i < fieldCount; i++) {
+                this.fieldNames[i] = names.get(i);
+                this.fieldTypes[i] = rowType.getTypeAt(i);
+            }
+            this.fieldGetters = InternalRow.createFieldGetters(rowType);
+        }
+
+        private void close() throws Exception {
+            try {
+                logScanner.close();
+            } finally {
+                table.close();
+            }
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReader.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReader.java
@@ -95,7 +95,7 @@ public class FlussSourceSplitReader implements SplitReader<FlussRecord, FlussSou
         this.pollTimeout = Duration.ofMillis(config.getPollTimeoutMs());
     }
 
-    private FlussAdminClient adminClient() {
+    FlussAdminClient adminClient() {
         if (adminClient == null) {
             adminClient =
                     new FlussAdminClient(
@@ -297,7 +297,7 @@ public class FlussSourceSplitReader implements SplitReader<FlussRecord, FlussSou
     }
 
     @SuppressWarnings("resource")
-    private TableScan createTableScan() {
+    TableScan createTableScan() {
         TablePath tablePath = config.getTablePath();
         com.alibaba.fluss.metadata.TablePath flussTablePath =
                 com.alibaba.fluss.metadata.TablePath.of(
@@ -392,7 +392,7 @@ public class FlussSourceSplitReader implements SplitReader<FlussRecord, FlussSou
     }
 
     /** The configured table's scanning resources. */
-    private static class TableScan {
+    static class TableScan {
         private final TablePath tablePath;
         private final Table table;
         private final LogScanner logScanner;
@@ -400,8 +400,7 @@ public class FlussSourceSplitReader implements SplitReader<FlussRecord, FlussSou
         private final DataType[] fieldTypes;
         private final InternalRow.FieldGetter[] fieldGetters;
 
-        private TableScan(
-                TablePath tablePath, Table table, LogScanner logScanner, RowType rowType) {
+        TableScan(TablePath tablePath, Table table, LogScanner logScanner, RowType rowType) {
             this.tablePath = tablePath;
             this.table = table;
             this.logScanner = logScanner;

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitState.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitState.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import lombok.Setter;
+
+/** Mutable read position for a {@link FlussSourceSplit}, advanced as records are emitted. */
+@Setter
+public class FlussSourceSplitState extends FlussSourceSplit {
+
+    private long currentOffset;
+
+    public FlussSourceSplitState(FlussSourceSplit split) {
+        super(
+                split.getTablePath(),
+                split.getTableId(),
+                split.getBucketId(),
+                split.getStartOffset(),
+                split.getEndOffset());
+        this.currentOffset = split.getStartOffset();
+    }
+
+    public FlussSourceSplit toFlussSourceSplit() {
+        return new FlussSourceSplit(
+                getTablePath(), getTableId(), getBucketId(), currentOffset, getEndOffset());
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceState.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceState.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/** Enumerator checkpoint state. */
+@Getter
+public class FlussSourceState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Set<FlussSourceSplit> pendingSplits;
+
+    public FlussSourceState(Set<FlussSourceSplit> pendingSplits) {
+        this.pendingSplits = pendingSplits;
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussTypeConverter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.common.exception.CommonError;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussBaseOptions;
+
+import com.alibaba.fluss.row.BinaryString;
+import com.alibaba.fluss.row.Decimal;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+import com.alibaba.fluss.types.BinaryType;
+import com.alibaba.fluss.types.CharType;
+import com.alibaba.fluss.types.DataType;
+import com.alibaba.fluss.types.LocalZonedTimestampType;
+import com.alibaba.fluss.types.TimeType;
+import com.alibaba.fluss.types.TimestampType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public final class FlussTypeConverter {
+
+    private FlussTypeConverter() {}
+
+    public static SeaTunnelDataType<?> toSeaTunnelType(String fieldName, DataType dataType) {
+        switch (dataType.getTypeRoot()) {
+            case BOOLEAN:
+                return BasicType.BOOLEAN_TYPE;
+            case TINYINT:
+                return BasicType.BYTE_TYPE;
+            case SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case INTEGER:
+                return BasicType.INT_TYPE;
+            case BIGINT:
+                return BasicType.LONG_TYPE;
+            case FLOAT:
+                return BasicType.FLOAT_TYPE;
+            case DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case CHAR:
+            case STRING:
+                return BasicType.STRING_TYPE;
+            case BINARY:
+            case BYTES:
+                return PrimitiveByteArrayType.INSTANCE;
+            case DECIMAL:
+                com.alibaba.fluss.types.DecimalType decimalType =
+                        (com.alibaba.fluss.types.DecimalType) dataType;
+                return new DecimalType(decimalType.getPrecision(), decimalType.getScale());
+            case DATE:
+                return LocalTimeType.LOCAL_DATE_TYPE;
+            case TIME_WITHOUT_TIME_ZONE:
+                return LocalTimeType.LOCAL_TIME_TYPE;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return LocalTimeType.LOCAL_DATE_TIME_TYPE;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return LocalTimeType.OFFSET_DATE_TIME_TYPE;
+            default:
+                throw CommonError.unsupportedDataType(
+                        FlussBaseOptions.CONNECTOR_IDENTITY,
+                        dataType.getTypeRoot().name(),
+                        fieldName);
+        }
+    }
+
+    public static Long columnLength(DataType dataType) {
+        switch (dataType.getTypeRoot()) {
+            case CHAR:
+                return (long) ((CharType) dataType).getLength();
+            case BINARY:
+                return (long) ((BinaryType) dataType).getLength();
+            case DECIMAL:
+                return (long) ((com.alibaba.fluss.types.DecimalType) dataType).getPrecision();
+            default:
+                return null;
+        }
+    }
+
+    public static Integer columnScale(DataType dataType) {
+        switch (dataType.getTypeRoot()) {
+            case DECIMAL:
+                return ((com.alibaba.fluss.types.DecimalType) dataType).getScale();
+            case TIME_WITHOUT_TIME_ZONE:
+                return ((TimeType) dataType).getPrecision();
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return ((TimestampType) dataType).getPrecision();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return ((LocalZonedTimestampType) dataType).getPrecision();
+            default:
+                return null;
+        }
+    }
+
+    public static Object toSeaTunnelValue(String fieldName, DataType dataType, Object value) {
+        if (value == null) {
+            return null;
+        }
+        switch (dataType.getTypeRoot()) {
+            case BOOLEAN:
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case BINARY:
+            case BYTES:
+                return value;
+            case CHAR:
+            case STRING:
+                return ((BinaryString) value).toString();
+            case DECIMAL:
+                return ((Decimal) value).toBigDecimal();
+            case DATE:
+                return LocalDate.ofEpochDay(((Integer) value).longValue());
+            case TIME_WITHOUT_TIME_ZONE:
+                return LocalTime.ofNanoOfDay(((Integer) value).longValue() * 1_000_000L);
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return ((TimestampNtz) value).toLocalDateTime();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return OffsetDateTime.ofInstant(((TimestampLtz) value).toInstant(), ZoneOffset.UTC);
+            default:
+                throw CommonError.unsupportedDataType(
+                        FlussBaseOptions.CONNECTOR_IDENTITY,
+                        dataType.getTypeRoot().name(),
+                        fieldName);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceFactoryTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.FlussSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.fluss.config.StartMode;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class FlussSourceFactoryTest {
+
+    private final OptionRule sourceRule = new FlussSourceFactory().optionRule();
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(sourceRule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(FlussSourceOptions.BOOTSTRAP_SERVERS.key(), "localhost:9123");
+        cfg.put(FlussSourceOptions.DATABASE.key(), "fluss_db");
+        cfg.put(FlussSourceOptions.TABLE.key(), "fluss_table");
+        return cfg;
+    }
+
+    @Test
+    void testFactoryIdentifierAndSourceClass() {
+        FlussSourceFactory factory = new FlussSourceFactory();
+        Assertions.assertEquals(FlussSourceOptions.CONNECTOR_IDENTITY, factory.factoryIdentifier());
+        Assertions.assertEquals(FlussSource.class, factory.getSourceClass());
+    }
+
+    @Test
+    void testValidConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testValidConfigWithOptionalOptions() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put(FlussSourceOptions.POLL_TIMEOUT_MS.key(), 5000L);
+        Map<String, String> clientConfig = new HashMap<>();
+        clientConfig.put("request.timeout", "30s");
+        cfg.put(FlussSourceOptions.CLIENT_CONFIG.key(), clientConfig);
+        Assertions.assertDoesNotThrow(() -> validate(cfg));
+    }
+
+    @Test
+    void testMissingRequiredOptionRejected() {
+        Map<String, Object> cfg = validConfig();
+        cfg.remove(FlussSourceOptions.TABLE.key());
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testBlankBootstrapServersRejected() {
+        Map<String, Object> emptyCfg = validConfig();
+        emptyCfg.put(FlussSourceOptions.BOOTSTRAP_SERVERS.key(), "");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(emptyCfg));
+
+        Map<String, Object> whitespaceCfg = validConfig();
+        whitespaceCfg.put(FlussSourceOptions.BOOTSTRAP_SERVERS.key(), "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(whitespaceCfg));
+    }
+
+    @Test
+    void testBlankDatabaseRejected() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put(FlussSourceOptions.DATABASE.key(), "   ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testBlankTableRejected() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put(FlussSourceOptions.TABLE.key(), "");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(cfg));
+    }
+
+    @Test
+    void testStartModeIsOptionalAndDefaultsToEarliest() {
+        Assertions.assertEquals(StartMode.EARLIEST, FlussSourceOptions.START_MODE.defaultValue());
+        Assertions.assertEquals(
+                StartMode.EARLIEST,
+                ReadonlyConfig.fromMap(validConfig()).get(FlussSourceOptions.START_MODE));
+    }
+
+    @Test
+    void testStartModeResolvesCaseInsensitively() {
+        Map<String, Object> lower = validConfig();
+        lower.put(FlussSourceOptions.START_MODE.key(), "latest");
+        Assertions.assertDoesNotThrow(() -> validate(lower));
+        Assertions.assertEquals(
+                StartMode.LATEST, ReadonlyConfig.fromMap(lower).get(FlussSourceOptions.START_MODE));
+
+        Map<String, Object> upper = validConfig();
+        upper.put(FlussSourceOptions.START_MODE.key(), "EARLIEST");
+        Assertions.assertEquals(
+                StartMode.EARLIEST,
+                ReadonlyConfig.fromMap(upper).get(FlussSourceOptions.START_MODE));
+    }
+
+    @Test
+    void testUnknownStartModeRejected() {
+        Map<String, Object> cfg = validConfig();
+        cfg.put(FlussSourceOptions.START_MODE.key(), "newest");
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> ReadonlyConfig.fromMap(cfg).get(FlussSourceOptions.START_MODE));
+    }
+
+    @Test
+    void testStartModeLatestRejectedInBatchMode() {
+        IllegalArgumentException ex =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FlussSource.checkStartMode(JobMode.BATCH, StartMode.LATEST));
+        Assertions.assertTrue(
+                ex.getMessage().contains(FlussSourceOptions.START_MODE.key())
+                        && ex.getMessage().contains("BATCH"),
+                "Message must name the offending option and job mode: " + ex.getMessage());
+    }
+
+    @Test
+    void testNonPositivePollTimeoutRejected() {
+        Map<String, Object> zeroCfg = validConfig();
+        zeroCfg.put(FlussSourceOptions.POLL_TIMEOUT_MS.key(), 0L);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(zeroCfg));
+
+        Map<String, Object> negativeCfg = validConfig();
+        negativeCfg.put(FlussSourceOptions.POLL_TIMEOUT_MS.key(), -1L);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(negativeCfg));
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumeratorTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.common.metrics.AbstractMetricsContext;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.Event;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class FlussSourceSplitEnumeratorTest {
+
+    private static final TablePath TABLE_PATH = TablePath.of("fluss_db", "fluss_tbl");
+    private static final long TABLE_ID = 1L;
+    private static final int BUCKET_ID = 0;
+
+    @Test
+    void runtimeFailoverReassignsReturnedSplitWithLiveOffset() throws Exception {
+        FlussSourceSplit restored =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 500L, Long.MAX_VALUE);
+        FlussSourceState restoreState =
+                new FlussSourceState(new HashSet<>(Collections.singletonList(restored)));
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, restoreState, true);
+
+        enumerator.run();
+        context.clearAssignments();
+
+        // Reader 0 fails after making progress; its split is returned carrying the live position.
+        FlussSourceSplit returned =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 800L, Long.MAX_VALUE);
+        enumerator.addSplitsBack(Collections.singletonList(returned), 0);
+
+        List<FlussSourceSplit> reassigned = context.getAllAssignedSplits();
+        Assertions.assertEquals(1, reassigned.size(), "Returned split must be reassigned once");
+        Assertions.assertEquals(
+                800L,
+                reassigned.get(0).getStartOffset(),
+                "Runtime failover must reassign the returned split at its live offset");
+    }
+
+    @Test
+    void batchRunSignalsNoMoreSplitsOncePerReader() throws Exception {
+        FlussSourceSplit split = new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 0L, 100L);
+        FlussSourceState restoreState =
+                new FlussSourceState(new HashSet<>(Collections.singletonList(split)));
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, restoreState, false); // batch
+
+        enumerator.run();
+        enumerator.run(); // idempotent: must not signal twice
+
+        Assertions.assertEquals(
+                Collections.singletonList(0),
+                context.getNoMoreSplitsSignals(),
+                "Batch reader must be signalled no-more-splits exactly once");
+    }
+
+    @Test
+    void streamingRunDoesNotSignalNoMoreSplits() throws Exception {
+        FlussSourceSplit split =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 0L, Long.MAX_VALUE);
+        FlussSourceState restoreState =
+                new FlussSourceState(new HashSet<>(Collections.singletonList(split)));
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, restoreState, true); // streaming
+
+        enumerator.run();
+
+        Assertions.assertTrue(
+                context.getNoMoreSplitsSignals().isEmpty(),
+                "Streaming reader must never be signalled no-more-splits");
+    }
+
+    @Test
+    void lateRegisterReaderTriggersAssignment() throws Exception {
+        FlussSourceSplit split =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 0L, Long.MAX_VALUE);
+        FlussSourceState restoreState =
+                new FlussSourceState(new HashSet<>(Collections.singletonList(split)));
+        // No readers registered yet.
+        TestingEnumeratorContext context = new TestingEnumeratorContext(1, new HashSet<>());
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, restoreState, true);
+
+        enumerator.run();
+        Assertions.assertTrue(
+                context.getAllAssignedSplits().isEmpty(),
+                "Nothing can be assigned before any reader registers");
+
+        context.registeredReaders().add(0);
+        enumerator.registerReader(0);
+
+        Assertions.assertEquals(
+                1,
+                context.getAllAssignedSplits().size(),
+                "Registering a reader after run() must assign the pending split");
+    }
+
+    @Test
+    void snapshotPersistsOnlyUnassignedSplits() throws Exception {
+        FlussSourceSplit bucket0 =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, 0, 0L, Long.MAX_VALUE);
+        FlussSourceSplit bucket1 =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, 1, 0L, Long.MAX_VALUE);
+        FlussSourceState restoreState =
+                new FlussSourceState(new HashSet<>(Arrays.asList(bucket0, bucket1)));
+        // parallelism 2 with only reader 0 registered: consecutive bucket ids hash to different
+        // owners, so exactly one split is assigned and the other stays pending.
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(2, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, restoreState, true);
+
+        enumerator.run();
+
+        List<FlussSourceSplit> assigned = context.getAllAssignedSplits();
+        Assertions.assertEquals(
+                1,
+                assigned.size(),
+                "Exactly one of the two buckets should be assigned to reader 0");
+
+        Set<FlussSourceSplit> persisted = enumerator.snapshotState(1L).getPendingSplits();
+        Assertions.assertEquals(
+                1, persisted.size(), "Snapshot must persist only the unassigned split");
+        Assertions.assertFalse(
+                persisted.contains(assigned.get(0)),
+                "The reader-owned (assigned) split must be absent from the snapshot");
+    }
+
+    @Test
+    void restoredEnumeratorNeitherRediscoversNorRedispatches() {
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(
+                        null, context, new FlussSourceState(new HashSet<>()), true);
+
+        Assertions.assertDoesNotThrow(enumerator::run, "Restored enumerator must skip discovery");
+
+        Assertions.assertTrue(
+                context.getAllAssignedSplits().isEmpty(),
+                "Restored enumerator with an empty backlog must dispatch nothing to readers");
+        Assertions.assertEquals(
+                0,
+                enumerator.snapshotState(1L).getPendingSplits().size(),
+                "Nothing to persist when the restored backlog is empty");
+    }
+
+    @Test
+    void handleSplitRequestThrows() {
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(null, context, null, true);
+
+        Assertions.assertThrows(
+                UnsupportedOperationException.class, () -> enumerator.handleSplitRequest(0));
+    }
+
+    @Test
+    void addSplitsBackIgnoresNullAndEmpty() {
+        TestingEnumeratorContext context =
+                new TestingEnumeratorContext(1, new HashSet<>(Collections.singletonList(0)));
+        FlussSourceSplitEnumerator enumerator =
+                new FlussSourceSplitEnumerator(
+                        null, context, new FlussSourceState(new HashSet<>()), true);
+
+        enumerator.addSplitsBack(null, 0);
+        enumerator.addSplitsBack(Collections.emptyList(), 0);
+
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
+        Assertions.assertTrue(context.getAllAssignedSplits().isEmpty());
+    }
+
+    private static final class TestingEnumeratorContext
+            implements SourceSplitEnumerator.Context<FlussSourceSplit> {
+        private final int parallelism;
+        private final Set<Integer> registeredReaders;
+        private final Map<Integer, List<FlussSourceSplit>> assignedSplitsByReader = new HashMap<>();
+        private final List<Integer> noMoreSplitsSignals = new ArrayList<>();
+        private final MetricsContext metricsContext = new AbstractMetricsContext() {};
+        private final EventListener eventListener =
+                new EventListener() {
+                    @Override
+                    public void onEvent(Event event) {
+                        // no-op
+                    }
+                };
+
+        private TestingEnumeratorContext(int parallelism, Set<Integer> registeredReaders) {
+            this.parallelism = parallelism;
+            this.registeredReaders = registeredReaders;
+        }
+
+        @Override
+        public int currentParallelism() {
+            return parallelism;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return registeredReaders;
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<FlussSourceSplit> splits) {
+            assignedSplitsByReader
+                    .computeIfAbsent(subtaskId, ignored -> new ArrayList<>())
+                    .addAll(splits);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            noMoreSplitsSignals.add(subtask);
+        }
+
+        @Override
+        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+            // no-op
+        }
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return metricsContext;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return eventListener;
+        }
+
+        private List<FlussSourceSplit> getAllAssignedSplits() {
+            return assignedSplitsByReader.values().stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+        }
+
+        private List<Integer> getNoMoreSplitsSignals() {
+            return noMoreSplitsSignals;
+        }
+
+        private void clearAssignments() {
+            assignedSplitsByReader.clear();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReaderTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReaderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.fluss.source;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsAddition;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsChange;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.fluss.client.table.scanner.log.LogScanner;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the reader's assignment-time / restore decisions:
+ *
+ * <ul>
+ *   <li>{@code isDrainedAtAssignment} — the local, earliest-free check that a bounded split whose
+ *       recorded start already reaches its end has nothing to read.
+ *   <li>the {@code handleSplitsChanges} split-change-type guard.
+ *   <li>the behavioral wiring that a fully consumed restore split is reported finished on the next
+ *       {@code fetch()} without ever subscribing.
+ * </ul>
+ */
+class FlussSourceSplitReaderTest {
+
+    private static final long EARLIEST_SENTINEL = LogScanner.EARLIEST_OFFSET;
+    private static final long UNBOUNDED = Long.MAX_VALUE;
+
+    private static final TablePath TABLE_PATH = TablePath.of("fluss_db", "fluss_tbl");
+    private static final long TABLE_ID = 1L;
+    private static final int BUCKET_ID = 0;
+
+    @Test
+    void fullyConsumedRestoreSplitIsDrainedAtAssignment() {
+        Assertions.assertTrue(FlussSourceSplitReader.isDrainedAtAssignment(100L, 100L));
+        Assertions.assertTrue(FlussSourceSplitReader.isDrainedAtAssignment(150L, 100L));
+    }
+
+    @Test
+    void partiallyConsumedRestoreSplitIsNotDrainedAtAssignment() {
+        Assertions.assertFalse(FlussSourceSplitReader.isDrainedAtAssignment(50L, 100L));
+        Assertions.assertFalse(FlussSourceSplitReader.isDrainedAtAssignment(0L, 100L));
+    }
+
+    @Test
+    void freshSplitIsNotDrainedAtAssignmentUnlessEmpty() {
+        Assertions.assertFalse(
+                FlussSourceSplitReader.isDrainedAtAssignment(EARLIEST_SENTINEL, 100L));
+        Assertions.assertTrue(FlussSourceSplitReader.isDrainedAtAssignment(EARLIEST_SENTINEL, 0L));
+    }
+
+    @Test
+    void streamingSplitIsNeverDrainedAtAssignment() {
+        Assertions.assertFalse(
+                FlussSourceSplitReader.isDrainedAtAssignment(EARLIEST_SENTINEL, UNBOUNDED));
+        Assertions.assertFalse(FlussSourceSplitReader.isDrainedAtAssignment(1000L, UNBOUNDED));
+    }
+
+    @Test
+    void handleSplitsChangesRejectsNonAddition() {
+        FlussSourceSplitReader reader = new FlussSourceSplitReader(newMockConfig());
+        SplitsChange<FlussSourceSplit> nonAddition =
+                new UnsupportedSplitsChange(
+                        Collections.singletonList(
+                                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 0L, 100L)));
+
+        Assertions.assertThrows(
+                UnsupportedOperationException.class, () -> reader.handleSplitsChanges(nonAddition));
+    }
+
+    @Test
+    void fullyConsumedRestoreSplitIsFinishedWithoutSubscribing() throws Exception {
+        FlussSourceSplitReader reader = new FlussSourceSplitReader(newMockConfig());
+        FlussSourceSplit drained =
+                new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, 100L, 100L);
+
+        reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(drained)));
+
+        RecordsWithSplitIds<FlussRecord> records = reader.fetch();
+        Assertions.assertEquals(
+                Collections.singleton(drained.splitId()),
+                records.finishedSplits(),
+                "A drained restore split must be reported finished without subscribing");
+        Assertions.assertNull(
+                records.nextSplit(), "No split should carry records for a drained assignment");
+    }
+
+    private static FlussSourceConfig newMockConfig() {
+        FlussSourceConfig config = mock(FlussSourceConfig.class);
+        when(config.getPollTimeoutMs()).thenReturn(10L);
+        return config;
+    }
+
+    private static final class UnsupportedSplitsChange extends SplitsChange<FlussSourceSplit> {
+        private UnsupportedSplitsChange(Collection<FlussSourceSplit> splits) {
+            super(splits);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReaderTest.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/test/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitReaderTest.java
@@ -25,12 +25,22 @@ import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreade
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.alibaba.fluss.client.table.Table;
 import com.alibaba.fluss.client.table.scanner.log.LogScanner;
+import com.alibaba.fluss.client.table.scanner.log.ScanRecords;
+import com.alibaba.fluss.exception.FetchException;
+import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
+import com.alibaba.fluss.types.DataField;
+import com.alibaba.fluss.types.DataTypes;
+import com.alibaba.fluss.types.RowType;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -108,10 +118,161 @@ class FlussSourceSplitReaderTest {
                 records.nextSplit(), "No split should carry records for a drained assignment");
     }
 
+    @Test
+    void emptyPollProducesNoRecordsAndNoFinishedSplits() throws Exception {
+        LogScanner scanner = mock(LogScanner.class);
+        ScanRecords empty = mock(ScanRecords.class);
+        when(empty.buckets()).thenReturn(Collections.emptySet());
+        when(scanner.poll(any(Duration.class))).thenReturn(empty);
+        FlussAdminClient admin = mock(FlussAdminClient.class);
+
+        TestReader reader = new TestReader(newMockConfig(), scanner, admin);
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split(0L, UNBOUNDED))));
+
+        RecordsWithSplitIds<FlussRecord> records = reader.fetch();
+
+        Assertions.assertNull(records.nextSplit(), "No split should carry records");
+        Assertions.assertTrue(records.finishedSplits().isEmpty(), "Nothing should be finished");
+        verify(scanner).subscribe(BUCKET_ID, 0L);
+        verify(scanner).poll(any(Duration.class));
+    }
+
+    @Test
+    void outOfRangeResetsLaggingBucketToEarliestAndDoesNotThrow() throws Exception {
+        LogScanner scanner = mock(LogScanner.class);
+        // A restored bucket subscribed at 100 whose offset retention discarded.
+        RuntimeException outOfRange = outOfRangeFetchException();
+        when(scanner.poll(any(Duration.class))).thenThrow(outOfRange);
+
+        FlussAdminClient admin = mock(FlussAdminClient.class);
+        // earliest advanced to 200, past the lagging nextOffset 100 -> recoverable truncation.
+        when(admin.earliestOffsets(any(), any()))
+                .thenReturn(Collections.singletonMap(BUCKET_ID, 200L));
+
+        TestReader reader = new TestReader(newMockConfig(), scanner, admin);
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split(100L, UNBOUNDED))));
+
+        RecordsWithSplitIds<FlussRecord> records = reader.fetch(); // must NOT throw
+
+        Assertions.assertTrue(records.finishedSplits().isEmpty());
+        verify(scanner).subscribe(BUCKET_ID, 100L); // initial assignment subscribe
+        verify(scanner).subscribe(BUCKET_ID, 200L); // reset to earliest
+    }
+
+    @Test
+    void outOfRangeWithNothingBehindEarliestRethrows() throws Exception {
+        LogScanner scanner = mock(LogScanner.class);
+        RuntimeException outOfRange = outOfRangeFetchException();
+        when(scanner.poll(any(Duration.class))).thenThrow(outOfRange);
+
+        FlussAdminClient admin = mock(FlussAdminClient.class);
+        // earliest == nextOffset -> no bucket is behind earliest -> not a front-side
+        // truncation.
+        when(admin.earliestOffsets(any(), any()))
+                .thenReturn(Collections.singletonMap(BUCKET_ID, 100L));
+
+        TestReader reader = new TestReader(newMockConfig(), scanner, admin);
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split(100L, UNBOUNDED))));
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, reader::fetch);
+        // The original out-of-range surfaces (its cause is the
+        // LogOffsetOutOfRangeException).
+        Assertions.assertSame(outOfRange, thrown);
+        // Only the assignment-time subscribe; no reset subscribe.
+        verify(scanner).subscribe(BUCKET_ID, 100L);
+    }
+
+    @Test
+    void boundedSentinelBucketDrainedByRetentionIsFinished() throws Exception {
+        LogScanner scanner = mock(LogScanner.class);
+        ScanRecords empty = mock(ScanRecords.class);
+        when(empty.buckets()).thenReturn(Collections.emptySet());
+        when(scanner.poll(any(Duration.class))).thenReturn(empty);
+
+        FlussAdminClient admin = mock(FlussAdminClient.class);
+        // earliest (60) has reached/passed the bounded end (50): the bucket is drained empty.
+        when(admin.earliestOffsets(any(), any()))
+                .thenReturn(Collections.singletonMap(BUCKET_ID, 60L));
+
+        TestReader reader = new TestReader(newMockConfig(), scanner, admin);
+        // Bounded split still on the -2 sentinel (never overruns, so no exception fires).
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split(EARLIEST_SENTINEL, 50L))));
+
+        RecordsWithSplitIds<FlussRecord> records = reader.fetch();
+
+        Assertions.assertEquals(
+                Collections.singleton(split(EARLIEST_SENTINEL, 50L).splitId()),
+                records.finishedSplits(),
+                "A bounded sentinel bucket whose earliest reached its end must be finished");
+    }
+
+    @Test
+    void boundedSentinelBucketNotFinishedWhenEarliestBelowEnd() throws Exception {
+        LogScanner scanner = mock(LogScanner.class);
+        ScanRecords empty = mock(ScanRecords.class);
+        when(empty.buckets()).thenReturn(Collections.emptySet());
+        when(scanner.poll(any(Duration.class))).thenReturn(empty);
+
+        FlussAdminClient admin = mock(FlussAdminClient.class);
+        // earliest (40) is still below the bounded end (50): data may still arrive; do not finish.
+        when(admin.earliestOffsets(any(), any()))
+                .thenReturn(Collections.singletonMap(BUCKET_ID, 40L));
+
+        TestReader reader = new TestReader(newMockConfig(), scanner, admin);
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(Collections.singletonList(split(EARLIEST_SENTINEL, 50L))));
+
+        RecordsWithSplitIds<FlussRecord> records = reader.fetch();
+
+        Assertions.assertTrue(
+                records.finishedSplits().isEmpty(),
+                "A sentinel bucket must not finish while earliest is below its end offset");
+    }
+
     private static FlussSourceConfig newMockConfig() {
         FlussSourceConfig config = mock(FlussSourceConfig.class);
         when(config.getPollTimeoutMs()).thenReturn(10L);
         return config;
+    }
+
+    private static FlussSourceSplit split(long startOffset, long endOffset) {
+        return new FlussSourceSplit(TABLE_PATH, TABLE_ID, BUCKET_ID, startOffset, endOffset);
+    }
+
+    private static RuntimeException outOfRangeFetchException() {
+        LogOffsetOutOfRangeException cause = mock(LogOffsetOutOfRangeException.class);
+        FetchException e = mock(FetchException.class);
+        when(e.getCause()).thenReturn(cause);
+        return e;
+    }
+
+    private static RowType oneIntRowType() {
+        return new RowType(Collections.singletonList(new DataField("f0", DataTypes.INT())));
+    }
+
+    private static final class TestReader extends FlussSourceSplitReader {
+        private final LogScanner logScanner;
+        private final FlussAdminClient admin;
+
+        TestReader(FlussSourceConfig config, LogScanner logScanner, FlussAdminClient admin) {
+            super(config);
+            this.logScanner = logScanner;
+            this.admin = admin;
+        }
+
+        @Override
+        FlussAdminClient adminClient() {
+            return admin;
+        }
+
+        @Override
+        TableScan createTableScan() {
+            return new TableScan(TABLE_PATH, mock(Table.class), logScanner, oneIntRowType());
+        }
     }
 
     private static final class UnsupportedSplitsChange extends SplitsChange<FlussSourceSplit> {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussSinkIT.java
@@ -17,72 +17,32 @@
 
 package org.apache.seatunnel.e2e.connector.fluss;
 
-import org.apache.seatunnel.shade.com.google.common.collect.Lists;
-
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerLoggerFactory;
 
 import com.alibaba.fluss.client.Connection;
-import com.alibaba.fluss.client.ConnectionFactory;
-import com.alibaba.fluss.client.admin.Admin;
 import com.alibaba.fluss.client.table.Table;
 import com.alibaba.fluss.client.table.scanner.ScanRecord;
 import com.alibaba.fluss.client.table.scanner.log.LogScanner;
 import com.alibaba.fluss.client.table.scanner.log.ScanRecords;
-import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.metadata.DatabaseDescriptor;
-import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
-import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.row.GenericRow;
 import com.alibaba.fluss.row.InternalRow;
-import com.alibaba.fluss.types.DataTypes;
 import com.alibaba.fluss.utils.CloseableIterator;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.net.Socket;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import static org.awaitility.Awaitility.given;
 
 @Slf4j
-public class FlussSinkIT extends TestSuiteBase implements TestResource {
-    private static final String DOCKER_IMAGE = "fluss/fluss:0.7.0";
-    private static final String DOCKER_ZK_IMAGE = "zookeeper:3.9.2";
-
-    private static final String FLUSS_Coordinator_HOST = "fluss_coordinator_e2e";
-    private static final String FLUSS_Tablet_HOST = "fluss_tablet_e2e";
-    private static final String ZK_HOST = "zk_e2e";
-    private static final int ZK_PORT = 2181;
-    private static final int FLUSS_Coordinator_PORT = 9123;
-    private static final int FLUSS_Tablet_PORT = 9124;
-    private static final int FLUSS_Coordinator_LOCAL_PORT = 8123;
-    private static final int FLUSS_Tablet_LOCAL_PORT = 8124;
-
-    private GenericContainer<?> zookeeperServer;
-    private GenericContainer<?> coordinatorServer;
-    private GenericContainer<?> tabletServer;
-
-    private Connection flussConnection;
+public class FlussSinkIT extends FlussTestBase {
 
     private static final String DB_NAME = "fluss_db_test";
     private static final String DB_NAME_2 = "fluss_db_test2";
@@ -90,187 +50,6 @@ public class FlussSinkIT extends TestSuiteBase implements TestResource {
     private static final String TABLE_NAME = "fluss_tb_table1";
     private static final String TABLE_NAME_2 = "fluss_tb_table2";
     private static final String TABLE_NAME_3 = "fluss_tb_table3";
-
-    @BeforeAll
-    @Override
-    public void startUp() {
-        createZookeeperContainer();
-        createFlussContainer();
-    }
-
-    private void createFlussContainer() {
-        log.info("Starting FlussServer container...");
-        String coordinatorEnv =
-                String.format(
-                        "zookeeper.address: %s:%d\n"
-                                + "bind.listeners: INTERNAL://%s:%d, LOCALCLIENT://%s:%d \n"
-                                + "advertised.listeners: INTERNAL://%s:%d, LOCALCLIENT://localhost:%d\n"
-                                + "internal.listener.name: INTERNAL",
-                        ZK_HOST,
-                        ZK_PORT,
-                        FLUSS_Coordinator_HOST,
-                        FLUSS_Coordinator_PORT,
-                        FLUSS_Coordinator_HOST,
-                        FLUSS_Coordinator_LOCAL_PORT,
-                        FLUSS_Coordinator_HOST,
-                        FLUSS_Coordinator_PORT,
-                        FLUSS_Coordinator_LOCAL_PORT);
-        coordinatorServer =
-                new GenericContainer<>(DOCKER_IMAGE)
-                        .withNetwork(NETWORK)
-                        .withNetworkAliases(FLUSS_Coordinator_HOST)
-                        .withEnv("FLUSS_PROPERTIES", coordinatorEnv)
-                        .withCommand("coordinatorServer")
-                        .withLogConsumer(
-                                new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger("coordinatorServer")));
-        coordinatorServer.setPortBindings(
-                Lists.newArrayList(
-                        String.format(
-                                "%s:%s",
-                                FLUSS_Coordinator_LOCAL_PORT, FLUSS_Coordinator_LOCAL_PORT)));
-        Startables.deepStart(Stream.of(coordinatorServer)).join();
-        given().ignoreExceptions()
-                .await()
-                .atMost(120, TimeUnit.SECONDS)
-                .pollInterval(5, TimeUnit.SECONDS)
-                .until(
-                        () ->
-                                checkPort(
-                                        coordinatorServer.getHost(),
-                                        FLUSS_Coordinator_LOCAL_PORT,
-                                        1000));
-        log.info("coordinatorServer container start success");
-
-        String tabletEnv =
-                String.format(
-                        "zookeeper.address: %s:%d\n"
-                                + "bind.listeners: INTERNAL://%s:%d, LOCALCLIENT://%s:%d\n"
-                                + "advertised.listeners: INTERNAL://%s:%d, LOCALCLIENT://localhost:%d\n"
-                                + "internal.listener.name: INTERNAL\n"
-                                + "tablet-server.id: 0\n"
-                                + "kv.snapshot.interval: 0s\n"
-                                + "data.dir: /tmp/fluss/data\n"
-                                + "remote.data.dir: /tmp/fluss/remote-data",
-                        ZK_HOST,
-                        ZK_PORT,
-                        FLUSS_Tablet_HOST,
-                        FLUSS_Tablet_PORT,
-                        FLUSS_Tablet_HOST,
-                        FLUSS_Tablet_LOCAL_PORT,
-                        FLUSS_Tablet_HOST,
-                        FLUSS_Tablet_PORT,
-                        FLUSS_Tablet_LOCAL_PORT);
-        tabletServer =
-                new GenericContainer<>(DOCKER_IMAGE)
-                        .withNetwork(NETWORK)
-                        .withNetworkAliases(FLUSS_Tablet_HOST)
-                        .withEnv("FLUSS_PROPERTIES", tabletEnv)
-                        .withCommand("tabletServer")
-                        .withLogConsumer(
-                                new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger("tabletServer")));
-        tabletServer.setPortBindings(
-                Lists.newArrayList(
-                        String.format("%s:%s", FLUSS_Tablet_LOCAL_PORT, FLUSS_Tablet_LOCAL_PORT)));
-        Startables.deepStart(Stream.of(tabletServer)).join();
-        given().ignoreExceptions()
-                .await()
-                .atMost(120, TimeUnit.SECONDS)
-                .pollInterval(5, TimeUnit.SECONDS)
-                .untilAsserted(this::initializeConnection);
-        log.info("tabletServer container start success");
-        log.info("FlussServer Containers are started");
-    }
-
-    private void createZookeeperContainer() {
-        log.info("Starting ZookeeperServer container...");
-        zookeeperServer =
-                new GenericContainer<>(DOCKER_ZK_IMAGE)
-                        .withNetwork(NETWORK)
-                        .withNetworkAliases(ZK_HOST)
-                        .withLogConsumer(
-                                new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger(DOCKER_ZK_IMAGE)));
-        zookeeperServer.setPortBindings(
-                Lists.newArrayList(String.format("%s:%s", ZK_PORT, ZK_PORT)));
-        Startables.deepStart(Stream.of(zookeeperServer)).join();
-        given().ignoreExceptions()
-                .await()
-                .atMost(60, TimeUnit.SECONDS)
-                .pollInterval(5, TimeUnit.SECONDS)
-                .until(() -> checkPort(zookeeperServer.getHost(), ZK_PORT, 1000));
-        log.info("ZookeeperServer Containers are started");
-    }
-
-    private void initializeConnection() throws ExecutionException, InterruptedException {
-        Configuration flussConfig = new Configuration();
-        flussConfig.setString(
-                "bootstrap.servers",
-                coordinatorServer.getHost() + ":" + FLUSS_Coordinator_LOCAL_PORT);
-        flussConnection = ConnectionFactory.createConnection(flussConfig);
-        createDb(flussConnection, DB_NAME);
-    }
-
-    public void createDb(Connection connection, String dbName)
-            throws ExecutionException, InterruptedException {
-        Admin admin = connection.getAdmin();
-        DatabaseDescriptor descriptor = DatabaseDescriptor.builder().build();
-        admin.dropDatabase(dbName, true, true).get();
-        admin.createDatabase(dbName, descriptor, true).get();
-    }
-
-    public Schema getFlussSchema() {
-        return Schema.newBuilder()
-                .column("fbytes", DataTypes.BYTES())
-                .column("fboolean", DataTypes.BOOLEAN())
-                .column("fint", DataTypes.INT())
-                .column("ftinyint", DataTypes.TINYINT())
-                .column("fsmallint", DataTypes.SMALLINT())
-                .column("fbigint", DataTypes.BIGINT())
-                .column("ffloat", DataTypes.FLOAT())
-                .column("fdouble", DataTypes.DOUBLE())
-                .column("fdecimal", DataTypes.DECIMAL(30, 8))
-                .column("fstring", DataTypes.STRING())
-                .column("fdate", DataTypes.DATE())
-                .column("ftime", DataTypes.TIME())
-                .column("ftimestamp", DataTypes.TIMESTAMP())
-                .column("ftimestamp_ltz", DataTypes.TIMESTAMP_LTZ())
-                .primaryKey("fstring")
-                .build();
-    }
-
-    public void createTable(Connection connection, String dbName, String tableName, Schema schema)
-            throws ExecutionException, InterruptedException {
-        Admin admin = connection.getAdmin();
-        TableDescriptor tableDescriptor = TableDescriptor.builder().schema(schema).build();
-        TablePath tablePath = TablePath.of(dbName, tableName);
-        admin.dropTable(tablePath, true).get();
-        admin.createTable(tablePath, tableDescriptor, true).get(); // blocking call
-    }
-
-    public static boolean checkPort(String host, int port, int timeoutMs) throws IOException {
-        try (Socket socket = new Socket()) {
-            socket.connect(new java.net.InetSocketAddress(host, port), timeoutMs);
-            return true;
-        } catch (Exception e) {
-            throw e;
-        }
-    }
-
-    @AfterAll
-    @Override
-    public void tearDown() throws Exception {
-        if (tabletServer != null) {
-            tabletServer.close();
-        }
-        if (coordinatorServer != null) {
-            coordinatorServer.close();
-        }
-        if (zookeeperServer != null) {
-            zookeeperServer.close();
-        }
-    }
 
     @TestTemplate
     public void testFlussSink(TestContainer container) throws Exception {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussSourceIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussSourceIT.java
@@ -1,0 +1,413 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.fluss;
+
+import org.apache.seatunnel.e2e.common.container.EngineType;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+
+import com.alibaba.fluss.client.table.Table;
+import com.alibaba.fluss.client.table.scanner.ScanRecord;
+import com.alibaba.fluss.client.table.scanner.log.LogScanner;
+import com.alibaba.fluss.client.table.scanner.log.ScanRecords;
+import com.alibaba.fluss.client.table.writer.AppendWriter;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.row.BinaryString;
+import com.alibaba.fluss.row.Decimal;
+import com.alibaba.fluss.row.GenericRow;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+import com.alibaba.fluss.types.DataTypes;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
+
+@Slf4j
+public class FlussSourceIT extends FlussTestBase {
+
+    private static final String DB_NAME = "fluss_source_db";
+    private static final String TABLE_NAME = "fluss_source_tb";
+    private static final String ALL_TYPES_TABLE = "fluss_all_types_tb";
+
+    private static final String STREAM_DB = "fluss_stream_db";
+    private static final String STREAM_SRC_TABLE = "fluss_stream_src";
+    private static final String STREAM_SINK_TABLE = "fluss_stream_sink";
+
+    private static final String LATEST_DB = "fluss_latest_db";
+    private static final String LATEST_SRC_TABLE = "fluss_latest_src";
+    private static final String LATEST_SINK_TABLE = "fluss_latest_sink";
+
+    private static final Object[][] ROWS = {
+        {1, "Alice", 20, 98.5d, true},
+        {2, "Bob", 31, 88.0d, false},
+        {3, "Carol", 42, 77.5d, true},
+    };
+
+    // ---------------------------------------------------------------------------------------------
+    // BATCH: multi-row read, count + per-column type + value-range validation.
+    // ---------------------------------------------------------------------------------------------
+    @TestTemplate
+    public void testFlussSource(TestContainer container) throws Exception {
+        createDb(flussConnection, DB_NAME);
+        createTable(flussConnection, DB_NAME, TABLE_NAME, getSourceSchema());
+        writeRows(DB_NAME, TABLE_NAME);
+
+        Container.ExecResult execResult = container.executeJob("/fluss_to_assert.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // BATCH: single row across the full type matrix, exact per-column value validation.
+    // ---------------------------------------------------------------------------------------------
+    @TestTemplate
+    public void testFlussSourceAllTypes(TestContainer container) throws Exception {
+        createDb(flussConnection, DB_NAME);
+        createTable(flussConnection, DB_NAME, ALL_TYPES_TABLE, getAllTypesSchema());
+        writeAllTypesRow(DB_NAME, ALL_TYPES_TABLE);
+
+        Container.ExecResult execResult = container.executeJob("/fluss_all_types_to_assert.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // STREAMING: unbounded read must keep discovering rows appended after the job starts.
+    // Zeta-only: the async run + status/cancel dance uses Zeta-only container APIs (getJobStatus /
+    // cancelJob), so Flink/Spark are excluded permanently (their streaming path is exercised
+    // elsewhere).
+    // ---------------------------------------------------------------------------------------------
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason = "Uses Zeta-only job status / cancel APIs")
+    public void testFlussSourceStreaming(TestContainer container) throws Exception {
+        createDb(flussConnection, STREAM_DB);
+        createTable(flussConnection, STREAM_DB, STREAM_SRC_TABLE, getStreamSchema());
+        createTable(flussConnection, STREAM_DB, STREAM_SINK_TABLE, getStreamSchema());
+
+        // Rows written before the job starts: an earliest streaming read must pick them up.
+        appendStreamRows(STREAM_SRC_TABLE, new Object[][] {{1, "a"}, {2, "b"}});
+
+        // Zeta's REST API parses the job id as a long, so it must be numeric.
+        String jobId = "96481357024680";
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        container.executeJob("/fluss_streaming_to_fluss.conf", jobId);
+                    } catch (Exception e) {
+                        log.error("Streaming job execution failed", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        awaitJobRunning(container, jobId);
+
+        // The two pre-start rows must arrive in the sink.
+        await().atMost(3, TimeUnit.MINUTES)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        new HashSet<>(Arrays.asList("a", "b")),
+                                        readSinkNames(STREAM_DB, STREAM_SINK_TABLE)));
+
+        // Rows appended while the job is running must be discovered by the unbounded read.
+        appendStreamRows(STREAM_SRC_TABLE, new Object[][] {{3, "c"}, {4, "d"}, {5, "e"}});
+
+        await().atMost(3, TimeUnit.MINUTES)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        new HashSet<>(Arrays.asList("a", "b", "c", "d", "e")),
+                                        readSinkNames(STREAM_DB, STREAM_SINK_TABLE)));
+
+        container.cancelJob(jobId);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // STREAMING + start_mode=latest: only rows appended AFTER the job starts must be read; rows
+    // written before the job starts must be skipped. Zeta-only for the same reason as the earliest
+    // streaming test (async run + Zeta-only job status / cancel APIs).
+    // ---------------------------------------------------------------------------------------------
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason = "Uses Zeta-only job status / cancel APIs")
+    public void testFlussSourceStreamingLatest(TestContainer container) throws Exception {
+        createDb(flussConnection, LATEST_DB);
+        createTable(flussConnection, LATEST_DB, LATEST_SRC_TABLE, getStreamSchema());
+        createTable(flussConnection, LATEST_DB, LATEST_SINK_TABLE, getStreamSchema());
+
+        // Rows written before the job starts: a latest streaming read must NOT pick them up.
+        appendStreamRows(LATEST_DB, LATEST_SRC_TABLE, new Object[][] {{1, "old1"}, {2, "old2"}});
+
+        // Zeta's REST API parses the job id as a long, so it must be numeric.
+        String jobId = "96481357024681";
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        container.executeJob("/fluss_streaming_latest_to_fluss.conf", jobId);
+                    } catch (Exception e) {
+                        log.error("Streaming (latest) job execution failed", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        awaitJobRunning(container, jobId);
+
+        // The enumerator captures the bucket tail inside run(), which can lag behind the job
+        // reaching RUNNING. Appending the asserted rows before that capture would place them
+        // at/behind the captured latest offset and skip them (flaky on slow machines). So first
+        // drive unique sync rows until one surfaces in the sink: that proves the reader is live and
+        // has advanced past the pre-start tail, after which any appended row is strictly newer.
+        AtomicInteger syncSeq = new AtomicInteger();
+        await().atMost(2, TimeUnit.MINUTES)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            int id = 100 + syncSeq.incrementAndGet();
+                            appendStreamRows(
+                                    LATEST_DB,
+                                    LATEST_SRC_TABLE,
+                                    new Object[][] {{id, "sync" + id}});
+                            Assertions.assertTrue(
+                                    readSinkNames(LATEST_DB, LATEST_SINK_TABLE).stream()
+                                            .anyMatch(name -> name.startsWith("sync")),
+                                    "Reader is not yet live past the pre-start tail");
+                        });
+
+        // The reader is live now: rows appended here are strictly after the captured latest offset.
+        appendStreamRows(
+                LATEST_DB,
+                LATEST_SRC_TABLE,
+                new Object[][] {{3, "new3"}, {4, "new4"}, {5, "new5"}});
+
+        await().atMost(3, TimeUnit.MINUTES)
+                .pollInterval(3, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertTrue(
+                                        readSinkNames(LATEST_DB, LATEST_SINK_TABLE)
+                                                .containsAll(Arrays.asList("new3", "new4", "new5")),
+                                        "All post-start rows must be read"));
+
+        // latest semantics: the two pre-start rows must never be read.
+        Set<String> sinkNames = readSinkNames(LATEST_DB, LATEST_SINK_TABLE);
+        Assertions.assertFalse(
+                sinkNames.contains("old1") || sinkNames.contains("old2"),
+                "Pre-start rows must be skipped by latest, but sink was: " + sinkNames);
+
+        container.cancelJob(jobId);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Schemas
+    // ---------------------------------------------------------------------------------------------
+    private Schema getSourceSchema() {
+        return Schema.newBuilder()
+                .column("id", DataTypes.INT())
+                .column("name", DataTypes.STRING())
+                .column("age", DataTypes.INT())
+                .column("score", DataTypes.DOUBLE())
+                .column("active", DataTypes.BOOLEAN())
+                .build();
+    }
+
+    private Schema getAllTypesSchema() {
+        return Schema.newBuilder()
+                .column("fbytes", DataTypes.BYTES())
+                .column("fboolean", DataTypes.BOOLEAN())
+                .column("fint", DataTypes.INT())
+                .column("ftinyint", DataTypes.TINYINT())
+                .column("fsmallint", DataTypes.SMALLINT())
+                .column("fbigint", DataTypes.BIGINT())
+                .column("ffloat", DataTypes.FLOAT())
+                .column("fdouble", DataTypes.DOUBLE())
+                .column("fdecimal", DataTypes.DECIMAL(30, 8))
+                .column("fstring", DataTypes.STRING())
+                .column("fdate", DataTypes.DATE())
+                .column("ftime", DataTypes.TIME())
+                .column("ftimestamp", DataTypes.TIMESTAMP())
+                .column("ftimestamp_ltz", DataTypes.TIMESTAMP_LTZ())
+                .build();
+    }
+
+    private Schema getStreamSchema() {
+        return Schema.newBuilder()
+                .column("id", DataTypes.INT())
+                .column("name", DataTypes.STRING())
+                .build();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Writers
+    // ---------------------------------------------------------------------------------------------
+    private void writeRows(String dbName, String tableName) throws Exception {
+        Table table = flussConnection.getTable(TablePath.of(dbName, tableName));
+        try {
+            AppendWriter writer = table.newAppend().createWriter();
+            for (Object[] row : ROWS) {
+                GenericRow genericRow = new GenericRow(row.length);
+                genericRow.setField(0, row[0]);
+                genericRow.setField(1, BinaryString.fromString((String) row[1]));
+                genericRow.setField(2, row[2]);
+                genericRow.setField(3, row[3]);
+                genericRow.setField(4, row[4]);
+                writer.append(genericRow);
+            }
+            writer.flush();
+        } finally {
+            table.close();
+        }
+        log.info("Wrote {} rows into {}.{}", ROWS.length, dbName, tableName);
+    }
+
+    /**
+     * Writes one row exercising every Fluss data type the source converter supports. The internal
+     * representations mirror {@code FlussSinkWriter#convert}; the values are asserted back in
+     * {@code fluss_all_types_to_assert.conf}.
+     */
+    private void writeAllTypesRow(String dbName, String tableName) throws Exception {
+        Table table = flussConnection.getTable(TablePath.of(dbName, tableName));
+        try {
+            AppendWriter writer = table.newAppend().createWriter();
+            GenericRow row = new GenericRow(14);
+            row.setField(0, new byte[] {1, 2, 3}); // fbytes -> base64 "AQID"
+            row.setField(1, true); // fboolean
+            row.setField(2, 42); // fint
+            row.setField(3, (byte) 7); // ftinyint
+            row.setField(4, (short) 1000); // fsmallint
+            row.setField(5, 9000000000L); // fbigint
+            row.setField(6, 1.5f); // ffloat
+            row.setField(7, 2.5d); // fdouble
+            row.setField(8, Decimal.fromBigDecimal(new BigDecimal("123.45000000"), 30, 8));
+            row.setField(9, BinaryString.fromString("hello")); // fstring
+            row.setField(10, (int) LocalDate.parse("2025-01-15").toEpochDay()); // fdate
+            row.setField(
+                    11,
+                    (int)
+                            (LocalTime.parse("12:34:56").toNanoOfDay()
+                                    / 1_000_000)); // ftime (millis)
+            row.setField(
+                    12, TimestampNtz.fromLocalDateTime(LocalDateTime.parse("2025-01-15T12:34:56")));
+            row.setField(13, TimestampLtz.fromInstant(Instant.parse("2025-01-15T04:34:56Z")));
+            writer.append(row);
+            writer.flush();
+        } finally {
+            table.close();
+        }
+        log.info("Wrote one all-types row into {}.{}", dbName, tableName);
+    }
+
+    private void appendStreamRows(String tableName, Object[][] rows) throws Exception {
+        appendStreamRows(STREAM_DB, tableName, rows);
+    }
+
+    private void appendStreamRows(String dbName, String tableName, Object[][] rows)
+            throws Exception {
+        Table table = flussConnection.getTable(TablePath.of(dbName, tableName));
+        try {
+            AppendWriter writer = table.newAppend().createWriter();
+            for (Object[] row : rows) {
+                GenericRow genericRow = new GenericRow(2);
+                genericRow.setField(0, row[0]);
+                genericRow.setField(1, BinaryString.fromString((String) row[1]));
+                writer.append(genericRow);
+            }
+            writer.flush();
+        } finally {
+            table.close();
+        }
+        log.info("Appended {} rows into {}.{}", rows.length, dbName, tableName);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Read-back helpers
+    // ---------------------------------------------------------------------------------------------
+    /** Reads the {@code name} column of every row currently in the given log table. */
+    private Set<String> readSinkNames(String dbName, String tableName) {
+        Set<String> names = new HashSet<>();
+        Table table = flussConnection.getTable(TablePath.of(dbName, tableName));
+        LogScanner logScanner = table.newScan().createLogScanner();
+        try {
+            int numBuckets = table.getTableInfo().getNumBuckets();
+            for (int i = 0; i < numBuckets; i++) {
+                logScanner.subscribeFromBeginning(i);
+            }
+            // Poll a few times; two consecutive empty polls means the log tail is drained.
+            int emptyRounds = 0;
+            int seen = 0;
+            while (emptyRounds < 2 && seen < 1000) {
+                ScanRecords scanRecords = logScanner.poll(Duration.ofSeconds(1));
+                if (scanRecords.isEmpty()) {
+                    emptyRounds++;
+                    continue;
+                }
+                emptyRounds = 0;
+                for (TableBucket bucket : scanRecords.buckets()) {
+                    for (ScanRecord record : scanRecords.records(bucket)) {
+                        InternalRow internalRow = record.getRow();
+                        names.add(internalRow.getString(1).toString());
+                        seen++;
+                    }
+                }
+            }
+        } finally {
+            try {
+                logScanner.close();
+            } catch (Exception e) {
+                log.warn("Failed to close log scanner", e);
+            }
+            try {
+                table.close();
+            } catch (Exception e) {
+                log.warn("Failed to close table", e);
+            }
+        }
+        return names;
+    }
+
+    private void awaitJobRunning(TestContainer container, String jobId) {
+        await().atMost(2, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> Assertions.assertEquals("RUNNING", container.getJobStatus(jobId)));
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussTestBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/java/org/apache/seatunnel/e2e/connector/fluss/FlussTestBase.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.e2e.connector.fluss;
+
+import org.apache.seatunnel.shade.com.google.common.collect.Lists;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.DatabaseDescriptor;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.types.DataTypes;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.given;
+
+@Slf4j
+public abstract class FlussTestBase extends TestSuiteBase implements TestResource {
+
+    protected static final String DOCKER_IMAGE = "fluss/fluss:0.7.0";
+    protected static final String DOCKER_ZK_IMAGE = "zookeeper:3.9.2";
+
+    protected static final String FLUSS_COORDINATOR_HOST = "fluss_coordinator_e2e";
+    protected static final String FLUSS_TABLET_HOST = "fluss_tablet_e2e";
+    protected static final String ZK_HOST = "zk_e2e";
+    protected static final int ZK_PORT = 2181;
+    protected static final int FLUSS_COORDINATOR_PORT = 9123;
+    protected static final int FLUSS_TABLET_PORT = 9124;
+    protected static final int FLUSS_COORDINATOR_LOCAL_PORT = 8123;
+    protected static final int FLUSS_TABLET_LOCAL_PORT = 8124;
+
+    private GenericContainer<?> zookeeperServer;
+    private GenericContainer<?> coordinatorServer;
+    private GenericContainer<?> tabletServer;
+
+    protected Connection flussConnection;
+
+    @BeforeAll
+    @Override
+    public void startUp() {
+        createZookeeperContainer();
+        createFlussContainer();
+    }
+
+    private void createFlussContainer() {
+        log.info("Starting FlussServer container...");
+        String coordinatorEnv =
+                String.format(
+                        "zookeeper.address: %s:%d\n"
+                                + "bind.listeners: INTERNAL://%s:%d, LOCALCLIENT://%s:%d \n"
+                                + "advertised.listeners: INTERNAL://%s:%d, LOCALCLIENT://localhost:%d\n"
+                                + "internal.listener.name: INTERNAL",
+                        ZK_HOST,
+                        ZK_PORT,
+                        FLUSS_COORDINATOR_HOST,
+                        FLUSS_COORDINATOR_PORT,
+                        FLUSS_COORDINATOR_HOST,
+                        FLUSS_COORDINATOR_LOCAL_PORT,
+                        FLUSS_COORDINATOR_HOST,
+                        FLUSS_COORDINATOR_PORT,
+                        FLUSS_COORDINATOR_LOCAL_PORT);
+        coordinatorServer =
+                new GenericContainer<>(DOCKER_IMAGE)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(FLUSS_COORDINATOR_HOST)
+                        .withEnv("FLUSS_PROPERTIES", coordinatorEnv)
+                        .withCommand("coordinatorServer")
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger("coordinatorServer")));
+        coordinatorServer.setPortBindings(
+                Lists.newArrayList(
+                        String.format(
+                                "%s:%s",
+                                FLUSS_COORDINATOR_LOCAL_PORT, FLUSS_COORDINATOR_LOCAL_PORT)));
+        Startables.deepStart(Stream.of(coordinatorServer)).join();
+        given().ignoreExceptions()
+                .await()
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .until(
+                        () ->
+                                checkPort(
+                                        coordinatorServer.getHost(),
+                                        FLUSS_COORDINATOR_LOCAL_PORT,
+                                        1000));
+        log.info("coordinatorServer container start success");
+
+        String tabletEnv =
+                String.format(
+                        "zookeeper.address: %s:%d\n"
+                                + "bind.listeners: INTERNAL://%s:%d, LOCALCLIENT://%s:%d\n"
+                                + "advertised.listeners: INTERNAL://%s:%d, LOCALCLIENT://localhost:%d\n"
+                                + "internal.listener.name: INTERNAL\n"
+                                + "tablet-server.id: 0\n"
+                                + "kv.snapshot.interval: 0s\n"
+                                + "data.dir: /tmp/fluss/data\n"
+                                + "remote.data.dir: /tmp/fluss/remote-data",
+                        ZK_HOST,
+                        ZK_PORT,
+                        FLUSS_TABLET_HOST,
+                        FLUSS_TABLET_PORT,
+                        FLUSS_TABLET_HOST,
+                        FLUSS_TABLET_LOCAL_PORT,
+                        FLUSS_TABLET_HOST,
+                        FLUSS_TABLET_PORT,
+                        FLUSS_TABLET_LOCAL_PORT);
+        tabletServer =
+                new GenericContainer<>(DOCKER_IMAGE)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(FLUSS_TABLET_HOST)
+                        .withEnv("FLUSS_PROPERTIES", tabletEnv)
+                        .withCommand("tabletServer")
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger("tabletServer")));
+        tabletServer.setPortBindings(
+                Lists.newArrayList(
+                        String.format("%s:%s", FLUSS_TABLET_LOCAL_PORT, FLUSS_TABLET_LOCAL_PORT)));
+        Startables.deepStart(Stream.of(tabletServer)).join();
+        given().ignoreExceptions()
+                .await()
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .untilAsserted(this::initializeConnection);
+        log.info("tabletServer container start success");
+        log.info("FlussServer Containers are started");
+    }
+
+    private void createZookeeperContainer() {
+        log.info("Starting ZookeeperServer container...");
+        zookeeperServer =
+                new GenericContainer<>(DOCKER_ZK_IMAGE)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(ZK_HOST)
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(DOCKER_ZK_IMAGE)));
+        zookeeperServer.setPortBindings(
+                Lists.newArrayList(String.format("%s:%s", ZK_PORT, ZK_PORT)));
+        Startables.deepStart(Stream.of(zookeeperServer)).join();
+        given().ignoreExceptions()
+                .await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> checkPort(zookeeperServer.getHost(), ZK_PORT, 1000));
+        log.info("ZookeeperServer Containers are started");
+    }
+
+    private void initializeConnection() throws ExecutionException, InterruptedException {
+        Configuration flussConfig = new Configuration();
+        flussConfig.setString(
+                "bootstrap.servers",
+                coordinatorServer.getHost() + ":" + FLUSS_COORDINATOR_LOCAL_PORT);
+        flussConnection = ConnectionFactory.createConnection(flussConfig);
+        // Perform a real admin RPC so the readiness await only passes once the tablet server
+        // actually answers, not merely when the (lazy) client object is constructed.
+        flussConnection.getAdmin().listDatabases().get();
+    }
+
+    protected void createDb(Connection connection, String dbName)
+            throws ExecutionException, InterruptedException {
+        Admin admin = connection.getAdmin();
+        DatabaseDescriptor descriptor = DatabaseDescriptor.builder().build();
+        admin.dropDatabase(dbName, true, true).get();
+        admin.createDatabase(dbName, descriptor, true).get();
+    }
+
+    protected Schema getFlussSchema() {
+        return Schema.newBuilder()
+                .column("fbytes", DataTypes.BYTES())
+                .column("fboolean", DataTypes.BOOLEAN())
+                .column("fint", DataTypes.INT())
+                .column("ftinyint", DataTypes.TINYINT())
+                .column("fsmallint", DataTypes.SMALLINT())
+                .column("fbigint", DataTypes.BIGINT())
+                .column("ffloat", DataTypes.FLOAT())
+                .column("fdouble", DataTypes.DOUBLE())
+                .column("fdecimal", DataTypes.DECIMAL(30, 8))
+                .column("fstring", DataTypes.STRING())
+                .column("fdate", DataTypes.DATE())
+                .column("ftime", DataTypes.TIME())
+                .column("ftimestamp", DataTypes.TIMESTAMP())
+                .column("ftimestamp_ltz", DataTypes.TIMESTAMP_LTZ())
+                .primaryKey("fstring")
+                .build();
+    }
+
+    protected void createTable(
+            Connection connection, String dbName, String tableName, Schema schema)
+            throws ExecutionException, InterruptedException {
+        Admin admin = connection.getAdmin();
+        TableDescriptor tableDescriptor = TableDescriptor.builder().schema(schema).build();
+        TablePath tablePath = TablePath.of(dbName, tableName);
+        admin.dropTable(tablePath, true).get();
+        admin.createTable(tablePath, tableDescriptor, true).get(); // blocking call
+    }
+
+    protected static boolean checkPort(String host, int port, int timeoutMs) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new java.net.InetSocketAddress(host, port), timeoutMs);
+            return true;
+        }
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() throws Exception {
+        if (flussConnection != null) {
+            flussConnection.close();
+        }
+        if (tabletServer != null) {
+            tabletServer.close();
+        }
+        if (coordinatorServer != null) {
+            coordinatorServer.close();
+        }
+        if (zookeeperServer != null) {
+            zookeeperServer.close();
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_all_types_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_all_types_to_assert.conf
@@ -1,0 +1,117 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_source_db"
+    table = "fluss_all_types_tb"
+    plugin_output = "fluss_all_types"
+  }
+}
+
+transform {
+}
+
+sink {
+  Assert {
+    plugin_input = "fluss_all_types"
+    rules {
+      row_rules = [
+        { rule_type = MAX_ROW, rule_value = 1 },
+        { rule_type = MIN_ROW, rule_value = 1 }
+      ]
+      field_rules = [
+        {
+          field_name = fbytes
+          field_type = bytes
+          field_value = [{ equals_to = "AQID" }]
+        },
+        {
+          field_name = fboolean
+          field_type = boolean
+          field_value = [{ equals_to = true }]
+        },
+        {
+          field_name = fint
+          field_type = int
+          field_value = [{ equals_to = 42 }]
+        },
+        {
+          field_name = ftinyint
+          field_type = tinyint
+          field_value = [{ equals_to = 7 }]
+        },
+        {
+          field_name = fsmallint
+          field_type = smallint
+          field_value = [{ equals_to = 1000 }]
+        },
+        {
+          field_name = fbigint
+          field_type = bigint
+          field_value = [{ equals_to = 9000000000 }]
+        },
+        {
+          field_name = ffloat
+          field_type = float
+          field_value = [{ equals_to = 1.5 }]
+        },
+        {
+          field_name = fdouble
+          field_type = double
+          field_value = [{ equals_to = 2.5 }]
+        },
+        {
+          field_name = fdecimal
+          field_type = "decimal(30, 8)"
+          field_value = [{ equals_to = "123.45000000" }]
+        },
+        {
+          field_name = fstring
+          field_type = string
+          field_value = [{ equals_to = "hello" }]
+        },
+        {
+          field_name = fdate
+          field_type = date
+          field_value = [{ equals_to = "2025-01-15" }]
+        },
+        {
+          field_name = ftime
+          field_type = time
+          field_value = [{ equals_to = "12:34:56" }]
+        },
+        {
+          field_name = ftimestamp
+          field_type = timestamp
+          field_value = [{ equals_to = "2025-01-15T12:34:56" }]
+        },
+        {
+          field_name = ftimestamp_ltz
+          field_type = timestamp_tz
+          field_value = [{ equals_to = "2025-01-15T04:34:56Z" }]
+        }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_streaming_latest_to_fluss.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_streaming_latest_to_fluss.conf
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_latest_db"
+    table = "fluss_latest_src"
+    start_mode = "latest"
+    plugin_output = "fluss_latest"
+  }
+}
+
+transform {
+}
+
+sink {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_latest_db"
+    table = "fluss_latest_sink"
+    plugin_input = "fluss_latest"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_streaming_to_fluss.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_streaming_to_fluss.conf
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_stream_db"
+    table = "fluss_stream_src"
+    start_mode = "earliest"
+    plugin_output = "fluss_stream"
+  }
+}
+
+transform {
+}
+
+sink {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_stream_db"
+    table = "fluss_stream_sink"
+    plugin_input = "fluss_stream"
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e/src/test/resources/fluss_to_assert.conf
@@ -1,0 +1,101 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss_coordinator_e2e:9123"
+    database = "fluss_source_db"
+    table = "fluss_source_tb"
+    plugin_output = "fluss_source"
+  }
+}
+
+transform {
+}
+
+sink {
+  Assert {
+    plugin_input = "fluss_source"
+    rules {
+      # Row count: exactly the three rows the test wrote.
+      row_rules = [
+        {
+          rule_type = MAX_ROW
+          rule_value = 3
+        },
+        {
+          rule_type = MIN_ROW
+          rule_value = 3
+        }
+      ]
+      # Per-column type + value bounds. field_type pins the source/target column
+      # mapping (a mis-decoded or mis-ordered column would surface here); the
+      # MIN/MAX / length bounds pin the read values to exactly the range written
+      # ({1,20,98.5},{2,31,88.0},{3,42,77.5}) so a corrupted or swapped column fails.
+      field_rules = [
+        {
+          field_name = id
+          field_type = int
+          field_value = [
+            { rule_type = NOT_NULL },
+            { rule_type = MIN, rule_value = 1 },
+            { rule_type = MAX, rule_value = 3 }
+          ]
+        },
+        {
+          field_name = name
+          field_type = string
+          field_value = [
+            { rule_type = NOT_NULL },
+            { rule_type = MIN_LENGTH, rule_value = 3 },
+            { rule_type = MAX_LENGTH, rule_value = 5 }
+          ]
+        },
+        {
+          field_name = age
+          field_type = int
+          field_value = [
+            { rule_type = NOT_NULL },
+            { rule_type = MIN, rule_value = 20 },
+            { rule_type = MAX, rule_value = 42 }
+          ]
+        },
+        {
+          field_name = score
+          field_type = double
+          field_value = [
+            { rule_type = NOT_NULL },
+            { rule_type = MIN, rule_value = 77.5 },
+            { rule_type = MAX, rule_value = 98.5 }
+          ]
+        },
+        {
+          field_name = active
+          field_type = boolean
+          field_value = [
+            { rule_type = NOT_NULL }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request

Closes #8816.

This PR adds the **source** side of the Fluss connector. It lets SeaTunnel read from Fluss log tables, both as a bounded batch read and as an unbounded streaming read.

Main additions:

1. `FlussSource` / `FlussSourceFactory` — `SeaTunnelSource` implementation (`SupportParallelism`) and factory wiring, reusing the existing `connector-fluss` module.
2. `FlussSourceSplitEnumerator` — discovers table buckets, assigns them as splits, and supports snapshot/restore with stable split allocation across restarts.
3. `FlussSourceSplitReader` / `FlussSourceReader` / `FlussRecordEmitter` — poll records per bucket on the reader's fetcher thread, and handle bounded/unbounded end conditions.
4. `StartMode` + `FlussSourceOptions` — `earliest` / `latest` startup offset options.
5. `FlussTypeConverter` — maps Fluss types to SeaTunnel `SeaTunnelDataType`.
6. English & Chinese connector docs under `docs/{en,zh}/connectors/source/Fluss.md`, and registration in `plugin-mapping.properties` / `config/plugin_config`.

### Does this PR introduce _any_ user-facing change?

Yes — a new `Fluss` source connector becomes available (previously only the Fluss sink existed). It only adds a new capability; no existing option key, default, or behavior is changed.

### How was this patch tested?

Scoped to the `connector-fluss` / `connector-fluss-e2e` modules (the modules this PR changes):

*   `./mvnw spotless:apply` pass.
*   `./mvnw test -pl seatunnel-connectors-v2/connector-fluss` → 26/26, 0 failures
    (FlussSourceSplitEnumeratorTest 8, FlussSourceFactoryTest 12, FlussSourceSplitReaderTest 6)
*   Built the dist + connector for e2e:
    `./mvnw install -DskipTests -Dskip.spotless=true -pl seatunnel-dist,seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e -am` → BUILD SUCCESS
*   `./mvnw verify -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-fluss-e2e -Dit.test=FlussSourceIT -DskipUT=true -DskipIT=false -DfailIfNoTests=false` → 4/4, 0 failures
    (testFlussSource, testFlussSourceAllTypes, testFlussSourceStreaming, testFlussSourceStreamingLatest)

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)