### PR TITLE
fix(trace-analyzer): remove redundant e.printStackTrace() after log.error()

### DIFF
--- a/seatunnel-trace/seatunnel-trace-analyzer/src/main/java/org/apache/seatunnel/trace/analyzer/TraceAnalyzerMain.java
+++ b/seatunnel-trace/seatunnel-trace-analyzer/src/main/java/org/apache/seatunnel/trace/analyzer/TraceAnalyzerMain.java
@@ -117,7 +117,6 @@ public class TraceAnalyzerMain {
         } catch (Exception e) {
             log.error("Analysis failed", e);
             System.err.println("Error: " + e.getMessage());
-            e.printStackTrace();
             System.exit(1);
         }
     }


### PR DESCRIPTION
## Problem

`TraceAnalyzerMain.java:120` contains a redundant `e.printStackTrace()` call that occurs immediately after `log.error("Analysis failed", e)` which already logs the full stack trace.

## Impact

- Duplicate stack trace output (once via logger, once to stderr)
- Stack trace to stderr bypasses log configuration (level, format, destination)
- Inconsistent with the rest of the codebase

## Fix

Remove the redundant `e.printStackTrace()` since `log.error("Analysis failed", e)` already captures the full exception with stack trace.

Closes #11600

Local environment limitations, relying on CI/CD automated testing.
