### PR TITLE
[Fix][Zeta] Handle missing checkpoint state during restore

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -1396,8 +1396,8 @@ public class CheckpointCoordinator {
         CheckpointCoordinatorStatus status =
                 (CheckpointCoordinatorStatus) runningJobStateIMap.get(checkpointStateImapKey);
         return latestCompletedCheckpoint.getCheckpointType().isFinalCheckpoint()
-                && (status.equals(CheckpointCoordinatorStatus.FINISHED)
-                        || status.equals(CheckpointCoordinatorStatus.SUSPEND))
+                && (CheckpointCoordinatorStatus.FINISHED.equals(status)
+                        || CheckpointCoordinatorStatus.SUSPEND.equals(status))
                 && !latestCompletedCheckpoint.isRestored();
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -910,10 +910,18 @@ public class CheckpointCoordinatorTest
     }
 
     @Test
-    void testIsNoErrorCompletedReturnsFalseWhenCheckpointStateIsMissing() {
+    void testIsNoErrorCompletedUsesCheckpointStateMatrix() {
         ExecutorService executorService = Executors.newCachedThreadPool();
         try {
             CheckpointCoordinator coordinator = buildMinimalCoordinator(executorService);
+            @SuppressWarnings("unchecked")
+            IMap<Object, Object> runningJobStateIMap =
+                    (IMap<Object, Object>)
+                            ReflectionUtils.getField(coordinator, "runningJobStateIMap")
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "runningJobStateIMap field not found"));
             CompletedCheckpoint completedCheckpoint =
                     new CompletedCheckpoint(
                             1L,
@@ -926,7 +934,27 @@ public class CheckpointCoordinatorTest
                             new HashMap<>());
             ReflectionUtils.setField(coordinator, "latestCompletedCheckpoint", completedCheckpoint);
 
-            Assertions.assertFalse(coordinator.isNoErrorCompleted());
+            CheckpointCoordinatorStatus[] incompleteStates = {
+                null,
+                CheckpointCoordinatorStatus.RUNNING,
+                CheckpointCoordinatorStatus.CANCELED,
+                CheckpointCoordinatorStatus.FAILED
+            };
+            for (CheckpointCoordinatorStatus status : incompleteStates) {
+                Mockito.when(runningJobStateIMap.get(Mockito.any())).thenReturn(status);
+                Assertions.assertFalse(
+                        coordinator.isNoErrorCompleted(),
+                        "Unexpected completed state for " + status);
+            }
+
+            CheckpointCoordinatorStatus[] completedStates = {
+                CheckpointCoordinatorStatus.FINISHED, CheckpointCoordinatorStatus.SUSPEND
+            };
+            for (CheckpointCoordinatorStatus status : completedStates) {
+                Mockito.when(runningJobStateIMap.get(Mockito.any())).thenReturn(status);
+                Assertions.assertTrue(
+                        coordinator.isNoErrorCompleted(), "Expected completed state for " + status);
+            }
         } finally {
             executorService.shutdownNow();
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -909,6 +909,29 @@ public class CheckpointCoordinatorTest
                 null);
     }
 
+    @Test
+    void testIsNoErrorCompletedReturnsFalseWhenCheckpointStateIsMissing() {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            CheckpointCoordinator coordinator = buildMinimalCoordinator(executorService);
+            CompletedCheckpoint completedCheckpoint =
+                    new CompletedCheckpoint(
+                            1L,
+                            1,
+                            1L,
+                            System.currentTimeMillis(),
+                            CheckpointType.COMPLETED_POINT_TYPE,
+                            System.currentTimeMillis(),
+                            new HashMap<>(),
+                            new HashMap<>());
+            ReflectionUtils.setField(coordinator, "latestCompletedCheckpoint", completedCheckpoint);
+
+            Assertions.assertFalse(coordinator.isNoErrorCompleted());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
     /**
      * Regression: when {@code notifyCompleted()} fails (returns {@code false}), {@code
      * completePendingCheckpoint} must return immediately without decrementing {@code

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -922,38 +922,45 @@ public class CheckpointCoordinatorTest
                                             () ->
                                                     new IllegalStateException(
                                                             "runningJobStateIMap field not found"));
-            CompletedCheckpoint completedCheckpoint =
-                    new CompletedCheckpoint(
-                            1L,
-                            1,
-                            1L,
-                            System.currentTimeMillis(),
-                            CheckpointType.COMPLETED_POINT_TYPE,
-                            System.currentTimeMillis(),
-                            new HashMap<>(),
-                            new HashMap<>());
-            ReflectionUtils.setField(coordinator, "latestCompletedCheckpoint", completedCheckpoint);
-
-            CheckpointCoordinatorStatus[] incompleteStates = {
+            CheckpointCoordinatorStatus[] states = {
                 null,
                 CheckpointCoordinatorStatus.RUNNING,
                 CheckpointCoordinatorStatus.CANCELED,
-                CheckpointCoordinatorStatus.FAILED
+                CheckpointCoordinatorStatus.FAILED,
+                CheckpointCoordinatorStatus.FINISHED,
+                CheckpointCoordinatorStatus.SUSPEND
             };
-            for (CheckpointCoordinatorStatus status : incompleteStates) {
-                Mockito.when(runningJobStateIMap.get(Mockito.any())).thenReturn(status);
-                Assertions.assertFalse(
-                        coordinator.isNoErrorCompleted(),
-                        "Unexpected completed state for " + status);
-            }
+            for (CheckpointType checkpointType : CheckpointType.values()) {
+                for (boolean restored : new boolean[] {false, true}) {
+                    CompletedCheckpoint completedCheckpoint =
+                            new CompletedCheckpoint(
+                                    1L,
+                                    1,
+                                    1L,
+                                    System.currentTimeMillis(),
+                                    checkpointType,
+                                    System.currentTimeMillis(),
+                                    new HashMap<>(),
+                                    new HashMap<>());
+                    completedCheckpoint.setRestored(restored);
+                    ReflectionUtils.setField(
+                            coordinator, "latestCompletedCheckpoint", completedCheckpoint);
 
-            CheckpointCoordinatorStatus[] completedStates = {
-                CheckpointCoordinatorStatus.FINISHED, CheckpointCoordinatorStatus.SUSPEND
-            };
-            for (CheckpointCoordinatorStatus status : completedStates) {
-                Mockito.when(runningJobStateIMap.get(Mockito.any())).thenReturn(status);
-                Assertions.assertTrue(
-                        coordinator.isNoErrorCompleted(), "Expected completed state for " + status);
+                    for (CheckpointCoordinatorStatus status : states) {
+                        Mockito.when(runningJobStateIMap.get(Mockito.any())).thenReturn(status);
+                        boolean expected =
+                                checkpointType.isFinalCheckpoint()
+                                        && (status == CheckpointCoordinatorStatus.FINISHED
+                                                || status == CheckpointCoordinatorStatus.SUSPEND)
+                                        && !restored;
+                        Assertions.assertEquals(
+                                expected,
+                                coordinator.isNoErrorCompleted(),
+                                String.format(
+                                        "checkpointType=%s, status=%s, restored=%s",
+                                        checkpointType, status, restored));
+                    }
+                }
             }
         } finally {
             executorService.shutdownNow();


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11563.

During Worker recovery, `CheckpointCoordinator.isNoErrorCompleted()` can have a
non-null final `latestCompletedCheckpoint` after the corresponding coordinator
state entry has already been cleaned. The method currently invokes
`status.equals(...)` on the nullable IMap result and fails pipeline restore with
a `NullPointerException`.

This patch uses constant-side enum equality. A missing state is therefore
treated as not completed and the existing restore path continues. Behavior for
the `FINISHED`, `SUSPEND`, and other non-null states remains unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. A Worker restart no longer fails an affected batch pipeline solely because
its checkpoint coordinator state entry has already been cleaned. There is no
public API, persistence format, or configuration change.

### How was this patch tested?

Added a regression that constructs a coordinator with a final completed
checkpoint and a missing state-map entry, then verifies
`isNoErrorCompleted()` returns `false` instead of throwing.

```shell
./mvnw -o -pl seatunnel-engine/seatunnel-engine-server \
  -Dtest=CheckpointCoordinatorTest test
```

Result on the PR branch: 14 tests passed, 0 failures, 0 errors.

The original fault was observed during controlled Worker recovery. The minimal
fix has not yet been revalidated with another cluster fault injection; the unit
regression directly covers the null-state failure boundary.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because there is no new feature or user configuration.
* [x] No incompatible change is introduced.
* [x] Connector-specific checklist items are not applicable.
