### PR TITLE
[Docs] Define CDC schema evolution runtime contract

### DIFF
--- a/docs/en/architecture/cdc-pipeline-architecture.md
+++ b/docs/en/architecture/cdc-pipeline-architecture.md
@@ -107,6 +107,7 @@ Related docs:
 - [Multi-Table](./features/multi-table.md)
 - [Catalog Table](./api-design/catalog-table.md)
 - [Schema Evolution Configuration](../introduction/configuration/schema-evolution.md)
+- [CDC Schema Evolution Contract](./cdc-schema-evolution-contract.md)
 
 ## Execution Phases
 

--- a/docs/en/architecture/cdc-schema-evolution-contract.md
+++ b/docs/en/architecture/cdc-schema-evolution-contract.md
@@ -1,0 +1,181 @@
+---
+title: CDC Schema Evolution Contract
+---
+
+# CDC Schema Evolution Contract
+
+## Purpose
+
+This page defines the end-to-end contract that a CDC schema evolution path must satisfy when a
+`SchemaChangeEvent` is enabled. It is a runtime contract, not only a connector feature list.
+
+The contract applies to any source, transform, engine, and sink path that advertises schema
+evolution support. A path that cannot satisfy this contract must fail explicitly or document a
+connector-specific limitation before it processes the ambiguous stream.
+
+## Scope
+
+The first version is defined per table. Schema changes for different tables may proceed
+independently as long as each table keeps its own ordering and recovery state. Cross-table atomic
+DDL is outside this version and must not be implied by connector documentation.
+
+The supported change types and connector matrix are documented in
+[Schema Evolution Configuration](../introduction/configuration/schema-evolution.md). This page
+defines the ordering, checkpoint, sink application, replay, and restore semantics around those
+events.
+
+## Contract Primitives
+
+### Table identity
+
+Every schema change event must carry the stable table identity used by the runtime and sink. The
+identity is the key for ordering, coordination, sink apply, checkpoint state, and restore.
+
+### Schema epoch
+
+For one table, every schema change must have a monotonic epoch or equivalent durable identity. The
+epoch is used to deduplicate replayed events and to tell whether a sink has already applied the same
+schema change after recovery.
+
+If a source or engine path cannot provide a stable event identity, that path must not claim
+recoverable schema evolution support.
+
+### Schema boundary
+
+For one table, a schema change creates a hard boundary:
+
+```text
+old-schema records -> SchemaChangeEvent(epoch=N) -> new-schema records
+```
+
+Records using the new schema must not overtake the schema change. Records using the old schema must
+not be released after the sink has moved to the new epoch unless the connector explicitly encodes
+them as old-epoch records and the sink can handle both epochs.
+
+## End-To-End Flow
+
+The target flow for a schema-evolution-capable path is:
+
+1. The source observes a DDL event and converts it to a `SchemaChangeEvent`.
+2. The source closes the old-schema prefix for that table and records a durable boundary before
+   new-schema data is released.
+3. Each transform maps the event through `SeaTunnelTransform.mapSchemaChangeEvent` and refreshes
+   downstream catalog state before it processes new-schema rows.
+4. The engine waits until old-schema data that must be flushed or committed before the DDL is
+   safely past the required checkpoint boundary.
+5. The engine sends the event to every sink subtask that owns the table.
+6. Every sink subtask applies the DDL or reports an explicit failure. A partial success must not be
+   treated as success.
+7. The engine records the applied epoch in checkpoint state before it releases or commits the
+   new-schema data stream as durable.
+
+## Ordering Rules
+
+For each table:
+
+- schema changes are processed in source order
+- only one schema change may be in the active apply window
+- new-schema records wait behind the schema event until all required sink subtasks have applied it
+- replayed schema events are deduplicated by epoch or fail with an actionable error
+- unsupported transforms or sinks fail before dropping, reordering, or silently ignoring the event
+
+For different tables:
+
+- schema changes may proceed independently in the first version
+- a blocked table must not silently reorder another table's records
+- connectors that share one physical sink transaction across tables must document whether that
+  transaction creates a wider coordination boundary
+
+## Recovery State Machine
+
+The engine or runtime integration must be able to distinguish these states for each table epoch.
+
+| State | Meaning | Recovery rule |
+| --- | --- | --- |
+| `OBSERVED` | The source saw the schema change, but the old-schema boundary is not durable yet. | Restore from the last checkpoint and re-read the event from the source offset. No sink DDL may have been applied. |
+| `BOUNDARY_DURABLE` | Old-schema records before the boundary are checkpointed or otherwise safe. | Apply the schema change before releasing new-schema records. |
+| `APPLYING` | One or more sink subtasks are applying the DDL. | Retry only through an idempotent sink apply path, or verify the external schema and fail with a clear error if the result is ambiguous. |
+| `APPLIED_NOT_DURABLE` | The external sink schema was changed, but the runtime epoch state is not checkpointed yet. | On restore, detect the already-applied epoch and complete the runtime state, or fail before writing data if the sink cannot prove the applied schema. |
+| `EPOCH_DURABLE` | The sink apply result and runtime epoch are durable. | New-schema records may continue from the restored checkpoint. Replayed events for the same epoch are treated as duplicates. |
+
+## Failure Rules
+
+The following cases must be deterministic:
+
+| Failure point | Required behavior |
+| --- | --- |
+| Before the boundary checkpoint | Replay from the previous source checkpoint. The sink must not have received the DDL. |
+| After the boundary checkpoint and before sink apply | Apply the DDL before releasing new-schema records. |
+| During sink apply | Retry idempotently, complete all subtasks, or fail the job. Partial apply must be visible in the error. |
+| After sink apply and before the next checkpoint | Restore by detecting the applied epoch, or fail fast if the sink cannot prove whether the DDL succeeded. |
+| During restore | Rebuild source offsets, transform catalog state, sink epoch state, and pending events before any new-schema records are emitted. |
+| Unsupported source, transform, engine, or sink path | Fail before ambiguous processing. Skipping or ignoring the event is not a valid schema evolution contract. |
+
+## Component Responsibilities
+
+### Source
+
+The source is responsible for emitting schema changes with table identity, a stable epoch, the
+post-change schema, and a checkpoint boundary that separates old-schema and new-schema records.
+Current source APIs expose this boundary through `Collector.markSchemaChangeBeforeCheckpoint`,
+`Collector.collect(SchemaChangeEvent)`, and `Collector.markSchemaChangeAfterCheckpoint`.
+
+### Transform
+
+A transform that changes table identity, column names, column order, or row shape must map the
+schema change event consistently with the data rows it will emit after the boundary. If a transform
+cannot map the event safely, it must fail instead of passing stale metadata downstream.
+
+### Engine
+
+The engine is responsible for serializing each table's schema epoch, waiting for the required
+checkpoint boundary, broadcasting the event to all required sink subtasks, collecting success or
+failure, and checkpointing the applied epoch.
+
+### Sink
+
+A sink that advertises schema evolution support must implement an idempotent or verifiable DDL apply
+path through `SupportSchemaEvolutionSinkWriter.applySchemaChange`. It must report unsupported
+change types and partial apply failures as task-failing errors with table and epoch context.
+
+## Validation Requirements
+
+Any implementation that claims this contract should include E2E coverage for:
+
+- consecutive add, drop, rename, and modify column events
+- failure before the schema-change boundary checkpoint
+- failure after the boundary checkpoint but before sink apply
+- failure during sink apply, including partial subtask success
+- failure after sink apply but before the following checkpoint completes
+- restore from checkpoints before and after the schema change
+- multiple tables changing schema independently
+- a sink that does not support the requested schema change
+
+At least one positive path should use MySQL CDC to a schema-evolution-capable JDBC sink. At least
+one negative path should use an unsupported sink and assert the explicit failure.
+
+## Follow-Up Implementation Areas
+
+This contract should be implemented through focused follow-up work:
+
+- API/event metadata: stable per-table epoch, serialization compatibility, and transform mapping
+  expectations
+- engine coordination: recoverable per-table state machine, sink subtask acknowledgement, timeout,
+  restore, and replay handling
+- E2E recovery: fault injection for every failure point above, including duplicate DDL and
+  unsupported-sink paths
+
+## Code References
+
+Start from these implementation points when changing code:
+
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/event/SchemaChangeEvent.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/source/Collector.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/transform/SeaTunnelTransform.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriter.java`
+- `seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializeSchema.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java`
+- `seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/schema/SchemaOperator.java`
+- `seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/schema/BroadcastSchemaSinkOperator.java`

--- a/docs/en/introduction/configuration/schema-evolution.md
+++ b/docs/en/introduction/configuration/schema-evolution.md
@@ -5,6 +5,9 @@ Schema Evolution means that the schema of a data table can be changed and the da
 
 - Zeta
 
+For the end-to-end ordering, checkpoint, sink-apply, replay, and restore contract, see
+[CDC Schema Evolution Contract](../../architecture/cdc-schema-evolution-contract.md).
+
 ## Supported schema change event types
 
 - `ADD COLUMN`

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -305,6 +305,7 @@ const sidebars = {
                 "architecture/core-api-design",
                 "architecture/transform-plugin-system",
                 "architecture/cdc-pipeline-architecture",
+                "architecture/cdc-schema-evolution-contract",
                 "architecture/data-format-handling",
                 "architecture/table-schema-and-type-system",
                 "architecture/plugin-discovery-and-class-loading",

--- a/docs/zh/architecture/cdc-pipeline-architecture.md
+++ b/docs/zh/architecture/cdc-pipeline-architecture.md
@@ -107,6 +107,7 @@ SeaTunnel 依赖表元数据来支持：
 - [多表支持](./features/multi-table.md)
 - [Catalog Table](./api-design/catalog-table.md)
 - [Schema Evolution 配置](../introduction/configuration/schema-evolution.md)
+- [CDC Schema Evolution 契约](./cdc-schema-evolution-contract.md)
 
 ## 执行阶段
 

--- a/docs/zh/architecture/cdc-schema-evolution-contract.md
+++ b/docs/zh/architecture/cdc-schema-evolution-contract.md
@@ -1,0 +1,165 @@
+---
+title: CDC Schema Evolution 契约
+---
+
+# CDC Schema Evolution 契约
+
+## 文档目标
+
+本文定义启用 `SchemaChangeEvent` 后，CDC schema evolution 链路必须满足的端到端契约。它不是
+单个 connector 的功能清单，而是 source、transform、engine、sink 共同遵守的运行时契约。
+
+任何声称支持 schema evolution 的路径，都必须满足这份契约。无法满足契约的路径，必须在进入
+含义不明确的数据流处理前显式失败，或者明确记录 connector 级限制。
+
+## 范围
+
+第一个版本按表定义。同一张表内必须保持自己的顺序与恢复状态；不同表的 schema change 可以
+独立推进。跨表原子 DDL 不属于这个版本，connector 文档也不能暗示具备跨表原子能力。
+
+支持的变更类型和 connector 矩阵见
+[Schema Evolution 配置](../introduction/configuration/schema-evolution.md)。本文定义这些事件周围的
+排序、checkpoint、sink apply、重放和恢复语义。
+
+## 契约原语
+
+### 表标识
+
+每个 schema change event 都必须携带运行时和 sink 使用的稳定表标识。表标识是排序、协调、
+sink apply、checkpoint 状态和恢复的 key。
+
+### Schema epoch
+
+对同一张表来说，每个 schema change 都必须有单调递增的 epoch，或者等价的可持久化事件标识。
+epoch 用来去重重放事件，并判断恢复后 sink 是否已经应用过同一个 schema change。
+
+如果某个 source 或 engine 路径无法提供稳定事件标识，就不能声明支持可恢复的 schema evolution。
+
+### Schema 边界
+
+对同一张表来说，schema change 会形成硬边界：
+
+```text
+old-schema records -> SchemaChangeEvent(epoch=N) -> new-schema records
+```
+
+使用新 schema 的记录不能越过 schema change event。使用旧 schema 的记录也不能在 sink 已经进入
+新 epoch 后再被释放，除非 connector 显式编码旧 epoch 记录，并且 sink 能同时处理两个 epoch。
+
+## 端到端流程
+
+支持 schema evolution 的目标路径如下：
+
+1. source 观察到 DDL，并转换成 `SchemaChangeEvent`。
+2. source 关闭该表的 old-schema 数据前缀，并在释放 new-schema 数据前记录可持久化边界。
+3. 每个 transform 通过 `SeaTunnelTransform.mapSchemaChangeEvent` 映射事件，并在处理 new-schema
+   行之前刷新下游 catalog 状态。
+4. engine 等待 old-schema 数据完成必须的 flush 或 commit，并越过要求的 checkpoint 边界。
+5. engine 把事件发送给拥有该表的每个 sink subtask。
+6. 每个 sink subtask 应用 DDL，或者上报显式失败。部分成功不能当作成功。
+7. engine 在 checkpoint 状态中记录已应用 epoch，然后才把 new-schema 数据流作为可恢复状态继续释放或提交。
+
+## 排序规则
+
+对每一张表：
+
+- schema change 按 source 观察顺序处理
+- 同一时刻只能有一个 schema change 处于 active apply 窗口
+- new-schema 记录必须等待 schema event，直到所有要求的 sink subtask 完成 apply
+- 重放的 schema event 必须按 epoch 去重，或者以可操作错误失败
+- 不支持的 transform 或 sink 必须在丢弃、乱序或静默忽略事件前失败
+
+对不同表：
+
+- 第一个版本允许不同表的 schema change 独立推进
+- 某张表被阻塞时，不能静默打乱另一张表的记录顺序
+- 如果 connector 在多张表之间共享同一个物理 sink 事务，必须说明这个事务是否扩大了协调边界
+
+## 恢复状态机
+
+engine 或运行时集成必须能为每张表的每个 epoch 区分这些状态。
+
+| 状态 | 含义 | 恢复规则 |
+| --- | --- | --- |
+| `OBSERVED` | source 已观察到 schema change，但 old-schema 边界尚未持久化。 | 从最近一次 checkpoint 恢复，并从 source offset 重新读取事件。sink 不应收到 DDL。 |
+| `BOUNDARY_DURABLE` | 边界前的 old-schema 记录已 checkpoint，或者已经以其他方式安全落地。 | 先应用 schema change，再释放 new-schema 记录。 |
+| `APPLYING` | 一个或多个 sink subtask 正在应用 DDL。 | 只能通过幂等 sink apply 路径重试；否则必须校验外部 schema，无法判断结果时显式失败。 |
+| `APPLIED_NOT_DURABLE` | 外部 sink schema 已改变，但运行时 epoch 状态尚未 checkpoint。 | 恢复时检测已应用 epoch 并补全运行时状态；如果 sink 无法证明已应用 schema，则在写入数据前失败。 |
+| `EPOCH_DURABLE` | sink apply 结果和运行时 epoch 都已持久化。 | 可以从恢复后的 checkpoint 继续 new-schema 记录；同 epoch 重放事件按重复事件处理。 |
+
+## 故障规则
+
+以下故障点必须是确定性的：
+
+| 故障点 | 必须行为 |
+| --- | --- |
+| 边界 checkpoint 前 | 从上一次 source checkpoint 重放。sink 不能已经收到 DDL。 |
+| 边界 checkpoint 后、sink apply 前 | 先应用 DDL，再释放 new-schema 记录。 |
+| sink apply 过程中 | 幂等重试、完成所有 subtask，或者让作业失败。部分 apply 必须能在错误里看出来。 |
+| sink apply 后、下一次 checkpoint 前 | 恢复时检测已应用 epoch；如果 sink 无法证明 DDL 是否成功，则 fail fast。 |
+| restore 过程中 | 在任何 new-schema 记录发出前，重建 source offset、transform catalog 状态、sink epoch 状态和 pending event。 |
+| source、transform、engine 或 sink 不支持 | 在含义不明确的处理发生前失败。跳过或静默忽略事件不满足 schema evolution 契约。 |
+
+## 组件职责
+
+### Source
+
+source 负责输出包含表标识、稳定 epoch、变更后 schema 的 schema change，并给出区分 old-schema 与
+new-schema 记录的 checkpoint 边界。当前 source API 通过
+`Collector.markSchemaChangeBeforeCheckpoint`、`Collector.collect(SchemaChangeEvent)` 和
+`Collector.markSchemaChangeAfterCheckpoint` 暴露这个边界。
+
+### Transform
+
+如果 transform 会改变表标识、列名、列顺序或行结构，它必须用和后续数据行一致的方式映射 schema
+change event。无法安全映射事件时，transform 必须失败，而不是把陈旧元数据继续传给下游。
+
+### Engine
+
+engine 负责对每张表的 schema epoch 做串行化处理，等待要求的 checkpoint 边界，把事件广播给所有
+需要的 sink subtask，收集成功或失败，并 checkpoint 已应用 epoch。
+
+### Sink
+
+声称支持 schema evolution 的 sink 必须通过
+`SupportSchemaEvolutionSinkWriter.applySchemaChange` 提供幂等或可验证的 DDL apply 路径。遇到不支持的
+变更类型或部分 apply 失败时，必须抛出带表和 epoch 上下文的 task-failing error。
+
+## 验证要求
+
+任何声称实现该契约的代码，都应包含以下 E2E 覆盖：
+
+- 连续 add、drop、rename、modify column 事件
+- schema-change 边界 checkpoint 前失败
+- 边界 checkpoint 后、sink apply 前失败
+- sink apply 过程中失败，包括部分 subtask 成功
+- sink apply 后、下一次 checkpoint 完成前失败
+- 从 schema change 前后的 checkpoint 恢复
+- 多张表独立发生 schema change
+- sink 不支持目标 schema change 时显式失败
+
+至少一个正向路径应使用 MySQL CDC 到支持 schema evolution 的 JDBC sink；至少一个负向路径应使用
+不支持的 sink，并断言明确失败。
+
+## 后续实现区域
+
+这份契约应拆成聚焦的后续实现：
+
+- API/event metadata：稳定的 per-table epoch、序列化兼容、transform 映射预期
+- engine coordination：可恢复的 per-table 状态机、sink subtask ack、timeout、restore 和 replay 处理
+- E2E recovery：覆盖以上每个故障点的故障注入，包括重复 DDL 和 unsupported-sink 路径
+
+## 代码入口
+
+修改代码时，建议从这些入口开始：
+
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/event/SchemaChangeEvent.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/source/Collector.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/transform/SeaTunnelTransform.java`
+- `seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriter.java`
+- `seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/debezium/row/SeaTunnelRowDebeziumDeserializeSchema.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java`
+- `seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java`
+- `seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/schema/SchemaOperator.java`
+- `seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/schema/BroadcastSchemaSinkOperator.java`

--- a/docs/zh/introduction/configuration/schema-evolution.md
+++ b/docs/zh/introduction/configuration/schema-evolution.md
@@ -5,6 +5,9 @@
 
 - Zeta
 
+端到端排序、checkpoint、sink apply、重放和恢复契约见
+[CDC Schema Evolution 契约](../../architecture/cdc-schema-evolution-contract.md)。
+
 ## 已支持的模式变更事件类型
 
 - `ADD COLUMN`


### PR DESCRIPTION
### Purpose

Refs #11402.

This PR records the CDC SchemaChangeEvent runtime contract before follow-up runtime implementation work. It defines the per-table ordering, schema epoch, checkpoint boundary, sink apply, replay, restore, and unsupported-path semantics that a schema-evolution-capable path must satisfy.

### Scope

- Add English and Chinese CDC schema evolution contract architecture docs.
- Link the contract from the CDC pipeline architecture docs and schema evolution configuration docs.
- Register the new architecture page in the docs sidebar.
- Documentation only; no runtime behavior is changed in this PR.

### Validation

- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -T 3C spotless:apply`
- `git diff --cached --check`

Local compile, unit tests, E2E, Docker, and runtime verification were not run. Per the SeaTunnel local workflow boundary for this task, build and test truth should come from GitHub CI for this PR head.