### PR TITLE
[Fix][Connector-V2] Pulsar Source: implement text format support (#11620)

### DIFF
--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -322,7 +322,8 @@ public class PulsarMultiTableConfig implements Serializable {
         String normalized = format.toUpperCase();
         if (!Objects.equals("JSON", normalized)
                 && !Objects.equals("CANAL_JSON", normalized)
-                && !Objects.equals("AVRO", normalized)) {
+                && !Objects.equals("AVRO", normalized)
+                && !Objects.equals("TEXT", normalized)) {
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                     String.format(

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -53,6 +53,7 @@ import org.apache.seatunnel.connectors.seatunnel.pulsar.source.format.PulsarCana
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.reader.PulsarSourceReader;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.seatunnel.format.avro.AvroDeserializationSchema;
+import org.apache.seatunnel.format.text.TextDeserializationSchema;
 import org.apache.seatunnel.format.json.JsonDeserializationSchema;
 import org.apache.seatunnel.format.json.canal.CanalJsonDeserializationSchema;
 import org.apache.seatunnel.format.json.exception.SeaTunnelJsonFormatException;
@@ -199,7 +200,7 @@ public class PulsarSource
                     new PulsarConsumerMetadata(
                             tablePath,
                             catalogTable,
-                            createDeserialization(tableConfig.getFormat(), catalogTable),
+                            createDeserialization(tableConfig.getFormat(), catalogTable, tableConfig.getSchemaConfig()),
                             createDiscoverer(tableConfig),
                             createStartCursor(tableConfig),
                             createStopCursor(tableConfig),
@@ -262,7 +263,7 @@ public class PulsarSource
     }
 
     private DeserializationSchema<SeaTunnelRow> createDeserialization(
-            String format, CatalogTable catalogTable) {
+            String format, CatalogTable catalogTable, ReadonlyConfig schemaConfig) {
         switch (format.toUpperCase()) {
             case "JSON":
                 return new JsonDeserializationSchema(
@@ -274,6 +275,12 @@ public class PulsarSource
                                 .build());
             case "AVRO":
                 return new AvroDeserializationSchema(catalogTable);
+            case "TEXT":
+                return TextDeserializationSchema.builder()
+                        .seaTunnelRowType(catalogTable.getSeaTunnelRowType())
+                        .delimiter(
+                                schemaConfig.get(PulsarSourceOptions.FIELD_DELIMITER))
+                        .build();
             default:
                 throw new SeaTunnelJsonFormatException(
                         CommonErrorCode.UNSUPPORTED_DATA_TYPE, "Unsupported format: " + format);


### PR DESCRIPTION
## Description

The Pulsar Source option contract and factory OptionRule claim that `format = text` is supported, but the runtime validation and deserialization path reject it:

1. `PulsarSourceFactory` OptionRule binds `field_delimiter` when `format = text`
2. `PulsarBaseOptions.FORMAT` description says "Optional text and avro format"
3. Pulsar Sink already supports text format via `TextSerializationSchema`
4. The `seatunnel-format-text` dependency is already present in `connector-pulsar`

However, `PulsarMultiTableConfig.validateFormat()` only allows JSON, CANAL_JSON and AVRO, and `PulsarSource.createDeserialization()` has no TEXT branch.

### Changes

1. **PulsarMultiTableConfig.java** — Allow `TEXT` in `validateFormat()` so that `format = text` passes configuration validation.

2. **PulsarSource.java** — Add a `TEXT` case in `createDeserialization()` that returns a `TextDeserializationSchema` configured with the user-specified `field_delimiter`. The `schemaConfig` (ReadonlyConfig) is now passed through to `createDeserialization()` so it can read `FIELD_DELIMITER`.

### Verification

After this fix, a Pulsar Source with `format = text` and `field_delimiter = ","` will:
- Pass configuration validation
- Use `TextDeserializationSchema` to deserialize text-format messages
- Work with the existing `seatunnel-format-text` dependency

Fixes #11620
