### PR TITLE
[Docs][Jdbc] Clarify MariaDB driver configuration

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -131,6 +131,19 @@ Expected rows:
 
 If the job fails before writing, check [Troubleshooting](#troubleshooting) first.
 
+:::note
+
+When connecting to MariaDB, use MariaDB Connector/J with the matching URL and driver:
+
+```hocon
+url = "jdbc:mariadb://localhost:3306/database"
+driver = "org.mariadb.jdbc.Driver"
+```
+
+Do not use MySQL Connector/J with a `jdbc:mysql:` URL for MariaDB. That configuration selects the MySQL dialect, which can reject a MariaDB server version as an unsupported MySQL version.
+
+:::
+
 ## Key Features
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)

--- a/docs/en/connectors/source/Jdbc.md
+++ b/docs/en/connectors/source/Jdbc.md
@@ -120,6 +120,19 @@ cd "${SEATUNNEL_HOME}"
 
 If the job fails before reading rows, check [Troubleshooting](#troubleshooting) first.
 
+:::note
+
+When connecting to MariaDB, use MariaDB Connector/J with the matching URL and driver:
+
+```hocon
+url = "jdbc:mariadb://localhost:3306/database"
+driver = "org.mariadb.jdbc.Driver"
+```
+
+Do not use MySQL Connector/J with a `jdbc:mysql:` URL for MariaDB. That configuration selects the MySQL dialect, which can reject a MariaDB server version as an unsupported MySQL version.
+
+:::
+
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -131,6 +131,19 @@ ORDER BY id;
 
 如果任务在写入前失败，请先检查[故障排查](#故障排查)。
 
+:::note
+
+连接 MariaDB 时，请使用 MariaDB Connector/J 以及匹配的 URL 和驱动：
+
+```hocon
+url = "jdbc:mariadb://localhost:3306/database"
+driver = "org.mariadb.jdbc.Driver"
+```
+
+不要使用 MySQL Connector/J 和 `jdbc:mysql:` URL 连接 MariaDB。该配置会选择 MySQL 方言，可能将 MariaDB 服务端版本判定为不支持的 MySQL 版本。
+
+:::
+
 ## 主要特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)

--- a/docs/zh/connectors/source/Jdbc.md
+++ b/docs/zh/connectors/source/Jdbc.md
@@ -120,6 +120,19 @@ cd "${SEATUNNEL_HOME}"
 
 如果任务在读取数据前失败，请先检查[故障排查](#故障排查)。
 
+:::note
+
+连接 MariaDB 时，请使用 MariaDB Connector/J 以及匹配的 URL 和驱动：
+
+```hocon
+url = "jdbc:mariadb://localhost:3306/database"
+driver = "org.mariadb.jdbc.Driver"
+```
+
+不要使用 MySQL Connector/J 和 `jdbc:mysql:` URL 连接 MariaDB。该配置会选择 MySQL 方言，可能将 MariaDB 服务端版本判定为不支持的 MySQL 版本。
+
+:::
+
 ## 关键特性
 
 - [x] [批](../../introduction/concepts/connector-v2-features.md)


### PR DESCRIPTION
### Purpose of this pull request

Closes #10030.

A MariaDB server was configured with MySQL Connector/J and a `jdbc:mysql:` URL, which selects SeaTunnel's MySQL dialect and causes the MariaDB 11.x server version to be rejected as an unsupported MySQL version.

This PR documents the correct MariaDB Connector/J configuration for JDBC source and sink in both English and Chinese:

```hocon
url = "jdbc:mariadb://localhost:3306/database"
driver = "org.mariadb.jdbc.Driver"
```

It also warns against mixing MySQL Connector/J/`jdbc:mysql:` with MariaDB.

### Does this PR introduce any user-facing change?

Yes. The JDBC connector documentation now makes the MariaDB driver and URL requirements explicit. No runtime behavior changes.

### How was this patch tested?

- `git diff --check`
- Verified all four JDBC source/sink English/Chinese pages contain matching MariaDB examples and balanced Docusaurus note/code blocks.
- Confirmed from the current implementation that `jdbc:mysql:` selects `MySqlDialectFactory`, while `jdbc:mariadb:` does not enter `MySqlVersion.parse`.
- Attempted `./mvnw -pl seatunnel-connectors-v2/connector-jdbc -am -DskipITs -Dtest=MysqlVersionTest -Dsurefire.failIfNoSpecifiedTests=false test`; the reactor was blocked before reaching the test by pre-existing missing generated classes in `seatunnel-config-shade`. Spotless checks passed for all reactor modules reached before that unrelated compilation failure.