### PR TITLE
[Feature][Zeta] Add incremental job monitoring API

### DIFF
--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -690,6 +690,100 @@ When we can't get the job info, the response will be:
 
 ------------------------------------------------------------------------------------------
 
+### Incrementally Query Terminal Job Changes
+
+<details>
+ <summary><code>GET</code> <code><b>/jobs?status=FAILED&start=latest&limit=100</b></code> <code>(Returns lightweight terminal-job changes for monitoring systems.)</code></summary>
+
+This endpoint is intended for polling and alert reconciliation. Unlike `/finished-jobs`, it does
+not load job DAGs or metrics. A durable sidecar outbox decouples monitoring from authoritative
+finished-job persistence. The background drain assigns each job a monotonically increasing
+sequence. One request performs exact-key lookups for at most `limit` sequence slots, so server-side
+query work is bounded independently of the total retained job count.
+
+#### Parameters
+
+> | name | type | data type | description |
+> |------|------|-----------|-------------|
+> | status | optional | string | Filters one terminal job status, such as `FAILED`, `FINISHED`, `CANCELED`, `SAVEPOINT_DONE`, or `UNKNOWABLE`. |
+> | start | required for the first request | string | `latest` starts after the current committed sequence. `beginning` starts at the earliest retained monitoring sequence. It cannot be combined with `cursor`. |
+> | cursor | required for subsequent requests | string | Opaque cursor returned by the previous response. It cannot be combined with `start`. |
+> | limit | optional | int | Maximum sequence slots examined. The default is `100`; the valid range is `1` through `1000`. The number of returned records can be smaller after status filtering or retention expiry. |
+
+#### Responses
+
+```json
+{
+  "data": [
+    {
+      "sequence": 42,
+      "jobId": "123456",
+      "jobName": "mysql_cdc_to_doris",
+      "jobStatus": "FAILED",
+      "createTime": 1717499900000,
+      "startTime": 1717499910000,
+      "finishTime": 1717500010000,
+      "observedTime": 1717500010100,
+      "errorSummary": "Doris stream load failed"
+    }
+  ],
+  "hasMore": false,
+  "limit": 100,
+  "scanned": 1,
+  "headSequence": 42,
+  "cursorReset": false,
+  "nextCursor": "Mnw0MnxGQUlMRUQ"
+}
+```
+
+Results are ordered by `sequence`. `nextCursor` points after the sequence window examined by this
+request, not necessarily after the last returned job. Always persist the returned cursor, including
+when `data` is empty. This safely advances across records excluded by the status filter. The cursor
+preserves the initial status filter; a conflicting status is rejected.
+
+`headSequence` is the earliest retained sequence. `start=beginning` starts there instead of scanning
+expired sequence gaps. When a cursor is older than `headSequence`, the server advances it to the
+retention head and returns `cursorReset=true`; records already removed by retention cannot be
+recovered. The outbox is drained asynchronously, so a just-finished job can appear after a short
+delay. Repeated terminal-state persistence for the same retained job is deduplicated by `jobId`.
+
+The durable outbox is capped at 100,000 records, with a 1,000-job durable overflow and a 1,000-job
+local last-resort buffer. These bounds prevent an extended ledger outage from exhausting heap
+memory. If all tiers are unavailable, SeaTunnel keeps the authoritative finished-job state, logs
+an error, and increments
+`engine_state_store_finished_job_monitoring_dropped_total`. A non-zero value means the monitoring
+stream must be treated as incomplete for that outage window.
+
+The authoritative finished-job state is written before the monitoring sidecar. The 100 ms outbox
+setting limits capacity and lock waiting; it is not a network RPC deadline. During a Hazelcast
+partition outage, the completion callback can still wait for the configured Hazelcast operation
+timeout, but a sidecar exception cannot roll back the finished-job state.
+
+`finishTime` can be `null` for abnormal recovery records; `observedTime` is always populated when
+SeaTunnel stores the monitoring record. `jobName` and `errorSummary` are capped at 256 and 1024
+characters respectively. Use `/job-info/{jobId}` when full job details are required.
+
+Monitoring records use the same retention period as finished-job history, controlled by
+`history-job-expire-minutes`. Records that existed before upgrading to a version containing this
+endpoint are not backfilled. Use `start=latest` to establish a monitoring watermark after upgrade,
+or `start=beginning` to replay records created by the new version that are still retained. For
+low-latency alerts, use the job event HTTP reporter and use this endpoint for periodic
+reconciliation.
+
+Example polling sequence:
+
+```bash
+# Establish a watermark without replaying older records
+curl "http://localhost:5801/jobs?status=FAILED&start=latest&limit=100"
+
+# Continue from nextCursor returned by the previous response
+curl "http://localhost:5801/jobs?cursor=Mnw0MnxGQUlMRUQ&limit=100"
+```
+
+</details>
+
+------------------------------------------------------------------------------------------
+
 ### Returns System Monitoring Information
 
 <details>

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -669,6 +669,94 @@ seatunnel:
 
 ------------------------------------------------------------------------------------------
 
+### 增量查询终态作业变化
+
+<details>
+ <summary><code>GET</code> <code><b>/jobs?status=FAILED&start=latest&limit=100</b></code> <code>(面向监控系统返回轻量的终态作业增量数据。)</code></summary>
+
+该接口用于作业失败轮询和告警补偿对账。与 `/finished-jobs` 不同，它不会加载作业
+DAG 和 metrics。持久化 sidecar outbox 将监控写入与权威 finished-job 状态解耦，
+后台 drain 会为每个作业分配单调递增的 sequence。每次请求最多对 `limit` 个 sequence
+做精确 key 查询，因此服务端查询开销不会随历史作业总量增长。
+
+#### 参数
+
+> | 参数名称 | 是否必传 | 参数类型 | 参数描述 |
+> |---------|----------|----------|----------|
+> | status | 否 | string | 过滤一个终态作业状态，例如 `FAILED`、`FINISHED`、`CANCELED`、`SAVEPOINT_DONE` 或 `UNKNOWABLE`。 |
+> | start | 首次请求必传 | string | `latest` 从当前已提交 sequence 之后开始；`beginning` 从当前最早保留的监控 sequence 开始。不能与 `cursor` 同时传入。 |
+> | cursor | 后续请求必传 | string | 上一次响应返回的不透明游标；不能与 `start` 同时传入。 |
+> | limit | 否 | int | 本次最多检查的 sequence 数量，默认值为 `100`，有效范围为 `1` 到 `1000`。经过状态过滤或保留期清理后，实际返回记录数可能更少。 |
+
+#### 响应
+
+```json
+{
+  "data": [
+    {
+      "sequence": 42,
+      "jobId": "123456",
+      "jobName": "mysql_cdc_to_doris",
+      "jobStatus": "FAILED",
+      "createTime": 1717499900000,
+      "startTime": 1717499910000,
+      "finishTime": 1717500010000,
+      "observedTime": 1717500010100,
+      "errorSummary": "Doris stream load failed"
+    }
+  ],
+  "hasMore": false,
+  "limit": 100,
+  "scanned": 1,
+  "headSequence": 42,
+  "cursorReset": false,
+  "nextCursor": "Mnw0MnxGQUlMRUQ"
+}
+```
+
+结果按照 `sequence` 升序排列。`nextCursor` 指向本次已检查 sequence 窗口的末尾，
+不一定是最后一条返回记录。即使 `data` 为空，也必须持久化本次返回的新游标；这样才能
+安全越过被状态条件过滤的记录。游标会保留首次请求的状态条件，传入冲突的状态会被拒绝。
+
+`headSequence` 表示当前最早保留的 sequence。`start=beginning` 会直接从该位置开始，
+不会逐个扫描已过期的 sequence 空洞。如果 cursor 已落后于 `headSequence`，服务端会
+自动前移到保留水位并返回 `cursorReset=true`；已经被保留策略删除的记录无法恢复。
+outbox 由后台异步 drain，因此刚结束的作业可能在短暂延迟后出现。同一个仍在保留期内的
+作业若重复写入终态，会按 `jobId` 去重。
+
+持久 outbox 最多保留 100,000 条记录，另有 1,000 个作业的持久 overflow 和 1,000 个
+作业的本地最后重试缓冲，避免 ledger 长期异常耗尽堆内存。如果所有缓冲层都不可用，
+SeaTunnel 仍会保留权威 finished-job 状态，同时记录错误日志并递增
+`engine_state_store_finished_job_monitoring_dropped_total`。该指标非零表示对应异常窗口
+内的监控增量流不完整。
+
+权威 finished-job 状态会先于监控 sidecar 写入。outbox 的 100 ms 只限制容量等待和
+加锁等待，不是网络 RPC 的墙钟超时；Hazelcast 分区异常时，完成回调仍可能等待已配置的
+Hazelcast operation timeout，但 sidecar 异常不会回滚 finished-job 状态。
+
+异常恢复记录的 `finishTime` 可能为 `null`；`observedTime` 是 SeaTunnel 写入监控
+记录时生成的非空时间。`jobName` 和 `errorSummary` 分别最多返回 256 和 1024 个字符；
+需要完整详情时使用 `/job-info/{jobId}`。
+
+监控记录与 finished-job history 使用相同保留时间，由
+`history-job-expire-minutes` 控制。升级前已存在的历史记录不会回填。升级后可使用
+`start=latest` 建立新的监控水位，或使用 `start=beginning` 回放新版本写入且仍在保留期
+内的记录。需要低延迟告警时，应使用作业事件 HTTP 回调，并用本接口进行周期性补偿对账。
+
+轮询示例：
+
+```bash
+# 建立水位，不回放已有记录
+curl "http://localhost:5801/jobs?status=FAILED&start=latest&limit=100"
+
+# 使用上一次响应中的 nextCursor 继续查询
+curl "http://localhost:5801/jobs?cursor=Mnw0MnxGQUlMRUQ&limit=100"
+```
+
+</details>
+
+------------------------------------------------------------------------------------------
+
 ### 返回系统监控信息
 
 <details>

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
@@ -47,6 +47,31 @@ public class Constant {
 
     public static final String IMAP_FINISHED_JOB_STATE = "engine_finishedJobState";
 
+    public static final String IMAP_FINISHED_JOB_MONITORING = "engine_finishedJobMonitoring";
+
+    public static final String IMAP_FINISHED_JOB_MONITORING_METADATA =
+            "engine_finishedJobMonitoringMetadata";
+
+    public static final String IMAP_FINISHED_JOB_MONITORING_PENDING =
+            "engine_finishedJobMonitoringPending";
+
+    public static final String IMAP_FINISHED_JOB_MONITORING_OVERFLOW =
+            "engine_finishedJobMonitoringOverflow";
+
+    public static final int FINISHED_JOB_MONITORING_PENDING_CAPACITY = 100000;
+
+    public static final String FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY = "committedSequence";
+
+    public static final String FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY = "headSequence";
+
+    public static final String FINISHED_JOB_MONITORING_JOB_SEQUENCE_KEY_PREFIX = "job:";
+
+    public static final String FINISHED_JOB_MONITORING_DRAIN_LOCK_KEY = "drainLock";
+
+    public static final String FINISHED_JOB_MONITORING_OVERFLOW_LOCK_KEY = "overflowLock";
+
+    public static final String FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY = "droppedRecords";
+
     public static final String IMAP_FINISHED_JOB_METRICS = "engine_finishedJobMetrics";
 
     public static final String IMAP_FINISHED_JOB_VERTEX_INFO = "engine_finishedJobVertexInfo";

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -535,6 +535,18 @@ public class CoordinatorService {
                         nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_FINISHED_JOB_STATE),
                         nodeEngine
                                 .getHazelcastInstance()
+                                .getMap(Constant.IMAP_FINISHED_JOB_MONITORING),
+                        nodeEngine
+                                .getHazelcastInstance()
+                                .getMap(Constant.IMAP_FINISHED_JOB_MONITORING_METADATA),
+                        nodeEngine
+                                .getHazelcastInstance()
+                                .getQueue(Constant.IMAP_FINISHED_JOB_MONITORING_PENDING),
+                        nodeEngine
+                                .getHazelcastInstance()
+                                .getMap(Constant.IMAP_FINISHED_JOB_MONITORING_OVERFLOW),
+                        nodeEngine
+                                .getHazelcastInstance()
                                 .getMap(Constant.IMAP_FINISHED_JOB_METRICS),
                         nodeEngine
                                 .getHazelcastInstance()
@@ -576,6 +588,9 @@ public class CoordinatorService {
     private void cleanupPendingPipelines() {
         if (!isActive) {
             return;
+        }
+        if (jobHistoryService != null) {
+            jobHistoryService.retryPendingJobMonitoringRecords();
         }
         IMap<PipelineLocation, PipelineCleanupRecord> pendingCleanupIMap =
                 this.pendingPipelineCleanupIMap;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
@@ -37,6 +37,7 @@ import org.apache.seatunnel.engine.server.rest.servlet.CurrentNodeLogServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.EncryptConfigServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.FinishedJobsServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.JobInfoServlet;
+import org.apache.seatunnel.engine.server.rest.servlet.JobsServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.MetricsServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.OptionRulesServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.OverviewServlet;
@@ -71,6 +72,7 @@ import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_CHEC
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_ENCRYPT_CONFIG;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_FINISHED_JOBS;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_GET_ALL_LOG_NAME;
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_JOBS;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_JOB_INFO;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_LOG;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_LOGS;
@@ -190,6 +192,7 @@ public class JettyService {
         ServletHolder systemMonitoringHolder =
                 new ServletHolder(new SystemMonitoringServlet(nodeEngine));
         ServletHolder jobInfoHolder = new ServletHolder(new JobInfoServlet(nodeEngine));
+        ServletHolder jobsHolder = new ServletHolder(new JobsServlet(nodeEngine));
         ServletHolder threadDumpHolder = new ServletHolder(new ThreadDumpServlet(nodeEngine));
 
         ServletHolder submitJobHolder = new ServletHolder(new SubmitJobServlet(nodeEngine));
@@ -228,6 +231,7 @@ public class JettyService {
         context.addServlet(
                 systemMonitoringHolder, convertUrlToPath(REST_URL_SYSTEM_MONITORING_INFORMATION));
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_JOB_INFO));
+        context.addServlet(jobsHolder, convertUrlToPath(REST_URL_JOBS));
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_RUNNING_JOB));
         context.addServlet(threadDumpHolder, convertUrlToPath(REST_URL_THREAD_DUMP));
         MultipartConfigElement multipartConfigElement = new MultipartConfigElement("");

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServerStarter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServerStarter.java
@@ -17,12 +17,14 @@
 
 package org.apache.seatunnel.engine.server;
 
+import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.server.telemetry.metrics.ExportsInstanceInitializer;
 
+import com.hazelcast.config.QueueConfig;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
@@ -55,6 +57,8 @@ public class SeaTunnelServerStarter {
     private static HazelcastInstanceImpl initializeHazelcastInstance(
             @NonNull SeaTunnelConfig seaTunnelConfig, String customInstanceName) {
 
+        configureFinishedJobMonitoringOutbox(seaTunnelConfig);
+
         // set the default async executor for Hazelcast InvocationFuture
         ConcurrencyUtil.setDefaultAsyncExecutor(CompletableFuture.EXECUTOR);
 
@@ -78,6 +82,26 @@ public class SeaTunnelServerStarter {
         }
 
         return original;
+    }
+
+    private static void configureFinishedJobMonitoringOutbox(SeaTunnelConfig seaTunnelConfig) {
+        QueueConfig queueConfig =
+                seaTunnelConfig
+                        .getHazelcastConfig()
+                        .getQueueConfigs()
+                        .get(Constant.IMAP_FINISHED_JOB_MONITORING_PENDING);
+        if (queueConfig == null) {
+            seaTunnelConfig
+                    .getHazelcastConfig()
+                    .addQueueConfig(
+                            new QueueConfig(Constant.IMAP_FINISHED_JOB_MONITORING_PENDING)
+                                    .setMaxSize(Constant.FINISHED_JOB_MONITORING_PENDING_CAPACITY));
+            return;
+        }
+        if (queueConfig.getMaxSize() <= 0
+                || queueConfig.getMaxSize() > Constant.FINISHED_JOB_MONITORING_PENDING_CAPACITY) {
+            queueConfig.setMaxSize(Constant.FINISHED_JOB_MONITORING_PENDING_CAPACITY);
+        }
     }
 
     public static HazelcastInstanceImpl createMasterAndWorkerHazelcastInstance(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobHistoryService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobHistoryService.java
@@ -39,11 +39,13 @@ import org.apache.seatunnel.engine.server.telemetry.log.operation.CleanLogOperat
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -60,6 +62,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -104,6 +107,40 @@ public class JobHistoryService {
      */
     @Getter private final IMap<Long, JobState> finishedJobStateImap;
 
+    private static final int MAX_MONITORING_JOB_NAME_LENGTH = 256;
+
+    private static final int MAX_MONITORING_ERROR_SUMMARY_LENGTH = 1024;
+
+    private static final int MAX_MONITORING_DRAIN_BATCH_SIZE = 1000;
+
+    private static final long MONITORING_RETRY_DELAY_SECONDS = 5L;
+
+    private static final long MONITORING_CAPACITY_OR_LOCK_WAIT_MILLIS = 100L;
+
+    private static final int MAX_LOCAL_MONITORING_RETRY_RECORDS = 1000;
+
+    // TTL-bound sequence ledger queried by the monitoring REST endpoint.
+    private final IMap<Long, JobMonitoringRecord> finishedJobMonitoringImap;
+
+    // Durable sequence, retention-head, and job-to-sequence watermarks.
+    private final IMap<String, Long> finishedJobMonitoringMetadataImap;
+
+    // Durable sidecar outbox; entries are removed only after ledger commit.
+    private final IQueue<JobMonitoringRecord> pendingJobMonitoringQueue;
+
+    // Bounded durable overflow used when the primary queue cannot accept a record.
+    private final IMap<Long, JobMonitoringRecord> overflowJobMonitoringImap;
+
+    // Last-resort retry buffer used only when the distributed outbox is temporarily unavailable.
+    private final Map<Long, JobMonitoringRecord> localPendingJobMonitoringRecords =
+            new ConcurrentHashMap<>();
+
+    // Prevents concurrent drain workers in one coordinator.
+    private final AtomicBoolean monitoringDrainScheduled = new AtomicBoolean(false);
+
+    // Node-local delta retained until it can be merged into the distributed dropped counter.
+    private final AtomicLong pendingDroppedJobMonitoringRecords = new AtomicLong();
+
     private final IMap<Long, JobMetrics> finishedJobMetricsImap;
 
     private final ObjectMapper objectMapper;
@@ -119,6 +156,10 @@ public class JobHistoryService {
             Map<Long, PendingJobInfo> pendingJobMasterMap,
             Map<Long, JobMaster> runningJobMasterMap,
             IMap<Long, JobState> finishedJobStateImap,
+            IMap<Long, JobMonitoringRecord> finishedJobMonitoringImap,
+            IMap<String, Long> finishedJobMonitoringMetadataImap,
+            IQueue<JobMonitoringRecord> pendingJobMonitoringQueue,
+            IMap<Long, JobMonitoringRecord> overflowJobMonitoringImap,
             IMap<Long, JobMetrics> finishedJobMetricsImap,
             IMap<Long, JobDAGInfo> finishedJobVertexInfoImap,
             int finishedJobExpireTime) {
@@ -128,10 +169,16 @@ public class JobHistoryService {
         this.pendingJobInfoMap = pendingJobMasterMap;
         this.runningJobMasterMap = runningJobMasterMap;
         this.finishedJobStateImap = finishedJobStateImap;
+        this.finishedJobMonitoringImap = finishedJobMonitoringImap;
+        this.finishedJobMonitoringMetadataImap = finishedJobMonitoringMetadataImap;
+        this.pendingJobMonitoringQueue = pendingJobMonitoringQueue;
+        this.overflowJobMonitoringImap = overflowJobMonitoringImap;
         this.finishedJobMetricsImap = finishedJobMetricsImap;
         this.finishedJobDAGInfoImap = finishedJobVertexInfoImap;
         this.finishedJobStateImap.addEntryListener(
                 new FinishedJobExpiredListener<>(Constant.IMAP_FINISHED_JOB_STATE), true);
+        this.finishedJobMonitoringImap.addEntryListener(
+                new FinishedJobExpiredListener<>(Constant.IMAP_FINISHED_JOB_MONITORING), true);
         this.finishedJobMetricsImap.addEntryListener(
                 new FinishedJobExpiredListener<>(Constant.IMAP_FINISHED_JOB_METRICS), true);
         this.finishedJobDAGInfoImap.addEntryListener(
@@ -139,6 +186,7 @@ public class JobHistoryService {
         this.objectMapper = new ObjectMapper();
         this.objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         this.finishedJobExpireTime = finishedJobExpireTime;
+        safelyScheduleMonitoringDrain(0L);
     }
 
     // Gets the status of a running and completed job.
@@ -257,11 +305,420 @@ public class JobHistoryService {
     public void storeFinishedJobState(JobMaster jobMaster) {
         JobState jobState = toJobStateMapper(jobMaster, false);
         jobState.setErrorMessage(jobMaster.getErrorMessage());
-        finishedJobStateImap.put(jobState.jobId, jobState, finishedJobExpireTime, TimeUnit.MINUTES);
+        storeFinishedJobState(jobState);
     }
 
     public void storeFinishedJobState(JobState jobState) {
         finishedJobStateImap.put(jobState.jobId, jobState, finishedJobExpireTime, TimeUnit.MINUTES);
+        tryEnqueueFinishedJobMonitoringRecord(jobState);
+    }
+
+    /**
+     * Appends one compact monitoring record under a cluster-wide sequence lock.
+     *
+     * <p>The record is stored before the committed watermark advances. Readers therefore never
+     * advance past a sequence whose value is not yet visible. A record left immediately after the
+     * watermark by a member failure is reconciled by the next drain writer.
+     *
+     * @param record pending terminal state to expose to monitoring clients
+     */
+    private void storeFinishedJobMonitoringRecord(JobMonitoringRecord record) {
+        finishedJobMonitoringMetadataImap.lock(
+                Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY);
+        try {
+            long committedSequence = reconcileMonitoringSequence();
+            String jobSequenceKey = monitoringJobSequenceKey(record.getJobId());
+            Long existingSequence = finishedJobMonitoringMetadataImap.get(jobSequenceKey);
+            if (existingSequence != null
+                    && finishedJobMonitoringImap.containsKey(existingSequence)) {
+                return;
+            }
+            if (committedSequence == Long.MAX_VALUE) {
+                throw new SeaTunnelEngineException(
+                        "The finished-job monitoring sequence is exhausted.");
+            }
+            long nextSequence = committedSequence + 1;
+            putMonitoringRecord(nextSequence, record);
+            finishedJobMonitoringMetadataImap.put(
+                    jobSequenceKey, nextSequence, finishedJobExpireTime, TimeUnit.MINUTES);
+            finishedJobMonitoringMetadataImap.putIfAbsent(
+                    Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, nextSequence);
+            finishedJobMonitoringMetadataImap.put(
+                    Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, nextSequence);
+        } finally {
+            finishedJobMonitoringMetadataImap.unlock(
+                    Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY);
+        }
+    }
+
+    private long reconcileMonitoringSequence() {
+        long committedSequence =
+                finishedJobMonitoringMetadataImap.getOrDefault(
+                        Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, 0L);
+        long headSequence =
+                finishedJobMonitoringMetadataImap.getOrDefault(
+                        Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 1L);
+        if (committedSequence == Long.MAX_VALUE) {
+            return committedSequence;
+        }
+        if (headSequence > committedSequence + 1) {
+            committedSequence = headSequence - 1;
+            finishedJobMonitoringMetadataImap.put(
+                    Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, committedSequence);
+        }
+        JobMonitoringRecord uncommittedRecord =
+                finishedJobMonitoringImap.get(committedSequence + 1);
+        if (uncommittedRecord == null) {
+            return committedSequence;
+        }
+        long reconciledSequence = committedSequence + 1;
+        finishedJobMonitoringMetadataImap.put(
+                monitoringJobSequenceKey(uncommittedRecord.getJobId()),
+                reconciledSequence,
+                finishedJobExpireTime,
+                TimeUnit.MINUTES);
+        finishedJobMonitoringMetadataImap.putIfAbsent(
+                Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, reconciledSequence);
+        finishedJobMonitoringMetadataImap.put(
+                Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, reconciledSequence);
+        return reconciledSequence;
+    }
+
+    private void putMonitoringRecord(long sequence, JobMonitoringRecord pendingRecord) {
+        JobMonitoringRecord storedRecord =
+                new JobMonitoringRecord(
+                        sequence,
+                        pendingRecord.getJobId(),
+                        pendingRecord.getJobName(),
+                        pendingRecord.getJobStatus(),
+                        pendingRecord.getSubmitTime(),
+                        pendingRecord.getStartTime(),
+                        pendingRecord.getFinishTime(),
+                        pendingRecord.getObservedTime(),
+                        pendingRecord.getErrorSummary());
+        finishedJobMonitoringImap.put(
+                sequence, storedRecord, finishedJobExpireTime, TimeUnit.MINUTES);
+    }
+
+    private JobMonitoringRecord toMonitoringRecord(JobState jobState) {
+        return new JobMonitoringRecord(
+                0L,
+                jobState.getJobId(),
+                truncate(jobState.getJobName(), MAX_MONITORING_JOB_NAME_LENGTH),
+                jobState.getJobStatus(),
+                jobState.getSubmitTime(),
+                jobState.getStartTime(),
+                jobState.getFinishTime(),
+                System.currentTimeMillis(),
+                truncate(jobState.getErrorMessage(), MAX_MONITORING_ERROR_SUMMARY_LENGTH));
+    }
+
+    private String monitoringJobSequenceKey(Long jobId) {
+        return Constant.FINISHED_JOB_MONITORING_JOB_SEQUENCE_KEY_PREFIX + jobId;
+    }
+
+    /**
+     * Persists the sidecar after authoritative history is already visible.
+     *
+     * <p>The 100 ms argument bounds queue-capacity and lock waiting only. Hazelcast RPC failures
+     * can still wait for the configured operation timeout. Such failures are isolated and cannot
+     * undo the authoritative finished-state write.
+     */
+    private void enqueueFinishedJobMonitoringRecord(JobMonitoringRecord record) {
+        long jobId = record.getJobId();
+        try {
+            boolean persisted =
+                    pendingJobMonitoringQueue.offer(
+                            record, MONITORING_CAPACITY_OR_LOCK_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+            if (!persisted) {
+                retainMonitoringRetry(jobId, record);
+                logger.warning(
+                        String.format(
+                                "Timed out persisting the monitoring outbox record for job %s",
+                                jobId));
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            retainMonitoringRetry(jobId, record);
+            logger.warning(
+                    String.format(
+                            "Interrupted while persisting the monitoring outbox record for job %s",
+                            jobId),
+                    e);
+        } catch (RuntimeException e) {
+            retainMonitoringRetry(jobId, record);
+            logger.warning(
+                    String.format(
+                            "Failed to persist the monitoring outbox record for job %s", jobId),
+                    e);
+        }
+        safelyScheduleMonitoringDrain(0L);
+    }
+
+    private void retainMonitoringRetry(long jobId, JobMonitoringRecord record) {
+        boolean overflowLockAcquired = false;
+        try {
+            overflowLockAcquired =
+                    finishedJobMonitoringMetadataImap.tryLock(
+                            Constant.FINISHED_JOB_MONITORING_OVERFLOW_LOCK_KEY,
+                            MONITORING_CAPACITY_OR_LOCK_WAIT_MILLIS,
+                            TimeUnit.MILLISECONDS);
+            if (!overflowLockAcquired) {
+                retainLocalMonitoringRetry(jobId, record);
+                return;
+            }
+            if (overflowJobMonitoringImap.containsKey(jobId)
+                    || overflowJobMonitoringImap.size() < MAX_LOCAL_MONITORING_RETRY_RECORDS) {
+                overflowJobMonitoringImap.put(jobId, record);
+                return;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning(
+                    String.format(
+                            "Interrupted while persisting the monitoring overflow record for job %s",
+                            jobId),
+                    e);
+        } catch (RuntimeException e) {
+            logger.warning(
+                    String.format(
+                            "Failed to persist the monitoring overflow record for job %s", jobId),
+                    e);
+        } finally {
+            if (overflowLockAcquired) {
+                try {
+                    finishedJobMonitoringMetadataImap.unlock(
+                            Constant.FINISHED_JOB_MONITORING_OVERFLOW_LOCK_KEY);
+                } catch (RuntimeException e) {
+                    logger.warning("Failed to release the monitoring overflow lock", e);
+                }
+            }
+        }
+        retainLocalMonitoringRetry(jobId, record);
+    }
+
+    private void retainLocalMonitoringRetry(long jobId, JobMonitoringRecord record) {
+        synchronized (localPendingJobMonitoringRecords) {
+            if (localPendingJobMonitoringRecords.size() < MAX_LOCAL_MONITORING_RETRY_RECORDS
+                    || localPendingJobMonitoringRecords.containsKey(jobId)) {
+                localPendingJobMonitoringRecords.put(jobId, record);
+                return;
+            }
+        }
+        long droppedRecords = incrementDroppedJobMonitoringRecords();
+        logger.severe(
+                String.format(
+                        "Dropped the monitoring sidecar for job %s because the durable outbox and "
+                                + "the bounded local retry buffer are unavailable; dropped total: %s",
+                        jobId, droppedRecords));
+    }
+
+    /** Returns monitoring records dropped after both bounded outbox tiers were unavailable. */
+    public long getDroppedJobMonitoringRecords() {
+        synchronized (pendingDroppedJobMonitoringRecords) {
+            long pendingDelta = pendingDroppedJobMonitoringRecords.get();
+            try {
+                return finishedJobMonitoringMetadataImap.getOrDefault(
+                                Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY, 0L)
+                        + pendingDelta;
+            } catch (RuntimeException e) {
+                return pendingDelta;
+            }
+        }
+    }
+
+    long incrementDroppedJobMonitoringRecords() {
+        synchronized (pendingDroppedJobMonitoringRecords) {
+            pendingDroppedJobMonitoringRecords.incrementAndGet();
+            return flushPendingDroppedJobMonitoringRecords();
+        }
+    }
+
+    /**
+     * Atomically merges this coordinator's pending delta into the distributed dropped counter.
+     *
+     * <p>The caller must hold the {@link #pendingDroppedJobMonitoringRecords} monitor. The delta is
+     * cleared only after the distributed put succeeds, so a temporary metadata failure can be
+     * retried without losing or double-counting records.
+     */
+    private long flushPendingDroppedJobMonitoringRecords() {
+        long pendingDelta = pendingDroppedJobMonitoringRecords.get();
+        boolean lockAcquired = false;
+        try {
+            lockAcquired =
+                    finishedJobMonitoringMetadataImap.tryLock(
+                            Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY,
+                            MONITORING_CAPACITY_OR_LOCK_WAIT_MILLIS,
+                            TimeUnit.MILLISECONDS);
+            if (!lockAcquired) {
+                return pendingDelta;
+            }
+            long persistentTotal =
+                    finishedJobMonitoringMetadataImap.getOrDefault(
+                            Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY, 0L);
+            if (pendingDelta > 0L) {
+                persistentTotal += pendingDelta;
+                finishedJobMonitoringMetadataImap.put(
+                        Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY, persistentTotal);
+                pendingDroppedJobMonitoringRecords.addAndGet(-pendingDelta);
+            }
+            return persistentTotal;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return pendingDelta;
+        } catch (RuntimeException e) {
+            return pendingDelta;
+        } finally {
+            if (lockAcquired) {
+                try {
+                    finishedJobMonitoringMetadataImap.unlock(
+                            Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY);
+                } catch (RuntimeException e) {
+                    logger.warning("Failed to release the monitoring dropped-records lock", e);
+                }
+            }
+        }
+    }
+
+    private void tryEnqueueFinishedJobMonitoringRecord(JobState jobState) {
+        try {
+            enqueueFinishedJobMonitoringRecord(toMonitoringRecord(jobState));
+        } catch (RuntimeException e) {
+            logger.warning(
+                    String.format(
+                            "Failed to enqueue the monitoring sidecar for finished job %s",
+                            jobState.getJobId()),
+                    e);
+        }
+    }
+
+    /** Schedules an outbox drain while isolating executor failures from job completion. */
+    private void safelyScheduleMonitoringDrain(long delaySeconds) {
+        try {
+            scheduleMonitoringDrain(delaySeconds);
+        } catch (RuntimeException e) {
+            monitoringDrainScheduled.set(false);
+            logger.warning("Failed to schedule the job monitoring outbox drain", e);
+        }
+    }
+
+    /** Periodic coordinator hook that wakes a durable outbox left by executor rejection. */
+    public void retryPendingJobMonitoringRecords() {
+        synchronized (pendingDroppedJobMonitoringRecords) {
+            flushPendingDroppedJobMonitoringRecords();
+        }
+        safelyScheduleMonitoringDrain(0L);
+    }
+
+    /** Ensures at most one drain worker is submitted by this service instance. */
+    private void scheduleMonitoringDrain(long delaySeconds) {
+        if (!monitoringDrainScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        Runnable drainTask = this::drainPendingJobMonitoringRecords;
+        if (delaySeconds == 0L) {
+            nodeEngine.getExecutionService().execute(ExecutionService.ASYNC_EXECUTOR, drainTask);
+        } else {
+            nodeEngine.getExecutionService().schedule(drainTask, delaySeconds, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Moves at most one bounded batch from the durable outbox into the sequence ledger.
+     *
+     * <p>The ledger append is idempotent by job id. The outbox entry is removed only after the
+     * committed sequence is visible, so a coordinator failure can cause a retry but not a lost
+     * terminal job.
+     */
+    private void drainPendingJobMonitoringRecords() {
+        boolean retryRequired = false;
+        boolean drainLockAcquired = false;
+        try {
+            int processedRecords = 0;
+            for (Map.Entry<Long, JobMonitoringRecord> entry :
+                    overflowJobMonitoringImap.entrySet()) {
+                if (processedRecords >= MAX_MONITORING_DRAIN_BATCH_SIZE) {
+                    break;
+                }
+                if (!pendingJobMonitoringQueue.offer(entry.getValue())) {
+                    retryRequired = true;
+                    break;
+                }
+                overflowJobMonitoringImap.remove(entry.getKey(), entry.getValue());
+                processedRecords++;
+            }
+            for (Map.Entry<Long, JobMonitoringRecord> entry :
+                    localPendingJobMonitoringRecords.entrySet()) {
+                if (processedRecords >= MAX_MONITORING_DRAIN_BATCH_SIZE) {
+                    break;
+                }
+                if (!pendingJobMonitoringQueue.offer(entry.getValue())) {
+                    retryRequired = true;
+                    break;
+                }
+                localPendingJobMonitoringRecords.remove(entry.getKey(), entry.getValue());
+                processedRecords++;
+            }
+
+            drainLockAcquired =
+                    finishedJobMonitoringMetadataImap.tryLock(
+                            Constant.FINISHED_JOB_MONITORING_DRAIN_LOCK_KEY,
+                            MONITORING_CAPACITY_OR_LOCK_WAIT_MILLIS,
+                            TimeUnit.MILLISECONDS);
+            if (!drainLockAcquired) {
+                retryRequired = true;
+            } else {
+                while (processedRecords < MAX_MONITORING_DRAIN_BATCH_SIZE) {
+                    JobMonitoringRecord record = pendingJobMonitoringQueue.peek();
+                    if (record == null) {
+                        break;
+                    }
+                    storeFinishedJobMonitoringRecord(record);
+                    pendingJobMonitoringQueue.poll();
+                    processedRecords++;
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            retryRequired = true;
+            logger.warning("Interrupted while draining pending job monitoring records", e);
+        } catch (RuntimeException e) {
+            retryRequired = true;
+            logger.warning("Failed to drain pending job monitoring records", e);
+        } finally {
+            if (drainLockAcquired) {
+                try {
+                    finishedJobMonitoringMetadataImap.unlock(
+                            Constant.FINISHED_JOB_MONITORING_DRAIN_LOCK_KEY);
+                } catch (RuntimeException e) {
+                    logger.warning("Failed to release the job monitoring drain lock", e);
+                }
+            }
+            monitoringDrainScheduled.set(false);
+        }
+        boolean pendingRecordsRemain = retryRequired;
+        if (!pendingRecordsRemain) {
+            try {
+                pendingRecordsRemain =
+                        !pendingJobMonitoringQueue.isEmpty()
+                                || !overflowJobMonitoringImap.isEmpty()
+                                || !localPendingJobMonitoringRecords.isEmpty();
+            } catch (RuntimeException e) {
+                retryRequired = true;
+                pendingRecordsRemain = true;
+                logger.warning("Failed to inspect the job monitoring outbox", e);
+            }
+        }
+        if (pendingRecordsRemain) {
+            safelyScheduleMonitoringDrain(retryRequired ? MONITORING_RETRY_DELAY_SECONDS : 0L);
+        }
+    }
+
+    private String truncate(String value, int maximumLength) {
+        if (value == null || value.length() <= maximumLength) {
+            return value;
+        }
+        return value.substring(0, maximumLength);
     }
 
     public void storeFinishedPipelineMetrics(long jobId, JobMetrics metrics) {
@@ -347,6 +804,13 @@ public class JobHistoryService {
     public Map<String, Long> getFinishedJobRecordCounts() {
         Map<String, Long> counts = new HashMap<>();
         counts.put(Constant.IMAP_FINISHED_JOB_STATE, (long) finishedJobStateImap.size());
+        counts.put(Constant.IMAP_FINISHED_JOB_MONITORING, (long) finishedJobMonitoringImap.size());
+        counts.put(
+                Constant.IMAP_FINISHED_JOB_MONITORING_PENDING,
+                (long) pendingJobMonitoringQueue.size());
+        counts.put(
+                Constant.IMAP_FINISHED_JOB_MONITORING_OVERFLOW,
+                (long) overflowJobMonitoringImap.size());
         counts.put(Constant.IMAP_FINISHED_JOB_METRICS, (long) finishedJobMetricsImap.size());
         counts.put(Constant.IMAP_FINISHED_JOB_VERTEX_INFO, (long) finishedJobDAGInfoImap.size());
         return counts;
@@ -357,6 +821,9 @@ public class JobHistoryService {
         counts.put(
                 Constant.IMAP_FINISHED_JOB_STATE,
                 getFinishedJobCleanupTotal(Constant.IMAP_FINISHED_JOB_STATE));
+        counts.put(
+                Constant.IMAP_FINISHED_JOB_MONITORING,
+                getFinishedJobCleanupTotal(Constant.IMAP_FINISHED_JOB_MONITORING));
         counts.put(
                 Constant.IMAP_FINISHED_JOB_METRICS,
                 getFinishedJobCleanupTotal(Constant.IMAP_FINISHED_JOB_METRICS));
@@ -409,6 +876,35 @@ public class JobHistoryService {
         @Override
         public void entryExpired(EntryEvent<Long, T> event) {
             incrementFinishedJobCleanupTotal(storeName);
+            if (Constant.IMAP_FINISHED_JOB_MONITORING.equals(storeName)) {
+                try {
+                    advanceMonitoringHead(event.getKey() + 1);
+                } catch (RuntimeException e) {
+                    logger.warning("Failed to advance the job monitoring retention head", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Advances the retained-sequence head monotonically when ledger entries expire.
+     *
+     * <p>Expiration callbacks can arrive out of order. Taking the maximum is safe because a later
+     * sequence can expire only after every earlier record's TTL has elapsed.
+     */
+    private void advanceMonitoringHead(long candidateHeadSequence) {
+        finishedJobMonitoringMetadataImap.lock(Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY);
+        try {
+            long currentHeadSequence =
+                    finishedJobMonitoringMetadataImap.getOrDefault(
+                            Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 1L);
+            if (candidateHeadSequence > currentHeadSequence) {
+                finishedJobMonitoringMetadataImap.put(
+                        Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, candidateHeadSequence);
+            }
+        } finally {
+            finishedJobMonitoringMetadataImap.unlock(
+                    Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY);
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMonitoringRecord.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMonitoringRecord.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master;
+
+import org.apache.seatunnel.engine.common.job.JobStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+
+/** Lightweight terminal-job record ordered by its actual insertion sequence. */
+@AllArgsConstructor
+@Data
+public final class JobMonitoringRecord implements Serializable {
+
+    private static final long serialVersionUID = -6843786249916106271L;
+
+    // Monotonic ledger position; zero is reserved for a pending outbox record.
+    private long sequence;
+
+    // Stable SeaTunnel job identifier.
+    private Long jobId;
+
+    // Bounded display name used by monitoring responses.
+    private String jobName;
+
+    // Terminal job status captured by the authoritative history write.
+    private JobStatus jobStatus;
+
+    // Original job submission timestamp.
+    private long submitTime;
+
+    // Optional job start timestamp.
+    private Long startTime;
+
+    // Optional terminal timestamp, which can be absent during abnormal recovery.
+    private Long finishTime;
+
+    // Non-null timestamp at which the sidecar observed the terminal state.
+    private long observedTime;
+
+    // Bounded error detail suitable for alert payloads.
+    private String errorSummary;
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
@@ -83,6 +83,10 @@ public class RestConstant {
     @Deprecated public static final String REST_URL_RUNNING_JOB = "/running-job";
     public static final String REST_URL_JOB_INFO = "/job-info";
     public static final String REST_URL_FINISHED_JOBS = "/finished-jobs";
+
+    // Lightweight incremental terminal-job endpoint for monitoring clients.
+    public static final String REST_URL_JOBS = "/jobs";
+
     public static final String REST_URL_ENCRYPT_CONFIG = "/encrypt-config";
     public static final String REST_URL_THREAD_DUMP = "/thread-dump";
     // only for test use

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobMonitoringService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobMonitoringService.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.server.master.JobMonitoringRecord;
+
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Reads terminal-job monitoring records with bounded sequence-key lookups.
+ *
+ * <p>Every request reads at most {@code limit} exact IMap keys. Query cost therefore does not grow
+ * with the number of retained finished jobs.
+ */
+public class JobMonitoringService extends BaseService {
+
+    // Initial position that replays from the current retention head.
+    private static final String START_BEGINNING = "beginning";
+
+    // Initial position that observes only future ledger commits.
+    private static final String START_LATEST = "latest";
+
+    // Cursor marker for an unfiltered terminal-status stream.
+    private static final String ALL_STATUSES = "*";
+
+    // Cursor version for sequence-based monitoring.
+    private static final String CURSOR_VERSION = "2";
+
+    // Default number of exact sequence keys examined per request.
+    private static final int DEFAULT_LIMIT = 100;
+
+    // Hard bound on member work and response record count.
+    private static final int MAX_LIMIT = 1000;
+
+    // Hard input bound applied before cursor decoding.
+    private static final int MAX_CURSOR_LENGTH = 256;
+
+    // TTL-bound compact monitoring ledger keyed by sequence.
+    private final IMap<Long, JobMonitoringRecord> monitoringRecordMap;
+
+    // Committed and retention-head watermarks for the ledger.
+    private final IMap<String, Long> monitoringMetadataMap;
+
+    /**
+     * Creates a monitoring service backed by the terminal-job sequence ledger.
+     *
+     * @param nodeEngine local Hazelcast node engine
+     */
+    public JobMonitoringService(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+        this.monitoringRecordMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_FINISHED_JOB_MONITORING);
+        this.monitoringMetadataMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_FINISHED_JOB_MONITORING_METADATA);
+    }
+
+    /**
+     * Returns one bounded sequence window of terminal-job records.
+     *
+     * @param status optional terminal status filter
+     * @param start initial position, either {@code beginning} or {@code latest}
+     * @param cursor opaque cursor returned by the previous request
+     * @param limit maximum number of sequence slots examined by this request
+     * @return monitoring records and the cursor after the examined window
+     */
+    public JsonObject getFinishedJobChanges(
+            String status, String start, String cursor, String limit) {
+        int pageSize = parseLimit(limit);
+        JobStatus requestedStatus = parseStatus(status);
+        long committedSequence = getCommittedSequence();
+        long headSequence = getHeadSequence(committedSequence);
+        QueryPosition position =
+                parsePosition(start, cursor, requestedStatus, committedSequence, headSequence);
+        boolean cursorReset = position.sequence < headSequence - 1;
+        long effectiveSequence = cursorReset ? headSequence - 1 : position.sequence;
+
+        Set<Long> keys = new HashSet<>();
+        long lastSequence = effectiveSequence;
+        if (effectiveSequence < committedSequence) {
+            lastSequence =
+                    Math.min(committedSequence, addWithoutOverflow(effectiveSequence, pageSize));
+            for (long sequence = effectiveSequence + 1; sequence <= lastSequence; sequence++) {
+                keys.add(sequence);
+            }
+        }
+        Map<Long, JobMonitoringRecord> recordsBySequence =
+                keys.isEmpty() ? Collections.emptyMap() : monitoringRecordMap.getAll(keys);
+        List<JobMonitoringRecord> records = new ArrayList<>(recordsBySequence.values());
+        records.sort((left, right) -> Long.compare(left.getSequence(), right.getSequence()));
+
+        JsonArray data = new JsonArray();
+        for (JobMonitoringRecord record : records) {
+            if (position.status == null || position.status == record.getJobStatus()) {
+                data.add(toMonitoringJson(record));
+            }
+        }
+
+        boolean hasMore = lastSequence < committedSequence;
+        return new JsonObject()
+                .add("data", data)
+                .add("hasMore", hasMore)
+                .add("limit", pageSize)
+                .add("scanned", keys.size())
+                .add("headSequence", headSequence)
+                .add("cursorReset", cursorReset)
+                .add("nextCursor", encodeCursor(lastSequence, position.status));
+    }
+
+    private long getCommittedSequence() {
+        return monitoringMetadataMap.getOrDefault(
+                Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, 0L);
+    }
+
+    /** Returns a valid retention head clamped to the committed ledger range. */
+    private long getHeadSequence(long committedSequence) {
+        long headSequence =
+                monitoringMetadataMap.getOrDefault(
+                        Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 1L);
+        return Math.max(1L, Math.min(headSequence, addWithoutOverflow(committedSequence, 1)));
+    }
+
+    /** Resolves and validates the initial position or opaque continuation cursor. */
+    private QueryPosition parsePosition(
+            String start,
+            String cursor,
+            JobStatus requestedStatus,
+            long committedSequence,
+            long headSequence) {
+        if (start != null && cursor != null) {
+            throw new IllegalArgumentException("start and cursor must not be provided together.");
+        }
+        if (cursor != null) {
+            QueryPosition position = decodeCursor(cursor);
+            if (position.sequence > committedSequence) {
+                throw new IllegalArgumentException(
+                        "cursor is ahead of the committed monitoring sequence.");
+            }
+            if (requestedStatus != null && requestedStatus != position.status) {
+                throw new IllegalArgumentException("status does not match the cursor.");
+            }
+            return position;
+        }
+        if (start == null) {
+            throw new IllegalArgumentException("start or cursor must be provided.");
+        }
+        if (START_BEGINNING.equalsIgnoreCase(start)) {
+            return new QueryPosition(headSequence - 1, requestedStatus);
+        }
+        if (START_LATEST.equalsIgnoreCase(start)) {
+            return new QueryPosition(committedSequence, requestedStatus);
+        }
+        throw new IllegalArgumentException("start must be beginning or latest.");
+    }
+
+    /** Parses an optional terminal status filter. */
+    private JobStatus parseStatus(String status) {
+        if (status == null || status.trim().isEmpty()) {
+            return null;
+        }
+        JobStatus jobStatus;
+        try {
+            jobStatus = JobStatus.fromString(status.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown job status: " + status, e);
+        }
+        if (!jobStatus.isEndState()) {
+            throw new IllegalArgumentException("status must be a terminal job status.");
+        }
+        return jobStatus;
+    }
+
+    /** Applies the default and hard per-request sequence bound. */
+    private int parseLimit(String limit) {
+        if (limit == null || limit.trim().isEmpty()) {
+            return DEFAULT_LIMIT;
+        }
+        int parsedLimit;
+        try {
+            parsedLimit = Integer.parseInt(limit.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("limit must be an integer.", e);
+        }
+        if (parsedLimit < 1 || parsedLimit > MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + MAX_LIMIT + ".");
+        }
+        return parsedLimit;
+    }
+
+    /** Adds a page size without allowing sequence overflow. */
+    private long addWithoutOverflow(long value, int increment) {
+        if (value > Long.MAX_VALUE - increment) {
+            return Long.MAX_VALUE;
+        }
+        return value + increment;
+    }
+
+    /** Encodes the scanned sequence and status contract into an opaque cursor. */
+    private String encodeCursor(long sequence, JobStatus status) {
+        String payload =
+                String.join(
+                        "|",
+                        CURSOR_VERSION,
+                        String.valueOf(sequence),
+                        status == null ? ALL_STATUSES : status.name());
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Decodes and validates an opaque sequence cursor. */
+    private QueryPosition decodeCursor(String cursor) {
+        try {
+            if (cursor.length() > MAX_CURSOR_LENGTH) {
+                throw new IllegalArgumentException("Cursor is too long.");
+            }
+            String payload =
+                    new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            String[] parts = payload.split("\\|", -1);
+            if (parts.length != 3 || !CURSOR_VERSION.equals(parts[0])) {
+                throw new IllegalArgumentException("Unsupported cursor format.");
+            }
+            long sequence = Long.parseLong(parts[1]);
+            if (sequence < 0) {
+                throw new IllegalArgumentException("Cursor sequence must not be negative.");
+            }
+            JobStatus status = ALL_STATUSES.equals(parts[2]) ? null : parseStatus(parts[2]);
+            return new QueryPosition(sequence, status);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid cursor.", e);
+        }
+    }
+
+    /** Converts one compact ledger record to the public monitoring representation. */
+    private JsonObject toMonitoringJson(JobMonitoringRecord record) {
+        JsonObject response =
+                new JsonObject()
+                        .add("sequence", record.getSequence())
+                        .add("jobId", String.valueOf(record.getJobId()))
+                        .add("jobName", record.getJobName())
+                        .add("jobStatus", record.getJobStatus().toString())
+                        .add("createTime", record.getSubmitTime())
+                        .add("observedTime", record.getObservedTime())
+                        .add("errorSummary", record.getErrorSummary());
+        if (record.getStartTime() == null) {
+            response.add("startTime", Json.NULL);
+        } else {
+            response.add("startTime", record.getStartTime());
+        }
+        if (record.getFinishTime() == null) {
+            response.add("finishTime", Json.NULL);
+        } else {
+            response.add("finishTime", record.getFinishTime());
+        }
+        return response;
+    }
+
+    private static final class QueryPosition {
+        // Last sequence already examined by the client.
+        private final long sequence;
+
+        // Status filter carried by the cursor.
+        private final JobStatus status;
+
+        private QueryPosition(long sequence, JobStatus status) {
+            this.sequence = sequence;
+            this.status = status;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/JobsServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/JobsServlet.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.servlet;
+
+import org.apache.seatunnel.engine.server.rest.service.JobMonitoringService;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Provides a lightweight, incremental view of terminal job state changes for monitoring systems.
+ */
+public class JobsServlet extends BaseServlet {
+
+    // Performs the bounded, sequence-based finished-state query.
+    private final JobMonitoringService jobMonitoringService;
+
+    /**
+     * Creates the monitoring servlet for the local SeaTunnel node.
+     *
+     * @param nodeEngine local Hazelcast node engine
+     */
+    public JobsServlet(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+        this.jobMonitoringService = new JobMonitoringService(nodeEngine);
+    }
+
+    /**
+     * Returns one bounded sequence window after the caller's start position or opaque cursor.
+     *
+     * @param req HTTP request containing the monitoring query parameters
+     * @param resp HTTP response
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        writeJson(
+                resp,
+                jobMonitoringService.getFinishedJobChanges(
+                        req.getParameter("status"),
+                        req.getParameter("start"),
+                        req.getParameter("cursor"),
+                        req.getParameter("limit")));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreLogicalMetricExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/EngineStateStoreLogicalMetricExports.java
@@ -78,6 +78,11 @@ public class EngineStateStoreLogicalMetricExports extends AbstractCollector {
                         "engine_state_store_finished_job_cleanup_total",
                         "Cleanup total for finished job state stores",
                         storeLabelNames);
+        CounterMetricFamily finishedJobMonitoringDroppedRecords =
+                new CounterMetricFamily(
+                        "engine_state_store_finished_job_monitoring_dropped_total",
+                        "Monitoring records dropped after bounded outbox capacity was exhausted",
+                        commonLabelNames);
         GaugeMetricFamily connectorJarTrackedJars =
                 new GaugeMetricFamily(
                         "engine_state_store_connector_jar_tracked_jars",
@@ -98,6 +103,7 @@ public class EngineStateStoreLogicalMetricExports extends AbstractCollector {
                     checkpointMonitorRetainedHistoryEntries,
                     finishedJobRecords,
                     finishedJobCleanupTotal,
+                    finishedJobMonitoringDroppedRecords,
                     connectorJarTrackedJars,
                     connectorJarTotalReferences);
         }
@@ -143,6 +149,10 @@ public class EngineStateStoreLogicalMetricExports extends AbstractCollector {
                     addStoreMetrics(
                             finishedJobCleanupTotal,
                             jobHistoryService.getFinishedJobCleanupTotals());
+                    addMetric(
+                            finishedJobMonitoringDroppedRecords,
+                            jobHistoryService.getDroppedJobMonitoringRecords(),
+                            labelValues(BACKEND));
                 });
 
         runSafely(
@@ -174,6 +184,7 @@ public class EngineStateStoreLogicalMetricExports extends AbstractCollector {
                 checkpointMonitorRetainedHistoryEntries,
                 finishedJobRecords,
                 finishedJobCleanupTotal,
+                finishedJobMonitoringDroppedRecords,
                 connectorJarTrackedJars,
                 connectorJarTotalReferences);
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/FollowerRunningJobsFilterTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/FollowerRunningJobsFilterTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server.master;
 
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
+import org.apache.seatunnel.engine.common.config.server.HttpConfig;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.runtime.ExecutionMode;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
@@ -52,6 +53,11 @@ class FollowerRunningJobsFilterTest
         try {
             SeaTunnelConfig seaTunnelConfig = loadSeaTunnelConfig();
             seaTunnelConfig.getEngineConfig().setMode(ExecutionMode.LOCAL);
+            // This follower only exposes its NodeEngine to JobInfoService; REST would contend for
+            // the same test HTTP port as the master on Windows CI.
+            HttpConfig httpConfig = seaTunnelConfig.getEngineConfig().getHttpConfig();
+            httpConfig.setEnabled(false);
+            httpConfig.setEnableHttps(false);
 
             Config hazelcastConfig = Config.loadFromString(getHazelcastConfig());
             hazelcastConfig.setClusterName(instance.getConfig().getClusterName());

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/JobHistoryServiceMonitoringFailureTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/JobHistoryServiceMonitoringFailureTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master;
+
+import org.apache.seatunnel.api.common.metrics.JobMetrics;
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.JobDAGInfo;
+import org.apache.seatunnel.engine.server.execution.PendingJobInfo;
+import org.apache.seatunnel.engine.server.master.JobHistoryService.JobState;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.ExecutionService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Verifies that the monitoring sidecar cannot prevent authoritative history persistence. */
+class JobHistoryServiceMonitoringFailureTest {
+
+    @Test
+    void testPendingMonitoringFailureDoesNotFailFinishedStateStore() throws Exception {
+        NodeEngine nodeEngine = mock(NodeEngine.class);
+        ExecutionService executionService = mock(ExecutionService.class);
+        ILogger logger = mock(ILogger.class);
+        IMap<Object, Object> runningStateMap = mock(IMap.class);
+        IMap<Long, JobState> finishedStateMap = mock(IMap.class);
+        IMap<Long, JobMonitoringRecord> monitoringMap = mock(IMap.class);
+        IMap<String, Long> monitoringMetadataMap = mock(IMap.class);
+        IQueue<JobMonitoringRecord> pendingMonitoringQueue = mock(IQueue.class);
+        IMap<Long, JobMonitoringRecord> overflowMonitoringMap = mock(IMap.class);
+        IMap<Long, JobMetrics> metricsMap = mock(IMap.class);
+        IMap<Long, JobDAGInfo> dagMap = mock(IMap.class);
+
+        when(nodeEngine.getExecutionService()).thenReturn(executionService);
+        when(monitoringMetadataMap.tryLock(
+                        eq(Constant.FINISHED_JOB_MONITORING_OVERFLOW_LOCK_KEY),
+                        eq(100L),
+                        eq(TimeUnit.MILLISECONDS)))
+                .thenReturn(true);
+        when(pendingMonitoringQueue.offer(
+                        any(JobMonitoringRecord.class), anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new IllegalStateException("injected monitoring failure"));
+
+        JobHistoryService service =
+                new JobHistoryService(
+                        nodeEngine,
+                        runningStateMap,
+                        logger,
+                        new HashMap<Long, PendingJobInfo>(),
+                        new HashMap<Long, JobMaster>(),
+                        finishedStateMap,
+                        monitoringMap,
+                        monitoringMetadataMap,
+                        pendingMonitoringQueue,
+                        overflowMonitoringMap,
+                        metricsMap,
+                        dagMap,
+                        60);
+        JobState state =
+                new JobState(
+                        1L,
+                        "failed-job",
+                        JobStatus.FAILED,
+                        1000L,
+                        null,
+                        2000L,
+                        Collections.emptyMap(),
+                        "expected failure");
+
+        Assertions.assertDoesNotThrow(() -> service.storeFinishedJobState(state));
+        verify(finishedStateMap).put(eq(1L), eq(state), eq(60L), eq(TimeUnit.MINUTES));
+        verify(pendingMonitoringQueue)
+                .offer(any(JobMonitoringRecord.class), eq(100L), eq(TimeUnit.MILLISECONDS));
+        verify(overflowMonitoringMap).put(eq(1L), any(JobMonitoringRecord.class));
+    }
+
+    @Test
+    void testDroppedCounterFlushesPendingDeltaAfterMetadataRecovery() throws Exception {
+        NodeEngine nodeEngine = mock(NodeEngine.class);
+        ExecutionService executionService = mock(ExecutionService.class);
+        IMap<String, Long> monitoringMetadataMap = mock(IMap.class);
+        AtomicLong persistentTotal = new AtomicLong();
+
+        when(nodeEngine.getExecutionService()).thenReturn(executionService);
+        when(monitoringMetadataMap.tryLock(
+                        eq(Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY),
+                        eq(100L),
+                        eq(TimeUnit.MILLISECONDS)))
+                .thenReturn(false, true);
+        when(monitoringMetadataMap.getOrDefault(
+                        eq(Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY), eq(0L)))
+                .thenAnswer(invocation -> persistentTotal.get());
+        when(monitoringMetadataMap.put(
+                        eq(Constant.FINISHED_JOB_MONITORING_DROPPED_RECORDS_KEY), anyLong()))
+                .thenAnswer(
+                        invocation -> {
+                            persistentTotal.set(invocation.getArgument(1));
+                            return null;
+                        });
+
+        JobHistoryService service =
+                new JobHistoryService(
+                        nodeEngine,
+                        mock(IMap.class),
+                        mock(ILogger.class),
+                        new HashMap<Long, PendingJobInfo>(),
+                        new HashMap<Long, JobMaster>(),
+                        mock(IMap.class),
+                        mock(IMap.class),
+                        monitoringMetadataMap,
+                        mock(IQueue.class),
+                        mock(IMap.class),
+                        mock(IMap.class),
+                        mock(IMap.class),
+                        60);
+
+        Assertions.assertEquals(1L, service.incrementDroppedJobMonitoringRecords());
+        Assertions.assertEquals(1L, service.getDroppedJobMonitoringRecords());
+        Assertions.assertEquals(2L, service.incrementDroppedJobMonitoringRecords());
+        Assertions.assertEquals(2L, persistentTotal.get());
+        Assertions.assertEquals(2L, service.getDroppedJobMonitoringRecords());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiHttpsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiHttpsTest.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.engine.server.rest;
 
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.HttpConfig;
+import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.runtime.ExecutionMode;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
@@ -28,6 +29,7 @@ import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
 import org.apache.seatunnel.engine.server.TestUtils;
+import org.apache.seatunnel.engine.server.master.JobHistoryService.JobState;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -195,6 +197,67 @@ public class RestApiHttpsTest extends AbstractSeaTunnelServerTest {
                     Assertions.assertTrue(resultJson != null);
                     Assertions.assertTrue(resultJson.size() == jobNum);
                 });
+        shutdown(jobInformation);
+    }
+
+    // Verifies that the incremental monitoring endpoint is exposed through the Jetty REST API.
+    @Test
+    public void testIncrementalJobsApi() throws Exception {
+        JobInformation jobInformation = getSeatunnelServer("testIncrementalJobsApi");
+        jobInformation
+                .coordinatorService
+                .getJobHistoryService()
+                .storeFinishedJobState(
+                        new JobState(
+                                5001L,
+                                "failed-job",
+                                JobStatus.FAILED,
+                                1000L,
+                                null,
+                                2000L,
+                                Collections.emptyMap(),
+                                "expected failure"));
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        1L,
+                                        jobInformation
+                                                .healcastInstance
+                                                .getMap(
+                                                        Constant
+                                                                .IMAP_FINISHED_JOB_MONITORING_METADATA)
+                                                .getOrDefault(
+                                                        Constant
+                                                                .FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY,
+                                                        0L)));
+
+        restApiRequestHttp(
+                "http://localhost:" + HTTP_PORT2 + "/jobs?status=FAILED&start=beginning&limit=10",
+                (code, content) -> {
+                    Assertions.assertEquals(200, code);
+                    JsonObject response = Json.parse(content).asObject();
+                    JsonArray data = response.get("data").asArray();
+                    Assertions.assertEquals(1, data.size());
+                    Assertions.assertEquals(
+                            "5001", data.get(0).asObject().getString("jobId", null));
+                    Assertions.assertEquals(
+                            "expected failure",
+                            data.get(0).asObject().getString("errorSummary", null));
+                    Assertions.assertFalse(response.getBoolean("hasMore", true));
+                    Assertions.assertNotNull(response.getString("nextCursor", null));
+                });
+        restApiRequestHttp(
+                "http://localhost:" + HTTP_PORT2 + "/jobs?start=latest&limit=1001",
+                (code, content) -> Assertions.assertEquals(400, code));
+
+        // The more specific existing checkpoint mappings must not be captured by /jobs/*.
+        restApiRequestHttp(
+                "http://localhost:" + HTTP_PORT2 + "/jobs/checkpoints/999",
+                (code, content) -> Assertions.assertEquals(200, code));
+        restApiRequestHttp(
+                "http://localhost:" + HTTP_PORT2 + "/jobs/checkpoints/history/999",
+                (code, content) -> Assertions.assertEquals(200, code));
         shutdown(jobInformation);
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiHttpsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiHttpsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.rest;
 
+import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.HttpConfig;
 import org.apache.seatunnel.engine.common.job.JobStatus;

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/JobMonitoringServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/JobMonitoringServiceTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.master.JobHistoryService;
+import org.apache.seatunnel.engine.server.master.JobHistoryService.JobState;
+import org.apache.seatunnel.engine.server.master.JobMonitoringRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+
+/** Verifies the insertion-sequence contract and bounded reads of the monitoring endpoint. */
+class JobMonitoringServiceTest extends AbstractSeaTunnelServerTest {
+
+    private IMap<Long, JobMonitoringRecord> monitoringRecordMap;
+
+    private IMap<String, Long> monitoringMetadataMap;
+
+    private IQueue<JobMonitoringRecord> pendingMonitoringRecordQueue;
+
+    private IMap<Long, JobMonitoringRecord> overflowMonitoringRecordMap;
+
+    private JobHistoryService jobHistoryService;
+
+    private JobMonitoringService jobMonitoringService;
+
+    @BeforeEach
+    void setUpMonitoringService() {
+        monitoringRecordMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_FINISHED_JOB_MONITORING);
+        monitoringMetadataMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_FINISHED_JOB_MONITORING_METADATA);
+        pendingMonitoringRecordQueue =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getQueue(Constant.IMAP_FINISHED_JOB_MONITORING_PENDING);
+        overflowMonitoringRecordMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_FINISHED_JOB_MONITORING_OVERFLOW);
+        monitoringRecordMap.clear();
+        monitoringMetadataMap.clear();
+        pendingMonitoringRecordQueue.clear();
+        overflowMonitoringRecordMap.clear();
+        nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_FINISHED_JOB_STATE).clear();
+        jobHistoryService = server.getCoordinatorService().getJobHistoryService();
+        jobMonitoringService = new JobMonitoringService((NodeEngineImpl) nodeEngine);
+    }
+
+    @AfterEach
+    void clearMonitoringRecords() {
+        monitoringRecordMap.clear();
+        monitoringMetadataMap.clear();
+        pendingMonitoringRecordQueue.clear();
+        overflowMonitoringRecordMap.clear();
+    }
+
+    @Test
+    void testLateOlderCompletionIsNotMissed() {
+        jobHistoryService.storeFinishedJobState(
+                jobState(20L, JobStatus.FAILED, 2000L, "failure-20"));
+        awaitMonitoringSequence(1L);
+
+        JsonObject firstPage =
+                jobMonitoringService.getFinishedJobChanges("FAILED", "beginning", null, "1");
+        String cursor = firstPage.getString("nextCursor", null);
+        Assertions.assertEquals(
+                "20", firstPage.get("data").asArray().get(0).asObject().getString("jobId", null));
+
+        jobHistoryService.storeFinishedJobState(
+                jobState(-10L, JobStatus.FAILED, 1000L, "late failure"));
+        awaitMonitoringSequence(2L);
+        JsonObject secondPage = jobMonitoringService.getFinishedJobChanges(null, null, cursor, "1");
+
+        Assertions.assertEquals(
+                "-10", secondPage.get("data").asArray().get(0).asObject().getString("jobId", null));
+        Assertions.assertEquals(
+                2L, secondPage.get("data").asArray().get(0).asObject().getLong("sequence", 0));
+    }
+
+    @Test
+    void testSequenceWindowIsBoundedAndSkipsExpiredGaps() {
+        monitoringRecordMap.put(1L, monitoringRecord(1L, 1L, JobStatus.FAILED, 1000L, "failure-1"));
+        monitoringRecordMap.put(
+                10000L, monitoringRecord(10000L, 2L, JobStatus.FAILED, 2000L, "failure-2"));
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, 10000L);
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 10000L);
+
+        JsonObject firstPage =
+                jobMonitoringService.getFinishedJobChanges(null, "beginning", null, "10");
+        Assertions.assertEquals(1, firstPage.getInt("scanned", 0));
+        Assertions.assertEquals(1, firstPage.get("data").asArray().size());
+        Assertions.assertFalse(firstPage.getBoolean("hasMore", true));
+        Assertions.assertEquals(10000L, firstPage.getLong("headSequence", 0L));
+    }
+
+    @Test
+    void testLatestStartAndStatusCursorContract() {
+        jobHistoryService.storeFinishedJobState(jobState(1L, JobStatus.FINISHED, 1000L, null));
+        awaitMonitoringSequence(1L);
+
+        JsonObject initial =
+                jobMonitoringService.getFinishedJobChanges("FAILED", "latest", null, null);
+        Assertions.assertEquals(0, initial.get("data").asArray().size());
+        Assertions.assertFalse(initial.getBoolean("hasMore", true));
+
+        jobHistoryService.storeFinishedJobState(jobState(2L, JobStatus.FAILED, 900L, "failure-2"));
+        awaitMonitoringSequence(2L);
+        JsonObject changes =
+                jobMonitoringService.getFinishedJobChanges(
+                        null, null, initial.getString("nextCursor", null), null);
+        Assertions.assertEquals(1, changes.get("data").asArray().size());
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        jobMonitoringService.getFinishedJobChanges(
+                                "FINISHED", null, changes.getString("nextCursor", null), null));
+    }
+
+    @Test
+    void testNullFinishTimeAndTextBounds() {
+        String longError = String.join("", Collections.nCopies(2000, "x"));
+        jobHistoryService.storeFinishedJobState(
+                new JobState(
+                        1L,
+                        String.join("", Collections.nCopies(400, "n")),
+                        JobStatus.FAILED,
+                        1000L,
+                        null,
+                        null,
+                        Collections.emptyMap(),
+                        longError));
+        awaitMonitoringSequence(1L);
+
+        JsonObject item =
+                jobMonitoringService
+                        .getFinishedJobChanges(null, "beginning", null, "1")
+                        .get("data")
+                        .asArray()
+                        .get(0)
+                        .asObject();
+        Assertions.assertTrue(item.get("finishTime").isNull());
+        Assertions.assertEquals(256, item.getString("jobName", null).length());
+        Assertions.assertEquals(1024, item.getString("errorSummary", null).length());
+        Assertions.assertTrue(item.getLong("observedTime", 0L) > 0);
+    }
+
+    @Test
+    void testInvalidParameters() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jobMonitoringService.getFinishedJobChanges(null, null, null, null));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        jobMonitoringService.getFinishedJobChanges(
+                                null, "beginning", "invalid", null));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jobMonitoringService.getFinishedJobChanges("RUNNING", "latest", null, null));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jobMonitoringService.getFinishedJobChanges(null, "latest", null, "0"));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> jobMonitoringService.getFinishedJobChanges(null, null, "invalid", null));
+    }
+
+    @Test
+    void testStaleCursorIsAdvancedToRetentionHead() {
+        monitoringRecordMap.put(1L, monitoringRecord(1L, 1L, JobStatus.FAILED, 1000L, "failure-1"));
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, 1L);
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 1L);
+        String staleCursor =
+                jobMonitoringService
+                        .getFinishedJobChanges(null, "beginning", null, "1")
+                        .getString("nextCursor", null);
+
+        monitoringRecordMap.clear();
+        monitoringRecordMap.put(
+                10000L, monitoringRecord(10000L, 2L, JobStatus.FAILED, 2000L, "failure-2"));
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY, 10000L);
+        monitoringMetadataMap.put(Constant.FINISHED_JOB_MONITORING_HEAD_SEQUENCE_KEY, 10000L);
+
+        JsonObject response =
+                jobMonitoringService.getFinishedJobChanges(null, null, staleCursor, "10");
+        Assertions.assertTrue(response.getBoolean("cursorReset", false));
+        Assertions.assertEquals(1, response.getInt("scanned", 0));
+        Assertions.assertEquals(
+                "2", response.get("data").asArray().get(0).asObject().getString("jobId", null));
+    }
+
+    @Test
+    void testUncommittedRecordIsReconciledBeforeNextAppend() {
+        monitoringRecordMap.put(1L, monitoringRecord(1L, 1L, JobStatus.FAILED, 1000L, "failure-1"));
+
+        jobHistoryService.storeFinishedJobState(jobState(2L, JobStatus.FAILED, 900L, "failure-2"));
+        awaitMonitoringSequence(2L);
+
+        JsonObject response =
+                jobMonitoringService.getFinishedJobChanges(null, "beginning", null, "2");
+        Assertions.assertEquals(2, response.get("data").asArray().size());
+        Assertions.assertEquals(
+                "1", response.get("data").asArray().get(0).asObject().getString("jobId", null));
+        Assertions.assertEquals(
+                "2", response.get("data").asArray().get(1).asObject().getString("jobId", null));
+    }
+
+    private void awaitMonitoringSequence(long expectedSequence) {
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        expectedSequence,
+                                        monitoringMetadataMap.getOrDefault(
+                                                Constant
+                                                        .FINISHED_JOB_MONITORING_COMMITTED_SEQUENCE_KEY,
+                                                0L)));
+    }
+
+    private JobState jobState(long jobId, JobStatus status, Long finishTime, String errorMessage) {
+        return new JobState(
+                jobId,
+                "job-" + jobId,
+                status,
+                500L,
+                null,
+                finishTime,
+                Collections.emptyMap(),
+                errorMessage);
+    }
+
+    private JobMonitoringRecord monitoringRecord(
+            long sequence, long jobId, JobStatus status, Long finishTime, String errorSummary) {
+        return new JobMonitoringRecord(
+                sequence,
+                jobId,
+                "job-" + jobId,
+                status,
+                500L,
+                null,
+                finishTime,
+                3000L,
+                errorSummary);
+    }
+}


### PR DESCRIPTION
What problem this PR solves

The existing `/finished-jobs` endpoint is designed for detailed history browsing. It loads job DAG
and metrics data and has no incremental cursor, so polling it across a large retained job history is
unnecessarily expensive for monitoring systems that only need terminal state changes.

What is changed

- Add `GET /jobs` as a lightweight terminal-job change feed.
- Support `start=latest|beginning`, an opaque continuation cursor, optional terminal `status`, and
  a bounded `limit` from 1 to 1000.
- Read at most `limit` exact sequence keys per request, independent of total retained job count.
- Persist only compact monitoring fields and keep detailed DAG/metrics behind `/job-info/{jobId}`.
- Add retention-head handling and `cursorReset=true` when a cursor falls behind retained history.
- Write authoritative finished-job state first, then deliver the monitoring sidecar through a
  bounded durable outbox with durable/local overflow and dropped-record telemetry.
- Add English and Chinese REST API documentation, including cursor, retention, delay, capacity,
  and degradation semantics.
- Add service, route-regression, null/boundary, stale-cursor, and failure-injection tests.

Example

```text
GET /jobs?start=latest&status=FAILED&limit=100
GET /jobs?cursor=<opaque-cursor>&limit=100
```

Validation

- `./mvnw -pl seatunnel-engine/seatunnel-engine-common,seatunnel-engine/seatunnel-engine-server spotless:apply spotless:check`
- Independent maintainer review: PASS, with no P1/P2 blockers.
- Local compilation, unit tests, and E2E were not run under the current local validation policy;
  GitHub CI is expected to provide those build and test gates.
