### PR TITLE
[Test][E2E] Give the E2E Flink TaskManager enough metaspace and heartbeat slack

### DIFF
--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/AbstractTestFlinkContainer.java
@@ -59,6 +59,21 @@ public abstract class AbstractTestFlinkContainer extends AbstractTestContainer {
                     "taskmanager.numberOfTaskSlots: 10",
                     "parallelism.default: 4",
                     "env.java.opts: -Doracle.jdbc.timezoneAsRegion=false",
+                    // One TaskManager serves every job of a test class, and each SeaTunnel job
+                    // loads its connector jars through a fresh user-code ClassLoader. With the
+                    // Flink default of 256mb the metaspace is exhausted part-way through a long
+                    // class ("OutOfMemoryError: Metaspace"), which kills the TaskManager and fails
+                    // whichever job happens to be running. Raise the process budget alongside it so
+                    // the extra metaspace is not taken out of the derived heap/network/managed
+                    // pools.
+                    "taskmanager.memory.process.size: 2048m",
+                    "taskmanager.memory.jvm-metaspace.size: 512m",
+                    // CI runners host several containers at once, so a TaskManager can be starved
+                    // of CPU for longer than the 50s Flink default before it answers a heartbeat.
+                    // A missed heartbeat fails the job outright, because SeaTunnel jobs run with
+                    // NoRestartBackoffTimeStrategy unless the job config asks for restarts.
+                    "heartbeat.timeout: 120000",
+                    "heartbeat.interval: 10000",
                     // limit restart attempts in e2e to avoid infinite retries
                     "restart-strategy: fixed-delay",
                     "restart-strategy.fixed-delay.attempts: 2",

--- a/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/Flink20Container.java
+++ b/seatunnel-e2e/seatunnel-e2e-common/src/test/java/org/apache/seatunnel/e2e/common/container/flink/Flink20Container.java
@@ -88,8 +88,24 @@ public class Flink20Container extends AbstractTestFlinkContainer {
                         "",
                         "# Memory Configuration",
                         "jobmanager.memory.process.size: 1600m",
-                        "taskmanager.memory.process.size: 1728m",
+                        // One TaskManager serves every job of a test class, and each SeaTunnel job
+                        // loads its connector jars through a fresh user-code ClassLoader. The
+                        // implied 256m metaspace was exhausted part-way through long classes
+                        // ("OutOfMemoryError: Metaspace"), killing the TaskManager. The process
+                        // budget grows by the same amount the metaspace does, so the derived Flink
+                        // memory stays at 1280m and the heap/network/managed pools are unchanged.
+                        "taskmanager.memory.process.size: 2048m",
                         "taskmanager.memory.flink.size: 1280m",
+                        "taskmanager.memory.jvm-metaspace.size: 512m",
+                        "",
+                        "# Heartbeat Configuration",
+                        // CI runners host several containers at once, so a TaskManager can be
+                        // starved of CPU for longer than the 50s Flink default before it answers a
+                        // heartbeat. A missed heartbeat fails the job outright, because SeaTunnel
+                        // jobs run with NoRestartBackoffTimeStrategy unless the job config asks for
+                        // restarts.
+                        "heartbeat.timeout: 120000",
+                        "heartbeat.interval: 10000",
                         "",
                         "# Network Buffer Configuration - Fix for insufficient network buffers",
                         "taskmanager.memory.network.fraction: 0.2",


### PR DESCRIPTION
### Purpose of this pull request

Fix connector E2E failures that are caused by the shared Flink test cluster dying, not by the PR under test.

`HttpIT#testSourceToAssertSink` failed with `expected: <0> but was: <1>` (the SeaTunnel job exited non-zero) on two unrelated PRs — `#11382` and `#10874`, neither of which touches the HTTP connector. Both failures happened on the Flink 1.20.1 container, and in both the TaskManager is what actually broke:

**`#10874` — the TaskManager ran out of metaspace:**

```
🐳 [tyrantlucifer/flink:1.20.1-scala_2.12_hadoop27:taskmanager] - STDOUT: java.lang.OutOfMemoryError: Metaspace. ...
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
```

**`#11382` — the TaskManager stopped answering heartbeats (13 occurrences):**

```
Caused by: java.util.concurrent.TimeoutException: Heartbeat of TaskManager with id 172.18.0.5:36859-7443e5 timed out.
Job http_binary_to_assert.conf (...) switched from state FAILING to FAILED.
Caused by: org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy
```

**Why it happens**

One TaskManager serves every job of a whole test class — `HttpIT` alone ran 28 jobs in that run — and each SeaTunnel job loads its connector jars through a fresh user-code `ClassLoader`. The E2E clusters never configure metaspace, so they inherit the implied 256m, which is exhausted part-way through a long class. Flink's own message names this case: *"either the job requires a larger size of JVM metaspace or there is a class loading leak"*. Here it is the former.

Heartbeats are the second half of the same story. CI runners host several containers at once, so a TaskManager can be starved of CPU past the 50s Flink default — and a metaspace-dead TaskManager stops answering entirely. A missed heartbeat is fatal rather than recoverable, because SeaTunnel jobs run with `NoRestartBackoffTimeStrategy` unless the job config asks for restarts.

### Does this PR introduce _any_ user-facing change?

No. E2E test-infrastructure only; no production code and no test assertions are touched.

- `taskmanager.memory.jvm-metaspace.size: 512m` (was the implied 256m).
- `taskmanager.memory.process.size: 2048m` (was 1728m) — the process budget grows by exactly the metaspace increase, so the derived heap / network / managed pools stay where they are today rather than shrinking to pay for the metaspace. For Flink 1.20, `taskmanager.memory.flink.size` stays pinned at `1280m`, so total Flink memory is unchanged and the derived JVM overhead lands at 256m, inside the default `[192m, 1g]` bounds.
- `heartbeat.timeout: 120000` with `heartbeat.interval: 10000` (was the 50s / 10s default).

`Flink20Container` overrides `getFlinkProperties()` with its own complete list rather than extending `DEFAULT_FLINK_PROPERTIES`, so it needs the same settings — and it is the container both observed failures happened on.

### How was this patch tested?

Verified by CI on this PR head, which exercises these containers across the whole Flink matrix (1.13 / 1.15 / 1.18 / 1.20) in `all-connectors-it-*`, `kafka-connector-it`, `transform-v2-it-*` and the other connector IT jobs.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
