### PR TITLE
[Test][E2E] Retry Hive plugin jar downloads in HiveIT

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
@@ -52,6 +52,17 @@ import static org.awaitility.Awaitility.given;
         type = {EngineType.SPARK, EngineType.FLINK})
 @Slf4j
 public class HiveIT extends TestSuiteBase implements TestResource {
+
+    /**
+     * Shell fragment used for every plugin jar download inside the Hive container.
+     *
+     * <p>A bare {@code wget} makes the whole E2E job fail on a single transient TLS or DNS hiccup
+     * against Maven Central, which has nothing to do with the behaviour under test. Retry a few
+     * times with a backoff and a per-attempt timeout so only a sustained outage fails the job.
+     */
+    private static final String WGET =
+            " && wget --tries=5 --waitretry=5 --retry-connrefused --timeout=30 ";
+
     private static final String CREATE_SQL =
             "CREATE TABLE test_hive_sink_on_hdfs"
                     + "("
@@ -186,7 +197,7 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                                         + pluginHiveDir
                                         + " && cd "
                                         + pluginHiveDir
-                                        + " && wget "
+                                        + WGET
                                         + hiveExeUrl());
                 Assertions.assertEquals(
                         0,
@@ -194,7 +205,7 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                         downloadHiveExeCommands.getStderr());
                 Container.ExecResult downloadLibFb303Commands =
                         container.execInContainer(
-                                "sh", "-c", "cd " + pluginHiveDir + " && wget " + libFb303Url());
+                                "sh", "-c", "cd " + pluginHiveDir + WGET + libFb303Url());
                 Assertions.assertEquals(
                         0,
                         downloadLibFb303Commands.getExitCode(),
@@ -202,7 +213,7 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                 // The jar of s3
                 Container.ExecResult downloadS3Commands =
                         container.execInContainer(
-                                "sh", "-c", "cd " + pluginHiveDir + " && wget " + hadoopAwsUrl());
+                                "sh", "-c", "cd " + pluginHiveDir + WGET + hadoopAwsUrl());
                 Assertions.assertEquals(
                         0, downloadS3Commands.getExitCode(), downloadS3Commands.getStderr());
                 // The jar of oss
@@ -212,18 +223,18 @@ public class HiveIT extends TestSuiteBase implements TestResource {
                                 "-c",
                                 "cd "
                                         + pluginHiveDir
-                                        + " && wget "
+                                        + WGET
                                         + aliyunSdkOssUrl()
-                                        + " && wget "
+                                        + WGET
                                         + jdomUrl()
-                                        + " && wget "
+                                        + WGET
                                         + hadoopAliyunUrl());
                 Assertions.assertEquals(
                         0, downloadOssCommands.getExitCode(), downloadOssCommands.getStderr());
                 // The jar of cos
                 Container.ExecResult downloadCosCommands =
                         container.execInContainer(
-                                "sh", "-c", "cd " + pluginHiveDir + " && wget " + hadoopCosUrl());
+                                "sh", "-c", "cd " + pluginHiveDir + WGET + hadoopCosUrl());
                 Assertions.assertEquals(
                         0, downloadCosCommands.getExitCode(), downloadCosCommands.getStderr());
             };


### PR DESCRIPTION
## Purpose

`HiveIT` downloads seven plugin jars into the Hive container with a bare `wget` and asserts the exit code is 0. A single transient network failure against Maven Central therefore fails the entire `all-connectors-it-4` job, on PRs that have nothing to do with Hive.

Observed on #11203 — a PR that only touches a Zeta REST API test:

```
Failed to resolve parameter [TestContainer arg0] in method
  HiveIT.testHiveSourceWholeDatabaseUseRegex
--2026-08-03 18:11:15--  https://repo1.maven.org/maven2/org/apache/thrift/libfb303/0.9.3/libfb303-0.9.3.jar
Connecting to repo1.maven.org|104.18.18.12|:443... connected.
GnuTLS: Error in the pull function.
Unable to establish SSL connection.
 ==> expected: <0> but was: <4>
```

Exit code 4 is wget's network-failure code. The download simply needs to be retried.

## Changes

Replace the seven bare `wget` invocations with a single shared constant that retries:

```
wget --tries=5 --waitretry=5 --retry-connrefused --timeout=30
```

A sustained outage still fails the job; a momentary hiccup no longer does. No assertion is relaxed — every download is still required to succeed.

## Does this PR introduce _any_ user-facing change?

No. E2E test infrastructure only.

## How was this patch tested?

The `all-connectors-it-4` job on this PR exercises the changed download path.