### PR TITLE
[Fix][Connector-CDC] Reassign restored splits to waiting readers after checkpoint recovery

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SourceSplitEnumerator.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SourceSplitEnumerator.java
@@ -39,9 +39,9 @@ public interface SourceSplitEnumerator<SplitT extends SourceSplit, StateT>
     void open();
 
     /**
-     * Executes engine setup steps in a fixed, non‑concurrent sequence.
+     * Executes engine setup steps.
      *
-     * <p>Before the first {@link #run()} invocation, methods are called in this order:
+     * <p>Methods are typically called in this order before the first {@link #run()} invocation:
      *
      * <ol>
      *   <li>{@link #open()}
@@ -49,8 +49,10 @@ public interface SourceSplitEnumerator<SplitT extends SourceSplit, StateT>
      *   <li>{@link #registerReader(int)}
      * </ol>
      *
-     * <p>{@implNote The engine guarantees this invocation order and ensures there are no
-     * concurrency issues between these calls.}
+     * <p>{@implNote Implementations must not rely on a strict invocation order: restored splits may
+     * arrive via {@link #addSplitsBack(List, int)} after the reader has already sent its split
+     * request (e.g. after a checkpoint restore), so a waiting reader must be re-assigned when
+     * restored splits are added.}
      */
     void run() throws Exception;
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumerator.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumerator.java
@@ -84,9 +84,15 @@ public class IncrementalSourceEnumerator
     }
 
     @Override
-    public void addSplitsBack(List<SourceSplitBase> splits, int subtaskId) {
+    public synchronized void addSplitsBack(List<SourceSplitBase> splits, int subtaskId) {
         LOG.debug("Incremental Source Enumerator adds splits back: {}", splits);
         splitAssigner.addSplits(splits);
+        // A restored split may arrive after the reader already sent its split request and is
+        // parked in readersAwaitingSplit; re-run the assignment loop so the waiting reader
+        // receives the restored split immediately instead of stalling until another trigger.
+        if (running) {
+            assignSplits();
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/IncrementalSourceEnumeratorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.cdc.base.source.enumerator;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.connectors.cdc.base.source.enumerator.state.PendingSplitsState;
+import org.apache.seatunnel.connectors.cdc.base.source.event.SnapshotSplitWatermark;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SnapshotSplit;
+import org.apache.seatunnel.connectors.cdc.base.source.split.SourceSplitBase;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class IncrementalSourceEnumeratorTest {
+
+    @Test
+    public void shouldAssignRestoredSplitsToWaitingReader() throws Exception {
+        TestingEnumeratorContext context = new TestingEnumeratorContext();
+        TestingSplitAssigner splitAssigner = new TestingSplitAssigner();
+        SourceSplitBase restoredSplit = new SnapshotSplit("restored", null, null, null, null);
+
+        IncrementalSourceEnumerator enumerator =
+                new IncrementalSourceEnumerator(context, splitAssigner);
+        enumerator.open();
+        enumerator.run();
+        enumerator.handleSplitRequest(0);
+        enumerator.addSplitsBack(Collections.singletonList(restoredSplit), 0);
+
+        Assertions.assertEquals(
+                Collections.singletonList(restoredSplit), splitAssigner.restoredSplits);
+        Assertions.assertEquals(Collections.singletonList(restoredSplit), context.assignedSplits);
+    }
+
+    private static final class TestingSplitAssigner implements SplitAssigner {
+        private List<SourceSplitBase> addedSplits = Collections.emptyList();
+        private List<SourceSplitBase> restoredSplits = Collections.emptyList();
+
+        @Override
+        public void open() {}
+
+        @Override
+        public Optional<SourceSplitBase> getNext() {
+            if (addedSplits.isEmpty()) {
+                return Optional.empty();
+            }
+            SourceSplitBase split = addedSplits.get(0);
+            addedSplits = Collections.emptyList();
+            return Optional.of(split);
+        }
+
+        @Override
+        public boolean waitingForCompletedSplits() {
+            return true;
+        }
+
+        @Override
+        public void onCompletedSplits(
+                List<SnapshotSplitWatermark> completedSnapshotSplitWatermarks) {}
+
+        @Override
+        public void addSplits(Collection<SourceSplitBase> splits) {
+            restoredSplits = Collections.unmodifiableList(new ArrayList<>(splits));
+            addedSplits = restoredSplits;
+        }
+
+        @Override
+        public PendingSplitsState snapshotState(long checkpointId) {
+            return null;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+    }
+
+    private static final class TestingEnumeratorContext
+            implements SourceSplitEnumerator.Context<SourceSplitBase> {
+        private List<SourceSplitBase> assignedSplits = Collections.emptyList();
+
+        @Override
+        public int currentParallelism() {
+            return 1;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return Collections.singleton(0);
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<SourceSplitBase> splits) {
+            assignedSplits = splits;
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {}
+
+        @Override
+        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/AbstractMysqlCDCITBase.java
@@ -179,6 +179,147 @@ public abstract class AbstractMysqlCDCITBase extends TestSuiteBase implements Te
             value = {},
             type = {EngineType.SPARK, EngineType.FLINK},
             disabledReason =
+                    "This case verifies Zeta automatic checkpoint recovery after a sink failure.")
+    public void testMysqlCdcContinuesAfterSinkFailure(TestContainer container) throws Exception {
+        // Regression guard for restored-split reassignment after a sink failure. With
+        // parallelism = 1 (see the conf), this clean full-pipeline restart drives the
+        // pre-existing handleSplitRequest() dispatch path: the restored split lands in the
+        // assigner while the enumerator is not yet running, and the reader picks it up via
+        // its requestSplit() -> handleSplitRequest() call. The new running == true branch in
+        // IncrementalSourceEnumerator.addSplitsBack() is covered deterministically by the unit
+        // test IncrementalSourceEnumeratorTest#shouldAssignRestoredSplitsToWaitingReader; this
+        // e2e proves the end-to-end recovery path through the real engine.
+        clearTable(MYSQL_DATABASE, SOURCE_TABLE_1);
+        clearTable(MYSQL_DATABASE, SINK_TABLE);
+        Long jobId = JobIdGenerator.newJobId();
+        upsertDeleteSourceTable(MYSQL_DATABASE, SOURCE_TABLE_1);
+        CompletableFuture<Container.ExecResult> executeJobFuture =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return container.executeJob(
+                                        "/mysqlcdc_to_mysql_with_sink_failure_recovery.conf",
+                                        String.valueOf(jobId));
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        "RUNNING", container.getJobStatus(String.valueOf(jobId))));
+
+        await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertIterableEquals(
+                                        query(getSourceQuerySQL(MYSQL_DATABASE, SOURCE_TABLE_1)),
+                                        query(getSinkQuerySQL(MYSQL_DATABASE, SINK_TABLE))));
+
+        // The test config checkpoints every five seconds. Wait until the snapshot state is
+        // durably checkpointed before failing the incremental CDC stream.
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertTrue(
+                                        container.getCompletedCheckpointCount(String.valueOf(jobId))
+                                                > 0));
+        String triggerName = "fail_cdc_sink_once";
+        executeSql("DROP TRIGGER IF EXISTS " + MYSQL_DATABASE + "." + triggerName);
+        executeSql(
+                "CREATE TRIGGER "
+                        + MYSQL_DATABASE
+                        + "."
+                        + triggerName
+                        + " BEFORE INSERT ON "
+                        + MYSQL_DATABASE
+                        + "."
+                        + SINK_TABLE
+                        + " FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected sink failure'");
+        try {
+            int logOffset = container.getServerLogs().length();
+            executeSql(
+                    "UPDATE "
+                            + MYSQL_DATABASE
+                            + "."
+                            + SOURCE_TABLE_1
+                            + " SET f_bigint = 20000 WHERE id = 5");
+            // The injected trigger makes the JDBC sink's insert fail, so the engine detects
+            // the sink failure and enters the restart cycle (job.retry.interval.seconds = 15).
+            // Wait for a positive signal in the engine log that the injected failure actually
+            // fired instead of a fixed sleep, so the test cannot silently pass without
+            // exercising the recovery path. The job status cannot be used here because on dev
+            // it stays RUNNING throughout the restart window. Once the failure is observed the
+            // finally block removes the trigger, so the post-restart replay of the
+            // f_bigint=20000 binlog event does not hit the trigger a second time.
+            await().atMost(30, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertTrue(
+                                            container
+                                                    .getServerLogs()
+                                                    .substring(logOffset)
+                                                    .contains("injected sink failure"),
+                                            "injected sink failure was not observed in the "
+                                                    + "engine logs after the f_bigint=20000 update"));
+        } finally {
+            executeSql("DROP TRIGGER IF EXISTS " + MYSQL_DATABASE + "." + triggerName);
+        }
+
+        // The job restarts from the last checkpoint and replays the binlog events written
+        // after it (including the f_bigint=20000 update). The trigger must be gone before
+        // that replay reaches the sink, otherwise the restored job fails again. Verify the
+        // trigger was actually dropped, then wait until the job is back to RUNNING (replay
+        // finished) before injecting the next change.
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        0L,
+                                        ((Number)
+                                                        query(
+                                                                        "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema = '"
+                                                                                + MYSQL_DATABASE
+                                                                                + "' AND trigger_name = '"
+                                                                                + triggerName
+                                                                                + "'")
+                                                                .get(0)
+                                                                .get(0))
+                                                .longValue()));
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        "RUNNING", container.getJobStatus(String.valueOf(jobId))));
+
+        executeSql(
+                "UPDATE "
+                        + MYSQL_DATABASE
+                        + "."
+                        + SOURCE_TABLE_1
+                        + " SET f_bigint = 30000 WHERE id = 5");
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertIterableEquals(
+                                        query(getSourceQuerySQL(MYSQL_DATABASE, SOURCE_TABLE_1)),
+                                        query(getSinkQuerySQL(MYSQL_DATABASE, SINK_TABLE))));
+        Assertions.assertEquals("RUNNING", container.getJobStatus(String.valueOf(jobId)));
+        Assertions.assertEquals(0, container.cancelJob(String.valueOf(jobId)).getExitCode());
+        await().atMost(60, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        "CANCELED", container.getJobStatus(String.valueOf(jobId))));
+        Assertions.assertEquals(0, executeJobFuture.get(60, TimeUnit.SECONDS).getExitCode());
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.SPARK, EngineType.FLINK},
+            disabledReason =
                     "Heartbeat action query is currently only supported by the zeta engine.")
     public void testMysqlCdcCheckDataE2eWithHeartbeat(TestContainer container)
             throws InterruptedException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_sink_failure_recovery.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_sink_failure_recovery.conf
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+  job.retry.times = 1
+  job.retry.interval.seconds = 15
+}
+
+source {
+  MySQL-CDC {
+    plugin_output = "customers_mysql_cdc"
+    server-id = 5652
+    username = "st_user_source"
+    password = "mysqlpw"
+    table-names = ["mysql_cdc.mysql_cdc_e2e_source_table"]
+    url = "jdbc:mysql://mysql_cdc_e2e:3306/mysql_cdc"
+  }
+}
+
+transform {
+  sql {
+    plugin_input = "customers_mysql_cdc"
+    query = """ select id, f_binary, f_blob, f_long_varbinary, f_longblob, f_tinyblob, f_varbinary, f_smallint, f_smallint_unsigned, f_mediumint,
+                f_mediumint_unsigned, f_int, f_int_unsigned, f_integer, f_integer_unsigned, f_bigint, f_bigint_unsigned, f_numeric, f_decimal,
+                f_float, f_double, f_double_precision, f_longtext, f_mediumtext, f_text, f_tinytext, f_varchar, f_date, f_datetime, f_timestamp,
+                f_bit1, f_bit64, f_char, f_enum, f_mediumblob, f_long_varchar, f_real, f_time, f_tinyint, f_tinyint_unsigned, f_json, f_year
+                from dual """
+    plugin_output = "trans_mysql_cdc"
+  }
+}
+
+sink {
+  jdbc {
+    plugin_input = "trans_mysql_cdc"
+    url = "jdbc:mysql://mysql_cdc_e2e:3306/mysql_cdc"
+    driver = "com.mysql.cj.jdbc.Driver"
+    user = "st_user_sink"
+    password = "mysqlpw"
+    generate_sink_sql = true
+    database = mysql_cdc
+    table = mysql_cdc_e2e_sink_table
+    primary_keys = ["id"]
+  }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSplitEnumeratorTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSplitEnumeratorTask.java
@@ -238,6 +238,13 @@ public class SourceSplitEnumeratorTask<SplitT extends SourceSplit> extends Coord
         }
         int taskSize = taskMemberMapping.size();
         if (maxReaderSize == taskSize) {
+            // Cross-class invariant: a reader's restoreState() synchronously delivers its
+            // checkpoint-restored splits to the enumerator (RestoredSplitOperation) before it
+            // registers, and run() only fires after every reader has registered below. So in a
+            // clean full-pipeline restart the restored splits normally reach the assigner while
+            // the enumerator is not running yet. That ordering is not guaranteed (multi-reader
+            // interleaving, retry-induced delay), so IncrementalSourceEnumerator.addSplitsBack()
+            // defensively re-runs assignment when the enumerator is already running.
             readerRegisterComplete = true;
             log.debug(String.format("reader register complete, current task size %d", taskSize));
         } else {


### PR DESCRIPTION
closes #11676

## Why

After a CDC job (e.g. MySQL CDC → a JDBC/Doris sink) fails and the engine restarts it from the last successful checkpoint, the source can silently stop producing data: the checkpoint completes, the job stays `RUNNING`, but no records flow. The reader-side restored splits are handed back to the enumerator via `RestoredSplitOperation` → `IncrementalSourceEnumerator.addSplitsBack()`, which only calls `splitAssigner.addSplits(splits)`. When `addSplitsBack()` is invoked while the enumerator is already running and the corresponding reader is parked in `readersAwaitingSplit`, `assignSplits()` is not re-invoked — the split stays in the assigner, the waiting reader does not receive it, and the job can stall on empty checkpoints until another assignment trigger fires.

**Reachability note (per review feedback):** in a clean, full-pipeline restart — the scenario the new e2e test drives with `parallelism = 1` — every reader's `restoreState()` synchronously sends `RestoredSplitOperation` *before* that same reader registers, and the enumerator's `run()` only fires after all readers have registered, so `running` is still `false` when `addSplitsBack()` is invoked and the new branch is a no-op there; the split is dispatched later through the pre-existing `handleSplitRequest()` path. The enumerator-level defect is real and reachable whenever `addSplitsBack()` races `run()`/`handleSplitRequest()` with `running == true` — the most likely production trigger being a partial/regional restart where the enumerator task survives (still `running`) while an individual reader task restarts and hands its restored splits back — which the deterministic unit test `shouldAssignRestoredSplitsToWaitingReader` proves independently of engine timing. The Vitess enumerator (same connector family, separate module) already calls its assignment routine unconditionally right after adding restored splits back, confirming this is the established, deliberate pattern. The fix is therefore best understood as necessary, low-risk defensive hardening at the enumerator's own contract boundary.

This is a different root cause from #10574 (Kafka source restore-offset logic, fixed by #10612): that one is in the Kafka source; this one is in the CDC enumerator's restored-split assignment.

## What changed

### `IncrementalSourceEnumerator.java`

`addSplitsBack()` becomes synchronous: after adding the restored splits to the assigner, if the enumerator is already running, immediately run `assignSplits()` so the splits are dispatched to the currently waiting reader and consumption resumes from the checkpointed offset.

```java
@Override
public synchronized void addSplitsBack(List<SourceSplitBase> splits, int subtaskId) {
    LOG.debug("Incremental Source Enumerator adds splits back: {}", splits);
    splitAssigner.addSplits(splits);
    if (running) {
        assignSplits();
    }
}
```

Non-goals: no checkpoint-semantics change, no sink stream-load/transaction change, no change to the transient sink error handling.

## File changes

| File | Change |
|---|---|
| `connector-cdc/connector-cdc-base/.../source/enumerator/IncrementalSourceEnumerator.java` | +3 (synchronized + `if (running) assignSplits()`) |
| `connector-cdc/connector-cdc-base/src/test/.../enumerator/IncrementalSourceEnumeratorTest.java` | new test `shouldAssignRestoredSplitsToWaitingReader` |
| `seatunnel-e2e/.../connector-cdc-mysql-e2e/.../mysql/AbstractMysqlCDCITBase.java` | new e2e `testMysqlCdcContinuesAfterSinkFailure` |
| `seatunnel-e2e/.../connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql_with_sink_failure_recovery.conf` | new e2e conf |

## Verification

- **Unit test**: `IncrementalSourceEnumeratorTest#shouldAssignRestoredSplitsToWaitingReader` — reader already waiting, restored split must be dispatched immediately.
- **Reproduced on upstream dev (2026-08-06)**: the ported test **fails on the original code** (`expected: <[SnapshotSplit(tableId=null, ...)]> but was: <[]>` — restored split never assigned) and **passes after the fix** (`Tests run: 1, Failures: 0, Errors: 0`, `BUILD SUCCESS`).
- **New official E2E (Zeta + Testcontainers)**: `MysqlCDCIT#testMysqlCdcContinuesAfterSinkFailure` — completes snapshot/checkpoint, asserts RUNNING + source/sink consistency, injects a JDBC sink failure via a temporary MySQL trigger, waits for Zeta auto-restart, removes the trigger, writes new binlog data, and asserts consistency again (validated locally on 2.3.13, 1/1 passed, ~95 s; will run on dev CI).

## Checklist

- [x] Code change complete and verified locally on 2.3.13
- [x] Ported onto `dev` + regression test reproduced the race before the fix and passes after it
- [ ] `mvn spotless:check` passes
- [ ] Related unit tests pass
- [x] Issue(s) referenced: #11676
- [ ] Docs updated if needed (none needed — behavior fix only)

## Note for upstream rebase

`IncrementalSourceEnumerator` on `dev` lives at `connector-cdc/connector-cdc-base/.../source/enumerator/` — same package layout; the patch ports as-is. The enumerator API (`addSplitsBack`, `assignSplits`, `running`) is unchanged on dev.