### PR TITLE
[Fix][Connector-V2] Wait for Doris data visibility

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
@@ -53,6 +53,7 @@ import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_ENABLE_DELETE;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_LABEL_PREFIX;
 import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_MAX_RETRIES;
+import static org.apache.seatunnel.connectors.doris.config.DorisSinkOptions.SINK_VISIBILITY_TIMEOUT_MS;
 
 @Slf4j
 @Setter
@@ -76,6 +77,7 @@ public class DorisSinkConfig implements Serializable {
     private String labelPrefix;
     private Integer checkInterval;
     private Integer maxRetries;
+    private Long visibilityTimeoutMs;
     private Integer bufferSize;
     private Integer bufferCount;
     private Properties streamLoadProps;
@@ -115,6 +117,7 @@ public class DorisSinkConfig implements Serializable {
         dorisSinkConfig.setLabelPrefix(config.get(SINK_LABEL_PREFIX));
         dorisSinkConfig.setCheckInterval(config.get(SINK_CHECK_INTERVAL));
         dorisSinkConfig.setMaxRetries(config.get(SINK_MAX_RETRIES));
+        dorisSinkConfig.setVisibilityTimeoutMs(config.get(SINK_VISIBILITY_TIMEOUT_MS));
         dorisSinkConfig.setBufferSize(config.get(SINK_BUFFER_SIZE));
         dorisSinkConfig.setBufferCount(config.get(SINK_BUFFER_COUNT));
         dorisSinkConfig.setEnableDelete(config.get(SINK_ENABLE_DELETE));
@@ -126,7 +129,17 @@ public class DorisSinkConfig implements Serializable {
         validateDirectWriteOptions(
                 dorisSinkConfig.isDirectToBe(), dorisSinkConfig.getBackends(), true);
 
+        validateVisibilityTimeout(dorisSinkConfig.getVisibilityTimeoutMs());
+
         return dorisSinkConfig;
+    }
+
+    private static void validateVisibilityTimeout(Long visibilityTimeoutMs) {
+        if (visibilityTimeoutMs == null || visibilityTimeoutMs <= 0) {
+            throw new DorisConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    "PluginName: Doris, Message: Option 'sink.visibility-timeout-ms' must be greater than 0.");
+        }
     }
 
     private static Properties parseStreamLoadProperties(ReadonlyConfig config) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkOptions.java
@@ -50,6 +50,13 @@ public class DorisSinkOptions extends DorisBaseOptions {
                     .intType()
                     .defaultValue(3)
                     .withDescription("the max retry times if writing records to database failed.");
+
+    public static final Option<Long> SINK_VISIBILITY_TIMEOUT_MS =
+            Options.key("sink.visibility-timeout-ms")
+                    .longType()
+                    .defaultValue(300000L)
+                    .withDescription(
+                            "Maximum time in milliseconds to wait for a 2PC load to reach the VISIBLE state on Doris FE after a successful stream-load commit. ABORTED and CANCELLED remain terminal failures. Must be greater than 0.");
     public static final Option<Integer> SINK_BUFFER_SIZE =
             Options.key("sink.buffer-size")
                     .intType()

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfo.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfo.java
@@ -33,10 +33,16 @@ public class DorisCommitInfo implements Serializable {
     private final String hostPort;
     private final String db;
     private final long txbID;
+    private final String label;
 
     public DorisCommitInfo(String hostPort, String db, long txbID) {
+        this(hostPort, db, txbID, null);
+    }
+
+    public DorisCommitInfo(String hostPort, String db, long txbID, String label) {
         this.hostPort = hostPort;
         this.db = db;
         this.txbID = txbID;
+        this.label = label;
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfoSerializer.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfoSerializer.java
@@ -35,6 +35,10 @@ public class DorisCommitInfoSerializer implements Serializer<DorisCommitInfo> {
             out.writeUTF(dorisCommittable.getHostPort());
             out.writeUTF(dorisCommittable.getDb());
             out.writeLong(dorisCommittable.getTxbID());
+            out.writeBoolean(dorisCommittable.getLabel() != null);
+            if (dorisCommittable.getLabel() != null) {
+                out.writeUTF(dorisCommittable.getLabel());
+            }
 
             out.flush();
             return baos.toByteArray();
@@ -48,7 +52,10 @@ public class DorisCommitInfoSerializer implements Serializer<DorisCommitInfo> {
             final String hostPort = in.readUTF();
             final String db = in.readUTF();
             final long txnId = in.readLong();
-            return new DorisCommitInfo(hostPort, db, txnId);
+            if (in.available() == 0) {
+                return new DorisCommitInfo(hostPort, db, txnId);
+            }
+            return new DorisCommitInfo(hostPort, db, txnId, in.readBoolean() ? in.readUTF() : null);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
@@ -30,14 +30,19 @@ import org.apache.seatunnel.connectors.doris.util.DorisRedirectExceptionBuilder;
 import org.apache.seatunnel.connectors.doris.util.HttpUtil;
 import org.apache.seatunnel.connectors.doris.util.ResponseUtil;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,8 +54,12 @@ import java.util.Map;
 @Slf4j
 public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
     private static final String COMMIT_PATTERN = "http://%s/api/%s/_stream_load_2pc";
+    private static final String LOAD_STATE_PATTERN = "http://%s/api/%s/get_load_state?label=%s";
     private static final int HTTP_OK = 200;
     private static final int HTTP_TEMPORARY_REDIRECT = 307;
+    private static final String LOAD_STATE_VISIBLE = "VISIBLE";
+    private static final String LOAD_STATE_ABORTED = "ABORTED";
+    private static final String LOAD_STATE_CANCELLED = "CANCELLED";
     private final CloseableHttpClient httpClient;
     private final DorisSinkConfig dorisSinkConfig;
     private final int maxRetry;
@@ -147,6 +156,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                     continue;
                 }
                 handleCommitSuccess(committable, hostPort, closeableResponse);
+                waitUntilLoadVisible(committable, retryHosts);
                 return;
             }
         }
@@ -258,6 +268,86 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
             } else {
                 log.info("load result {}", loadResult);
             }
+        }
+    }
+
+    /** Waits until the 2PC load is visible before reporting the checkpoint as committed. */
+    private void waitUntilLoadVisible(DorisCommitInfo committable, List<String> retryHosts)
+            throws IOException {
+        if (committable.getLabel() == null) {
+            log.warn(
+                    "Skip waiting for Doris load visibility because the restored commit info has no label. txnId: {}",
+                    committable.getTxbID());
+            return;
+        }
+
+        int attempt = 0;
+        while (true) {
+            String hostPort = retryHosts.get(attempt % retryHosts.size());
+            try {
+                if (isLoadVisible(committable, hostPort)) {
+                    return;
+                }
+            } catch (DorisConnectorException e) {
+                throw e;
+            } catch (IOException e) {
+                log.warn(
+                        "Failed to get Doris load state for label {} from {}. Retrying.",
+                        committable.getLabel(),
+                        hostPort,
+                        e);
+            }
+            retrySleeper.sleep(Math.min(++attempt, 5));
+        }
+    }
+
+    private boolean isLoadVisible(DorisCommitInfo committable, String hostPort) throws IOException {
+        String encodedLabel =
+                URLEncoder.encode(committable.getLabel(), StandardCharsets.UTF_8.name());
+        String requestUrl =
+                String.format(LOAD_STATE_PATTERN, hostPort, committable.getDb(), encodedLabel);
+        HttpGet get = new HttpGet(requestUrl);
+        String authInfo = dorisSinkConfig.getUsername() + ":" + dorisSinkConfig.getPassword();
+        get.setHeader(
+                HttpHeaders.AUTHORIZATION,
+                "Basic "
+                        + new String(
+                                Base64.encodeBase64(authInfo.getBytes(StandardCharsets.UTF_8)),
+                                StandardCharsets.UTF_8));
+        try (CloseableHttpResponse response =
+                HttpUtil.executeWithRedirectTracking(
+                        httpClient,
+                        get,
+                        requestUrl,
+                        dorisSinkConfig.isDirectToBe(),
+                        dorisSinkConfig.getEnable2PC(),
+                        "get-load-state")) {
+            if (response.getStatusLine().getStatusCode() != HTTP_OK
+                    || response.getEntity() == null) {
+                throw new IOException(
+                        "Failed to get Doris load state, response: " + response.getStatusLine());
+            }
+            String responseBody = EntityUtils.toString(response.getEntity());
+            Map<String, Object> result =
+                    new ObjectMapper()
+                            .readValue(
+                                    responseBody, new TypeReference<HashMap<String, Object>>() {});
+            String loadState = String.valueOf(result.get("data"));
+            if (LOAD_STATE_VISIBLE.equalsIgnoreCase(loadState)) {
+                log.info("Doris load label {} is visible", committable.getLabel());
+                return true;
+            }
+            if (LOAD_STATE_ABORTED.equalsIgnoreCase(loadState)
+                    || LOAD_STATE_CANCELLED.equalsIgnoreCase(loadState)) {
+                throw new DorisConnectorException(
+                        DorisConnectorErrorCode.COMMIT_FAILED,
+                        "Doris load label "
+                                + committable.getLabel()
+                                + " reached terminal state "
+                                + loadState);
+            }
+            log.info("Doris load label {} is in state {}", committable.getLabel(), loadState);
+            return false;
         }
     }
 

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitter.java
@@ -63,6 +63,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
     private final CloseableHttpClient httpClient;
     private final DorisSinkConfig dorisSinkConfig;
     private final int maxRetry;
+    private final long visibilityTimeoutMs;
     private final RetrySleeper retrySleeper;
 
     public DorisCommitter(DorisSinkConfig dorisSinkConfig) {
@@ -80,6 +81,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
         this.dorisSinkConfig = dorisSinkConfig;
         this.httpClient = client;
         this.maxRetry = dorisSinkConfig.getMaxRetries();
+        this.visibilityTimeoutMs = dorisSinkConfig.getVisibilityTimeoutMs();
         this.retrySleeper = retrySleeper;
     }
 
@@ -271,7 +273,11 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
         }
     }
 
-    /** Waits until the 2PC load is visible before reporting the checkpoint as committed. */
+    /**
+     * Waits until the 2PC load is visible before reporting the checkpoint as committed. Bounded by
+     * {@link DorisSinkConfig#getVisibilityTimeoutMs()} so a stuck or unknown state cannot block the
+     * checkpoint forever; ABORTED / CANCELLED remain terminal failures.
+     */
     private void waitUntilLoadVisible(DorisCommitInfo committable, List<String> retryHosts)
             throws IOException {
         if (committable.getLabel() == null) {
@@ -281,6 +287,7 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
             return;
         }
 
+        long deadlineNanos = System.nanoTime() + visibilityTimeoutMs * 1_000_000L;
         int attempt = 0;
         while (true) {
             String hostPort = retryHosts.get(attempt % retryHosts.size());
@@ -296,6 +303,15 @@ public class DorisCommitter implements SinkCommitter<DorisCommitInfo> {
                         committable.getLabel(),
                         hostPort,
                         e);
+            }
+            if (System.nanoTime() >= deadlineNanos) {
+                throw new DorisConnectorException(
+                        DorisConnectorErrorCode.COMMIT_FAILED,
+                        "Timed out after "
+                                + visibilityTimeoutMs
+                                + "ms waiting for Doris load label "
+                                + committable.getLabel()
+                                + " to reach VISIBLE state.");
             }
             retrySleeper.sleep(Math.min(++attempt, 5));
         }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisSinkWriter.java
@@ -262,7 +262,12 @@ public class DorisSinkWriter
         }
         long txnId = respContent.getTxnId();
 
-        return Optional.of(new DorisCommitInfo(controlHostPort, dorisStreamLoad.getDb(), txnId));
+        return Optional.of(
+                new DorisCommitInfo(
+                        controlHostPort,
+                        dorisStreamLoad.getDb(),
+                        txnId,
+                        dorisStreamLoad.getLabel()));
     }
 
     private RespContent flush() throws IOException {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisStreamLoad.java
@@ -281,6 +281,10 @@ public class DorisStreamLoad implements Serializable {
         this.loading = true;
     }
 
+    public String getLabel() {
+        return label;
+    }
+
     private void startStreamLoad() {
         HttpPutBuilder putBuilder = new HttpPutBuilder();
         log.info("stream load started for {}", label);

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfoSerializerTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitInfoSerializerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.doris.sink.committer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+class DorisCommitInfoSerializerTest {
+
+    private final DorisCommitInfoSerializer serializer = new DorisCommitInfoSerializer();
+
+    @Test
+    void testSerializeAndDeserializeLabel() throws IOException {
+        DorisCommitInfo commitInfo = new DorisCommitInfo("fe1:8030", "test_db", 12L, "job_label");
+
+        DorisCommitInfo restored = serializer.deserialize(serializer.serialize(commitInfo));
+
+        Assertions.assertEquals(commitInfo, restored);
+    }
+
+    @Test
+    void testDeserializeLegacyCommitInfoWithoutLabel() throws IOException {
+        DorisCommitInfo restored = serializer.deserialize(legacySerializedCommitInfo());
+
+        Assertions.assertEquals("fe1:8030", restored.getHostPort());
+        Assertions.assertEquals("test_db", restored.getDb());
+        Assertions.assertEquals(12L, restored.getTxbID());
+        Assertions.assertNull(restored.getLabel());
+    }
+
+    private byte[] legacySerializedCommitInfo() throws IOException {
+        try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                DataOutputStream output = new DataOutputStream(bytes)) {
+            output.writeUTF("fe1:8030");
+            output.writeUTF("test_db");
+            output.writeLong(12L);
+            output.flush();
+            return bytes.toByteArray();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
@@ -188,6 +188,108 @@ public class DorisCommitterTest {
     }
 
     @Test
+    void testCommitFailsWhenLoadStateIsAborted() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse commitResponse = successResponse();
+        CloseableHttpResponse abortedResponse = loadStateResponse("ABORTED");
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(commitResponse)
+                .thenReturn(abortedResponse);
+        DorisCommitter committer =
+                new DorisCommitter(createSinkConfig(true, true), httpClient, attempts -> {});
+
+        DorisConnectorException exception =
+                Assertions.assertThrows(
+                        DorisConnectorException.class,
+                        () ->
+                                committer.commit(
+                                        Collections.singletonList(
+                                                new DorisCommitInfo(
+                                                        "fe1:8030", "test_db", 13L, "job_label"))));
+
+        Assertions.assertTrue(exception.getMessage().contains("ABORTED"));
+        Assertions.assertTrue(exception.getMessage().contains("job_label"));
+    }
+
+    @Test
+    void testCommitFailsWhenLoadStateIsCancelled() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse commitResponse = successResponse();
+        CloseableHttpResponse cancelledResponse = loadStateResponse("CANCELLED");
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(commitResponse)
+                .thenReturn(cancelledResponse);
+        DorisCommitter committer =
+                new DorisCommitter(createSinkConfig(true, true), httpClient, attempts -> {});
+
+        DorisConnectorException exception =
+                Assertions.assertThrows(
+                        DorisConnectorException.class,
+                        () ->
+                                committer.commit(
+                                        Collections.singletonList(
+                                                new DorisCommitInfo(
+                                                        "fe1:8030", "test_db", 14L, "job_label"))));
+
+        Assertions.assertTrue(exception.getMessage().contains("CANCELLED"));
+    }
+
+    @Test
+    void testCommitTimesOutWhenLoadStateStaysUnresolved() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse commitResponse = successResponse();
+        CloseableHttpResponse pendingResponse = loadStateResponse("PRE_COMMIT");
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(commitResponse)
+                .thenReturn(pendingResponse);
+        List<Integer> sleepRetries = new ArrayList<>();
+        DorisCommitter committer =
+                new DorisCommitter(
+                        createSinkConfigWithVisibilityTimeout(true, true, 1L),
+                        httpClient,
+                        sleepRetries::add);
+
+        DorisConnectorException exception =
+                Assertions.assertThrows(
+                        DorisConnectorException.class,
+                        () ->
+                                committer.commit(
+                                        Collections.singletonList(
+                                                new DorisCommitInfo(
+                                                        "fe1:8030", "test_db", 15L, "job_label"))));
+
+        Assertions.assertTrue(exception.getMessage().contains("Timed out"));
+        Assertions.assertTrue(exception.getMessage().contains("1ms"));
+        Assertions.assertTrue(exception.getMessage().contains("job_label"));
+    }
+
+    @Test
+    void testCommitRetriesLoadStatePollOnIOExceptionBeforeDeadline() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse commitResponse = successResponse();
+        CloseableHttpResponse visibleResponse = loadStateResponse("VISIBLE");
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(commitResponse)
+                .thenThrow(new IOException("transient fe failure"))
+                .thenReturn(visibleResponse);
+        List<Integer> sleepRetries = new ArrayList<>();
+        DorisCommitter committer =
+                new DorisCommitter(
+                        createSinkConfigWithVisibilityTimeout(true, true, 60000L),
+                        httpClient,
+                        sleepRetries::add);
+
+        committer.commit(
+                Collections.singletonList(
+                        new DorisCommitInfo("fe1:8030", "test_db", 16L, "job_label")));
+
+        ArgumentCaptor<HttpUriRequest> requestCaptor =
+                ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(httpClient, times(3)).execute(requestCaptor.capture(), any(HttpContext.class));
+        Assertions.assertEquals(Arrays.asList(1), sleepRetries);
+    }
+
+    @Test
     void testAbortRetriesNextFrontendOnIOException() throws IOException {
         CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
         CloseableHttpResponse successResponse = successResponse();
@@ -299,6 +401,24 @@ public class DorisCommitterTest {
         options.put("direct_to_be", directToBe);
         options.put("sink.enable-2pc", enable2PC);
         options.put("sink.max-retries", maxRetries);
+        options.put("username", "root");
+        options.put("password", "");
+        options.put("database", "test_db");
+        options.put("table", "test_table");
+        options.put("sink.label-prefix", "test_job");
+        options.put("doris.config", createStreamLoadProperties());
+        return DorisSinkConfig.of(ReadonlyConfig.fromMap(options));
+    }
+
+    private DorisSinkConfig createSinkConfigWithVisibilityTimeout(
+            boolean directToBe, boolean enable2PC, long visibilityTimeoutMs) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("fenodes", "fe1:8030");
+        options.put("benodes", "be1:8040");
+        options.put("direct_to_be", directToBe);
+        options.put("sink.enable-2pc", enable2PC);
+        options.put("sink.max-retries", 3);
+        options.put("sink.visibility-timeout-ms", visibilityTimeoutMs);
         options.put("username", "root");
         options.put("password", "");
         options.put("database", "test_db");

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/committer/DorisCommitterTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.connectors.doris.util.HttpUtil;
 import org.apache.http.Header;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
@@ -155,6 +156,35 @@ public class DorisCommitterTest {
         Assertions.assertEquals(
                 "http://fe2:8030/api/test_db/_stream_load_2pc",
                 requestCaptor.getAllValues().get(1).getURI().toString());
+    }
+
+    @Test
+    void testCommitWaitsUntilLoadIsVisible() throws IOException {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse commitResponse = successResponse();
+        CloseableHttpResponse committedResponse = loadStateResponse("COMMITTED");
+        CloseableHttpResponse visibleResponse = loadStateResponse("VISIBLE");
+        when(httpClient.execute(any(HttpUriRequest.class), any(HttpContext.class)))
+                .thenReturn(commitResponse)
+                .thenReturn(committedResponse)
+                .thenReturn(visibleResponse);
+        List<Integer> sleepRetries = new ArrayList<>();
+        DorisCommitter committer =
+                new DorisCommitter(createSinkConfig(true, true), httpClient, sleepRetries::add);
+
+        committer.commit(
+                Collections.singletonList(
+                        new DorisCommitInfo("fe1:8030", "test_db", 12L, "job_label")));
+
+        ArgumentCaptor<HttpUriRequest> requestCaptor =
+                ArgumentCaptor.forClass(HttpUriRequest.class);
+        verify(httpClient, times(3)).execute(requestCaptor.capture(), any(HttpContext.class));
+        Assertions.assertTrue(requestCaptor.getAllValues().get(0) instanceof HttpPut);
+        Assertions.assertTrue(requestCaptor.getAllValues().get(1) instanceof HttpGet);
+        Assertions.assertEquals(
+                "http://fe1:8030/api/test_db/get_load_state?label=job_label",
+                requestCaptor.getAllValues().get(1).getURI().toString());
+        Assertions.assertEquals(Collections.singletonList(1), sleepRetries);
     }
 
     @Test
@@ -320,6 +350,14 @@ public class DorisCommitterTest {
     private CloseableHttpResponse successResponse() throws IOException {
         return responseWithStatus(
                 200, "OK", new StringEntity("{\"status\":\"Success\",\"msg\":\"\"}"));
+    }
+
+    private CloseableHttpResponse loadStateResponse(String state) throws IOException {
+        return responseWithStatus(
+                200,
+                "OK",
+                new StringEntity(
+                        String.format("{\"msg\":\"success\",\"code\":0,\"data\":\"%s\"}", state)));
     }
 
     private CloseableHttpResponse responseWithStatus(


### PR DESCRIPTION
## What does this PR do?

Fixes #11433.

The Doris 2PC committer now carries the stream-load label from the writer and polls the Doris FE load-state endpoint after the transaction commit succeeds. SeaTunnel reports the checkpoint as committed only after the label reaches `VISIBLE`; `ABORTED` and `CANCELLED` remain terminal failures.

Existing serialized commit information remains readable. When restoring an older checkpoint that does not contain a label, the existing commit behavior is retained.

## Tests

- Added a unit test for `COMMITTED` to `VISIBLE` polling.
- Added serializer round-trip and legacy-data compatibility tests.
- `./mvnw -q -DskipTests verify`
- `./mvnw -o -f seatunnel-connectors-v2/connector-doris/pom.xml -Dtest=DorisCommitterTest,DorisCommitInfoSerializerTest test`