### PR TITLE
[Improve][Connector-V2][Assert] Remove redundant rules validation

### DIFF
--- a/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSink.java
+++ b/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSink.java
@@ -59,9 +59,7 @@ public class AssertSink extends AbstractSimpleSink<SeaTunnelRow, Void>
 
     public AssertSink(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
         this.seaTunnelRowType = catalogTable.getSeaTunnelRowType();
-        if (!pluginConfig.getOptional(RULES).isPresent()) {
-            Throwables.throwIfUnchecked(new ConfigException.Missing(RULES.key()));
-        }
+
         assertFieldRules = new ConcurrentHashMap<>();
         assertRowRules = new ConcurrentHashMap<>();
         assertCatalogTableRule = new ConcurrentHashMap<>();

--- a/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertFactoryTest.java
@@ -17,11 +17,17 @@
 
 package org.apache.seatunnel.flink.assertion;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.assertion.sink.AssertSinkFactory;
+import org.apache.seatunnel.connectors.seatunnel.assertion.sink.AssertSinkOptions;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 public class AssertFactoryTest {
 
@@ -30,5 +36,20 @@ public class AssertFactoryTest {
         AssertSinkFactory factory = new AssertSinkFactory();
         OptionRule optionRule = factory.optionRule();
         Assertions.assertNotNull(optionRule);
+    }
+
+    @Test
+    public void testMissingRulesFailsValidation() {
+        AssertSinkFactory factory = new AssertSinkFactory();
+        OptionRule optionRule = factory.optionRule();
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(Collections.emptyMap());
+
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () -> ConfigValidator.of(readonlyConfig).validate(optionRule));
+        Assertions.assertTrue(
+                optionValidationException.getMessage().contains(AssertSinkOptions.RULES.key()));
     }
 }

--- a/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertSinkTest.java
+++ b/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/flink/assertion/AssertSinkTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.flink.assertion;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigException;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.assertion.sink.AssertSink;
+import org.apache.seatunnel.connectors.seatunnel.assertion.sink.AssertSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AssertSinkTest {
+
+    @Test
+    public void testEmptyRulesFailsAtRuntime() {
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(AssertSinkOptions.RULES.key(), Collections.emptyMap());
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(configMap);
+        CatalogTable catalogTable = createCatalogTable();
+
+        ConfigException.BadValue badValue =
+                Assertions.assertThrows(
+                        ConfigException.BadValue.class,
+                        () -> new AssertSink(readonlyConfig, catalogTable));
+
+        Assertions.assertTrue(badValue.getMessage().contains("Assert rule config is empty"));
+    }
+
+    @Test
+    public void testEffectivelyEmptyRulesFailsAtRuntime() {
+        Map<String, Object> rules = new HashMap<>();
+        rules.put(ConnectorCommonOptions.TABLE_NAMES.key(), Collections.emptyList());
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(AssertSinkOptions.RULES.key(), rules);
+
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        CatalogTable catalogTable = createCatalogTable();
+
+        ConfigException.BadValue exception =
+                Assertions.assertThrows(
+                        ConfigException.BadValue.class, () -> new AssertSink(config, catalogTable));
+
+        Assertions.assertTrue(exception.getMessage().contains("Assert rule config is empty"));
+    }
+
+    private CatalogTable createCatalogTable() {
+        SeaTunnelRowType seaTunnelRowType =
+                new SeaTunnelRowType(
+                        new String[] {"id"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        return CatalogTableUtil.getCatalogTable("test", seaTunnelRowType);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007.

The `rules` option is already declared as required in
`AssertSinkFactory#optionRule()`. Therefore, the missing-`RULES` check in
`AssertSink` is redundant after declarative option validation.

This PR:

- Removes the redundant missing-`RULES` check from `AssertSink`.
- Keeps the existing runtime validation for parsed/effectively empty rules.
- Adds focused tests for missing, empty, and effectively empty rules.
- Preserves the existing runtime assertion semantics.

### Does this PR introduce _any_ user-facing change?

No.

This change removes duplicated validation without changing the supported
configuration options or normal runtime assertion behavior.

### How was this patch tested?

Added unit tests covering:

- Missing `rules` rejected by declarative `OptionRule` validation.
- Present but empty `rules` rejected by `AssertSink`.
- Effectively empty rules rejected by `AssertSink`.

The connector module tests passed with:

```bash
./mvnw -pl seatunnel-connectors-v2/connector-assert test
```

The changes were also checked with:

```bash
git diff --check
```

### Check list

- [x] No new Jar binary package is added.
- [x] No documentation update is required because the supported configuration and behavior remain unchanged.
- [x] No incompatible change is introduced.
- [x] No connector registration, distribution, plugin mapping, or E2E update is required because this modifies an existing connector only.