### PR TITLE
fix: address silent connector KB degradation and self-referencing suggestions

### DIFF
--- a/seatunnel-cli/seatunnel_cli/connectors.py
+++ b/seatunnel-cli/seatunnel_cli/connectors.py
@@ -340,6 +340,10 @@ def _load_runtime_metadata() -> dict | None:
                 logger.debug(f"Failed to load runtime metadata from {p}: {e}")
 
     _RUNTIME_METADATA = {}  # Empty dict = tried but not found
+    logger.warning(
+        "No connector_metadata.json found. Connector KB will be empty. "
+        "Run `seatunnel --export-metadata` or set SEATUNNEL_HOME to generate it."
+    )
     return _RUNTIME_METADATA
 
 
@@ -1070,8 +1074,17 @@ def get_connector_detail(name: str, connector_type: str | None = None) -> str | 
 
     # ── 4. Suggest ──
     suggestions = route_by_keyword(name)
+    # Filter out the queried name itself from suggestions
+    suggestions = [s for s in suggestions if s.lower() != name.lower()]
     if suggestions:
         return f"Connector '{name}' not found. Did you mean: {', '.join(suggestions)}?\nUse get_connector_info with the exact name."
+
+    # Check if the name matches a known connector alias (even without metadata)
+    all_known_connectors = set()
+    for aliases in KEYWORD_ALIASES.values():
+        all_known_connectors.update(a.lower() for a in aliases)
+    if name.lower() in all_known_connectors:
+        return f"Connector '{name}' is a known connector but its metadata is not available. Run `seatunnel --export-metadata` to generate connector metadata."
     return f"Connector '{name}' not found. Use list_connectors to see all available connectors."
 
 


### PR DESCRIPTION
## Description

Fixes #11650

Two related defects in the CLI's connector knowledge base, both causing silent failures and misleading error messages:

### 1. Silent degradation when `connector_metadata.json` is not found

`_load_runtime_metadata()` silently returns an empty dict when no `connector_metadata.json` is found, logging only at `logger.debug` level. This means:
- The system-prompt catalog renders as `0 connectors, 0 endpoints` — the model thinks there are no connectors at all
- `validate_connector_options()` returns `valid: True` for everything with a note "metadata not available"
- `get_connector_detail("Doris")` falls through to "not found"

**Fix**: Changed the log level to `logger.warning` with a clear remediation hint (`Run \`seatunnel --export-metadata\` or set SEATUNNEL_HOME to generate it`).

### 2. Self-referencing suggestions for known connector names

`get_connector_detail()` uses `route_by_keyword()` for suggestions, which matches the queried name itself as a keyword alias. This produces the absurd: `Connector 'Doris' not found. Did you mean: Doris?`

**Fix**: 
- Filter out the queried name from suggestions (case-insensitive)
- When the name is a known connector (from `KEYWORD_ALIASES`) but metadata is unavailable, show a more helpful message: "Known connector, metadata not available — run `seatunnel --export-metadata` to generate it"
