### PR TITLE
[Docs] Fix OpenAI dead links in LLM transform docs

### DIFF
--- a/docs/en/transforms/llm.md
+++ b/docs/en/transforms/llm.md
@@ -90,8 +90,7 @@ transform {
 ### model
 
 The model to use. Different model providers have different models. For example, the OpenAI model can be `gpt-4o-mini`.
-If you use OpenAI model, please refer https://platform.openai.com/docs/models/model-endpoint-compatibility
-of `/v1/chat/completions` endpoint.
+If you use an OpenAI model, please refer to https://developers.openai.com/api/docs/models for supported models and endpoints, including `/v1/chat/completions` where available.
 
 ### api_key
 

--- a/docs/zh/transforms/llm.md
+++ b/docs/zh/transforms/llm.md
@@ -88,7 +88,7 @@ transform {
 ### model
 
 要使用的模型。不同的模型提供者有不同的模型。例如，OpenAI 模型可以是 `gpt-4o-mini`。
-如果使用 OpenAI 模型，请参考 https://platform.openai.com/docs/models/model-endpoint-compatibility 文档的`/v1/chat/completions` 端点。
+如果使用 OpenAI 模型，请参考 https://developers.openai.com/api/docs/models 了解当前支持的模型与端点，包括可用的 `/v1/chat/completions`。
 
 ### api_key
 


### PR DESCRIPTION
## Summary

- Replace the retired OpenAI model-endpoint compatibility URL in the English and Chinese LLM transform documentation.
- Point both references to the current official OpenAI models documentation.
<img width="1932" height="947" alt="image" src="https://github.com/user-attachments/assets/b403db0d-9252-4111-affc-9659828dc243" />

## Root cause

OpenAI retired the former `platform.openai.com/docs/models/model-endpoint-compatibility` deep link, causing the repository-wide Markdown link check to receive HTTP 404 responses.

## Validation

- `npx --yes markdown-link-check -c .dlc.json -q docs/en/transforms/llm.md`
- `npx --yes markdown-link-check -c .dlc.json -q docs/zh/transforms/llm.md`
- `./mvnw.cmd spotless:apply`
- `./mvnw.cmd -q -DskipTests verify` (timed out after five minutes in the local execution environment without error output)