### PR TITLE
[Improve][CI] Stabilize workflow run detection

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -48,6 +48,7 @@ jobs:
             // TODO: Should use pull_request.user and pull_request.user.repos_url?
             // If a different person creates a commit to another forked repo,
             // it wouldn't be able to detect.
+            const head_sha = context.payload.pull_request.head.sha
             const params = {
               owner: context.payload.pull_request.head.repo.owner.login,
               repo: context.payload.pull_request.head.repo.name,
@@ -66,8 +67,36 @@ jobs:
             console.log('SHA: ' + context.payload.pull_request.head.sha)
 
             const name = 'Build'
-            const head_sha = context.payload.pull_request.head.sha
-            let status = 'queued'
+            const createDetectionFailedCheck = async () => {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: name,
+                head_sha: head_sha,
+                status: 'completed',
+                conclusion: 'action_required',
+                output: {
+                  title: 'Workflow run detection failed',
+                  summary: `
+            Unable to detect the workflow run for testing the changes in your PR.
+
+            1. If you did not enable GitHub Actions in your forked repository, please enable it by clicking the button as shown in the image below. See also [Disabling or limiting GitHub Actions for a repository](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository) for more details.
+            2. Create and push an empty commit to trigger the workflow.
+            3. It is possible your branch is based on the old \`dev\` branch in Apache SeaTunnel, please sync your branch to the latest dev branch. For example as below:
+                \`\`\`bash
+                git fetch upstream
+                git rebase upstream/dev
+                git push origin YOUR_BRANCH --force
+                \`\`\``,
+                  images: [
+                    {
+                      alt: 'enabling workflows button',
+                      image_url: 'https://raw.githubusercontent.com/apache/spark/master/.github/workflows/images/workflow-enable-button.png'
+                    }
+                  ]
+                }
+              })
+            }
 
             async function findBuildWorkflowRun() {
               const lookupDeadline = Date.now() + MAX_LOOKUP_DURATION_MS
@@ -76,9 +105,8 @@ jobs:
               while (true) {
                 try {
                   const runs = await github.request(endpoint, params)
-                  const buildRun = runs.data.workflow_runs.find(
-                    (run) => run.head_sha === head_sha
-                  )
+                  const workflowRuns = runs && runs.data ? runs.data.workflow_runs : []
+                  const buildRun = workflowRuns.find((run) => run.head_sha === head_sha)
 
                   console.log('runs: ' + JSON.stringify(runs))
                   if (buildRun) {
@@ -102,39 +130,11 @@ jobs:
 
             const build_run = await findBuildWorkflowRun()
             if (!build_run) {
-              status = 'completed'
-              const conclusion = 'action_required'
+              await createDetectionFailedCheck()
+              return
+            }
 
-              await github.rest.checks.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: name,
-                head_sha: head_sha,
-                status: status,
-                conclusion: conclusion,
-                output: {
-                  title: 'Workflow run detection failed',
-                  summary: `
-            Unable to detect the workflow run for testing the changes in your PR.
-
-            1. If you did not enable GitHub Actions in your forked repository, please enable it by clicking the button as shown in the image below. See also [Disabling or limiting GitHub Actions for a repository](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository) for more details.
-            2. Create and push an empty commit to trigger the workflow.
-            3. It is possible your branch is based on the old \`dev\` branch in Apache SeaTunnel, please sync your branch to the latest dev branch. For example as below:
-                \`\`\`bash
-                git fetch upstream
-                git rebase upstream/dev
-                git push origin YOUR_BRANCH --force
-                \`\`\``,
-                  images: [
-                    {
-                      alt: 'enabling workflows button',
-                      image_url: 'https://raw.githubusercontent.com/apache/spark/master/.github/workflows/images/workflow-enable-button.png'
-                    }
-                  ]
-                }
-              })
-            } else {
-              const run_id = build_run.id
+            const run_id = build_run.id
 
               // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
               const check_runs = await github.request(check_run_endpoint, check_run_params)
@@ -162,7 +162,7 @@ jobs:
                 repo: context.repo.repo,
                 name: name,
                 head_sha: head_sha,
-                status: status,
+                status: 'queued',
                 output: {
                   title: 'Test results',
                   summary: '[See test results](' + check_run_url + ')',

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -136,42 +136,41 @@ jobs:
 
             const run_id = build_run.id
 
-              // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
-              const check_runs = await github.request(check_run_endpoint, check_run_params)
-              console.log('check_runs: ' + JSON.stringify(check_runs))
-              const actions_url = 'https://github.com/'
-                + context.payload.pull_request.head.repo.full_name
-                + '/actions/runs/'
-                + run_id
-              const run_url_part = '/actions/runs/' + run_id
-              const check_run_head = check_runs.data.check_runs.find(r =>
-                r.head_sha === build_run.head_sha
-                  && (
-                    (r.details_url && r.details_url.includes(run_url_part))
-                    || (r.html_url && r.html_url.includes(run_url_part))
-                  )
-              )
+            // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
+            const check_runs = await github.request(check_run_endpoint, check_run_params)
+            console.log('check_runs: ' + JSON.stringify(check_runs))
+            const actions_url = 'https://github.com/'
+              + context.payload.pull_request.head.repo.full_name
+              + '/actions/runs/'
+              + run_id
+            const run_url_part = '/actions/runs/' + run_id
+            const check_run_head = check_runs.data.check_runs.find(r =>
+              r.head_sha === build_run.head_sha
+                && (
+                  (r.details_url && r.details_url.includes(run_url_part))
+                  || (r.html_url && r.html_url.includes(run_url_part))
+                )
+            )
 
-              console.log('check_run_head: ' + JSON.stringify(check_run_head))
-              const check_run_url = check_run_head
-                ? (check_run_head.html_url || check_run_head.details_url || actions_url)
-                : actions_url
+            console.log('check_run_head: ' + JSON.stringify(check_run_head))
+            const check_run_url = check_run_head
+              ? (check_run_head.html_url || check_run_head.details_url || actions_url)
+              : actions_url
 
-              await github.rest.checks.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: name,
-                head_sha: head_sha,
-                status: 'queued',
-                output: {
-                  title: 'Test results',
-                  summary: '[See test results](' + check_run_url + ')',
-                  text: JSON.stringify({
-                    owner: context.payload.pull_request.head.repo.owner.login,
-                    repo: context.payload.pull_request.head.repo.name,
-                    run_id: run_id
-                  })
-                },
-                details_url: actions_url,
-              })
-            }
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: name,
+              head_sha: head_sha,
+              status: 'queued',
+              output: {
+                title: 'Test results',
+                summary: '[See test results](' + check_run_url + ')',
+                text: JSON.stringify({
+                  owner: context.payload.pull_request.head.repo.owner.login,
+                  repo: context.payload.pull_request.head.repo.name,
+                  run_id: run_id
+                })
+              },
+              details_url: actions_url,
+            })

--- a/mvnw
+++ b/mvnw
@@ -232,23 +232,37 @@ else
       wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
     fi
 
+    download_with_retries() {
+        attempts=1
+        while [ "$attempts" -le 5 ]; do
+            "$@" && return 0
+            rm -f "$wrapperJarPath"
+            if [ "$attempts" -lt 5 ]; then
+                echo "Maven wrapper download failed, retrying in 5 seconds ..." >&2
+                sleep 5
+            fi
+            attempts=`expr "$attempts" + 1`
+        done
+        return 1
+    }
+
     if command -v wget > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found wget ... using wget"
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            download_with_retries wget "$jarUrl" -O "$wrapperJarPath"
         else
-            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            download_with_retries wget --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$jarUrl" -O "$wrapperJarPath"
         fi
     elif command -v curl > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found curl ... using curl"
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            curl -o "$wrapperJarPath" "$jarUrl" -f
+            download_with_retries curl -o "$wrapperJarPath" "$jarUrl" -f
         else
-            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+            download_with_retries curl --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$jarUrl" -f
         fi
 
     else


### PR DESCRIPTION
### Purpose

This PR stabilizes CI/tooling failures observed on `dev` and PR-notification workflows during the 2026-07-27 to 2026-07-29 window. The failures are unrelated to individual PR code changes.

### Root causes observed

- `On pull request update` can fail by itself when the latest workflow run found by branch does not belong to the current PR head SHA. Example: https://github.com/apache/seatunnel/actions/runs/30420088096 failed with `There was a new unsynced commit pushed. Please retrigger the workflow.`
- `Build` on `dev` can fail while bootstrapping Maven Wrapper when Maven Central returns a transient `429 Too Many Requests`, leaving `maven-wrapper.jar` missing. Example: https://github.com/apache/seatunnel/actions/runs/30428769947
- `Upgrade Compatibility` on `dev` can pick the edge-agent binary archive while looking for the current SeaTunnel distribution, then fail because the extracted directory does not contain `bin/seatunnel.sh`. Example: https://github.com/apache/seatunnel/actions/runs/30388071330 failed with `Missing required file: .../target/upgrade-compatibility/current/bin/seatunnel.sh`.

### Changes

- Match PR notification Build workflow runs by the exact PR head SHA and create an `action_required` check instead of failing the notification workflow when the run cannot be detected.
- Retry Maven Wrapper jar downloads for transient network/rate-limit failures and clean partial jar files between attempts.
- Exclude `apache-seatunnel-edge-agent-*-bin.tar.gz` when the upgrade compatibility script auto-detects the current SeaTunnel distribution archive.

### Verification

Local verification was intentionally limited to formatting and static checks per the SeaTunnel local-validation rule for this task. I did not run Docker, compile, tests, E2E, packaging, services, or jobs locally.

Executed:

- `sh -n mvnw`
- `bash -n tools/upgrade_compatibility/run_upgrade_compatibility.sh`
- YAML parse check for `.github/workflows/backend.yml` and `.github/workflows/notify_test_workflow.yml`
- Extracted `actions/github-script` body and ran `node --check`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home ./mvnw -nsu -Dmaven.gitcommitid.skip=true spotless:apply`
- `git diff --check`

The final functional gate should be the GitHub CI for this PR head.
