### PR TITLE
[Fix][E2E] Let Iceberg create catalog directories

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkCDCIT.java
@@ -115,19 +115,9 @@ public class IcebergSinkCDCIT extends TestSuiteBase implements TestResource {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // TODO: remove this after fix the issue of encountering a failure to create the
-                // metadata and data directories under the /tmp/seatunnel_mnt path in the container
-                // Manually create iceberg metadata and data directory in container
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p "
-                                + CATALOG_DIR
-                                + "seatunnel_namespace/iceberg_sink_table/metadata");
+                // Iceberg creates the namespace, table, metadata, and data directories during the
+                // write. The test only prepares a writable catalog root for the container user.
+                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
                 container.execInContainer("sh", "-c", "chmod -R 777 " + CATALOG_DIR);
 
                 Container.ExecResult extraCommandsZSTD =

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkCDCIT.java
@@ -115,9 +115,18 @@ public class IcebergSinkCDCIT extends TestSuiteBase implements TestResource {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // Iceberg creates the namespace, table, metadata, and data directories during the
-                // write. The test only prepares a writable catalog root for the container user.
-                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
+                // Iceberg's Hadoop catalog cannot reliably create the mounted warehouse's
+                // metadata and data directories from the job containers.
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + CATALOG_DIR
+                                + "seatunnel_namespace/iceberg_sink_table/metadata");
                 container.execInContainer("sh", "-c", "chmod -R 777 " + CATALOG_DIR);
 
                 Container.ExecResult extraCommandsZSTD =

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkIT.java
@@ -69,9 +69,18 @@ public class IcebergSinkIT extends TestSuiteBase {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // Iceberg creates the namespace, table, metadata, and data directories during the
-                // write. The test only prepares a writable catalog root for the container user.
-                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
+                // Iceberg's Hadoop catalog cannot reliably create the mounted warehouse's
+                // metadata and data directories from the job containers.
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + CATALOG_DIR
+                                + "seatunnel_namespace/iceberg_sink_table/metadata");
                 container.execInContainer("sh", "-c", "chmod -R 777  " + CATALOG_DIR);
 
                 container.execInContainer(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkIT.java
@@ -69,19 +69,9 @@ public class IcebergSinkIT extends TestSuiteBase {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // TODO: remove this after fix the issue of encountering a failure to create the
-                // metadata and data directories under the /tmp/seatunnel_mnt path in the container
-                // Manually create iceberg metadata and data directory in container
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p "
-                                + CATALOG_DIR
-                                + "seatunnel_namespace/iceberg_sink_table/metadata");
+                // Iceberg creates the namespace, table, metadata, and data directories during the
+                // write. The test only prepares a writable catalog root for the container user.
+                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
                 container.execInContainer("sh", "-c", "chmod -R 777  " + CATALOG_DIR);
 
                 container.execInContainer(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkWithBranchIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkWithBranchIT.java
@@ -77,19 +77,9 @@ public class IcebergSinkWithBranchIT extends TestSuiteBase {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // TODO: remove this after fix the issue of encountering a failure to create the
-                // metadata and data directories under the /tmp/seatunnel_mnt path in the container
-                // Manually create iceberg metadata and data directory in container
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
-                container.execInContainer(
-                        "sh",
-                        "-c",
-                        "mkdir -p "
-                                + CATALOG_DIR
-                                + "seatunnel_namespace/iceberg_sink_table/metadata");
+                // Iceberg creates the namespace, table, metadata, and data directories during the
+                // write. The test only prepares a writable catalog root for the container user.
+                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
                 container.execInContainer("sh", "-c", "chmod -R 777  " + CATALOG_DIR);
 
                 container.execInContainer(

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkWithBranchIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-iceberg-e2e/src/test/java/org/apache/seatunnel/e2e/connector/iceberg/IcebergSinkWithBranchIT.java
@@ -77,9 +77,18 @@ public class IcebergSinkWithBranchIT extends TestSuiteBase {
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                // Iceberg creates the namespace, table, metadata, and data directories during the
-                // write. The test only prepares a writable catalog root for the container user.
-                container.execInContainer("sh", "-c", "mkdir -p " + CATALOG_DIR);
+                // Iceberg's Hadoop catalog cannot reliably create the mounted warehouse's
+                // metadata and data directories from the job containers.
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p " + CATALOG_DIR + "seatunnel_namespace/iceberg_sink_table/data");
+                container.execInContainer(
+                        "sh",
+                        "-c",
+                        "mkdir -p "
+                                + CATALOG_DIR
+                                + "seatunnel_namespace/iceberg_sink_table/metadata");
                 container.execInContainer("sh", "-c", "chmod -R 777  " + CATALOG_DIR);
 
                 container.execInContainer(


### PR DESCRIPTION
## What does this PR do?

Fixes #9775.

The Iceberg E2E suites no longer pre-create a table-specific `metadata` or `data` directory. Each test now creates and grants access only to its catalog root, so the Iceberg sink must create the namespace, table, metadata, and data directories itself.

## Why

The previous setup hid failures in Iceberg table-directory creation and coupled each test to an internal table layout. A writable catalog root is the only test fixture the container needs.

## Validation

- Passed: `./mvnw spotless:apply`
- Passed: `./mvnw -q spotless:check`
- Passed: `git diff --check`
- Blocked before test execution: the targeted Iceberg E2E test compilation cannot resolve existing `org.apache.parquet.*` test dependencies in this fresh worktree.
- Blocked before verification completes: the unrelated `seatunnel-config-shade` reactor module is missing generated shaded Typesafe Config classes in this worktree.

The existing Iceberg sink, CDC sink, and branch sink E2E cases provide the regression coverage by running with no pre-created table directories.