### PR TITLE
[Fix][E2E] Elasticsearch]Isolate MySQL network alias for recipe test

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/java/org/apache/seatunnel/e2e/connector/elasticsearch/ElasticsearchRecipeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/java/org/apache/seatunnel/e2e/connector/elasticsearch/ElasticsearchRecipeIT.java
@@ -74,7 +74,7 @@ import static org.awaitility.Awaitility.await;
 public class ElasticsearchRecipeIT extends TestSuiteBase implements TestResource {
 
     // MySQL hostname referenced by the documented job config.
-    private static final String MYSQL_HOST = "mysql_cdc_e2e";
+    private static final String MYSQL_HOST = "mysql_cdc_elasticsearch_recipe";
     // Source database consumed by the CDC job.
     private static final String MYSQL_DATABASE = "crm";
     // Application user used for incremental source changes.

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/resources/elasticsearch/mysqlcdc_to_elasticsearch_recipe.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e/src/test/resources/elasticsearch/mysqlcdc_to_elasticsearch_recipe.conf
@@ -23,7 +23,7 @@ env {
 source {
   MySQL-CDC {
     plugin_output = "mysql_customer_raw"
-    url = "jdbc:mysql://mysql_cdc_e2e:3306/crm"
+    url = "jdbc:mysql://mysql_cdc_elasticsearch_recipe:3306/crm"
     username = "st_user_source"
     password = "mysqlpw"
     server-id = 5701-5704


### PR DESCRIPTION
## Purpose

Fix the flaky `ElasticsearchRecipeIT#testMysqlCdcToElasticsearchRecipe` E2E test.

## Root cause

`ElasticsearchRecipeIT` and `ElasticsearchSchemaChangeIT` both use the shared Docker network alias `mysql_cdc_e2e`.

`ElasticsearchSchemaChangeIT` keeps a static MySQL container running with the `shop` database. When `ElasticsearchRecipeIT` starts another MySQL container with the `crm` database under the same alias, Docker DNS may resolve `mysql_cdc_e2e` to the wrong container.

The failed CI run showed that the recipe job expected `crm.customer_profile`, but connected to the container containing `shop`:

```text
list of available databases is:
[information_schema, mysql, performance_schema, shop, sys]

SnapshotSplitAssigner created with remaining tables: []
```

Because no snapshot split was created, Elasticsearch remained empty and the test timed out with:

```text
expected: <1> but was: <0> within 2 minutes
```

## Changes

* Give `ElasticsearchRecipeIT` a dedicated MySQL network alias:

  * from `mysql_cdc_e2e`
  * to `mysql_cdc_elasticsearch_recipe_e2e`
* Update `mysqlcdc_to_elasticsearch_recipe.conf` to use the new alias.

This follows the same isolation approach used for `ElasticsearchTimerFlushIT` in #11531.

## User-facing change

No. This change only improves E2E test isolation and stability.

## Validation

```bash
./mvnw spotless:apply
```

```bash
./mvnw \
  -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e \
  -DskipUT \
  -DskipIT \
  test-compile
```

Focused Zeta E2E validation:

```bash
RUN_ALL_CONTAINER=false RUN_ZETA_CONTAINER=true \
./mvnw \
  -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-elasticsearch-e2e \
  -DskipUT \
  -DskipIT=false \
  -Dit.test=ElasticsearchRecipeIT \
  verify
```
