### PR TITLE
[Fix][Format-JSON] Apply column defaultValue when JSON field is null or missing (#11632)

### DIFF
--- a/seatunnel-formats/seatunnel-format-json/src/main/java/org/apache/seatunnel/format/json/JsonDeserializationSchema.java
+++ b/seatunnel-formats/seatunnel-format-json/src/main/java/org/apache/seatunnel/format/json/JsonDeserializationSchema.java
@@ -29,6 +29,7 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.NullNode;
 import org.apache.seatunnel.api.serialization.DeserializationSchema;
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.CompositeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
@@ -40,6 +41,7 @@ import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.format.json.exception.SeaTunnelJsonFormatException;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkNotNull;
@@ -99,8 +101,24 @@ public class JsonDeserializationSchema implements DeserializationSchema<SeaTunne
         this.rowType = checkNotNull(catalogTable.getSeaTunnelRowType());
         this.failOnMissingField = failOnMissingField;
         this.ignoreParseErrors = ignoreParseErrors;
+
+        // Extract default values from the catalog table schema.
+        // Only physical columns have defaults; toPhysicalRowDataType() filters
+        // non-physical columns, so we apply the same filter here.
+        Object[] defaultValues = null;
+        List<Column> columns = catalogTable.getTableSchema().getColumns();
+        if (columns != null) {
+            defaultValues = new Object[columns.size()];
+            int physIdx = 0;
+            for (int i = 0; i < columns.size(); i++) {
+                if (columns.get(i).isPhysical()) {
+                    defaultValues[physIdx++] = columns.get(i).getDefaultValue();
+                }
+            }
+        }
+
         this.runtimeConverter =
-                new JsonToRowConverters(failOnMissingField, ignoreParseErrors)
+                new JsonToRowConverters(failOnMissingField, ignoreParseErrors, defaultValues)
                         .createRowConverter(checkNotNull(rowType));
 
         if (hasDecimalType(rowType)) {

--- a/seatunnel-formats/seatunnel-format-json/src/main/java/org/apache/seatunnel/format/json/JsonToRowConverters.java
+++ b/seatunnel-formats/seatunnel-format-json/src/main/java/org/apache/seatunnel/format/json/JsonToRowConverters.java
@@ -78,11 +78,20 @@ public class JsonToRowConverters implements Serializable {
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     private final boolean ignoreParseErrors;
 
+    /** Default values for each column, indexed by physical column position. */
+    private final Object[] defaultValues;
+
     public Map<String, DateTimeFormatter> fieldFormatterMap = new HashMap<>();
 
     public JsonToRowConverters(boolean failOnMissingField, boolean ignoreParseErrors) {
+        this(failOnMissingField, ignoreParseErrors, null);
+    }
+
+    public JsonToRowConverters(
+            boolean failOnMissingField, boolean ignoreParseErrors, Object[] defaultValues) {
         this.failOnMissingField = failOnMissingField;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.defaultValues = defaultValues;
     }
 
     /** Creates a runtime converter which is null safe. */
@@ -411,6 +420,12 @@ public class JsonToRowConverters implements Serializable {
                             fieldName = rowFieldName + "." + fieldName;
                         }
                         Object convertedField = convertField(fieldConverters[i], fieldName, field);
+                        if (convertedField == null
+                                && defaultValues != null
+                                && i < defaultValues.length
+                                && defaultValues[i] != null) {
+                            convertedField = defaultValues[i];
+                        }
                         row.setField(i, convertedField);
                     } catch (Throwable t) {
                         throw CommonError.jsonOperationError(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11632

### Problem Summary

When a source connector using the JSON format (Kafka, Pulsar, HTTP, etc.) configures `schema { columns = [ { name = "GROUPID", type = "int", defaultValue = 0 } ] }`, the `defaultValue` is parsed and stored on the `Column` but never applied during deserialization: if the JSON message is missing the field or contains an explicit `null`, the row field stays `null` instead of the configured default value.

### Root Cause

The `defaultValue` is lost on the way from `CatalogTable` to the row converter:

1. `CatalogTable.getSeaTunnelRowType()` calls `toPhysicalRowDataType()`, which creates a `SeaTunnelRowType` with only `fieldNames[]` and `fieldTypes[]` — the `defaultValue` is dropped.
2. `JsonToRowConverters` builds converters from `SeaTunnelRowType` and has no access to `Column` metadata.
3. When `convertField()` encounters a `null` or missing field, it returns `null` without consulting the default value.

### What Changed

1. **`JsonToRowConverters`**: Added an optional `defaultValues` array parameter. When a field is `null`/missing and a non-null default value exists for that column, the default value is used instead of `null`.

2. **`JsonDeserializationSchema`**: Extracts default values from `CatalogTable.getTableSchema().getColumns()` (filtering to physical columns to match `toPhysicalRowDataType()` behavior) and passes them to the converters.

### How was this tested?

- Existing tests pass without modification (the `defaultValues` array is `null` by default, preserving backward compatibility).
- Manually verified that the scenario from the issue (Kafka JSON source with `defaultValue = 0` / `defaultValue = "unknown"`) now correctly applies defaults when fields are missing or `null`.

