### PR TITLE
[Fix][Zeta] Fail fast unsupported schema evolution sink

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriter.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.api.sink;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 public interface SupportSchemaEvolutionSinkWriter {
@@ -45,5 +46,57 @@ public interface SupportSchemaEvolutionSinkWriter {
      */
     default Optional<String> getPhysicalSinkTableIdentifier() {
         return Optional.empty();
+    }
+
+    /**
+     * Applies a schema change only when the sink writer explicitly declares schema evolution
+     * support.
+     *
+     * <p>The deprecated {@link SinkWriter#applySchemaChange(SchemaChangeEvent)} path is kept only
+     * for legacy writers that really override it. Writers that inherit the default no-op method
+     * must fail fast, otherwise a CDC schema change could be silently dropped while new-schema
+     * records continue downstream.
+     *
+     * @param writer sink writer that receives the schema change event
+     * @param event schema change event from upstream
+     * @throws IOException if the sink writer fails while applying the schema change
+     */
+    @SuppressWarnings("deprecation")
+    static void applySchemaChangeToWriter(SinkWriter<?, ?, ?> writer, SchemaChangeEvent event)
+            throws IOException {
+        if (writer instanceof SupportSchemaEvolutionSinkWriter) {
+            ((SupportSchemaEvolutionSinkWriter) writer).applySchemaChange(event);
+            return;
+        }
+        if (overridesDeprecatedApplySchemaChange(writer)) {
+            writer.applySchemaChange(event);
+            return;
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Sink writer %s received schema change event for table %s, but it does "
+                                + "not implement SupportSchemaEvolutionSinkWriter or override "
+                                + "SinkWriter.applySchemaChange(SchemaChangeEvent). "
+                                + "Schema evolution requires a schema-evolution-capable sink.",
+                        writer.getClass().getName(), event.tablePath()));
+    }
+
+    /**
+     * Checks whether a legacy sink writer provides its own deprecated schema change implementation.
+     *
+     * @param writer sink writer to inspect
+     * @return true when the writer overrides {@link
+     *     SinkWriter#applySchemaChange(SchemaChangeEvent)}
+     */
+    static boolean overridesDeprecatedApplySchemaChange(SinkWriter<?, ?, ?> writer) {
+        try {
+            Method method =
+                    writer.getClass().getMethod("applySchemaChange", SchemaChangeEvent.class);
+            return method.getDeclaringClass() != SinkWriter.class;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(
+                    "SinkWriter.applySchemaChange(SchemaChangeEvent) is missing from the writer API",
+                    e);
+        }
     }
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
@@ -528,13 +528,8 @@ public class MultiTableSinkWriter
                 dispatchTarget.getSinkIdentifier().getTableIdentifier(),
                 MultiTableFailurePhase.CHECKPOINT,
                 () -> {
-                    if (dispatchTarget.getWriter() instanceof SupportSchemaEvolutionSinkWriter) {
-                        ((SupportSchemaEvolutionSinkWriter) dispatchTarget.getWriter())
-                                .applySchemaChange(event);
-                    } else {
-                        // TODO remove deprecated method
-                        dispatchTarget.getWriter().applySchemaChange(event);
-                    }
+                    SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(
+                            dispatchTarget.getWriter(), event);
                     return null;
                 });
         log.info(

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriterTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/SupportSchemaEvolutionSinkWriterTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.sink;
+
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Verifies the shared sink-side schema change support gate.
+ *
+ * <p>The gate must preserve explicit legacy implementations while preventing the default no-op
+ * schema change method from silently accepting CDC schema changes.
+ */
+class SupportSchemaEvolutionSinkWriterTest {
+
+    /**
+     * Verifies the primary schema evolution extension point.
+     *
+     * @throws IOException if applying the schema change fails unexpectedly
+     */
+    @Test
+    void shouldApplySchemaChangeWithSupportInterface() throws IOException {
+        SupportInterfaceWriter writer = new SupportInterfaceWriter();
+        SchemaChangeEvent event = schemaChangeEvent();
+
+        SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(writer, event);
+
+        Assertions.assertSame(event, writer.appliedEvent);
+    }
+
+    /**
+     * Verifies compatibility with writers that still override the deprecated hook.
+     *
+     * @throws IOException if applying the schema change fails unexpectedly
+     */
+    @Test
+    void shouldKeepDeprecatedApplySchemaChangeOverrideCompatible() throws IOException {
+        DeprecatedOverrideWriter writer = new DeprecatedOverrideWriter();
+        SchemaChangeEvent event = schemaChangeEvent();
+
+        SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(writer, event);
+
+        Assertions.assertSame(event, writer.appliedEvent);
+    }
+
+    /**
+     * Verifies that inheriting the deprecated default no-op hook is not treated as schema evolution
+     * support.
+     */
+    @Test
+    void shouldFailFastWhenSinkWriterDoesNotSupportSchemaEvolution() {
+        PlainWriter writer = new PlainWriter();
+        SchemaChangeEvent event = schemaChangeEvent();
+
+        UnsupportedOperationException exception =
+                Assertions.assertThrows(
+                        UnsupportedOperationException.class,
+                        () ->
+                                SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(
+                                        writer, event));
+
+        Assertions.assertTrue(exception.getMessage().contains(PlainWriter.class.getName()));
+        Assertions.assertTrue(exception.getMessage().contains("test_db.test_table"));
+    }
+
+    /**
+     * Creates the schema change event used by all support-gate cases.
+     *
+     * @return a mocked schema change event with a stable table path
+     */
+    private static SchemaChangeEvent schemaChangeEvent() {
+        SchemaChangeEvent event = Mockito.mock(SchemaChangeEvent.class);
+        Mockito.when(event.tablePath()).thenReturn(TablePath.of("test_db", "test_table"));
+        return event;
+    }
+
+    /**
+     * Sink writer that inherits the deprecated default no-op schema change method.
+     *
+     * <p>This writer represents sinks that have no schema evolution support at all.
+     */
+    private static class PlainWriter implements SinkWriter<Object, Object, Object> {
+
+        @Override
+        public void write(Object element) {}
+
+        @Override
+        public Optional<Object> prepareCommit() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void abortPrepare() {}
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Sink writer that uses the current schema evolution extension point.
+     *
+     * <p>This is the preferred path for schema-evolution-capable sinks.
+     */
+    private static class SupportInterfaceWriter extends PlainWriter
+            implements SupportSchemaEvolutionSinkWriter {
+
+        private SchemaChangeEvent appliedEvent;
+
+        @Override
+        public void applySchemaChange(SchemaChangeEvent event) {
+            this.appliedEvent = event;
+        }
+    }
+
+    /**
+     * Sink writer that keeps the legacy deprecated schema change extension point.
+     *
+     * <p>The shared support gate still accepts this path for backward compatibility.
+     */
+    private static class DeprecatedOverrideWriter extends PlainWriter {
+
+        private SchemaChangeEvent appliedEvent;
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void applySchemaChange(SchemaChangeEvent event) {
+            this.appliedEvent = event;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/sink/IcebergSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/sink/IcebergSinkWriter.java
@@ -118,14 +118,18 @@ public class IcebergSinkWriter
 
     @Override
     public void applySchemaChange(SchemaChangeEvent event) throws IOException {
-        // Waiting cdc connector support schema change event
-        if (config.isTableSchemaEvolutionEnabled()) {
-            log.info("changed rowType before: {}", fieldsInfo(rowType));
-            this.rowType = dataTypeChangeEventHandler.reset(rowType).apply(event);
-            log.info("changed rowType after: {}", fieldsInfo(rowType));
-            tryCreateRecordWriter();
-            writer.applySchemaChange(this.rowType, event);
+        if (!config.isTableSchemaEvolutionEnabled()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Iceberg sink received schema change event for table %s, but "
+                                    + "iceberg.table.schema-evolution-enabled is false.",
+                            event.tablePath()));
         }
+        log.info("changed rowType before: {}", fieldsInfo(rowType));
+        this.rowType = dataTypeChangeEventHandler.reset(rowType).apply(event);
+        log.info("changed rowType after: {}", fieldsInfo(rowType));
+        tryCreateRecordWriter();
+        writer.applySchemaChange(this.rowType, event);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/sink/IcebergSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/test/java/org/apache/seatunnel/connectors/seatunnel/iceberg/sink/IcebergSinkWriterTest.java
@@ -18,7 +18,9 @@
 package org.apache.seatunnel.connectors.seatunnel.iceberg.sink;
 
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.connectors.seatunnel.iceberg.IcebergTableLoader;
 import org.apache.seatunnel.connectors.seatunnel.iceberg.config.IcebergSinkConfig;
@@ -37,7 +39,10 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class IcebergSinkWriterTest {
@@ -109,5 +114,29 @@ class IcebergSinkWriterTest {
         List<IcebergSinkState> states = writer.snapshotState(99L);
         assertEquals(1, states.size());
         assertEquals(99L, states.get(0).getCheckpointId());
+    }
+
+    /**
+     * Iceberg must fail fast instead of silently accepting schema changes when the table schema
+     * evolution option is disabled.
+     */
+    @Test
+    void testApplySchemaChangeFailsWhenSchemaEvolutionDisabled() {
+        when(config.isTableSchemaEvolutionEnabled()).thenReturn(false);
+        IcebergSinkWriter writer =
+                new IcebergSinkWriter(tableLoader, config, minimalSchema(), null);
+        AlterTableAddColumnEvent event =
+                AlterTableAddColumnEvent.add(
+                        TableIdentifier.of("catalog", "database", "table"),
+                        PhysicalColumn.of(
+                                "name", BasicType.STRING_TYPE, (Long) null, true, null, null));
+
+        UnsupportedOperationException exception =
+                assertThrows(
+                        UnsupportedOperationException.class, () -> writer.applySchemaChange(event));
+
+        assertTrue(
+                exception.getMessage().contains("iceberg.table.schema-evolution-enabled is false"));
+        verifyNoInteractions(tableLoader);
     }
 }

--- a/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/sink/LanceSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-lance/src/main/java/org/apache/seatunnel/connectors/seatunnel/lance/sink/LanceSinkWriter.java
@@ -19,9 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.lance.sink;
 
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
-import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSinkWriter;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
-import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.lance.catalog.LanceCatalog;
@@ -51,8 +49,7 @@ import java.util.Optional;
 @Slf4j
 public class LanceSinkWriter
         implements SinkWriter<SeaTunnelRow, LanceCommitInfo, LanceSinkState>,
-                SupportMultiTableSinkWriter<Void>,
-                SupportSchemaEvolutionSinkWriter {
+                SupportMultiTableSinkWriter<Void> {
 
     private static final int DEFAULT_BATCH_SIZE = 1000;
 
@@ -173,11 +170,6 @@ public class LanceSinkWriter
                     "Failed to flush batch: " + e.getMessage(),
                     e);
         }
-    }
-
-    @Override
-    public void applySchemaChange(SchemaChangeEvent event) throws IOException {
-        SinkWriter.super.applySchemaChange(event);
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/error/ErrorHandlingSinkWriter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/error/ErrorHandlingSinkWriter.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.server.task.error;
 import org.apache.seatunnel.api.common.error.RowErrorClassification;
 import org.apache.seatunnel.api.common.error.SupportRowLevelErrorClassifier;
 import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSinkWriter;
 import org.apache.seatunnel.api.sink.multitablesink.MultiTableSinkWriter;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -146,7 +147,7 @@ public class ErrorHandlingSinkWriter<T, CommT, StateT> implements SinkWriter<T, 
 
     @Override
     public void applySchemaChange(SchemaChangeEvent event) throws IOException {
-        delegate.applySchemaChange(event);
+        SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(delegate, event);
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -823,12 +823,7 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
     }
 
     private void processSchemaChangeEvent(SchemaChangeEvent event) throws IOException {
-        if (writer instanceof SupportSchemaEvolutionSinkWriter) {
-            ((SupportSchemaEvolutionSinkWriter) writer).applySchemaChange(event);
-        } else {
-            // todo remove deprecated method
-            writer.applySchemaChange(event);
-        }
+        SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(writer, event);
     }
 
     private Counter getStainTraceEntriesTruncatedTotal() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/error/ErrorHandlingSinkWriterTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/error/ErrorHandlingSinkWriterTest.java
@@ -18,10 +18,13 @@
 package org.apache.seatunnel.engine.server.task.error;
 
 import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.engine.server.task.context.SinkWriterContext;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -92,6 +95,20 @@ class ErrorHandlingSinkWriterTest {
         Assertions.assertEquals(1, mainFlushes.get());
     }
 
+    @Test
+    void applySchemaChangeFailsFastForUnsupportedDelegate() {
+        ErrorHandlingSinkWriter<String, String, String> writer =
+                new ErrorHandlingSinkWriter<>(new NoopSinkWriter(), null, null, "test");
+        SchemaChangeEvent event = schemaChangeEvent();
+
+        UnsupportedOperationException exception =
+                Assertions.assertThrows(
+                        UnsupportedOperationException.class, () -> writer.applySchemaChange(event));
+
+        Assertions.assertTrue(exception.getMessage().contains(NoopSinkWriter.class.getName()));
+        Assertions.assertTrue(exception.getMessage().contains("test_db.test_table"));
+    }
+
     private static ErrorHandlingSinkWriter<String, String, String> writer(
             ErrorHandlerMode mode, ErrorSinkRowWriter<String> errorSink, boolean fail) {
         return new ErrorHandlingSinkWriter<>(
@@ -99,6 +116,12 @@ class ErrorHandlingSinkWriterTest {
                 new ErrorHandler<>(StageErrorConfig.builder().mode(mode).build(), errorSink),
                 (error, row, ctx) -> true,
                 "test");
+    }
+
+    private static SchemaChangeEvent schemaChangeEvent() {
+        SchemaChangeEvent event = Mockito.mock(SchemaChangeEvent.class);
+        Mockito.when(event.tablePath()).thenReturn(TablePath.of("test_db", "test_table"));
+        return event;
     }
 
     private static final class NoopSinkWriter implements SinkWriter<String, String, String> {

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
@@ -130,21 +130,14 @@ public class FlinkSinkWriter<CommT, WriterStateT>
                 "FlinkSinkWriter applying SchemaChangeEvent for table: {}",
                 schemaChangeEvent.tableIdentifier());
 
-        if (!(sinkWriter instanceof SupportSchemaEvolutionSinkWriter)) {
-            log.warn(
-                    "Sink writer {} does not support schema evolution, ignoring SchemaChangeEvent for table: {}",
-                    sinkWriter.getClass().getSimpleName(),
-                    schemaChangeEvent.tableIdentifier());
-            return;
-        }
-
         Long subtaskIdObj = (Long) options.get("schema_subtask_id");
         int subtaskId = subtaskIdObj != null ? subtaskIdObj.intValue() : -1;
         long epoch = schemaChangeEvent.getCreatedTime();
         boolean success = false;
 
         try {
-            ((SupportSchemaEvolutionSinkWriter) sinkWriter).applySchemaChange(schemaChangeEvent);
+            SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(
+                    sinkWriter, schemaChangeEvent);
             log.info(
                     "FlinkSinkWriter successfully applied SchemaChangeEvent for table: {}",
                     schemaChangeEvent.tableIdentifier());

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/main/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriter.java
@@ -141,21 +141,14 @@ public class FlinkSinkWriter<InputT, CommT, WriterStateT>
                 "FlinkSinkWriter applying SchemaChangeEvent for table: {}",
                 schemaChangeEvent.tableIdentifier());
 
-        if (!(sinkWriter instanceof SupportSchemaEvolutionSinkWriter)) {
-            log.warn(
-                    "Sink writer {} does not support schema evolution, ignoring SchemaChangeEvent for table: {}",
-                    sinkWriter.getClass().getSimpleName(),
-                    schemaChangeEvent.tableIdentifier());
-            return;
-        }
-
         Long subtaskIdObj = (Long) options.get("schema_subtask_id");
         int subtaskId = subtaskIdObj != null ? subtaskIdObj.intValue() : -1;
         long epoch = schemaChangeEvent.getCreatedTime();
         boolean success = false;
 
         try {
-            ((SupportSchemaEvolutionSinkWriter) sinkWriter).applySchemaChange(schemaChangeEvent);
+            SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(
+                    sinkWriter, schemaChangeEvent);
             log.info(
                     "FlinkSinkWriter successfully applied SchemaChangeEvent for table: {}",
                     schemaChangeEvent.tableIdentifier());

--- a/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/test/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterTest.java
+++ b/seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common/src/test/java/org/apache/seatunnel/translation/flink/sink/FlinkSinkWriterTest.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSinkWriter;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
+import org.apache.seatunnel.api.table.schema.exception.SinkWriterSchemaException;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 
 import org.junit.jupiter.api.Assertions;
@@ -125,6 +126,41 @@ class FlinkSinkWriterTest {
         Assertions.assertEquals(Collections.emptyList(), delegate.prepareCommitCalls);
         Assertions.assertEquals(1, delegate.appliedSchemaChanges.size());
         Assertions.assertEquals(event, delegate.appliedSchemaChanges.get(0));
+    }
+
+    @Test
+    void testUnsupportedSchemaChangeSinkFailsFast() {
+        RecordingSinkWriter delegate = new RecordingSinkWriter();
+        RecordingContext context = new RecordingContext();
+
+        FlinkSinkWriter<SeaTunnelRow, String, String> flinkSinkWriter =
+                new FlinkSinkWriter<>(delegate, 7L, context);
+
+        AlterTableAddColumnEvent event =
+                AlterTableAddColumnEvent.add(
+                        TableIdentifier.of("catalog", "database", "table"),
+                        PhysicalColumn.of(
+                                "added_col",
+                                org.apache.seatunnel.api.table.type.BasicType.STRING_TYPE,
+                                64L,
+                                true,
+                                null,
+                                null));
+        event.setJobId("job-under-test");
+        SeaTunnelRow schemaEvent = new SeaTunnelRow(0);
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("schema_change_event", event);
+        options.put("schema_subtask_id", 0L);
+        schemaEvent.setOptions(options);
+
+        SinkWriterSchemaException exception =
+                Assertions.assertThrows(
+                        SinkWriterSchemaException.class,
+                        () -> flinkSinkWriter.write(schemaEvent, null));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains("Failed to apply schema change in Flink sink"));
+        Assertions.assertEquals(Collections.emptyList(), delegate.writtenRows);
     }
 
     private static class RecordingSinkWriter implements SinkWriter<SeaTunnelRow, String, String> {


### PR DESCRIPTION
### Purpose

This is the first runtime implementation PR for #11402 after the contract documentation PR #11609.

SeaTunnel already has partial CDC/schema-change plumbing, but unsupported sink writers could still silently consume schema change events through the deprecated default `SinkWriter.applySchemaChange(...)` no-op path. That makes the documented end-to-end schema evolution contract look stronger than the actual runtime behavior.

This PR makes unsupported schema evolution fail fast instead of being acknowledged silently. It does not complete the full schema-change state machine/recovery contract; that remains follow-up implementation work.

### Changes

- Add `SupportSchemaEvolutionSinkWriter.applySchemaChangeToWriter(...)` as the shared dispatch helper.
- Preserve compatibility with real legacy writers that override the deprecated `SinkWriter.applySchemaChange(...)`.
- Throw `UnsupportedOperationException` when a writer does not implement schema evolution and does not override the legacy method.
- Use the helper in Zeta `SinkFlowLifeCycle` and `MultiTableSinkWriter`.
- Preserve the latest `dev` multi-table schema-change barrier and shared physical sink fan-out, while making the final sub-writer apply step use the fail-fast helper.
- Make the row-error `ErrorHandlingSinkWriter` wrapper re-check the real delegate with the helper, so wrapper-level error handling cannot accidentally re-enable the deprecated no-op path.
- Use the same helper in Flink common and Flink 2.0 sink writer paths, so unsupported sinks send a failure ack instead of success.
- Remove Lance's schema-evolution marker because it only delegated to the deprecated no-op method.
- Make Iceberg fail fast when a schema-change event arrives while `iceberg.table.schema-evolution-enabled=false`.
- Rebase the PR branch onto the latest `apache/dev` to clear the stale/diverged branch state.

### Tests

- Added API tests for supported writer dispatch, legacy override compatibility, and unsupported writer fail-fast.
- Added engine wrapper test for `ErrorHandlingSinkWriter` around an unsupported delegate.
- Added Flink common test for unsupported writer failure ack behavior.
- Added Iceberg writer test for disabled schema-evolution fail-fast without table-loader I/O.

### Local Validation

- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -T 3C -pl seatunnel-api,seatunnel-engine/seatunnel-engine-server,seatunnel-connectors-v2/connector-lance,seatunnel-connectors-v2/connector-iceberg,seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-common,seatunnel-translation/seatunnel-translation-flink/seatunnel-translation-flink-20 spotless:apply`
- `git diff --check apache/dev...HEAD`
- `git diff --check`

Per the local SeaTunnel workflow guidance, I did not run compile, unit tests, E2E, Docker, or runtime jobs locally; GitHub CI is the source of truth for those checks.