### PR TITLE
[Docs][Zeta] Add live metrics chart design

### DIFF
--- a/docs/en/engines/zeta/live-metrics-chart.md
+++ b/docs/en/engines/zeta/live-metrics-chart.md
@@ -1,0 +1,141 @@
+# Live Metrics Chart
+
+## Status
+
+This page is the proposed design contract for [issue #11666](https://github.com/apache/seatunnel/issues/11666). The first delivery should turn the existing Job Detail realtime time-series into a selectable live chart without adding another metrics pipeline or copying the Flink Metrics page layout.
+
+The design is intentionally bounded:
+
+- reuse the existing Job Detail Overview page and detail drawer
+- reuse active-master in-memory realtime metrics (`/metrics/realtime/jobs/{jobId}/vertices|edges`)
+- align capability with Flink-style "pick metrics and keep watching", not Flink page structure
+- avoid persistent metric history, alerting, and custom derived expressions in the first version
+
+## Problem
+
+SeaTunnel already returns windowed realtime series through `windowMs`, and the Job Detail drawer already shows those points as a table. Operators still cannot:
+
+- see trend at a glance instead of reading rows
+- keep one or more series visible after closing the vertex or edge drawer
+- compare metrics from more than one vertex or edge side by side
+
+## Existing Foundation
+
+| Area | Existing contract |
+|---|---|
+| Vertex series | `GET /metrics/realtime/jobs/{jobId}/vertices?windowMs=` |
+| Edge series | `GET /metrics/realtime/jobs/{jobId}/edges?windowMs=` |
+| UI polling | Job Detail Overview already polls both endpoints every 2 seconds while the job is running |
+| Window | Default 3 minutes, capped at 10 minutes |
+| Drawer | Clicking a vertex or edge opens the existing detail drawer with key fields and a raw series table |
+
+## Goals
+
+1. Render realtime series as a line chart in addition to, or instead of, the raw table in the drawer.
+2. Let users pin one or more numeric metrics so the chart remains visible after the drawer closes.
+3. Allow comparing pinned metrics from multiple vertices or edges on one chart.
+4. Expose a shared chart component contract that later features such as [#11351](https://github.com/apache/seatunnel/issues/11351) and [#11352](https://github.com/apache/seatunnel/issues/11352) can reuse.
+5. Keep client cost bounded regardless of how many series a user pins.
+
+## Non-Goals
+
+- long-term historical metrics storage or export
+- alerting or threshold notifications
+- arbitrary custom or derived metric expressions
+- redesigning Job Detail into a Flink-like Metrics tab layout
+- adding a second polling loop per pinned metric
+
+## UX Placement
+
+V1 stays on the current Job Detail Overview layout:
+
+```text
+Overview
+├─ DAG
+├─ Pinned live metrics chart panel   ← new
+└─ Existing summary metrics table
+```
+
+- **Drawer**: keep the existing key-field summary above the divider. Replace or augment only the bottom series table with a live line chart and pin controls. Do not redesign the whole drawer.
+- **Pinned panel**: place it between the DAG and the existing Overview summary table so operators can keep watching after the drawer closes.
+- **Layout**: keep SeaTunnel Web UI structure and components. Do not introduce a separate Metrics tab or Flink-style card grid as a hard requirement.
+
+Pin means "keep this metric visible in the Overview chart panel", not a requirement to copy Flink chrome.
+
+## Shared Chart Component Contract
+
+The chart component must be request-agnostic. Pages inject already-fetched series.
+
+```text
+Input series item:
+- id: stable series id, for example vertex:12:sourceReadRatio
+- name: display label
+- points: [{ ts: number, value: number }, ...]
+
+Input chart props:
+- series: series item[]
+- windowMs: number
+- emptyText?: string
+```
+
+Behavior:
+
+- draw one line per series over the existing bounded window
+- sort points by ascending `ts`
+- tolerate repeated buckets from a refresh interval shorter than the collector interval
+- show an empty state when there are no points
+- do not fetch metrics itself
+
+### Chart library
+
+V1 uses **Apache ECharts** in `seatunnel-engine-ui` only.
+
+| Item | Decision |
+|---|---|
+| Library | Apache ECharts |
+| License | Apache License 2.0 (ASF project) |
+| Scope | Chart rendering only; pages still own polling and series mapping |
+
+The implementation PR must call out the ECharts npm dependency and must not add a second chart library.
+
+## Pin Model
+
+Pinned series are session-scoped to the current Job Detail visit:
+
+| Event | Behavior |
+|---|---|
+| Pin from drawer | Add series to the Overview pinned panel |
+| Close drawer | Keep pinned series |
+| Switch Overview / Exception / Configuration / Log | Keep pinned series while staying on the same job page |
+| Leave Job Detail | Clear pinned series |
+| Job reaches a terminal state | Clear pinned series |
+| Exceed pin limit | Reject the new pin and show a short message |
+
+Default pin limit: **6** series.
+
+Pinned series consume the same Overview realtime response already polled for the DAG. Pinning must not create additional REST traffic.
+
+## Refresh, Retention, and Cost
+
+V1 keeps the existing refresh and retention model:
+
+- one job-level poll for vertices and edges every 2 seconds while Overview is open and the job is running
+- default query window 3 minutes, maximum 10 minutes
+- no chart data written to disk
+- concurrent browser users each poll independently, but each client still issues the same two requests per poll interval regardless of pin count
+
+This keeps live-chart cost proportional to today's realtime observability feature.
+
+## Acceptance Criteria
+
+- From Job Detail, a user can pin at least one metric and see it as a live-updating chart without keeping the drawer open.
+- Multiple metrics or vertices can be compared on the same chart.
+- Documented pin limit and shared polling keep memory and request cost bounded.
+- English and Chinese docs describe the behavior.
+
+## Related
+
+- Issue: [#11666](https://github.com/apache/seatunnel/issues/11666)
+- Umbrella: [#11668](https://github.com/apache/seatunnel/issues/11668)
+- Related: [#11351](https://github.com/apache/seatunnel/issues/11351), [#11352](https://github.com/apache/seatunnel/issues/11352)
+- Existing docs: [Realtime Observability](realtime-observability.md), [Web UI](web-ui.md)

--- a/docs/en/engines/zeta/web-ui.md
+++ b/docs/en/engines/zeta/web-ui.md
@@ -73,6 +73,7 @@ On the Job Detail page, the DAG view can display realtime metrics for the recent
 - **Vertex busyness**: busy and idle ratios for Source, Transform, and Sink vertices.
 - **Edge downstream wait ratio**: when the job inserts queues at async boundaries or before Sink IO, edges are colored and thickened by downstream wait ratio and queue fill ratio.
 - **Interaction**: click a vertex or edge to open the detail drawer and view realtime curves and key fields.
+- **Pinned live chart**: pin one or more numeric metrics from the drawer so a live line chart remains visible on Overview after the drawer closes. Multiple vertices or edges can be compared on the same chart. See [Live Metrics Chart](live-metrics-chart.md) for the design contract, pin lifecycle, and cost bounds.
 
 This capability requires the job to enable `env.engine.observability` or configure an option that auto-enables it, such as `async_boundaries` or `split_sink_io`. See [Realtime Observability](realtime-observability.md) for configuration and metric semantics.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -280,6 +280,7 @@ const sidebars = {
                         "engines/zeta/log-analysis-with-ai",
                         "engines/zeta/telemetry",
                         "engines/zeta/busyness-and-backpressure",
+                        "engines/zeta/live-metrics-chart",
                         "engines/zeta/slot-allocation-strategy",
                         "engines/zeta/tuning-guide"
                     ]

--- a/docs/zh/engines/zeta/live-metrics-chart.md
+++ b/docs/zh/engines/zeta/live-metrics-chart.md
@@ -1,0 +1,141 @@
+# 实时指标图（Live Metrics Chart）
+
+## 状态
+
+本页是 [issue #11666](https://github.com/apache/seatunnel/issues/11666) 的设计约定。第一版应把 Job Detail 中已有的实时时序数据做成可选的实时图表，而不是新增指标管线，也不是照搬 Flink Metrics 页面布局。
+
+设计边界：
+
+- 复用现有 Job Detail Overview 与详情抽屉
+- 复用 active master 内存中的实时指标（`/metrics/realtime/jobs/{jobId}/vertices|edges`）
+- 对齐 Flink「挑选指标并持续观察」的能力，而不是对齐 Flink 的页面结构
+- 第一版不做长期历史存储、告警、自定义派生表达式
+
+## 问题
+
+SeaTunnel 已通过 `windowMs` 返回窗口化时序，Job Detail 抽屉也已经用表格展示这些点。运维仍无法：
+
+- 一眼看到趋势，而不是逐行读表
+- 关闭节点/边抽屉后继续保留一条或多条曲线
+- 并排对比多个 vertex/edge 的指标
+
+## 现有基础
+
+| 领域 | 现有契约 |
+|---|---|
+| Vertex 时序 | `GET /metrics/realtime/jobs/{jobId}/vertices?windowMs=` |
+| Edge 时序 | `GET /metrics/realtime/jobs/{jobId}/edges?windowMs=` |
+| UI 轮询 | Job Detail Overview 在作业运行时每 2 秒轮询上述接口 |
+| 窗口 | 默认 3 分钟，最大 10 分钟 |
+| 抽屉 | 点击节点或边打开详情抽屉，展示关键字段与原始时序表 |
+
+## 目标
+
+1. 在抽屉中把实时时序渲染为折线图（可保留或替代原始表格）。
+2. 支持 pin 一条或多条数值指标，关闭抽屉后图表仍可见。
+3. 支持在同一张图上对比来自多个 vertex/edge 的 pin 指标。
+4. 提供可被 [#11351](https://github.com/apache/seatunnel/issues/11351)、[#11352](https://github.com/apache/seatunnel/issues/11352) 复用的共享图表组件契约。
+5. 无论 pin 多少条 series，客户端请求成本保持有界。
+
+## 非目标
+
+- 长期历史指标存储或导出
+- 告警或阈值通知
+- 任意自定义/派生指标表达式
+- 把 Job Detail 改造成 Flink 风格 Metrics 页签布局
+- 为每条 pin 指标增加额外轮询
+
+## 交互落点
+
+V1 仍落在当前 Job Detail Overview 布局：
+
+```text
+Overview
+├─ DAG
+├─ Pin 实时指标图面板   ← 新增
+└─ 现有汇总指标表
+```
+
+- **抽屉**：分隔线上方的关键字段摘要保留；只改分隔线下方的时序表格为实时折线，并提供 pin 操作。不重做整个抽屉。
+- **Pin 面板**：放在 DAG 与 Overview 现有汇总表之间，关闭抽屉后仍可继续观察。
+- **布局**：保持 SeaTunnel Web UI 现有结构与组件风格。不把独立 Metrics 页签或 Flink 风格卡片网格作为硬性要求。
+
+Pin 的含义是「把该指标保留在 Overview 图表面板中」，不是要求复制 Flink 外观。
+
+## 共享图表组件契约
+
+图表组件不负责发请求，由页面注入已拉取的 series。
+
+```text
+series item:
+- id: 稳定 id，例如 vertex:12:sourceReadRatio
+- name: 展示名
+- points: [{ ts: number, value: number }, ...]
+
+chart props:
+- series: series item[]
+- windowMs: number
+- emptyText?: string
+```
+
+行为：
+
+- 在既有有界窗口内为每条 series 画折线
+- 按 `ts` 升序排序
+- 容忍刷新间隔短于采集间隔带来的重复 bucket
+- 无数据时展示空态
+- 不自行请求指标
+
+### 图表库
+
+V1 在 `seatunnel-engine-ui` 中使用 **Apache ECharts**。
+
+| 项 | 决定 |
+|---|---|
+| 库 | Apache ECharts |
+| 协议 | Apache License 2.0（ASF 项目） |
+| 范围 | 只负责渲染；轮询与 series 映射仍由页面完成 |
+
+实现 PR 必须说明新增 ECharts npm 依赖，且不得再并行引入第二套图表库。
+
+## Pin 模型
+
+Pin 作用域为当前 Job Detail 会话：
+
+| 事件 | 行为 |
+|---|---|
+| 从抽屉 pin | 加入 Overview pin 面板 |
+| 关闭抽屉 | 保留已 pin series |
+| 在同一作业页切换 Overview / Exception / Configuration / Log | 保留已 pin series |
+| 离开 Job Detail | 清空 |
+| 作业进入终态 | 清空 |
+| 超过 pin 上限 | 拒绝新增并给出简短提示 |
+
+默认 pin 上限：**6** 条 series。
+
+已 pin series 只消费 Overview 已在轮询的同一份 realtime 响应，不得额外增加 REST 流量。
+
+## 刷新、保留与成本
+
+V1 保持现有刷新与保留模型：
+
+- Overview 打开且作业运行时，每个作业每 2 秒轮询 vertices/edges 各一次
+- 默认查询窗口 3 分钟，最大 10 分钟
+- 图表数据不落盘
+- 多用户各自轮询，但单个客户端无论 pin 多少条，每个轮询周期仍是这两次请求
+
+因此实时图成本与现有 realtime observability 成正比。
+
+## 验收标准
+
+- 在 Job Detail 中至少能 pin 一条指标，并在不保持抽屉打开的情况下看到实时更新的图。
+- 可在同一张图上对比多个指标或 vertex。
+- 文档写明 pin 上限与共享轮询，保证内存与请求成本有界。
+- 同步更新中英文文档。
+
+## 相关链接
+
+- Issue: [#11666](https://github.com/apache/seatunnel/issues/11666)
+- Umbrella: [#11668](https://github.com/apache/seatunnel/issues/11668)
+- Related: [#11351](https://github.com/apache/seatunnel/issues/11351), [#11352](https://github.com/apache/seatunnel/issues/11352)
+- 现有文档：[实时可观测性](realtime-observability.md)、[Web UI](web-ui.md)

--- a/docs/zh/engines/zeta/web-ui.md
+++ b/docs/zh/engines/zeta/web-ui.md
@@ -73,6 +73,7 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 - **节点忙碌度**：Source/Transform/Sink 的忙闲比例（例如 Source Read/Idle，Transform Busy，Sink Busy）。
 - **边的下游等待占比**：当作业在某些位置插入了队列（例如 async boundary 队列、sink 前拆分 IO 队列）时，边会根据下游等待占比与队列填充率进行着色/加粗。
 - **交互**：点击节点或边可在右侧抽屉查看该对象的实时曲线与关键字段。
+- **Pin 实时图**：可从抽屉 pin 一条或多条数值指标，关闭抽屉后 Overview 上仍保留实时折线图，并支持对比多个 vertex/edge。设计约定、pin 生命周期与成本边界见：[实时指标图](live-metrics-chart.md)。
 
 > 该能力需要作业侧开启 `env.engine.observability`（或满足默认开启条件），并按需配置 `async_boundaries`、`split_sink_io` 等。
 > 详细配置与指标说明请参考：[实时可观测性](realtime-observability.md)。


### PR DESCRIPTION
## Purpose

Add the STIP/design contract for issue #11666 before implementation. It defines a Flink-style *capability* for selectable live metrics charts on the existing Job Detail page, without copying the Flink Metrics page layout or adding a new metrics pipeline.

## Changes

- Add English and Chinese live metrics chart design pages.
- Register the new Zeta document in the sidebar.
- Link the design from Web UI documentation.

## Design summary

- Reuse `/metrics/realtime/jobs/{jobId}/vertices|edges` and the current Overview 2s polling; pinning must not add extra REST traffic.
- Drawer: keep the key-field summary; change only the bottom series table into a live line chart with pin controls.
- Pin panel: between the DAG and the existing Overview summary table; session-scoped; max 6 series.
- Chart library: Apache ECharts (Apache-2.0 / ASF) in `seatunnel-engine-ui` only.

## Non-goals

- Long-term historical metrics storage or export
- Alerting / threshold notifications
- Custom derived metric expressions
- Redesigning Job Detail into a Flink-like Metrics tab

## Test plan

- [x] Docs en/zh pages and sidebar id added
- [x] Relative links from `web-ui.md` verified
- [ ] CI docs checks on this PR

## Related

- Issue: #11666
- Umbrella: #11668
- Similar design PR pattern: #11612


Made with [Cursor](https://cursor.com)