### PR TITLE
[fix][seatunnel-engine] Add public-url config for log links behind Ingress

### DIFF
--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
@@ -78,6 +78,10 @@ public class HttpConfig implements Serializable {
     private String basicAuthPassword =
             ServerConfigOptions.MasterServerConfigOptions.BASIC_AUTH_PASSWORD.defaultValue();
 
+    /** The public base URL for the HTTP server, used when the server is behind a reverse proxy or Ingress. */
+    private String publicUrl =
+            ServerConfigOptions.MasterServerConfigOptions.PUBLIC_URL.defaultValue();
+
     public void setPort(int port) {
         checkPositive(port, ServerConfigOptions.MasterServerConfigOptions.HTTP + " must be > 0");
         this.port = port;

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -373,6 +373,15 @@ public class ServerConfigOptions {
                         .stringType()
                         .defaultValue("admin")
                         .withDescription("The password for basic authentication.");
+        public static final Option<String> PUBLIC_URL =
+                Options.key("public-url")
+                        .stringType()
+                        .noDefaultValue()
+                        .withDescription(
+                                "The public base URL of the HTTP server, used when the server is behind a reverse proxy or Ingress. "
+                                        + "When set, this URL is used to generate absolute log links in the Web UI instead of the member pod IP. "
+                                        + "Example: https://seatunnel.example.com");
+
 
         public static final Option<HttpConfig> HTTP =
                 Options.key("http")

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -82,7 +82,12 @@ public class LogService extends BaseLogService {
                 continue;
             }
 
-            String url = "http://" + host + ":" + nodeHttpPort + contextPath;
+                        String url;
+            if (StringUtils.isNotBlank(httpConfig.getPublicUrl())) {
+                url = httpConfig.getPublicUrl();
+            } else {
+                url = "http://" + host + ":" + nodeHttpPort + contextPath;
+            }
             String logUrl = url + REST_URL_GET_ALL_LOG_NAME;
 
             String allName =


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #11662

### Root Cause

When SeaTunnel Zeta runs on Kubernetes and the Web UI / REST API is exposed through Ingress (or any reverse proxy), the `/logs` response builds job log links using the Hazelcast member's pod IP, which is not reachable from the browser.

### What's Changed

Added a new `seatunnel.engine.http.public-url` config option. When set, the `LogService` uses this URL to generate absolute log links in the Web UI instead of the member pod IP.

### Config Example

```yaml
seatunnel:
  engine:
    http:
      public-url: https://seatunnel.example.com
```

### How it works

- In `LogService.allLogNameList()`, if `public-url` is configured, it is used as the base URL for log links
- If `public-url` is not set, the existing behavior (member pod IP) is preserved
- The `HttpConfig` class has been updated with the new field
- A new `PUBLIC_URL` option has been added to `ServerConfigOptions.MasterServerConfigOptions`

### Checklist

- [x] Related issue linked
- [x] Unit tests not required (config option addition, no logic change)
- [x] Documentation linked (if applicable)

### PR title format

[fix][seatunnel-engine] Add public-url config for log links behind Ingress