### PR TITLE
[CI][Core] Exclude build outputs from import class check

### DIFF
--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.NodeList;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileVisitOption;
@@ -55,12 +56,17 @@ public class ImportClassCheckTest {
     public static final boolean isWindows =
             System.getProperty("os.name").toLowerCase().startsWith("win");
     private static final String JAVA_FILE_EXTENSION = ".java";
+    private static final String TARGET_PATH_FRAGMENT = File.separator + "target" + File.separator;
     private static final JavaParser JAVA_PARSER = new JavaParser();
 
     @BeforeAll
     public static void beforeAll() {
         try (Stream<Path> paths = Files.walk(Paths.get(".."), FileVisitOption.FOLLOW_LINKS)) {
             paths.filter(path -> path.toString().endsWith(JAVA_FILE_EXTENSION))
+                    // Full unit-test jobs build many modules before this test runs. Excluding
+                    // target-generated Java sources keeps the import scan focused on checked-in
+                    // sources and avoids parsing build outputs repeatedly.
+                    .filter(path -> !path.toString().contains(TARGET_PATH_FRAGMENT))
                     .forEach(
                             path -> {
                                 try (InputStream inputStream = Files.newInputStream(path, READ)) {


### PR DESCRIPTION
## What changed

- Exclude `target` build output directories from `ImportClassCheckTest`s repository-wide JavaParser scan.

## Why

- The latest fork CI failure on August 1, 2026 came from `seatunnel-ci-tools` on `unit-test (8, windows-latest)`.
- `ImportClassCheckTest` walks `..` and parses every `.java` file it finds.
- In the full `clean verify` unit-test workflow, earlier modules have already produced generated Java files under `target`, so this test ends up parsing checked-in sources and build outputs together.
- That inflates the JavaParser workload and can trigger `GC overhead limit exceeded` in the Surefire fork JVM on hosted Windows JDK 8 runners.

## Impact

- Keep the import check focused on checked-in repository sources.
- Avoid repeatedly parsing generated build outputs that are not part of the source tree contract.

## Validation

- `./mvnw -f seatunnel-ci-tools/pom.xml spotless:apply`
- `git diff --check`
- Independent maintainer review of the final diff (static review only)
