### PR TITLE
docs: add Windows local deployment guidance

### DIFF
--- a/docs/en/getting-started/locally/deployment.md
+++ b/docs/en/getting-started/locally/deployment.md
@@ -27,12 +27,36 @@ wget "https://archive.apache.org/dist/seatunnel/${version}/apache-seatunnel-${ve
 tar -xzvf "apache-seatunnel-${version}-bin.tar.gz"
 ```
 
+On Windows, download the `.zip` archive from the [SeaTunnel Download Page](https://seatunnel.apache.org/download), then extract it with File Explorer or PowerShell:
+
+```powershell
+$version = "3.0.0"
+Invoke-WebRequest `
+  "https://archive.apache.org/dist/seatunnel/$version/apache-seatunnel-$version-bin.zip" `
+  -OutFile "apache-seatunnel-$version-bin.zip"
+Expand-Archive "apache-seatunnel-$version-bin.zip" -DestinationPath .
+Set-Location "apache-seatunnel-$version"
+```
+
 ### Download The Connector Plugins
 
 Starting from version 2.2.0-beta, the binary package no longer provides connector dependencies by default. Therefore, the first time you use it, you need to run the following command to install the connectors (Alternatively, you can manually download the connectors from the [Apache Maven Repository](https://repo.maven.apache.org/maven2/org/apache/seatunnel/) and move them to the `connectors/` directory. For versions before 2.3.5, place them in the `connectors/seatunnel` directory)：
 
 ```bash
 sh bin/install-plugin.sh
+```
+
+On Windows, run the bundled batch script from the extracted directory. It uses the Maven Wrapper, so a separate Maven installation is not required:
+
+```bat
+cd apache-seatunnel-3.0.0
+bin\install-plugin.cmd
+```
+
+To install connectors for a specific release, pass the version to the same script:
+
+```bat
+bin\install-plugin.cmd 3.0.0
 ```
 
 If you need a specific connector version, taking 3.0.0 as an example, you need to execute the following command:

--- a/docs/en/getting-started/locally/quick-start-seatunnel-engine.md
+++ b/docs/en/getting-started/locally/quick-start-seatunnel-engine.md
@@ -36,6 +36,12 @@ connector-console
 sh bin/install-plugin.sh
 ```
 
+On Windows, use the batch script instead:
+
+```bat
+bin\install-plugin.cmd
+```
+
 ### Step 1: Deploy SeaTunnel And Connectors
 
 Before starting, make sure you have downloaded and deployed SeaTunnel as described in [Deployment](deployment.md).
@@ -101,6 +107,13 @@ Starting from version 2.3.1, the parameter -e in seatunnel.sh is deprecated, use
 cd "apache-seatunnel-${version}"
 ./bin/seatunnel.sh --config ./config/v2.batch.config.template -m local
 
+```
+
+On Windows, run the equivalent batch entry point from the SeaTunnel directory:
+
+```bat
+cd apache-seatunnel-3.0.0
+bin\seatunnel.cmd --config config\v2.batch.config.template -m local
 ```
 
 **See The Output**: When you run the command, you can see its output in your console. This


### PR DESCRIPTION
## Summary

- document the Windows PowerShell download and extraction path
- document connector installation with `bin\\install-plugin.cmd`
- document the Windows local-mode quick-start command

This is the local Windows slice requested in #10617. It keeps the change limited to the English deployment and quick-start guides and does not change runtime behavior.

## Validation

- `git diff --check`
- verified the referenced Windows scripts exist in the packaged source tree

Fixes #10617