### PR TITLE
[Fix][CI] Prevent ImportClassCheckTest OOM in CI

### DIFF
--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
@@ -24,10 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.ImportDeclaration;
-import com.github.javaparser.ast.NodeList;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -50,7 +47,7 @@ import static java.nio.file.StandardOpenOption.READ;
 @Slf4j
 public class ImportClassCheckTest {
 
-    private static Map<String, NodeList<ImportDeclaration>> importsMap = new HashMap<>();
+    private static Map<String, List<ImportClassEntry>> importsMap = new HashMap<>();
     private final String SEATUNNEL_SHADE_PREFIX = "org.apache.seatunnel.shade.";
     public static final boolean isWindows =
             System.getProperty("os.name").toLowerCase().startsWith("win");
@@ -68,7 +65,9 @@ public class ImportClassCheckTest {
                                             JAVA_PARSER.parse(inputStream);
                                     Optional<CompilationUnit> result = parseResult.getResult();
                                     if (result.isPresent()) {
-                                        importsMap.put(path.toString(), result.get().getImports());
+                                        importsMap.put(
+                                                path.toString(),
+                                                extractImportEntries(result.get()));
                                     } else {
                                         log.error("Failed to parse Java file: " + path);
                                     }
@@ -181,6 +180,29 @@ public class ImportClassCheckTest {
         log.info("check java concurrent CompletableFuture successfully");
     }
 
+    @Test
+    public void shouldKeepImportNameAndLineWhenPrecomputingImportEntries() {
+        ParseResult<CompilationUnit> parseResult =
+                JAVA_PARSER.parse(
+                        "package org.apache.seatunnel.api;\n"
+                                + "import java.util.List;\n"
+                                + "import org.apache.commons.lang3.StringUtils;\n"
+                                + "class Sample {}");
+        CompilationUnit compilationUnit = parseResult.getResult().orElseThrow(AssertionError::new);
+
+        List<ImportClassEntry> importEntries = extractImportEntries(compilationUnit);
+
+        Assertions.assertEquals(2, importEntries.size());
+        Assertions.assertEquals("java.util.List", importEntries.get(0).getImportClassName());
+        Assertions.assertEquals(2, importEntries.get(0).getLineNumber());
+        Assertions.assertEquals(
+                "org.apache.commons.lang3.StringUtils", importEntries.get(1).getImportClassName());
+        Assertions.assertEquals(3, importEntries.get(1).getLineNumber());
+        Assertions.assertEquals(
+                "org.apache.commons.lang3.StringUtils  [3]",
+                formatImportClassLine(importEntries.get(1)));
+    }
+
     private Map<String, List<String>> checkImportClassPrefixWithAll(List<String> prefixList) {
         return checkImportClassPrefix(prefixList, Collections.emptyList(), Collections.emptyList());
     }
@@ -221,13 +243,15 @@ public class ImportClassCheckTest {
                         List<String> collect =
                                 imports.stream()
                                         .filter(
-                                                importDeclaration -> {
-                                                    String importClz =
-                                                            importDeclaration.getName().asString();
-                                                    return prefixList.stream()
-                                                            .anyMatch(importClz::startsWith);
-                                                })
-                                        .map(this::getImportClassLineNum)
+                                                importEntry ->
+                                                        prefixList.stream()
+                                                                .anyMatch(
+                                                                        prefix ->
+                                                                                importEntry
+                                                                                        .getImportClassName()
+                                                                                        .startsWith(
+                                                                                                prefix)))
+                                        .map(this::formatImportClassLine)
                                         .collect(Collectors.toList());
                         if (!collect.isEmpty()) {
                             errorMap.put(clazzPath, collect);
@@ -256,13 +280,45 @@ public class ImportClassCheckTest {
         return msg.toString();
     }
 
-    private String getImportClassLineNum(ImportDeclaration importDeclaration) {
-        Range range = importDeclaration.getRange().get();
-        return String.format("%s  [%s]", importDeclaration.getName().asString(), range.end.line);
+    private static List<ImportClassEntry> extractImportEntries(CompilationUnit compilationUnit) {
+        return compilationUnit.getImports().stream()
+                .map(
+                        importDeclaration ->
+                                new ImportClassEntry(
+                                        importDeclaration.getNameAsString(),
+                                        importDeclaration
+                                                .getRange()
+                                                .map(range -> range.end.line)
+                                                .orElse(-1)))
+                .collect(Collectors.toList());
+    }
+
+    private String formatImportClassLine(ImportClassEntry importClassEntry) {
+        return String.format(
+                "%s  [%s]",
+                importClassEntry.getImportClassName(), importClassEntry.getLineNumber());
     }
 
     @AfterAll
     public static void cleanup() {
         importsMap.clear();
+    }
+
+    private static final class ImportClassEntry {
+        private final String importClassName;
+        private final int lineNumber;
+
+        private ImportClassEntry(String importClassName, int lineNumber) {
+            this.importClassName = importClassName;
+            this.lineNumber = lineNumber;
+        }
+
+        private String getImportClassName() {
+            return importClassName;
+        }
+
+        private int getLineNumber() {
+            return lineNumber;
+        }
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

<img width="2640" height="1160" alt="image" src="https://github.com/user-attachments/assets/d1576ab8-688a-4ed1-a221-0caaa30dadc6" />


I found the above error when running CI, so after analyzing it, I tried to refactor `ImportClassCheckTest` to avoid caching JavaParser import AST nodes for all repository Java files.

  ## Changes

  - Replace cached ImportDeclaration AST data with lightweight ImportClassEntry values
  - Precompute and store only import name and line number
  - Keep the existing import prefix check behavior and error message format unchanged
  - Add a focused regression test for the precomputed import extraction path
  - Fix the Optional.get() warning on import range access

  ## Why

`ImportClassCheckTest` scans the whole repository in CI. On the dev branch, caching full import AST nodes created unnecessary heap pressure and could trigger GC overhead limit exceeded in GitHub CI with low heap settings.


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
