### PR TITLE
[Fix][Connector-V2] Support Dameng national character types in JDBC connector

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -64,9 +64,11 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_CHAR = "CHAR";
 
     public static final String DM_CHARACTER = "CHARACTER";
+    public static final String DM_NCHAR = "NCHAR";
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
+    public static final String DM_NVARCHAR2 = "NVARCHAR2";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
     public static final String DM_TEXT = "TEXT";
@@ -197,6 +199,13 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
+            case DM_NCHAR:
+                // NCHAR is the fixed-length national character type, the counterpart of NVARCHAR.
+                // Keep the declared type name so it is not reported as CHAR.
+                builder.sourceType(String.format("%s(%s)", DM_NCHAR, typeDefine.getLength()));
+                builder.dataType(BasicType.STRING_TYPE);
+                builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
+                break;
             case DM_VARCHAR:
             case DM_VARCHAR2:
                 builder.sourceType(String.format("%s(%s)", DM_VARCHAR2, typeDefine.getLength()));
@@ -204,7 +213,10 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case DM_NVARCHAR:
-                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
+            case DM_NVARCHAR2:
+                // NVARCHAR2 is the Oracle-compatible synonym of NVARCHAR in Dameng, keep the
+                // declared type name so the source type round-trips unchanged.
+                builder.sourceType(String.format("%s(%s)", dmType, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
@@ -347,6 +347,22 @@ public class DmdbTypeConverterTest {
     }
 
     @Test
+    public void testNchar() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("nchar(2)")
+                        .dataType("nchar")
+                        .length(2L)
+                        .build();
+        Column column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(8, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
+    }
+
+    @Test
     public void testNvarchar() {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()
@@ -356,6 +372,19 @@ public class DmdbTypeConverterTest {
                         .length(2L)
                         .build();
         Column column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(8, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
+
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("nvarchar2(2)")
+                        .dataType("nvarchar2")
+                        .length(2L)
+                        .build();
+        column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
         Assertions.assertEquals(typeDefine.getName(), column.getName());
         Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
         Assertions.assertEquals(8, column.getColumnLength());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDmIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDmIT.java
@@ -81,8 +81,10 @@ public class JdbcDmIT extends AbstractJdbcIT {
                     + "\n"
                     + "    DM_CHAR             CHAR,\n"
                     + "    DM_CHARACTER        CHARACTER,\n"
+                    + "    DM_NCHAR            NCHAR(50),\n"
                     + "    DM_VARCHAR          VARCHAR,\n"
                     + "    DM_VARCHAR2         VARCHAR2,\n"
+                    + "    DM_NVARCHAR2        NVARCHAR2(50),\n"
                     + "    DM_TEXT             TEXT,\n"
                     + "    DM_LONG             LONG,\n"
                     + "    DM_LONGVARCHAR      LONGVARCHAR,\n"
@@ -159,8 +161,10 @@ public class JdbcDmIT extends AbstractJdbcIT {
                     "DM_DOUBLE",
                     "DM_CHAR",
                     "DM_CHARACTER",
+                    "DM_NCHAR",
                     "DM_VARCHAR",
                     "DM_VARCHAR2",
+                    "DM_NVARCHAR2",
                     "DM_TEXT",
                     "DM_LONG",
                     "DM_LONGVARCHAR",
@@ -199,8 +203,14 @@ public class JdbcDmIT extends AbstractJdbcIT {
                                 Double.parseDouble("1.1"),
                                 'f',
                                 'f',
+                                // DM_NCHAR: multi-byte content exercises the national
+                                // character path
+                                String.format("达梦_%s", i),
                                 String.format("f1_%s", i),
                                 String.format("f1_%s", i),
+                                // DM_NVARCHAR2: multi-byte content exercises the national
+                                // character path
+                                String.format("达梦_%s", i),
                                 String.format("f1_%s", i),
                                 String.format("{\"aa\":\"bb_%s\"}", i),
                                 String.format("f1_%s", i),

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/resources/jdbc_dm_source_and_sink.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/resources/jdbc_dm_source_and_sink.conf
@@ -41,9 +41,9 @@ sink {
     password = "SYSDBA"
     query = """
 INSERT INTO SYSDBA.e2e_table_sink (DM_BIT, DM_INT, DM_INTEGER, DM_PLS_INTEGER, DM_TINYINT, DM_BYTE, DM_SMALLINT, DM_BIGINT, DM_NUMERIC, DM_NUMBER,
- DM_DECIMAL, DM_DEC, DM_REAL, DM_FLOAT, DM_DOUBLE_PRECISION, DM_DOUBLE, DM_CHAR, DM_CHARACTER, DM_VARCHAR, DM_VARCHAR2, DM_TEXT, DM_LONG,
+ DM_DECIMAL, DM_DEC, DM_REAL, DM_FLOAT, DM_DOUBLE_PRECISION, DM_DOUBLE, DM_CHAR, DM_CHARACTER, DM_NCHAR, DM_VARCHAR, DM_VARCHAR2, DM_NVARCHAR2, DM_TEXT, DM_LONG,
  DM_LONGVARCHAR, DM_CLOB, DM_TIMESTAMP, DM_DATETIME, DM_DATE, DM_BLOB, DM_BINARY, DM_VARBINARY, DM_LONGVARBINARY, DM_IMAGE, DM_BFILE)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
   }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10635 and #11688.

`DmdbTypeConverter` handles `CHAR`, `CHARACTER`, `VARCHAR` and `VARCHAR2`, but among the national character types it only handles `NVARCHAR`. Reading a Dameng table with `NCHAR` or `NVARCHAR2` columns falls through to the `default` branch and fails:

```
ErrorCode:[COMMON-17], ErrorDescription:['Dameng' unsupported convert type 'nvarchar2' of 'test' to SeaTunnel data type.]
ErrorCode:[COMMON-17], ErrorDescription:['Dameng' unsupported convert type 'nchar' of 'test' to SeaTunnel data type.]
```

In a multi-table job (`table_list`) the catalog aggregates these into the `COMMON-21` error reported in #10635, and the whole job fails before any data is read:

```
ErrorCode:[COMMON-21], ErrorDescription:['Dameng' tables unsupported get catalog table，
the corresponding field types in the following tables are not supported:
'{"test.test_nvarchar2":{"id":"nvarchar2","name":"nvarchar2","age":"nvarchar2"}}'
```

`NVARCHAR2` is the Oracle-compatible synonym of `NVARCHAR`, and `NCHAR` is its fixed-length counterpart. Supporting `NVARCHAR` but neither of the other two is an oversight rather than an intentional restriction, so this PR completes the family in one change.

**Length rule.** Every character type in this converter — `CHAR`, `CHARACTER`, `VARCHAR`, `VARCHAR2` and `NVARCHAR` — uses `charTo4ByteLength`. Both new types follow the same rule, so no new length behaviour is introduced and no assumption is made about how Dameng reports lengths. That matters here, because Dameng's `LENGTH_IN_CHAR` parameter makes byte-vs-character length a database-level setting.

**Source type.** `NVARCHAR2` shares the `NVARCHAR` branch but `sourceType` is now built from the matched type name rather than the hard-coded constant, so `NVARCHAR` keeps reporting `NVARCHAR(n)` exactly as before. `NCHAR` gets its own case rather than joining `CHAR`/`CHARACTER`, because that branch rewrites `sourceType` to the `CHAR` constant and would report `NCHAR` columns as `CHAR(n)`.

> Scope note: this PR previously covered only `NVARCHAR2`. #11689 covered `NCHAR` separately, and the two overlapped in the same E2E table. They are folded together here as a single national-character-type fix, and #11689 has been closed in favour of this PR.

### Does this PR introduce _any_ user-facing change?

Yes, in the sense that previously failing configurations now work: Dameng tables containing `NCHAR` or `NVARCHAR2` columns can now be read by the JDBC source, and those columns map to SeaTunnel `STRING`.

No config option, default value, or existing type mapping changes. `NVARCHAR` behaviour is byte-for-byte identical to before and the other two cases are purely additive, so this is backward compatible.

### How was this patch tested?

**Unit tests.** Extended `DmdbTypeConverterTest#testNvarchar` with an `nvarchar2(2)` case and added `testNchar`, each asserting the mapped data type, column length and source type.

```
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=DmdbTypeConverterTest
Tests run: 35, Failures: 0, Errors: 0, Skipped: 0
```

Reverting only the `DmdbTypeConverter` change makes both fail with the reported errors, confirming they are genuine regression tests:

```
[ERROR] testNvarchar » SeaTunnelRuntime ErrorCode:[COMMON-17] ... unsupported convert type 'nvarchar2'
[ERROR] testNchar    » SeaTunnelRuntime ErrorCode:[COMMON-17] ... unsupported convert type 'nchar'
```

**E2E test.** `JdbcDmIT` previously covered `CHAR`, `CHARACTER`, `VARCHAR` and `VARCHAR2` but no national character type at all, which is likely why this gap went unnoticed. Added `DM_NCHAR NCHAR(50)` and `DM_NVARCHAR2 NVARCHAR2(50)`, together with the matching `fieldNames` entries, row values and the explicit insert column list in `jdbc_dm_source_and_sink.conf`. Both are populated with multi-byte content so the national character path is exercised end to end. `JdbcDmUpsetIT` declares its own table and is unaffected.

I could not run this suite locally — Docker is unavailable in my environment — so the `laglangyue/dmdb8` container path is validated by CI rather than by me. `./mvnw test-compile` on `connector-jdbc-e2e-part-5` passes, and the `CREATE_SQL` columns, `fieldNames`, row array, insert column list and placeholder count are all consistent at 35 entries.

`./mvnw spotless:apply` was run over both modules.

### Related follow-up (not in this PR)

`DamengCatalog#SELECT_COLUMNS_SQL` omits the national character types from the `CASE` branch that appends the length to `SOURCE_TYPE`, so those columns report a bare type name without `(n)`. That is cosmetic, does not affect this failure, and I could not verify Dameng's `DATA_LENGTH` semantics for national character types without a real instance. Happy to open a separate issue for it.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependency
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — not applicable, no option or documented behaviour changed
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR — not applicable, change is backward compatible
* [x] If you are contributing the connector code, please check that the following files are updated — not applicable, no new connector; E2E coverage added to the existing `JdbcDmIT`
