### PR TITLE
[Test][API] Avoid ImportClassCheckTest OOM on generated sources

### DIFF
--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
@@ -230,7 +230,8 @@ public class ImportClassCheckTest {
                                 imports.stream()
                                         .filter(
                                                 importMetadata -> {
-                                                    String importClz = importMetadata.getClassName();
+                                                    String importClz =
+                                                            importMetadata.getClassName();
                                                     return prefixList.stream()
                                                             .anyMatch(importClz::startsWith);
                                                 })
@@ -264,15 +265,12 @@ public class ImportClassCheckTest {
     }
 
     private String getImportClassLineNum(ImportMetadata importMetadata) {
-        return String.format("%s  [%s]", importMetadata.getClassName(), importMetadata.getLineNum());
+        return String.format(
+                "%s  [%s]", importMetadata.getClassName(), importMetadata.getLineNum());
     }
 
     private static ImportMetadata toImportMetadata(ImportDeclaration importDeclaration) {
-        int lineNum =
-                importDeclaration
-                        .getRange()
-                        .map(range -> range.end.line)
-                        .orElse(-1);
+        int lineNum = importDeclaration.getRange().map(range -> range.end.line).orElse(-1);
         return new ImportMetadata(importDeclaration.getName().asString(), lineNum);
     }
 

--- a/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
+++ b/seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java
@@ -24,12 +24,11 @@ import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
-import com.github.javaparser.ast.NodeList;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,22 +50,21 @@ import static java.nio.file.StandardOpenOption.READ;
 @Slf4j
 public class ImportClassCheckTest {
 
-    private static Map<String, NodeList<ImportDeclaration>> importsMap = new HashMap<>();
+    private static Map<String, List<ImportMetadata>> importsMap = new HashMap<>();
     private final String SEATUNNEL_SHADE_PREFIX = "org.apache.seatunnel.shade.";
     public static final boolean isWindows =
             System.getProperty("os.name").toLowerCase().startsWith("win");
     private static final String JAVA_FILE_EXTENSION = ".java";
     private static final String TARGET_PATH_FRAGMENT = File.separator + "target" + File.separator;
+    private static final String PROTO_PATH_FRAGMENT = File.separator + "proto" + File.separator;
+    private static final String PROTOBUF_GENERATED_MARKER = "@@protoc_insertion_point";
+    private static final int GENERATED_SOURCE_SCAN_LINE_LIMIT = 200;
     private static final JavaParser JAVA_PARSER = new JavaParser();
 
     @BeforeAll
     public static void beforeAll() {
         try (Stream<Path> paths = Files.walk(Paths.get(".."), FileVisitOption.FOLLOW_LINKS)) {
-            paths.filter(path -> path.toString().endsWith(JAVA_FILE_EXTENSION))
-                    // Full unit-test jobs build many modules before this test runs. Excluding
-                    // target-generated Java sources keeps the import scan focused on checked-in
-                    // sources and avoids parsing build outputs repeatedly.
-                    .filter(path -> !path.toString().contains(TARGET_PATH_FRAGMENT))
+            paths.filter(ImportClassCheckTest::shouldScanJavaFile)
                     .forEach(
                             path -> {
                                 try (InputStream inputStream = Files.newInputStream(path, READ)) {
@@ -74,7 +72,11 @@ public class ImportClassCheckTest {
                                             JAVA_PARSER.parse(inputStream);
                                     Optional<CompilationUnit> result = parseResult.getResult();
                                     if (result.isPresent()) {
-                                        importsMap.put(path.toString(), result.get().getImports());
+                                        importsMap.put(
+                                                path.toString(),
+                                                result.get().getImports().stream()
+                                                        .map(ImportClassCheckTest::toImportMetadata)
+                                                        .collect(Collectors.toList()));
                                     } else {
                                         log.error("Failed to parse Java file: " + path);
                                     }
@@ -227,9 +229,8 @@ public class ImportClassCheckTest {
                         List<String> collect =
                                 imports.stream()
                                         .filter(
-                                                importDeclaration -> {
-                                                    String importClz =
-                                                            importDeclaration.getName().asString();
+                                                importMetadata -> {
+                                                    String importClz = importMetadata.getClassName();
                                                     return prefixList.stream()
                                                             .anyMatch(importClz::startsWith);
                                                 })
@@ -262,13 +263,75 @@ public class ImportClassCheckTest {
         return msg.toString();
     }
 
-    private String getImportClassLineNum(ImportDeclaration importDeclaration) {
-        Range range = importDeclaration.getRange().get();
-        return String.format("%s  [%s]", importDeclaration.getName().asString(), range.end.line);
+    private String getImportClassLineNum(ImportMetadata importMetadata) {
+        return String.format("%s  [%s]", importMetadata.getClassName(), importMetadata.getLineNum());
+    }
+
+    private static ImportMetadata toImportMetadata(ImportDeclaration importDeclaration) {
+        int lineNum =
+                importDeclaration
+                        .getRange()
+                        .map(range -> range.end.line)
+                        .orElse(-1);
+        return new ImportMetadata(importDeclaration.getName().asString(), lineNum);
+    }
+
+    private static boolean shouldScanJavaFile(Path path) {
+        if (!path.toString().endsWith(JAVA_FILE_EXTENSION)) {
+            return false;
+        }
+
+        // Full unit-test jobs build many modules before this test runs. Excluding
+        // target-generated Java sources keeps the import scan focused on checked-in
+        // sources and avoids parsing build outputs repeatedly.
+        if (path.toString().contains(TARGET_PATH_FRAGMENT)) {
+            return false;
+        }
+
+        return !isGeneratedProtobufSource(path);
+    }
+
+    private static boolean isGeneratedProtobufSource(Path path) {
+        if (!path.toString().contains(PROTO_PATH_FRAGMENT)) {
+            return false;
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            for (int i = 0; i < GENERATED_SOURCE_SCAN_LINE_LIMIT; i++) {
+                String line = reader.readLine();
+                if (line == null) {
+                    return false;
+                }
+                if (line.contains(PROTOBUF_GENERATED_MARKER)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Failed to inspect Java file marker before parsing: {}", path, e);
+        }
+        return false;
     }
 
     @AfterAll
     public static void cleanup() {
         importsMap.clear();
+    }
+
+    private static final class ImportMetadata {
+        private final String className;
+        private final int lineNum;
+
+        private ImportMetadata(String className, int lineNum) {
+            this.className = className;
+            this.lineNum = lineNum;
+        }
+
+        private String getClassName() {
+            return className;
+        }
+
+        private int getLineNum() {
+            return lineNum;
+        }
     }
 }


### PR DESCRIPTION
## Why
- on Sunday, August 2, 2026, `apache/seatunnel#11198` is still failing in the fork `unit-test (8, ubuntu-latest)` lane with `java.lang.OutOfMemoryError: GC overhead limit exceeded` while running `seatunnel-ci-tools` `ImportClassCheckTest`
- `apache/seatunnel#11621` already excluded `target` build outputs, but the test can still parse checked-in generated protobuf sources and keep all JavaParser import nodes for the whole repository in memory

## What
- skip protobuf-generated Java sources detected by the `@@protoc_insertion_point` marker before parsing
- store lightweight import metadata instead of retaining JavaParser import nodes for every file

## Validation
- `./mvnw -pl seatunnel-ci-tools -DspotlessFiles=seatunnel-ci-tools/src/test/java/org/apache/seatunnel/api/ImportClassCheckTest.java spotless:apply`
- `git diff --check`