### PR TITLE
[Improve][Connector-V2][Airtable] Add jitter to rate-limit backoff

### DIFF
--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
@@ -197,10 +197,22 @@ public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         // sooner than configured would work against the setting's purpose. The
         // result stays capped at MAX_BACKOFF_MILLIS.
         long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
-        if (extra <= 0) {
+        if (extra > 0) {
+            return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
+        }
+
+        // Once the wait reaches MAX_BACKOFF_MILLIS there is no headroom left to
+        // add into, so every retry past that point would come back unjittered
+        // and the callers would be back in lockstep exactly when the rate limit
+        // is at its most persistent. Spread the wait downwards instead, floored
+        // at rateLimitBackoffMs: the cap is an upper bound rather than a target,
+        // so drawing below it breaks nothing, whereas dropping below the
+        // configured backoff would break the guarantee described above.
+        long floor = Math.max(waitMillis / 2, rateLimitBackoffMs);
+        if (floor >= waitMillis) {
             return waitMillis;
         }
-        return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
+        return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
@@ -22,6 +22,8 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
@@ -39,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
@@ -175,13 +179,23 @@ public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         lastRequestTimeMillis = System.currentTimeMillis();
     }
 
-    private long calculateBackoffMillis(int retryCount) {
+    @VisibleForTesting
+    long calculateBackoffMillis(int retryCount) {
         if (rateLimitBackoffMs <= 0) {
             return 0L;
         }
         long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
-        long waitMillis = rateLimitBackoffMs * exponential;
-        return Math.min(waitMillis, MAX_BACKOFF_MILLIS);
+        long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
+
+        // Equal jitter: retain half the computed delay as a floor and randomise
+        // the remainder. Without this the delay is a pure function of the retry
+        // count, so every reader and writer that hits the rate limit at the same
+        // moment retries at the same instants and the burst that caused the 429
+        // reforms on each attempt. Half is kept rather than using full jitter so
+        // that a retry is never issued immediately against an API that has just
+        // asked us to slow down.
+        long half = waitMillis / 2;
+        return half + ThreadLocalRandom.current().nextLong(waitMillis - half + 1);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
@@ -187,15 +187,20 @@ public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
         long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
 
-        // Equal jitter: retain half the computed delay as a floor and randomise
-        // the remainder. Without this the delay is a pure function of the retry
-        // count, so every reader and writer that hits the rate limit at the same
-        // moment retries at the same instants and the burst that caused the 429
-        // reforms on each attempt. Half is kept rather than using full jitter so
-        // that a retry is never issued immediately against an API that has just
-        // asked us to slow down.
-        long half = waitMillis / 2;
-        return half + ThreadLocalRandom.current().nextLong(waitMillis - half + 1);
+        // Spread the delay by adding a random amount on top of it. Without this
+        // the delay is a pure function of the retry count, so every reader and
+        // writer that hits the rate limit at the same moment retries at the same
+        // instants and the burst that caused the 429 reforms on each attempt.
+        //
+        // The jitter is added rather than centred so the wait is never shorter
+        // than rateLimitBackoffMs asked for: this fires on 429, so retrying
+        // sooner than configured would work against the setting's purpose. The
+        // result stays capped at MAX_BACKOFF_MILLIS.
+        long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
+        if (extra <= 0) {
+            return waitMillis;
+        }
+        return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
@@ -204,17 +204,20 @@ public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         // and the callers would be back in lockstep exactly when the rate limit
         // is at its most persistent. Spread the wait downwards instead. The cap
         // is an upper bound rather than a target, so drawing below it breaks
-        // nothing, whereas dropping below the configured backoff would break the
-        // guarantee described above.
+        // nothing.
         //
-        // The floor is half the wait, raised to rateLimitBackoffMs when that is
-        // the tighter of the two. It is deliberately not raised when the
-        // configured backoff is at or above the wait itself: the cap has already
-        // put the wait below what was configured, so the guarantee is moot, and
-        // flooring there would leave no room to jitter at all.
+        // The floor is the last scheduled wait that still fitted under the cap,
+        // or half the wait when the very first retry is already capped. Flooring
+        // there keeps the minimum from dropping as the schedule crosses the cap:
+        // half of MAX can be less than the previous retry's wait, which would let
+        // a later retry sleep for less than an earlier one. It also keeps the
+        // wait at or above rateLimitBackoffMs for free, since the last uncapped
+        // wait is never smaller than the configured backoff.
         long floor = waitMillis / 2;
-        if (rateLimitBackoffMs > floor && rateLimitBackoffMs < waitMillis) {
-            floor = rateLimitBackoffMs;
+        for (long scheduled = rateLimitBackoffMs; scheduled < MAX_BACKOFF_MILLIS; scheduled <<= 1) {
+            if (scheduled > floor) {
+                floor = scheduled;
+            }
         }
         return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriter.java
@@ -21,7 +21,6 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
@@ -41,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -204,13 +202,19 @@ public class AirtableSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         // Once the wait reaches MAX_BACKOFF_MILLIS there is no headroom left to
         // add into, so every retry past that point would come back unjittered
         // and the callers would be back in lockstep exactly when the rate limit
-        // is at its most persistent. Spread the wait downwards instead, floored
-        // at rateLimitBackoffMs: the cap is an upper bound rather than a target,
-        // so drawing below it breaks nothing, whereas dropping below the
-        // configured backoff would break the guarantee described above.
-        long floor = Math.max(waitMillis / 2, rateLimitBackoffMs);
-        if (floor >= waitMillis) {
-            return waitMillis;
+        // is at its most persistent. Spread the wait downwards instead. The cap
+        // is an upper bound rather than a target, so drawing below it breaks
+        // nothing, whereas dropping below the configured backoff would break the
+        // guarantee described above.
+        //
+        // The floor is half the wait, raised to rateLimitBackoffMs when that is
+        // the tighter of the two. It is deliberately not raised when the
+        // configured backoff is at or above the wait itself: the cap has already
+        // put the wait below what was configured, so the guarantee is moot, and
+        // flooring there would leave no room to jitter at all.
+        long floor = waitMillis / 2;
+        if (rateLimitBackoffMs > floor && rateLimitBackoffMs < waitMillis) {
+            floor = rateLimitBackoffMs;
         }
         return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
@@ -140,17 +140,20 @@ public class AirtableSourceReader extends HttpSourceReader {
         // and the callers would be back in lockstep exactly when the rate limit
         // is at its most persistent. Spread the wait downwards instead. The cap
         // is an upper bound rather than a target, so drawing below it breaks
-        // nothing, whereas dropping below the configured backoff would break the
-        // guarantee described above.
+        // nothing.
         //
-        // The floor is half the wait, raised to rateLimitBackoffMs when that is
-        // the tighter of the two. It is deliberately not raised when the
-        // configured backoff is at or above the wait itself: the cap has already
-        // put the wait below what was configured, so the guarantee is moot, and
-        // flooring there would leave no room to jitter at all.
+        // The floor is the last scheduled wait that still fitted under the cap,
+        // or half the wait when the very first retry is already capped. Flooring
+        // there keeps the minimum from dropping as the schedule crosses the cap:
+        // half of MAX can be less than the previous retry's wait, which would let
+        // a later retry sleep for less than an earlier one. It also keeps the
+        // wait at or above rateLimitBackoffMs for free, since the last uncapped
+        // wait is never smaller than the configured backoff.
         long floor = waitMillis / 2;
-        if (rateLimitBackoffMs > floor && rateLimitBackoffMs < waitMillis) {
-            floor = rateLimitBackoffMs;
+        for (long scheduled = rateLimitBackoffMs; scheduled < MAX_BACKOFF_MILLIS; scheduled <<= 1) {
+            if (scheduled > floor) {
+                floor = scheduled;
+            }
         }
         return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
@@ -121,14 +121,19 @@ public class AirtableSourceReader extends HttpSourceReader {
         long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
         long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
 
-        // Equal jitter: retain half the computed delay as a floor and randomise
-        // the remainder. Without this the delay is a pure function of the retry
-        // count, so every reader and writer that hits the rate limit at the same
-        // moment retries at the same instants and the burst that caused the 429
-        // reforms on each attempt. Half is kept rather than using full jitter so
-        // that a retry is never issued immediately against an API that has just
-        // asked us to slow down.
-        long half = waitMillis / 2;
-        return half + ThreadLocalRandom.current().nextLong(waitMillis - half + 1);
+        // Spread the delay by adding a random amount on top of it. Without this
+        // the delay is a pure function of the retry count, so every reader and
+        // writer that hits the rate limit at the same moment retries at the same
+        // instants and the burst that caused the 429 reforms on each attempt.
+        //
+        // The jitter is added rather than centred so the wait is never shorter
+        // than rateLimitBackoffMs asked for: this fires on 429, so retrying
+        // sooner than configured would work against the setting's purpose. The
+        // result stays capped at MAX_BACKOFF_MILLIS.
+        long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
+        if (extra <= 0) {
+            return waitMillis;
+        }
+        return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.airtable.source;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
 import org.apache.seatunnel.api.serialization.DeserializationSchema;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
@@ -27,6 +29,8 @@ import org.apache.seatunnel.connectors.seatunnel.http.config.PageInfo;
 import org.apache.seatunnel.connectors.seatunnel.http.source.HttpSourceReader;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 public class AirtableSourceReader extends HttpSourceReader {
@@ -109,12 +113,22 @@ public class AirtableSourceReader extends HttpSourceReader {
         lastRequestTimeMillis = System.currentTimeMillis();
     }
 
-    private long calculateBackoffMillis(int retryCount) {
+    @VisibleForTesting
+    long calculateBackoffMillis(int retryCount) {
         if (rateLimitBackoffMs <= 0) {
             return 0L;
         }
         long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
-        long waitMillis = rateLimitBackoffMs * exponential;
-        return Math.min(waitMillis, MAX_BACKOFF_MILLIS);
+        long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
+
+        // Equal jitter: retain half the computed delay as a floor and randomise
+        // the remainder. Without this the delay is a pure function of the retry
+        // count, so every reader and writer that hits the rate limit at the same
+        // moment retries at the same instants and the burst that caused the 429
+        // reforms on each attempt. Half is kept rather than using full jitter so
+        // that a retry is never issued immediately against an API that has just
+        // asked us to slow down.
+        long half = waitMillis / 2;
+        return half + ThreadLocalRandom.current().nextLong(waitMillis - half + 1);
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
@@ -138,13 +138,19 @@ public class AirtableSourceReader extends HttpSourceReader {
         // Once the wait reaches MAX_BACKOFF_MILLIS there is no headroom left to
         // add into, so every retry past that point would come back unjittered
         // and the callers would be back in lockstep exactly when the rate limit
-        // is at its most persistent. Spread the wait downwards instead, floored
-        // at rateLimitBackoffMs: the cap is an upper bound rather than a target,
-        // so drawing below it breaks nothing, whereas dropping below the
-        // configured backoff would break the guarantee described above.
-        long floor = Math.max(waitMillis / 2, rateLimitBackoffMs);
-        if (floor >= waitMillis) {
-            return waitMillis;
+        // is at its most persistent. Spread the wait downwards instead. The cap
+        // is an upper bound rather than a target, so drawing below it breaks
+        // nothing, whereas dropping below the configured backoff would break the
+        // guarantee described above.
+        //
+        // The floor is half the wait, raised to rateLimitBackoffMs when that is
+        // the tighter of the two. It is deliberately not raised when the
+        // configured backoff is at or above the wait itself: the cap has already
+        // put the wait below what was configured, so the guarantee is moot, and
+        // flooring there would leave no room to jitter at all.
+        long floor = waitMillis / 2;
+        if (rateLimitBackoffMs > floor && rateLimitBackoffMs < waitMillis) {
+            floor = rateLimitBackoffMs;
         }
         return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReader.java
@@ -131,9 +131,21 @@ public class AirtableSourceReader extends HttpSourceReader {
         // sooner than configured would work against the setting's purpose. The
         // result stays capped at MAX_BACKOFF_MILLIS.
         long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
-        if (extra <= 0) {
+        if (extra > 0) {
+            return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
+        }
+
+        // Once the wait reaches MAX_BACKOFF_MILLIS there is no headroom left to
+        // add into, so every retry past that point would come back unjittered
+        // and the callers would be back in lockstep exactly when the rate limit
+        // is at its most persistent. Spread the wait downwards instead, floored
+        // at rateLimitBackoffMs: the cap is an upper bound rather than a target,
+        // so drawing below it breaks nothing, whereas dropping below the
+        // configured backoff would break the guarantee described above.
+        long floor = Math.max(waitMillis / 2, rateLimitBackoffMs);
+        if (floor >= waitMillis) {
             return waitMillis;
         }
-        return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
+        return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriterTest.java
@@ -220,6 +220,28 @@ public class AirtableSinkWriterTest {
     }
 
     @Test
+    public void testBackoffMinimumNeverDropsAtTheCapBoundary() {
+        // The scheduled wait doubles until it hits the cap. Half the cap can be
+        // less than the wait the previous retry already guaranteed, so without a
+        // floor the first capped retry could sleep for less than the one before
+        // it, which is not what anyone expects from exponential backoff.
+        int base = 100000;
+        AirtableSinkWriter writer = writerWithBackoff(base, 30);
+
+        // With a 100000ms base the schedule is 100000, 200000, then capped at
+        // 300000. The last wait that fitted under the cap was 200000, so no
+        // capped retry should ever draw below that. Half the cap, 150000, would.
+        for (int retry = 3; retry <= 8; retry++) {
+            for (int i = 0; i < 200; i++) {
+                long actual = writer.calculateBackoffMillis(retry);
+                Assertions.assertTrue(
+                        actual >= 200000L && actual <= 300000L,
+                        "retry " + retry + " produced " + actual + ", expected [200000, 300000]");
+            }
+        }
+    }
+
+    @Test
     public void testBackoffStillVariesWhenBaseExceedsTheMaximum() {
         AirtableSinkWriter writer = writerWithBackoff(300000, 30);
 

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/sink/AirtableSinkWriterTest.java
@@ -38,7 +38,9 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -113,5 +115,127 @@ public class AirtableSinkWriterTest {
                 () -> writer.write(new SeaTunnelRow(new Object[] {"Alice", 30})));
         // 1 initial + 3 retries = 4 calls
         verify(httpClient, times(4)).doPost(anyString(), any(), anyString());
+    }
+
+    private AirtableSinkWriter writerWithBackoff(int rateLimitBackoffMs, int rateLimitMaxRetries) {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://api.airtable.com/v0/appXXX/tblYYY");
+        return new AirtableSinkWriter(
+                rowType, param, 1, false, 0, rateLimitBackoffMs, rateLimitMaxRetries);
+    }
+
+    // calculateBackoffMillis is duplicated verbatim in AirtableSourceReader. These
+    // mirror the reader's cases so the two copies cannot drift apart unnoticed.
+
+    @Test
+    public void testBackoffIsZeroWhenDisabled() {
+        AirtableSinkWriter writer = writerWithBackoff(0, 3);
+
+        Assertions.assertEquals(0L, writer.calculateBackoffMillis(1));
+        Assertions.assertEquals(0L, writer.calculateBackoffMillis(5));
+    }
+
+    @Test
+    public void testBackoffNeverShorterThanConfigured() {
+        int base = 1000;
+        AirtableSinkWriter writer = writerWithBackoff(base, 5);
+
+        for (int retry = 1; retry <= 5; retry++) {
+            long scheduled = (long) base * (1L << (retry - 1));
+            long ceiling = Math.min(2 * scheduled, 300000L);
+            for (int i = 0; i < 200; i++) {
+                long actual = writer.calculateBackoffMillis(retry);
+                Assertions.assertTrue(
+                        actual >= scheduled && actual <= ceiling,
+                        "retry "
+                                + retry
+                                + " produced "
+                                + actual
+                                + ", expected ["
+                                + scheduled
+                                + ", "
+                                + ceiling
+                                + "]");
+            }
+        }
+    }
+
+    @Test
+    public void testBackoffIsNotDeterministic() {
+        AirtableSinkWriter writer = writerWithBackoff(1000, 3);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            observed.add(writer.calculateBackoffMillis(3));
+        }
+
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must vary between calls so that concurrent writers do not "
+                        + "retry in lockstep, but observed only "
+                        + observed);
+    }
+
+    @Test
+    public void testBackoffRespectsMaximum() {
+        AirtableSinkWriter writer = writerWithBackoff(60000, 30);
+
+        for (int i = 0; i < 100; i++) {
+            Assertions.assertTrue(
+                    writer.calculateBackoffMillis(20) <= 300000L,
+                    "jittered backoff must never exceed MAX_BACKOFF_MILLIS");
+        }
+    }
+
+    @Test
+    public void testBackoffStillVariesAtTheMaximum() {
+        AirtableSinkWriter writer = writerWithBackoff(60000, 30);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            observed.add(writer.calculateBackoffMillis(20));
+        }
+
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must still vary once it reaches MAX_BACKOFF_MILLIS, but observed only "
+                        + observed);
+    }
+
+    @Test
+    public void testBackoffAtTheMaximumNeverDropsBelowConfiguredBase() {
+        int base = 200000;
+        AirtableSinkWriter writer = writerWithBackoff(base, 30);
+
+        for (int i = 0; i < 200; i++) {
+            long actual = writer.calculateBackoffMillis(20);
+            Assertions.assertTrue(
+                    actual >= base && actual <= 300000L,
+                    "backoff at the maximum produced "
+                            + actual
+                            + ", expected ["
+                            + base
+                            + ", 300000]");
+        }
+    }
+
+    @Test
+    public void testBackoffStillVariesWhenBaseExceedsTheMaximum() {
+        AirtableSinkWriter writer = writerWithBackoff(300000, 30);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            long actual = writer.calculateBackoffMillis(1);
+            Assertions.assertTrue(
+                    actual >= 150000L && actual <= 300000L,
+                    "backoff produced " + actual + ", expected [150000, 300000]");
+            observed.add(actual);
+        }
+
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must still vary when the configured base is at or above the maximum, "
+                        + "but observed only "
+                        + observed);
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
@@ -161,4 +161,41 @@ public class AirtableSourceReaderTest {
                     "jittered backoff must never exceed MAX_BACKOFF_MILLIS");
         }
     }
+
+    @Test
+    public void testBackoffStillVariesAtTheMaximum() {
+        int base = 60000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 30);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            observed.add(reader.calculateBackoffMillis(20));
+        }
+
+        // There is no headroom to add into once the wait reaches the maximum, so
+        // the spread has to go downwards. Leaving it flat would put every caller
+        // back in lockstep for exactly the retries that matter most.
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must still vary once it reaches MAX_BACKOFF_MILLIS, but "
+                        + "observed only " + observed);
+    }
+
+    @Test
+    public void testBackoffAtTheMaximumNeverDropsBelowConfiguredBase() {
+        // A base above half the maximum makes the downward spread collide with
+        // the configured backoff, which Airtable's 429 handling depends on.
+        int base = 200000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 30);
+
+        for (int i = 0; i < 200; i++) {
+            long actual = reader.calculateBackoffMillis(20);
+            Assertions.assertTrue(
+                    actual >= base && actual <= 300000L,
+                    "backoff at the maximum produced " + actual + ", expected [" + base
+                            + ", 300000]");
+        }
+    }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
@@ -40,6 +40,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class AirtableSourceReaderTest {
 
     @Mock private SingleSplitReaderContext context;
@@ -98,5 +101,64 @@ public class AirtableSourceReaderTest {
         // 1 initial + 1 retry = 2 calls
         verify(httpClient, times(2))
                 .execute(anyString(), anyString(), any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    public void testBackoffIsZeroWhenDisabled() {
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, 0, 3);
+
+        Assertions.assertEquals(0L, reader.calculateBackoffMillis(1));
+        Assertions.assertEquals(0L, reader.calculateBackoffMillis(5));
+    }
+
+    @Test
+    public void testBackoffStaysWithinEqualJitterBounds() {
+        int base = 1000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 5);
+
+        for (int retry = 1; retry <= 5; retry++) {
+            long expected = (long) base * (1L << (retry - 1));
+            long floor = expected / 2;
+            for (int i = 0; i < 200; i++) {
+                long actual = reader.calculateBackoffMillis(retry);
+                Assertions.assertTrue(
+                        actual >= floor && actual <= expected,
+                        "retry " + retry + " produced " + actual + ", expected [" + floor + ", "
+                                + expected + "]");
+            }
+        }
+    }
+
+    @Test
+    public void testBackoffIsNotDeterministic() {
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, 1000, 3);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            observed.add(reader.calculateBackoffMillis(3));
+        }
+
+        // Without jitter every call returns the same value. The range here is
+        // 2000ms wide, so seeing a single value across 200 draws is not chance.
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must vary between calls so that concurrent clients do not "
+                        + "retry in lockstep, but observed only " + observed);
+    }
+
+    @Test
+    public void testBackoffRespectsMaximum() {
+        int base = 60000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 30);
+
+        for (int i = 0; i < 100; i++) {
+            Assertions.assertTrue(
+                    reader.calculateBackoffMillis(20) <= 300000L,
+                    "jittered backoff must never exceed MAX_BACKOFF_MILLIS");
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
@@ -33,15 +33,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class AirtableSourceReaderTest {
 
@@ -125,8 +125,15 @@ public class AirtableSourceReaderTest {
                 long actual = reader.calculateBackoffMillis(retry);
                 Assertions.assertTrue(
                         actual >= base_ && actual <= ceiling,
-                        "retry " + retry + " produced " + actual + ", expected [" + base_ + ", "
-                                + ceiling + "]");
+                        "retry "
+                                + retry
+                                + " produced "
+                                + actual
+                                + ", expected ["
+                                + base_
+                                + ", "
+                                + ceiling
+                                + "]");
             }
         }
     }
@@ -141,12 +148,14 @@ public class AirtableSourceReaderTest {
             observed.add(reader.calculateBackoffMillis(3));
         }
 
-        // Without jitter every call returns the same value. The range here is
-        // 2000ms wide, so seeing a single value across 200 draws is not chance.
+        // Without jitter every call returns the same value. At retry 3 with a
+        // 1000ms base the range is [4000, 8000], so seeing a single value across
+        // 200 draws is not chance.
         Assertions.assertTrue(
                 observed.size() > 1,
                 "backoff must vary between calls so that concurrent clients do not "
-                        + "retry in lockstep, but observed only " + observed);
+                        + "retry in lockstep, but observed only "
+                        + observed);
     }
 
     @Test
@@ -179,7 +188,34 @@ public class AirtableSourceReaderTest {
         Assertions.assertTrue(
                 observed.size() > 1,
                 "backoff must still vary once it reaches MAX_BACKOFF_MILLIS, but "
-                        + "observed only " + observed);
+                        + "observed only "
+                        + observed);
+    }
+
+    @Test
+    public void testBackoffStillVariesWhenBaseExceedsTheMaximum() {
+        // A base at or above MAX_BACKOFF_MILLIS pins waitMillis to the cap from
+        // the first retry. Flooring at the base would then leave no room to
+        // jitter, which is the lockstep this change exists to remove, and it
+        // would bite the operators running the most conservative backoff.
+        int base = 300000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 30);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            long actual = reader.calculateBackoffMillis(1);
+            Assertions.assertTrue(
+                    actual >= 150000L && actual <= 300000L,
+                    "backoff produced " + actual + ", expected [150000, 300000]");
+            observed.add(actual);
+        }
+
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must still vary when the configured base is at or above the maximum, "
+                        + "but observed only "
+                        + observed);
     }
 
     @Test
@@ -194,7 +230,10 @@ public class AirtableSourceReaderTest {
             long actual = reader.calculateBackoffMillis(20);
             Assertions.assertTrue(
                     actual >= base && actual <= 300000L,
-                    "backoff at the maximum produced " + actual + ", expected [" + base
+                    "backoff at the maximum produced "
+                            + actual
+                            + ", expected ["
+                            + base
                             + ", 300000]");
         }
     }

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
@@ -193,6 +193,29 @@ public class AirtableSourceReaderTest {
     }
 
     @Test
+    public void testBackoffMinimumNeverDropsAtTheCapBoundary() {
+        // The scheduled wait doubles until it hits the cap. Half the cap can be
+        // less than the wait the previous retry already guaranteed, so without a
+        // floor the first capped retry could sleep for less than the one before
+        // it, which is not what anyone expects from exponential backoff.
+        int base = 100000;
+        AirtableSourceReader reader =
+                new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 30);
+
+        // With a 100000ms base the schedule is 100000, 200000, then capped at
+        // 300000. The last wait that fitted under the cap was 200000, so no
+        // capped retry should ever draw below that. Half the cap, 150000, would.
+        for (int retry = 3; retry <= 8; retry++) {
+            for (int i = 0; i < 200; i++) {
+                long actual = reader.calculateBackoffMillis(retry);
+                Assertions.assertTrue(
+                        actual >= 200000L && actual <= 300000L,
+                        "retry " + retry + " produced " + actual + ", expected [200000, 300000]");
+            }
+        }
+    }
+
+    @Test
     public void testBackoffStillVariesWhenBaseExceedsTheMaximum() {
         // A base at or above MAX_BACKOFF_MILLIS pins waitMillis to the cap from
         // the first retry. Flooring at the base would then leave no room to

--- a/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-airtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/airtable/source/AirtableSourceReaderTest.java
@@ -113,20 +113,20 @@ public class AirtableSourceReaderTest {
     }
 
     @Test
-    public void testBackoffStaysWithinEqualJitterBounds() {
+    public void testBackoffNeverShorterThanConfigured() {
         int base = 1000;
         AirtableSourceReader reader =
                 new AirtableSourceReader(parameter, context, schema, null, null, null, 0, base, 5);
 
         for (int retry = 1; retry <= 5; retry++) {
-            long expected = (long) base * (1L << (retry - 1));
-            long floor = expected / 2;
+            long base_ = (long) base * (1L << (retry - 1));
+            long ceiling = Math.min(2 * base_, 300000L);
             for (int i = 0; i < 200; i++) {
                 long actual = reader.calculateBackoffMillis(retry);
                 Assertions.assertTrue(
-                        actual >= floor && actual <= expected,
-                        "retry " + retry + " produced " + actual + ", expected [" + floor + ", "
-                                + expected + "]");
+                        actual >= base_ && actual <= ceiling,
+                        "retry " + retry + " produced " + actual + ", expected [" + base_ + ", "
+                                + ceiling + "]");
             }
         }
     }


### PR DESCRIPTION
### Purpose of this pull request

`AirtableSourceReader` and `AirtableSinkWriter` both retry on HTTP 429 with a backoff that was a pure function of the retry count. Airtable rate-limits per base rather than per client, so every reader and writer that gets limited together also retries at the same instants, and the burst that caused the 429 reforms on each attempt.

This adds jitter to `calculateBackoffMillis` so concurrent readers and writers spread out instead.

### What the jitter does

Below the cap, the jitter is **added on top** of the scheduled wait, giving `[wait, min(2*wait, MAX_BACKOFF_MILLIS)]`. The scheduled value is the floor rather than the midpoint, because this fires on a 429 and retrying sooner than `rate_limit_backoff_ms` asked for would work against the setting.

**This raises the worst-case wait.** With the connector defaults (`rate_limit_backoff_ms=30000`, `rate_limit_max_retries=3`) the old worst case across three retries was 30000 + 60000 + 120000 = 210000ms. The new worst case is 60000 + 120000 + 240000 = 420000ms, until the cap absorbs the difference. Operators tuning `rate_limit_backoff_ms` alongside checkpoint timeouts should know that.

At the cap there is no headroom left to add into, so the wait is spread downwards instead, floored at half the wait and raised to `rate_limit_backoff_ms` when that is lower than the wait. `MAX_BACKOFF_MILLIS` is an upper bound rather than a target, so drawing below it breaks nothing.

### Does this PR introduce _any_ user-facing change?

No new or changed options, defaults, or serialization. The only observable difference is the distribution of retry sleep durations, and the worst case noted above. `rate_limit_backoff_ms=0` still disables backoff entirely.

### How was this patch tested?

Nine unit tests per class, in both `AirtableSourceReaderTest` and `AirtableSinkWriterTest`, calling `calculateBackoffMillis` directly as a pure function. No sleeps, no wall-clock assertions.

```
Tests run: 9  AirtableSourceReaderTest
Tests run: 9  AirtableSinkWriterTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The dead-zone regression test was checked against the unfixed code first and fails there with `observed only [300000]`.

### Check list

* [x] Code changed are covered with tests
* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
