### PR TITLE
[FIX][CI] increase time and memory management

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -473,9 +473,17 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: run all modules unit test
-        run: ./mvnw -B -T 1 clean verify -DskipUT=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true -DargLine="-Xmx3072m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" --no-snapshot-updates
+        run: ./mvnw -B -T 1 clean verify -DskipUT=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true "-Dsurefire.jvm.args=$SUREFIRE_JVM_ARGS" --no-snapshot-updates
         env:
           MAVEN_OPTS: -Xmx1536m -Dfile.encoding=UTF-8
+          SUREFIRE_JVM_ARGS: -Xmx3072m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+        if: runner.os != 'Windows'
+      - name: run all modules unit test (Windows)
+        run: ./mvnw -B -T 1 clean verify -DskipUT=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true "-Dsurefire.jvm.args=$env:SUREFIRE_JVM_ARGS" --no-snapshot-updates
+        env:
+          MAVEN_OPTS: -Xmx1536m -Dfile.encoding=UTF-8
+          SUREFIRE_JVM_ARGS: -Xmx3072m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+        if: runner.os == 'Windows'
 
   updated-modules-integration-test-part-1:
     needs: [ changes, sanity-check ]

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -470,10 +470,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: run all modules unit test
-        run: |
-          ./mvnw -B -T 1 clean verify -DskipUT=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates
+        run: ./mvnw -B -T 1 clean verify -DskipUT=false -DskipIT=true -D"license.skipAddThirdParty"=true -D"skip.ui"=true -DargLine="-Xmx3072m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" --no-snapshot-updates
         env:
-          MAVEN_OPTS: -Xmx4096m -Dfile.encoding=UTF-8
+          MAVEN_OPTS: -Xmx1536m -Dfile.encoding=UTF-8
 
   updated-modules-integration-test-part-1:
     needs: [ changes, sanity-check ]
@@ -940,7 +939,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 210
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -670,6 +670,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
+                        <argLine>${argLine}</argLine>
                         <skip>${skipUT}</skip>
                         <systemPropertyVariables>
                             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
@@ -701,6 +702,7 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
                     <configuration>
+                        <argLine>${argLine}</argLine>
                         <skip>${skipIT}</skip>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <jakarta.servlet-api>4.0.4</jakarta.servlet-api>
         <hugegraph.client.version>1.5.0</hugegraph.client.version>
         <!-- Option args -->
+        <surefire.jvm.args>-Dfile.encoding=UTF-8</surefire.jvm.args>
         <skipUT>false</skipUT>
         <skipIT>true</skipIT>
         <elasticsearch>7</elasticsearch>
@@ -670,7 +671,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <argLine>${argLine}</argLine>
+                        <argLine>${surefire.jvm.args}</argLine>
                         <skip>${skipUT}</skip>
                         <systemPropertyVariables>
                             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
@@ -702,7 +703,7 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
                     <configuration>
-                        <argLine>${argLine}</argLine>
+                        <argLine>${surefire.jvm.args}</argLine>
                         <skip>${skipIT}</skip>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### Purpose

This pull request addresses CI failures by updating memory consumption and increasing timeout. It also updates the Maven command for running unit tests.

### Changes Made

* Updated Maven command to use OS-based settings:
	+ Added separate tasks for Linux/macOS and Windows
	+ Set MAVEN_OPTS and SUREFIRE_JVM_ARGS environment variables
* Increased timeout-minutes for `all-connectors-it-3` from 210 to 240
* Updated POM file with `surefire.jvm.args` configuration

### Testing and Validation

* This patch was tested as part of commit https://github.com/apache/seatunnel/pull/11198/commits/eb5ced99596e7b88f38740c8d9ac6a0ccd7cc631
* A build was triggered and completed successfully: https://github.com/srijan-singh/seatunnel/actions/runs/30786984078