### PR TITLE
[Fix][Zeta] Resolve allowed environment variables in REST HOCON

### DIFF
--- a/config/seatunnel.yaml
+++ b/config/seatunnel.yaml
@@ -48,3 +48,6 @@ seatunnel:
       # enable-basic-auth: true
       # basic-auth-username: admin
       # basic-auth-password: admin
+      # Environment variables that REST-submitted HOCON jobs may resolve
+      # hocon-environment-variable-allowlist:
+      #   - JOB_NAME

--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -771,6 +771,18 @@ When we can't get the job info, the response will be:
 
 **Note:** The dry-run feature is intentionally not supported via the REST API. It is exclusively available through the SeaTunnel CLI.
 
+HOCON request bodies can resolve environment variables explicitly allowed by the server. Add the variable names to `seatunnel.engine.http.hocon-environment-variable-allowlist` in `seatunnel.yaml`, and make the variables available to the SeaTunnel Engine process before submitting the job:
+
+```yaml
+seatunnel:
+  engine:
+    http:
+      hocon-environment-variable-allowlist:
+        - JOB_NAME
+```
+
+The job configuration can then use `job.name = ${JOB_NAME}`. The allowlist is empty by default to prevent REST callers from reading arbitrary server-side environment variables. JVM system properties are never exposed through this mechanism. The REST API does not accept CLI `-i` variables.
+
 #### Body
 
 You can choose json, hocon or sql to pass request body.
@@ -907,6 +919,8 @@ The name of the uploaded file key is config_file, and supports the following for
 - `.json` files: parsed in JSON format
 - `.conf` or `.config` files: parsed in HOCON format
 - `.sql` files: parsed in SQL format, supports CREATE TABLE and INSERT INTO syntax
+
+Uploaded HOCON files use the same `hocon-environment-variable-allowlist` as HOCON request bodies.
 
 curl Example :
 ```bash

--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -781,7 +781,7 @@ seatunnel:
         - JOB_NAME
 ```
 
-The job configuration can then use `job.name = ${JOB_NAME}`. The allowlist is empty by default to prevent REST callers from reading arbitrary server-side environment variables. JVM system properties are never exposed through this mechanism. The REST API does not accept CLI `-i` variables.
+The job configuration can then use `job.name = ${JOB_NAME}`. The allowlist is empty by default to prevent REST callers from reading arbitrary server-side environment variables. JVM system properties are never exposed through this mechanism. The REST API does not accept CLI `-i` variables. SeaTunnel connector runtime placeholders, such as `${table_name}`, remain reserved placeholders and are not resolved from the Engine environment.
 
 #### Body
 

--- a/docs/en/engines/zeta/security.md
+++ b/docs/en/engines/zeta/security.md
@@ -21,6 +21,10 @@ seatunnel:
       basic-auth-password: "your_password"
 ```
 
+## REST HOCON Environment Variables
+
+HOCON jobs submitted through REST can resolve only the Engine process environment variables listed in `seatunnel.engine.http.hocon-environment-variable-allowlist`. The list is empty by default, and JVM system properties are never exposed. Add only variables whose values every REST job submitter is authorized to read. Configure the same allowlist and values on every node that accepts REST submissions. See [RESTful API V2](./rest-api-v2.md) for an example.
+
 ## HTTPS Configuration
 
 You can secure your REST-API-V2 service by enabling HTTPS. Both HTTP and HTTPS can be enabled simultaneously, or only one of them can be enabled.

--- a/docs/en/engines/zeta/security.md
+++ b/docs/en/engines/zeta/security.md
@@ -23,7 +23,7 @@ seatunnel:
 
 ## REST HOCON Environment Variables
 
-HOCON jobs submitted through REST can resolve only the Engine process environment variables listed in `seatunnel.engine.http.hocon-environment-variable-allowlist`. The list is empty by default, and JVM system properties are never exposed. Add only variables whose values every REST job submitter is authorized to read. Configure the same allowlist and values on every node that accepts REST submissions. See [RESTful API V2](./rest-api-v2.md) for an example.
+HOCON jobs submitted through REST can resolve only the Engine process environment variables listed in `seatunnel.engine.http.hocon-environment-variable-allowlist`. The list is empty by default, and JVM system properties are never exposed. Add only variables whose values every REST job submitter is authorized to read. Configure the same allowlist and values on every node that accepts REST submissions. SeaTunnel connector runtime placeholders, such as `${table_name}`, remain reserved placeholders and are not resolved from the Engine environment. See [RESTful API V2](./rest-api-v2.md) for an example.
 
 ## HTTPS Configuration
 

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -750,6 +750,18 @@ seatunnel:
 
 **注意:** REST API 不支持 dry-run 功能。该功能仅通过 CLI 提供。
 
+HOCON 请求体可以解析服务端显式允许的环境变量。先在 `seatunnel.yaml` 中把变量名加入 `seatunnel.engine.http.hocon-environment-variable-allowlist`，并确保 SeaTunnel Engine 进程能够读取这些变量：
+
+```yaml
+seatunnel:
+  engine:
+    http:
+      hocon-environment-variable-allowlist:
+        - JOB_NAME
+```
+
+之后作业配置即可使用 `job.name = ${JOB_NAME}`。允许列表默认为空，防止 REST 调用方读取任意服务端环境变量；该机制也不会暴露 JVM system property。REST API 不接收 CLI 的 `-i` 变量。
+
 #### 请求体
 
 你可以选择用json、hocon或者sql的方式来传递请求体。
@@ -886,6 +898,8 @@ INSERT INTO console_sink SELECT * FROM fake_source;
 - `.json` 文件：按照 JSON 格式解析
 - `.conf` 或 `.config` 文件：按照 HOCON 格式解析
 - `.sql` 文件：按照 SQL 格式解析，支持 CREATE TABLE 和 INSERT INTO 语法
+
+上传的 HOCON 文件与 HOCON 请求体共用 `hocon-environment-variable-allowlist`。
 
 curl Example
 

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -760,7 +760,7 @@ seatunnel:
         - JOB_NAME
 ```
 
-之后作业配置即可使用 `job.name = ${JOB_NAME}`。允许列表默认为空，防止 REST 调用方读取任意服务端环境变量；该机制也不会暴露 JVM system property。REST API 不接收 CLI 的 `-i` 变量。
+之后作业配置即可使用 `job.name = ${JOB_NAME}`。允许列表默认为空，防止 REST 调用方读取任意服务端环境变量；该机制也不会暴露 JVM system property。REST API 不接收 CLI 的 `-i` 变量。SeaTunnel connector runtime placeholder，例如 `${table_name}`，仍是保留占位符，不会从 Engine 环境变量解析。
 
 #### 请求体
 

--- a/docs/zh/engines/zeta/security.md
+++ b/docs/zh/engines/zeta/security.md
@@ -26,6 +26,10 @@ seatunnel:
       basic-auth-password: "your_password"
 ```
 
+## REST HOCON 环境变量
+
+通过 REST 提交的 HOCON 作业只能解析 `seatunnel.engine.http.hocon-environment-variable-allowlist` 中列出的 Engine 进程环境变量。该列表默认为空，并且不会暴露 JVM system property。只应加入所有 REST 作业提交者都有权读取其值的变量；所有接收 REST 提交的节点都应配置相同的允许列表和变量值。配置示例见 [RESTful API V2](./rest-api-v2.md)。
+
 ## HTTPS 配置
 
 您可以通过开启 HTTPS 来保护您的 API 服务。HTTP 和 HTTPS 可同时开启，也可以只开启其中一个。

--- a/docs/zh/engines/zeta/security.md
+++ b/docs/zh/engines/zeta/security.md
@@ -28,7 +28,7 @@ seatunnel:
 
 ## REST HOCON 环境变量
 
-通过 REST 提交的 HOCON 作业只能解析 `seatunnel.engine.http.hocon-environment-variable-allowlist` 中列出的 Engine 进程环境变量。该列表默认为空，并且不会暴露 JVM system property。只应加入所有 REST 作业提交者都有权读取其值的变量；所有接收 REST 提交的节点都应配置相同的允许列表和变量值。配置示例见 [RESTful API V2](./rest-api-v2.md)。
+通过 REST 提交的 HOCON 作业只能解析 `seatunnel.engine.http.hocon-environment-variable-allowlist` 中列出的 Engine 进程环境变量。该列表默认为空，并且不会暴露 JVM system property。只应加入所有 REST 作业提交者都有权读取其值的变量；所有接收 REST 提交的节点都应配置相同的允许列表和变量值。SeaTunnel connector runtime placeholder，例如 `${table_name}`，仍是保留占位符，不会从 Engine 环境变量解析。配置示例见 [RESTful API V2](./rest-api-v2.md)。
 
 ## HTTPS 配置
 

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -47,6 +47,7 @@ import com.hazelcast.internal.config.AbstractDomConfigProcessor;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -645,6 +646,15 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                     .key()
                     .equals(name)) {
                 httpConfig.setEnableBasicAuth(getBooleanValue(getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions
+                    .HOCON_ENVIRONMENT_VARIABLE_ALLOWLIST
+                    .key()
+                    .equals(name)) {
+                ArrayList<String> environmentVariableAllowlist = new ArrayList<>();
+                for (Node variableNode : childElements(node)) {
+                    environmentVariableAllowlist.add(getTextContent(variableNode));
+                }
+                httpConfig.setHoconEnvironmentVariableAllowlist(environmentVariableAllowlist);
             } else if (ServerConfigOptions.MasterServerConfigOptions.BASIC_AUTH_USERNAME
                     .key()
                     .equals(name)) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.engine.common.config.server;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.hazelcast.internal.util.Preconditions.checkPositive;
 
@@ -69,6 +71,16 @@ public class HttpConfig implements Serializable {
     /** Whether to enable basic authentication. */
     private boolean enableBasicAuth =
             ServerConfigOptions.MasterServerConfigOptions.ENABLE_BASIC_AUTH.defaultValue();
+
+    /**
+     * Environment variables that HOCON job configurations submitted through the REST API may
+     * resolve.
+     */
+    private List<String> hoconEnvironmentVariableAllowlist =
+            new ArrayList<>(
+                    ServerConfigOptions.MasterServerConfigOptions
+                            .HOCON_ENVIRONMENT_VARIABLE_ALLOWLIST
+                            .defaultValue());
 
     /** The username for basic authentication. */
     private String basicAuthUsername =

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -23,6 +23,8 @@ import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 import org.apache.seatunnel.api.metadata.MetadataConfig;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /** Declares the server-side configuration keys that are exposed through `seatunnel.yaml`. */
@@ -352,6 +354,14 @@ public class ServerConfigOptions {
                         .booleanType()
                         .defaultValue(false)
                         .withDescription("Whether to enable basic authentication for the web UI.");
+
+        /** Environment variables exposed to HOCON configurations submitted through REST. */
+        public static final Option<List<String>> HOCON_ENVIRONMENT_VARIABLE_ALLOWLIST =
+                Options.key("hocon-environment-variable-allowlist")
+                        .listType()
+                        .defaultValue(Collections.emptyList())
+                        .withDescription(
+                                "Environment variables that HOCON job configurations submitted through the REST API may resolve.");
 
         public static final Option<String> BASIC_AUTH_USERNAME =
                 Options.key("basic-auth-username")

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.YamlClientConfigBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
 
@@ -81,6 +82,9 @@ public class YamlSeaTunnelConfigParserTest {
         Assertions.assertEquals(8080, config.getEngineConfig().getHttpConfig().getPort());
         Assertions.assertEquals(200, config.getEngineConfig().getHttpConfig().getPortRange());
         Assertions.assertEquals(8443, config.getEngineConfig().getHttpConfig().getHttpsPort());
+        Assertions.assertEquals(
+                Arrays.asList("JOB_NAME", "SOURCE_URL"),
+                config.getEngineConfig().getHttpConfig().getHoconEnvironmentVariableAllowlist());
         Assertions.assertEquals(
                 30, config.getEngineConfig().getCoordinatorServiceConfig().getCoreThreadNum());
         Assertions.assertEquals(

--- a/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel.yaml
@@ -43,3 +43,6 @@ seatunnel:
              port: 8080
              enable-dynamic-port: true
              port-range: 200
+             hocon-environment-variable-allowlist:
+               - JOB_NAME
+               - SOURCE_URL

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
@@ -18,7 +18,6 @@
 package org.apache.seatunnel.engine.server.rest.service;
 
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
-import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.common.metrics.JobMetrics;
 import org.apache.seatunnel.common.utils.DateTimeUtils;
@@ -70,6 +69,19 @@ public class JobInfoService extends BaseService {
 
     public JobInfoService(NodeEngineImpl nodeEngine) {
         super(nodeEngine);
+    }
+
+    /**
+     * Parses a REST HOCON job configuration using the server-side environment variable allowlist.
+     */
+    public Config buildHoconConfig(String content) {
+        return RestUtil.buildHoconConfig(
+                content,
+                getSeaTunnelServer(false)
+                        .getSeaTunnelConfig()
+                        .getEngineConfig()
+                        .getHttpConfig()
+                        .getHoconEnvironmentVariableAllowlist());
     }
 
     public JsonObject getJobInfoJson(Long jobId) {
@@ -394,7 +406,7 @@ public class JobInfoService extends BaseService {
 
         switch (configFormat) {
             case HOCON:
-                config = ConfigFactory.parseString(new String(requestBody, StandardCharsets.UTF_8));
+                config = buildHoconConfig(new String(requestBody, StandardCharsets.UTF_8));
                 break;
             case SQL:
                 config = SqlConfigBuilder.of(new String(requestBody, StandardCharsets.UTF_8));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/SubmitJobByUploadFileServlet.java
@@ -72,7 +72,7 @@ public class SubmitJobByUploadFileServlet extends BaseServlet {
                 break;
             case HOCON:
             default:
-                config = ConfigFactory.parseString(content);
+                config = jobInfoService.buildHoconConfig(content);
                 break;
         }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
@@ -20,9 +20,11 @@ package org.apache.seatunnel.engine.server.utils;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigException;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigResolveOptions;
 
+import org.apache.seatunnel.api.sink.TablePlaceholder;
 import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
 import org.apache.seatunnel.engine.server.rest.RestConstant;
@@ -33,10 +35,15 @@ import scala.Tuple2;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -44,6 +51,19 @@ import static org.apache.seatunnel.engine.common.Constant.REST_SUBMIT_JOBS_PARAM
 
 public class RestUtil {
     private RestUtil() {}
+
+    /**
+     * Finds HOCON-style substitutions so REST env resolution can protect SeaTunnel placeholders.
+     */
+    private static final Pattern HOCON_PLACEHOLDER_PATTERN =
+            Pattern.compile("\\$\\{([^}:]+)(:[^}]*)?}");
+
+    /** Prefix used for temporary placeholder protection before Typesafe Config resolution. */
+    private static final String PROTECTED_PLACEHOLDER_PREFIX =
+            "__SEATUNNEL_REST_SYSTEM_PLACEHOLDER_";
+
+    /** Suffix used for temporary placeholder protection before Typesafe Config resolution. */
+    private static final String PROTECTED_PLACEHOLDER_SUFFIX = "__";
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -101,10 +121,158 @@ public class RestUtil {
                         }
                     });
         }
-        return ConfigFactory.parseString(content)
-                .resolveWith(
-                        ConfigFactory.parseMap(allowedEnvironment),
-                        ConfigResolveOptions.noSystem().setAllowUnresolved(true));
+        PlaceholderProtection placeholderProtection =
+                protectSystemPlaceholders(content, allowedEnvironment.values());
+        Config resolvedConfig =
+                ConfigFactory.parseString(placeholderProtection.content)
+                        .resolveWith(
+                                ConfigFactory.parseMap(allowedEnvironment),
+                                ConfigResolveOptions.noSystem().setAllowUnresolved(true));
+        return restoreSystemPlaceholders(resolvedConfig, placeholderProtection.replacements);
+    }
+
+    /**
+     * Temporarily protects SeaTunnel runtime placeholders from HOCON substitution resolution.
+     *
+     * <p>Those placeholders, for example {@code ${table_name}}, are consumed later by connector
+     * runtime logic. They are not server-side environment variables and must not be resolved or
+     * rejected by REST HOCON environment substitution.
+     */
+    private static PlaceholderProtection protectSystemPlaceholders(
+            String content, Collection<Object> allowedEnvironmentValues) {
+        Matcher matcher = HOCON_PLACEHOLDER_PATTERN.matcher(content);
+        Map<String, String> replacements = new HashMap<>();
+        StringBuffer protectedContent = new StringBuffer();
+        int placeholderIndex = 0;
+        String placeholderNonce = UUID.randomUUID().toString().replace("-", "");
+        while (matcher.find()) {
+            String placeholderName = matcher.group(1);
+            if (!TablePlaceholder.isSystemPlaceholder(placeholderName)) {
+                continue;
+            }
+            String replacement =
+                    nextProtectedPlaceholderToken(
+                            content,
+                            allowedEnvironmentValues,
+                            replacements.keySet(),
+                            placeholderNonce,
+                            placeholderIndex);
+            placeholderIndex++;
+            replacements.put(replacement, matcher.group());
+            matcher.appendReplacement(protectedContent, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(protectedContent);
+        return new PlaceholderProtection(protectedContent.toString(), replacements);
+    }
+
+    /**
+     * Generates a temporary placeholder token that cannot collide with user config or env values.
+     */
+    private static String nextProtectedPlaceholderToken(
+            String content,
+            Collection<Object> allowedEnvironmentValues,
+            Collection<String> usedTokens,
+            String placeholderNonce,
+            int placeholderIndex) {
+        String replacement;
+        int candidateIndex = placeholderIndex;
+        do {
+            replacement =
+                    PROTECTED_PLACEHOLDER_PREFIX
+                            + placeholderNonce
+                            + "_"
+                            + candidateIndex++
+                            + PROTECTED_PLACEHOLDER_SUFFIX;
+        } while (containsProtectedPlaceholderToken(
+                content, allowedEnvironmentValues, usedTokens, replacement));
+        return replacement;
+    }
+
+    /** Checks whether a generated placeholder token would collide with existing user data. */
+    private static boolean containsProtectedPlaceholderToken(
+            String content,
+            Collection<Object> allowedEnvironmentValues,
+            Collection<String> usedTokens,
+            String replacement) {
+        if (content.contains(replacement) || usedTokens.contains(replacement)) {
+            return true;
+        }
+        return allowedEnvironmentValues.stream()
+                .map(String::valueOf)
+                .anyMatch(value -> value.contains(replacement));
+    }
+
+    /**
+     * Restores protected SeaTunnel runtime placeholders after environment resolution completes.
+     *
+     * <p>If the config still contains an intentionally unresolved non-allowlisted substitution,
+     * restoring through {@code root().unwrapped()} is impossible. In that failure path, returning
+     * the unresolved config preserves the existing REST rejection behavior without exposing values.
+     */
+    private static Config restoreSystemPlaceholders(
+            Config config, Map<String, String> protectedPlaceholders) {
+        if (protectedPlaceholders.isEmpty()) {
+            return config;
+        }
+        try {
+            Map<String, Object> restoredConfig =
+                    (Map<String, Object>)
+                            restoreSystemPlaceholders(
+                                    config.root().unwrapped(), protectedPlaceholders);
+            return ConfigFactory.parseMap(restoredConfig)
+                    .resolve(ConfigResolveOptions.noSystem().setAllowUnresolved(true));
+        } catch (ConfigException.NotResolved ignored) {
+            return config;
+        }
+    }
+
+    /** Restores protected placeholders inside nested maps, lists and string values. */
+    private static Object restoreSystemPlaceholders(
+            Object value, Map<String, String> protectedPlaceholders) {
+        if (value instanceof String) {
+            String restoredValue = (String) value;
+            for (Map.Entry<String, String> entry : protectedPlaceholders.entrySet()) {
+                restoredValue = restoredValue.replace(entry.getKey(), entry.getValue());
+            }
+            return restoredValue;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> restoredMap = new LinkedHashMap<>();
+            ((Map<?, ?>) value)
+                    .forEach(
+                            (mapKey, mapValue) ->
+                                    restoredMap.put(
+                                            String.valueOf(mapKey),
+                                            restoreSystemPlaceholders(
+                                                    mapValue, protectedPlaceholders)));
+            return restoredMap;
+        }
+        if (value instanceof List) {
+            List<Object> restoredList = new ArrayList<>();
+            ((List<?>) value)
+                    .forEach(
+                            listValue ->
+                                    restoredList.add(
+                                            restoreSystemPlaceholders(
+                                                    listValue, protectedPlaceholders)));
+            return restoredList;
+        }
+        return value;
+    }
+
+    /** Holds HOCON content and the temporary placeholder replacement map. */
+    private static class PlaceholderProtection {
+
+        /** HOCON content after temporary placeholder protection. */
+        private final String content;
+
+        /** Mapping from temporary tokens to original SeaTunnel placeholders. */
+        private final Map<String, String> replacements;
+
+        private PlaceholderProtection(String content, Map<String, String> replacements) {
+            this.content = content;
+            this.replacements = replacements;
+        }
     }
 
     public static List<Tuple2<Map<String, String>, Config>> buildConfigList(JsonNode jsonNode) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/RestUtil.java
@@ -20,6 +20,8 @@ package org.apache.seatunnel.engine.server.utils;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigResolveOptions;
 
 import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
@@ -31,6 +33,8 @@ import scala.Tuple2;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -74,6 +78,33 @@ public class RestUtil {
     public static Config buildConfig(JsonNode jsonNode) {
         Map<String, Object> objectMap = JsonUtils.toMap(jsonNode);
         return ConfigBuilder.of(objectMap);
+    }
+
+    /**
+     * Parses a HOCON REST request and resolves only explicitly allowed environment variables.
+     *
+     * <p>System properties and all other process environment variables are excluded because REST
+     * callers must not be able to inspect arbitrary server-side secrets. Unresolved substitutions
+     * remain unresolved, matching the CLI configuration loading policy.
+     */
+    public static Config buildHoconConfig(
+            String content, Collection<String> environmentVariableAllowlist) {
+        Map<String, Object> allowedEnvironment = new HashMap<>();
+        if (environmentVariableAllowlist != null) {
+            environmentVariableAllowlist.forEach(
+                    variableName -> {
+                        if (variableName != null && !variableName.isEmpty()) {
+                            String value = System.getenv(variableName);
+                            if (value != null) {
+                                allowedEnvironment.put(variableName, value);
+                            }
+                        }
+                    });
+        }
+        return ConfigFactory.parseString(content)
+                .resolveWith(
+                        ConfigFactory.parseMap(allowedEnvironment),
+                        ConfigResolveOptions.noSystem().setAllowUnresolved(true));
     }
 
     public static List<Tuple2<Map<String, String>, Config>> buildConfigList(JsonNode jsonNode) {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.org.eclipse.jetty.server.ServerConnector;
 
 import org.apache.seatunnel.common.utils.ExceptionUtils;
 import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.HttpConfig;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
@@ -49,12 +51,13 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * Integration test verifying that REST API submit-job endpoints correctly call
- * ConfigShadeUtils.decryptConfig() for HOCON, SQL and upload formats.
+ * Integration test verifying HOCON variable resolution and ConfigShade decryption across REST API
+ * submit-job endpoints.
  *
  * @see <a href="https://github.com/apache/seatunnel/issues/10590">#10590</a>
  */
@@ -63,6 +66,18 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
 
     private static final String ENCRYPTED_USERNAME = "c2VhdHVubmVs";
     private static final String ENCRYPTED_PASSWORD = "c2VhdHVubmVsX3Bhc3N3b3Jk";
+
+    /** Allowlisted environment variable used by REST submission tests. */
+    private static final String REST_JOB_NAME_ENV = "SEATUNNEL_REST_TEST_JOB_NAME";
+
+    /** Expected job name after resolving the allowlisted environment variable. */
+    private static final String REST_JOB_NAME = "rest_environment_variable_job";
+
+    /** Environment variable intentionally excluded from the REST allowlist. */
+    private static final String DENIED_ENV = "SEATUNNEL_REST_TEST_DENIED_ENV";
+
+    /** Secret marker that must never appear in a REST response. */
+    private static final String DENIED_ENV_VALUE = "must_not_be_exposed";
 
     private HazelcastInstanceImpl instance;
     private SeaTunnelServer server;
@@ -86,6 +101,8 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
         httpConfig.setPort(24000);
         httpConfig.setEnableDynamicPort(true);
         httpConfig.setPortRange(2000);
+        httpConfig.setHoconEnvironmentVariableAllowlist(
+                Collections.singletonList(REST_JOB_NAME_ENV));
 
         instance = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
         server = instance.node.nodeEngine.getService(SeaTunnelServer.SERVICE_NAME);
@@ -169,6 +186,43 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
         Assertions.assertTrue(
                 response.body.contains("jobId"),
                 "Response should contain jobId, got: " + response.body);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = REST_JOB_NAME_ENV, value = REST_JOB_NAME)
+    public void testSubmitJobWithHoconFormatResolvesEnvironmentVariable() throws Exception {
+        String requestUrl = "http://localhost:" + restPort + "/submit-job?format=hocon";
+
+        HttpResponse response = post(requestUrl, "text/plain", buildEnvironmentVariableHoconBody());
+
+        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
+        Assertions.assertEquals(
+                REST_JOB_NAME, JsonUtils.parseObject(response.body).get("jobName").asText());
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = REST_JOB_NAME_ENV, value = REST_JOB_NAME)
+    public void testSubmitJobByUploadHoconFileResolvesEnvironmentVariable() throws Exception {
+        String requestUrl = "http://localhost:" + restPort + "/submit-job/upload";
+
+        HttpResponse response =
+                postMultipart(requestUrl, "job.conf", buildEnvironmentVariableHoconBody());
+
+        Assertions.assertEquals(200, response.code, () -> "responseBody=" + response.body);
+        Assertions.assertEquals(
+                REST_JOB_NAME, JsonUtils.parseObject(response.body).get("jobName").asText());
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = DENIED_ENV, value = DENIED_ENV_VALUE)
+    public void testSubmitJobDoesNotExposeEnvironmentVariableOutsideAllowlist() throws Exception {
+        String requestUrl = "http://localhost:" + restPort + "/submit-job?format=hocon";
+
+        HttpResponse response =
+                post(requestUrl, "text/plain", buildEnvironmentVariableHoconBody(DENIED_ENV));
+
+        Assertions.assertNotEquals(200, response.code);
+        Assertions.assertFalse(response.body.contains(DENIED_ENV_VALUE));
     }
 
     @Test
@@ -321,6 +375,29 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
                 + "    password = \""
                 + ENCRYPTED_PASSWORD
                 + "\"\n"
+                + "    schema { fields { name = \"string\" } }\n"
+                + "  }\n"
+                + "}\n"
+                + "transform {}\n"
+                + "sink { Console {} }";
+    }
+
+    /** Builds a HOCON job that references the allowlisted test environment variable. */
+    private String buildEnvironmentVariableHoconBody() {
+        return buildEnvironmentVariableHoconBody(REST_JOB_NAME_ENV);
+    }
+
+    /** Builds a HOCON job whose name references the requested environment variable. */
+    private String buildEnvironmentVariableHoconBody(String variableName) {
+        return "env {\n"
+                + "  job.mode = \"BATCH\"\n"
+                + "  job.name = ${"
+                + variableName
+                + "}\n"
+                + "}\n"
+                + "source {\n"
+                + "  FakeSource {\n"
+                + "    row.num = 1\n"
                 + "    schema { fields { name = \"string\" } }\n"
                 + "  }\n"
                 + "}\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/RestUtilTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/RestUtilTest.java
@@ -18,7 +18,7 @@
 package org.apache.seatunnel.engine.server.utils;
 
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
-import org.apache.seatunnel.shade.com.typesafe.config.ConfigRenderOptions;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigException;
 
 import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
 
@@ -33,28 +33,47 @@ import java.util.Collections;
 /** Tests the security and compatibility boundaries of REST HOCON configuration resolution. */
 public class RestUtilTest {
 
+    /** Environment variable whose value collides with a temporary placeholder token. */
+    private static final String COLLISION_ENV = "SEATUNNEL_REST_COLLISION_ENV";
+
+    /** User-provided value that must not be rewritten during placeholder restoration. */
+    private static final String COLLISION_ENV_VALUE = "__SEATUNNEL_REST_SYSTEM_PLACEHOLDER_1__";
+
     /**
      * Verifies that only allowlisted environment variables are resolved while normal HOCON
      * references continue to work.
      */
     @Test
     @SetEnvironmentVariable(key = "SEATUNNEL_REST_ALLOWED_ENV", value = "allowed-value")
-    @SetEnvironmentVariable(key = "SEATUNNEL_REST_DENIED_ENV", value = "denied-value")
-    public void testBuildHoconConfigResolvesOnlyAllowlistedEnvironmentVariables() {
+    public void testBuildHoconConfigResolvesAllowlistedEnvironmentVariables() {
         Config config =
                 RestUtil.buildHoconConfig(
                         "base = \"internal-value\"\n"
                                 + "internal = ${base}\n"
-                                + "allowed = ${SEATUNNEL_REST_ALLOWED_ENV}\n"
-                                + "denied = ${SEATUNNEL_REST_DENIED_ENV}",
+                                + "allowed = ${SEATUNNEL_REST_ALLOWED_ENV}",
                         Collections.singletonList("SEATUNNEL_REST_ALLOWED_ENV"));
 
         Assertions.assertEquals("internal-value", config.getString("internal"));
         Assertions.assertEquals("allowed-value", config.getString("allowed"));
+        Assertions.assertTrue(config.isResolved());
+    }
+
+    /**
+     * Verifies that environment variables outside the REST allowlist remain unresolved and their
+     * values are not exposed.
+     */
+    @Test
+    @SetEnvironmentVariable(key = "SEATUNNEL_REST_DENIED_ENV", value = "denied-value")
+    public void testBuildHoconConfigDoesNotResolveEnvironmentVariablesOutsideAllowlist() {
+        Config config =
+                RestUtil.buildHoconConfig(
+                        "denied = ${SEATUNNEL_REST_DENIED_ENV}", Collections.emptyList());
+
         Assertions.assertFalse(config.isResolved());
-        Assertions.assertEquals(
-                "${SEATUNNEL_REST_DENIED_ENV}",
-                config.root().get("denied").render(ConfigRenderOptions.concise()));
+        ConfigException.NotResolved exception =
+                Assertions.assertThrows(
+                        ConfigException.NotResolved.class, () -> config.getString("denied"));
+        Assertions.assertFalse(exception.getMessage().contains("denied-value"));
     }
 
     /** Verifies that JVM system properties are never exposed to REST HOCON requests. */
@@ -66,9 +85,10 @@ public class RestUtilTest {
                         "value = ${SEATUNNEL_REST_SYSTEM_PROPERTY}", Collections.emptyList());
 
         Assertions.assertFalse(config.isResolved());
-        Assertions.assertEquals(
-                "${SEATUNNEL_REST_SYSTEM_PROPERTY}",
-                config.root().get("value").render(ConfigRenderOptions.concise()));
+        ConfigException.NotResolved exception =
+                Assertions.assertThrows(
+                        ConfigException.NotResolved.class, () -> config.getString("value"));
+        Assertions.assertFalse(exception.getMessage().contains("system-secret"));
     }
 
     /**
@@ -79,6 +99,7 @@ public class RestUtilTest {
     @SetEnvironmentVariable(
             key = "SEATUNNEL_REST_ENCRYPTED_PASSWORD",
             value = "c2VhdHVubmVsX3Bhc3N3b3Jk")
+    @SetEnvironmentVariable(key = COLLISION_ENV, value = COLLISION_ENV_VALUE)
     public void testBuildHoconConfigPreservesOptionalAndConnectorPlaceholderSemantics() {
         Config config =
                 RestUtil.buildHoconConfig(
@@ -87,23 +108,39 @@ public class RestUtilTest {
                                 + "  job.mode = \"BATCH\"\n"
                                 + "  shade.identifier = \"base64\"\n"
                                 + "}\n"
+                                + "token.prefix = \"__SEATUNNEL_REST_SYSTEM_\"\n"
+                                + "token.suffix = \"PLACEHOLDER_0__\"\n"
                                 + "source = [{\n"
                                 + "  plugin_name = \"FakeSource\"\n"
                                 + "  password = ${SEATUNNEL_REST_ENCRYPTED_PASSWORD}\n"
-                                + "  string.template = \"${table_name}\"\n"
+                                + "  literal.collision = \"__SEATUNNEL_REST_SYSTEM_PLACEHOLDER_0__\"\n"
+                                + "  env.collision = ${"
+                                + COLLISION_ENV
+                                + "}\n"
+                                + "  resolved.collision = ${token.prefix}${token.suffix}\n"
+                                + "  string.template = ${table_name}\n"
+                                + "  default.template = ${table_name:default_table}\n"
                                 + "}]\n"
                                 + "sink = [{ plugin_name = \"Console\" }]",
                         Arrays.asList(
-                                "SEATUNNEL_REST_MISSING_ENV", "SEATUNNEL_REST_ENCRYPTED_PASSWORD"));
+                                "SEATUNNEL_REST_MISSING_ENV",
+                                "SEATUNNEL_REST_ENCRYPTED_PASSWORD",
+                                COLLISION_ENV));
 
         Config decryptedConfig = ConfigShadeUtils.decryptConfig(config);
+        Config sourceConfig = decryptedConfig.getConfigList("source").get(0);
 
         Assertions.assertFalse(decryptedConfig.hasPath("optional"));
         Assertions.assertEquals(
-                "${table_name}",
-                decryptedConfig.getConfigList("source").get(0).getString("string.template"));
+                "__SEATUNNEL_REST_SYSTEM_PLACEHOLDER_0__",
+                sourceConfig.getString("literal.collision"));
+        Assertions.assertEquals(COLLISION_ENV_VALUE, sourceConfig.getString("env.collision"));
         Assertions.assertEquals(
-                "seatunnel_password",
-                decryptedConfig.getConfigList("source").get(0).getString("password"));
+                "__SEATUNNEL_REST_SYSTEM_PLACEHOLDER_0__",
+                sourceConfig.getString("resolved.collision"));
+        Assertions.assertEquals("${table_name}", sourceConfig.getString("string.template"));
+        Assertions.assertEquals(
+                "${table_name:default_table}", sourceConfig.getString("default.template"));
+        Assertions.assertEquals("seatunnel_password", sourceConfig.getString("password"));
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/RestUtilTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/RestUtilTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.utils;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigRenderOptions;
+
+import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/** Tests the security and compatibility boundaries of REST HOCON configuration resolution. */
+public class RestUtilTest {
+
+    /**
+     * Verifies that only allowlisted environment variables are resolved while normal HOCON
+     * references continue to work.
+     */
+    @Test
+    @SetEnvironmentVariable(key = "SEATUNNEL_REST_ALLOWED_ENV", value = "allowed-value")
+    @SetEnvironmentVariable(key = "SEATUNNEL_REST_DENIED_ENV", value = "denied-value")
+    public void testBuildHoconConfigResolvesOnlyAllowlistedEnvironmentVariables() {
+        Config config =
+                RestUtil.buildHoconConfig(
+                        "base = \"internal-value\"\n"
+                                + "internal = ${base}\n"
+                                + "allowed = ${SEATUNNEL_REST_ALLOWED_ENV}\n"
+                                + "denied = ${SEATUNNEL_REST_DENIED_ENV}",
+                        Collections.singletonList("SEATUNNEL_REST_ALLOWED_ENV"));
+
+        Assertions.assertEquals("internal-value", config.getString("internal"));
+        Assertions.assertEquals("allowed-value", config.getString("allowed"));
+        Assertions.assertFalse(config.isResolved());
+        Assertions.assertEquals(
+                "${SEATUNNEL_REST_DENIED_ENV}",
+                config.root().get("denied").render(ConfigRenderOptions.concise()));
+    }
+
+    /** Verifies that JVM system properties are never exposed to REST HOCON requests. */
+    @Test
+    @SetSystemProperty(key = "SEATUNNEL_REST_SYSTEM_PROPERTY", value = "system-secret")
+    public void testBuildHoconConfigDoesNotResolveSystemProperties() {
+        Config config =
+                RestUtil.buildHoconConfig(
+                        "value = ${SEATUNNEL_REST_SYSTEM_PROPERTY}", Collections.emptyList());
+
+        Assertions.assertFalse(config.isResolved());
+        Assertions.assertEquals(
+                "${SEATUNNEL_REST_SYSTEM_PROPERTY}",
+                config.root().get("value").render(ConfigRenderOptions.concise()));
+    }
+
+    /**
+     * Verifies optional missing environment variables and connector placeholders keep their
+     * established semantics when allowlist resolution is followed by ConfigShade decryption.
+     */
+    @Test
+    @SetEnvironmentVariable(
+            key = "SEATUNNEL_REST_ENCRYPTED_PASSWORD",
+            value = "c2VhdHVubmVsX3Bhc3N3b3Jk")
+    public void testBuildHoconConfigPreservesOptionalAndConnectorPlaceholderSemantics() {
+        Config config =
+                RestUtil.buildHoconConfig(
+                        "optional = ${?SEATUNNEL_REST_MISSING_ENV}\n"
+                                + "env {\n"
+                                + "  job.mode = \"BATCH\"\n"
+                                + "  shade.identifier = \"base64\"\n"
+                                + "}\n"
+                                + "source = [{\n"
+                                + "  plugin_name = \"FakeSource\"\n"
+                                + "  password = ${SEATUNNEL_REST_ENCRYPTED_PASSWORD}\n"
+                                + "  string.template = \"${table_name}\"\n"
+                                + "}]\n"
+                                + "sink = [{ plugin_name = \"Console\" }]",
+                        Arrays.asList(
+                                "SEATUNNEL_REST_MISSING_ENV", "SEATUNNEL_REST_ENCRYPTED_PASSWORD"));
+
+        Config decryptedConfig = ConfigShadeUtils.decryptConfig(config);
+
+        Assertions.assertFalse(decryptedConfig.hasPath("optional"));
+        Assertions.assertEquals(
+                "${table_name}",
+                decryptedConfig.getConfigList("source").get(0).getString("string.template"));
+        Assertions.assertEquals(
+                "seatunnel_password",
+                decryptedConfig.getConfigList("source").get(0).getString("password"));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

REST HOCON submission parsed request bodies and uploaded configuration files without resolving environment substitutions. This change adds the same capability to both HOCON paths while protecting the Engine process boundary with an explicit `seatunnel.engine.http.hocon-environment-variable-allowlist`. The allowlist is empty by default, and JVM system properties are never exposed.

### Does this PR introduce _any_ user-facing change?

Yes. Operators can list environment variable names under `seatunnel.engine.http.hocon-environment-variable-allowlist`, then use substitutions such as `job.name = ${JOB_NAME}` in direct or uploaded HOCON REST submissions. English and Chinese REST/security documentation and the default configuration template are updated.

### How was this patch tested?

- Added `RestUtilTest` coverage for allowlisted and denied variables, JVM system-property isolation, internal HOCON references, optional substitutions, connector placeholders, and ConfigShade decryption ordering.
- Extended YAML parsing coverage for the new allowlist.
- Extended the existing REST integration test for direct HOCON submission, uploaded HOCON submission, exact resolved job names, and denied-variable non-disclosure.
- Ran scoped `spotless:apply`, scoped `spotless:check`, and `git diff --check` locally. Compile and functional test results are delegated to GitHub CI for the current PR head.

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese documentation are updated.
* [x] No incompatible change is introduced.
* [x] This is not a connector change.