### PR TITLE
[Fix][CI] Isolate Hazelcast test port ranges in CI

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
@@ -56,6 +56,8 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
 
     protected static ILogger LOGGER;
 
+    private final int hazelcastPort = TestUtils.getAvailablePort(100);
+
     @BeforeAll
     public void before() {
         String name = ((T) this).getClass().getName();
@@ -88,7 +90,9 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
                 + "    port:\n"
                 + "      auto-increment: true\n"
                 + "      port-count: 100\n"
-                + "      port: 5801\n"
+                + "      port: "
+                + getHazelcastPort()
+                + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
@@ -97,6 +101,10 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"
                 + "    hazelcast.operation.generic.thread.count: 200\n";
+    }
+
+    protected int getHazelcastPort() {
+        return hazelcastPort;
     }
 
     public SeaTunnelConfig loadSeaTunnelConfig() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TestUtils.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TestUtils.java
@@ -47,7 +47,9 @@ import org.apache.seatunnel.engine.core.dag.logical.LogicalEdge;
 import org.apache.seatunnel.engine.core.dag.logical.LogicalVertex;
 import org.apache.seatunnel.engine.core.parse.MultipleTableJobConfigParser;
 
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.ServerSocket;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,8 +58,67 @@ import java.util.List;
 import java.util.Set;
 
 public class TestUtils {
+    private static final int MIN_PORT = 1024;
+    private static final int MAX_PORT = 65535;
+    private static final int MAX_PORT_ALLOCATION_ATTEMPTS = 1000;
+    private static final List<int[]> ALLOCATED_PORT_RANGES = new ArrayList<>();
+
     public static String getResource(String confFile) {
         return System.getProperty("user.dir") + "/src/test/resources/" + confFile;
+    }
+
+    public static int getAvailablePort() {
+        return getAvailablePort(1);
+    }
+
+    public static synchronized int getAvailablePort(int portCount) {
+        if (portCount <= 0 || portCount > MAX_PORT - MIN_PORT + 1) {
+            throw new IllegalArgumentException("Invalid port count: " + portCount);
+        }
+        for (int i = 0; i < MAX_PORT_ALLOCATION_ATTEMPTS; i++) {
+            int port = getRandomAvailablePort();
+            if (isAvailablePortRange(port, portCount)) {
+                ALLOCATED_PORT_RANGES.add(new int[] {port, port + portCount - 1});
+                return port;
+            }
+        }
+        throw new IllegalStateException("Failed to allocate an available port range");
+    }
+
+    private static int getRandomAvailablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to allocate an available port", e);
+        }
+    }
+
+    private static boolean isAvailablePortRange(int port, int portCount) {
+        if (port < MIN_PORT || port > MAX_PORT - portCount + 1) {
+            return false;
+        }
+        int rangeEnd = port + portCount - 1;
+        for (int[] allocatedPortRange : ALLOCATED_PORT_RANGES) {
+            if (port <= allocatedPortRange[1] && rangeEnd >= allocatedPortRange[0]) {
+                return false;
+            }
+        }
+        for (int currentPort = port; currentPort <= rangeEnd; currentPort++) {
+            if (!isBindablePort(currentPort)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isBindablePort(int port) {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress(port));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public static LogicalDag getTestLogicalDag(JobContext jobContext, JobConfig config)

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TestUtilsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TestUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.ServerSocket;
+
+class TestUtilsTest {
+
+    @Test
+    void getAvailablePortReturnsBindablePort() throws Exception {
+        int port = TestUtils.getAvailablePort();
+
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            Assertions.assertTrue(port > 0);
+        }
+    }
+
+    @Test
+    void getAvailablePortReturnsNonOverlappingPortRanges() {
+        int firstPort = TestUtils.getAvailablePort(10);
+        int secondPort = TestUtils.getAvailablePort(10);
+
+        Assertions.assertTrue(
+                firstPort + 9 < secondPort || secondPort + 9 < firstPort,
+                "Allocated port ranges should not overlap");
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/WorkerTagTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/WorkerTagTest.java
@@ -65,7 +65,9 @@ public class WorkerTagTest extends AbstractSeaTunnelServerTest<WorkerTagTest> {
                 + "    port:\n"
                 + "      auto-increment: true\n"
                 + "      port-count: 100\n"
-                + "      port: 5801\n"
+                + "      port: "
+                + getHazelcastPort()
+                + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.hasItem;
 class OptionRulesApiTest {
 
     private static final int HTTP_PORT = 18082;
+    private static final int HAZELCAST_PORT = TestUtils.getAvailablePort(100);
 
     private static HazelcastInstanceImpl instance;
     private static Config originalHazelcastConfig;
@@ -164,7 +165,9 @@ class OptionRulesApiTest {
                 + "    port:\n"
                 + "      auto-increment: true\n"
                 + "      port-count: 100\n"
-                + "      port: 5801\n"
+                + "      port: "
+                + HAZELCAST_PORT
+                + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -63,6 +63,7 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
 
     private static final String ENCRYPTED_USERNAME = "c2VhdHVubmVs";
     private static final String ENCRYPTED_PASSWORD = "c2VhdHVubmVsX3Bhc3N3b3Jk";
+    private static final int HAZELCAST_PORT = TestUtils.getAvailablePort(100);
 
     private HazelcastInstanceImpl instance;
     private SeaTunnelServer server;
@@ -372,7 +373,9 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
                 + "    port:\n"
                 + "      auto-increment: true\n"
                 + "      port-count: 100\n"
-                + "      port: 5801\n"
+                + "      port: "
+                + HAZELCAST_PORT
+                + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
@@ -75,6 +75,7 @@ public class RestApiSubmitJobStartWithSavePointTest {
 
     private static final String SOURCE_FACTORY_ID = "FakeSource";
     private static final String TEST_JOB_NAME = "test";
+    private static final int HAZELCAST_PORT = TestUtils.getAvailablePort(100);
 
     private HazelcastInstanceImpl masterInstance;
     private HazelcastInstanceImpl workerInstance;
@@ -524,7 +525,9 @@ public class RestApiSubmitJobStartWithSavePointTest {
                 + "    port:\n"
                 + "      auto-increment: true\n"
                 + "      port-count: 100\n"
-                + "      port: 5801\n"
+                + "      port: "
+                + HAZELCAST_PORT
+                + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Fix CI flakes caused by engine-server tests sharing hardcoded Hazelcast port ranges.

**Changes**

  - Add test utility support for allocating bindable, non-overlapping port ranges.
  - Replace hardcoded Hazelcast `5801` test ports with dynamic range-aware ports.
  - Add coverage for port allocation behavior.


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
