### PR TITLE
[Feature][Connector-V2/Sink/Paimon] Add OSS-backed storage support for Paimon sink

### DIFF
--- a/docs/en/connectors/sink/Paimon.md
+++ b/docs/en/connectors/sink/Paimon.md
@@ -51,6 +51,8 @@ hive-exec-xxx.jar
 libfb303-xxx.jar
 ```
 
+> If you use the OSS filesystem for the Paimon warehouse, add the required Jindo SDK jars and the matching Paimon OSS filesystem jars for the bundled Paimon version to `${SEATUNNEL_HOME}/lib` before starting the engine. You can use the [OSS Jindo connector documentation](./OssJindoFile.md) as the base runtime setup reference.
+
 > Some versions of the hive-exec package do not have libfb303-xxx.jar, so you also need to manually import the Jar package.
 
 ## Key features
@@ -131,9 +133,11 @@ All `changelog-producer` modes are currently supported. The default is `none`.
 > When you use a streaming mode to read paimon table，different mode will produce [different results](../source/Paimon.md#changelog)。
 
 ## Filesystems
-The Paimon connector supports writing data to multiple file systems. Currently, the supported file systems are hdfs and s3.
-If you use the s3 filesystem. You can configure the `fs.s3a.access-key`、`fs.s3a.secret-key`、`fs.s3a.endpoint`、`fs.s3a.path.style.access`、`fs.s3a.aws.credentials.provider` properties in the `paimon.hadoop.conf` option.
-Besides, the warehouse should start with `s3a://`.
+The Paimon connector supports writing data to multiple file systems. Currently, the supported file systems are hdfs, s3 and oss.
+- If you use the s3 filesystem, configure the `fs.s3a.access-key`, `fs.s3a.secret-key`, `fs.s3a.endpoint`, `fs.s3a.path.style.access`, and `fs.s3a.aws.credentials.provider` properties in `paimon.hadoop.conf`.
+- If you use the oss filesystem, configure the required `fs.oss.*` Hadoop properties in `paimon.hadoop.conf` and make sure the corresponding OSS/Jindo runtime jars are available in `${SEATUNNEL_HOME}/lib`.
+
+Besides, the warehouse should start with `s3a://` or `oss://`.
 
 ## Schema Evolution
 Cdc Ingestion supports a limited number of schema changes. Currently supported schema changes includes:

--- a/docs/zh/connectors/sink/Paimon.md
+++ b/docs/zh/connectors/sink/Paimon.md
@@ -51,6 +51,8 @@ hive-exec-xxx.jar
 libfb303-xxx.jar
 ```
 
+> 如果您将 Paimon warehouse 部署在 OSS 文件系统上，请在启动引擎前将所需的 Jindo SDK 依赖以及与当前 Paimon 版本匹配的 OSS 文件系统 Jar 放到 `${SEATUNNEL_HOME}/lib`。Jindo 运行时准备方式可以参考 [OSS Jindo 文件连接器文档](./OssJindoFile.md)。
+
 > 有些版本的hive-exec包没有libfb303-xxx.jar，所以您还需要手动导入Jar包。
 
 ## 主要特性
@@ -131,9 +133,11 @@ Paimon表的changelog产生模式有[四种](https://paimon.apache.org/docs/mast
 > 当你使用流模式去读paimon表的数据时，不同模式将会产生[不同的结果](../source/Paimon.md#changelog)。
 
 ## 文件系统
-Paimon连接器支持向多文件系统写入数据。目前支持的文件系统有hdfs和s3。
-如果您使用s3文件系统。您可以配置`fs.s3a.access-key `， `fs.s3a.secret-key`， `fs.s3a.endpoint`， `fs.s3a.path.style.access`， `fs.s3a.aws.credentials`。在`paimon.hadoop.conf`选项中设置提供程序的属性。
-除此之外，warehouse应该以`s3a://`开头。
+Paimon连接器支持向多文件系统写入数据。目前支持的文件系统有 hdfs、s3 和 oss。
+- 如果您使用 s3 文件系统，请在 `paimon.hadoop.conf` 中配置 `fs.s3a.access-key`、`fs.s3a.secret-key`、`fs.s3a.endpoint`、`fs.s3a.path.style.access`、`fs.s3a.aws.credentials.provider` 等属性。
+- 如果您使用 oss 文件系统，请在 `paimon.hadoop.conf` 中配置所需的 `fs.oss.*` Hadoop 属性，并确保对应的 OSS/Jindo 运行时 Jar 已放入 `${SEATUNNEL_HOME}/lib`。
+
+除此之外，warehouse 应该以 `s3a://` 或 `oss://` 开头。
 
 ## 模式演变
 Cdc采集支持有限数量的模式更改。目前支持的模式更改包括：

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoader.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoader.java
@@ -49,6 +49,7 @@ public class PaimonCatalogLoader implements Serializable {
 
     private static final String HDFS_PREFIX = "hdfs://";
     private static final String S3A_PREFIX = "s3a://";
+    private static final String OSS_PREFIX = "oss://";
     /** ******* Hdfs constants ************* */
     private static final String HDFS_IMPL = "org.apache.hadoop.hdfs.DistributedFileSystem";
 
@@ -73,9 +74,7 @@ public class PaimonCatalogLoader implements Serializable {
         this.password = paimonConfig.getPassword();
     }
 
-    public Catalog loadCatalog() {
-        // When using the seatunnel engine, set the current class loader to prevent loading failures
-        Thread.currentThread().setContextClassLoader(PaimonCatalogLoader.class.getClassLoader());
+    Map<String, String> buildCatalogOptions() {
         final Map<String, String> optionsMap = new HashMap<>(1);
         optionsMap.put(CatalogOptions.WAREHOUSE.key(), warehouse);
         optionsMap.put(CatalogOptions.METASTORE.key(), catalogType.getType());
@@ -90,14 +89,20 @@ public class PaimonCatalogLoader implements Serializable {
             if (StringUtils.isNotBlank(username)) {
                 UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(username));
             }
-        } else if (warehouse.startsWith(S3A_PREFIX)) {
+        } else if (warehouse.startsWith(S3A_PREFIX) || warehouse.startsWith(OSS_PREFIX)) {
             optionsMap.putAll(paimonHadoopConfiguration.getPropsWithPrefix(StringUtils.EMPTY));
         }
         if (PaimonCatalogEnum.HIVE.getType().equals(catalogType.getType())) {
             optionsMap.put(CatalogOptions.URI.key(), catalogUri);
             optionsMap.putAll(paimonHadoopConfiguration.getPropsWithPrefix(StringUtils.EMPTY));
         }
-        final Options options = Options.fromMap(optionsMap);
+        return optionsMap;
+    }
+
+    public Catalog loadCatalog() {
+        // When using the seatunnel engine, set the current class loader to prevent loading failures
+        Thread.currentThread().setContextClassLoader(PaimonCatalogLoader.class.getClassLoader());
+        final Options options = Options.fromMap(buildCatalogOptions());
         PaimonSecurityContext.shouldEnableKerberos(paimonHadoopConfiguration);
         final CatalogContext catalogContext =
                 CatalogContext.create(options, paimonHadoopConfiguration);

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoaderTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/connectors/seatunnel/paimon/catalog/PaimonCatalogLoaderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.paimon.catalog;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonBaseOptions;
+import org.apache.seatunnel.connectors.seatunnel.paimon.config.PaimonConfig;
+
+import org.apache.paimon.options.CatalogOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonCatalogLoaderTest {
+
+    @Test
+    public void shouldIncludeOssHadoopConfForOssWarehouse() {
+        Map<String, String> hadoopConf = new HashMap<>();
+        hadoopConf.put("fs.oss.accessKeyId", "access-key");
+        hadoopConf.put("fs.oss.accessKeySecret", "access-secret");
+        hadoopConf.put("fs.oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
+
+        PaimonCatalogLoader catalogLoader =
+                new PaimonCatalogLoader(
+                        new PaimonConfig(
+                                ReadonlyConfig.fromMap(
+                                        createProperties("oss://bucket/warehouse", hadoopConf))));
+
+        Map<String, String> catalogOptions = catalogLoader.buildCatalogOptions();
+
+        Assertions.assertEquals(
+                "oss://bucket/warehouse", catalogOptions.get(CatalogOptions.WAREHOUSE.key()));
+        Assertions.assertEquals("access-key", catalogOptions.get("fs.oss.accessKeyId"));
+        Assertions.assertEquals("access-secret", catalogOptions.get("fs.oss.accessKeySecret"));
+        Assertions.assertEquals(
+                "oss-cn-hangzhou.aliyuncs.com", catalogOptions.get("fs.oss.endpoint"));
+    }
+
+    @Test
+    public void shouldNotIncludeObjectStoreConfForLocalWarehouse() {
+        Map<String, String> hadoopConf = new HashMap<>();
+        hadoopConf.put("fs.oss.accessKeyId", "access-key");
+
+        PaimonCatalogLoader catalogLoader =
+                new PaimonCatalogLoader(
+                        new PaimonConfig(
+                                ReadonlyConfig.fromMap(
+                                        createProperties("file:///tmp/paimon", hadoopConf))));
+
+        Map<String, String> catalogOptions = catalogLoader.buildCatalogOptions();
+
+        Assertions.assertFalse(catalogOptions.containsKey("fs.oss.accessKeyId"));
+    }
+
+    private Map<String, Object> createProperties(String warehouse, Map<String, String> hadoopConf) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(PaimonBaseOptions.CATALOG_NAME.key(), "paimon");
+        properties.put(PaimonBaseOptions.WAREHOUSE.key(), warehouse);
+        properties.put(PaimonBaseOptions.HADOOP_CONF.key(), hadoopConf);
+        return properties;
+    }
+}


### PR DESCRIPTION
## Summary
- rescue the stale #10134 change on top of the current `dev` head
- add `oss://` warehouse handling in `PaimonCatalogLoader`
- move the OSS guidance to the active Paimon sink docs and add a focused loader test

## Why this follow-up PR
The original PR #10134 is currently far behind the latest `dev` branch and GitHub reports merge conflicts. I also could not update the original source fork branch directly with the current daniel2 permissions, so this PR carries the same intent forward on the live base branch instead of leaving the fix blocked on the stale branch.

## Validation
- `./mvnw -f seatunnel-connectors-v2/connector-paimon/pom.xml -Dtest=PaimonCatalogLoaderTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
