### PR TITLE
[Fix][Connector-V2] Support YashanDB VARCHAR2 and NVARCHAR2 type conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
@@ -71,12 +71,17 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
     // ============================ Character Data Types ============================
 
     // CHAR: [1,8000] bytes; VARCHAR: [1,65534] bytes
+    // VARCHAR2 is the Oracle-compatible synonym of VARCHAR and shares its byte length semantics.
     public static final String CHAR = "CHAR";
     public static final String VARCHAR = "VARCHAR";
+    public static final String VARCHAR2 = "VARCHAR2";
 
     // NCHAR: [1,4000]; NVARCHAR: [1,32767] (Unicode)
+    // NVARCHAR2 is the Oracle-compatible synonym of NVARCHAR and shares its character length
+    // semantics.
     public static final String NCHAR = "NCHAR";
     public static final String NVARCHAR = "NVARCHAR";
+    public static final String NVARCHAR2 = "NVARCHAR2";
 
     // ============================ Date & Time Data Types ============================
 
@@ -213,11 +218,13 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 // ====================== Character types ======================
             case CHAR:
             case VARCHAR:
+            case VARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case NCHAR:
             case NVARCHAR:
+            case NVARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(
                         TypeDefineUtils.doubleByteTo4ByteLength(typeDefine.getLength()));

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverterTest.java
@@ -257,6 +257,36 @@ public class YashanDbTypeConverterTest {
         column = INSTANCE.convert(typeDefine);
         Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
         Assertions.assertEquals(200L, column.getColumnLength());
+
+        // VARCHAR2 is an alias of VARCHAR and must behave identically.
+        // YashanDbCatalog always feeds BasicTypeDefine#length from cols.data_length, which is a
+        // byte count, so a declared VARCHAR2(200) arrives as length=200 -> 200 * 4.
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("VARCHAR2(200)")
+                        .dataType("VARCHAR2")
+                        .length(200L)
+                        .build();
+        column = INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(800L, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+
+        // NVARCHAR2 is an alias of NVARCHAR and must behave identically.
+        // A declared NVARCHAR2(100) holds 100 characters at 2 bytes each, so data_length is 200
+        // and the double-byte rule yields 200 * 2 = 400, i.e. 100 characters at 4 bytes.
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("NVARCHAR2(100)")
+                        .dataType("NVARCHAR2")
+                        .length(200L)
+                        .build();
+        column = INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(400L, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
     }
 
     @Test

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcYashanDbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcYashanDbIT.java
@@ -71,6 +71,8 @@ public class JdbcYashanDbIT extends AbstractJdbcIT {
                     + "    YAS_NUMBER        NUMBER(10, 2),\n"
                     + "    YAS_CHAR          CHAR(20),\n"
                     + "    YAS_VARCHAR       VARCHAR(200),\n"
+                    + "    YAS_VARCHAR2      VARCHAR2(200),\n"
+                    + "    YAS_NVARCHAR2     NVARCHAR2(100),\n"
                     + "    YAS_CLOB          CLOB,\n"
                     + "    YAS_DATE          DATE,\n"
                     + "    YAS_TIMESTAMP     TIMESTAMP,\n"
@@ -89,6 +91,8 @@ public class JdbcYashanDbIT extends AbstractJdbcIT {
                 "YAS_NUMBER",
                 "YAS_CHAR",
                 "YAS_VARCHAR",
+                "YAS_VARCHAR2",
+                "YAS_NVARCHAR2",
                 "YAS_CLOB",
                 "YAS_DATE",
                 "YAS_TIMESTAMP",
@@ -155,6 +159,9 @@ public class JdbcYashanDbIT extends AbstractJdbcIT {
                                 BigDecimal.valueOf(i, 2),
                                 String.format("char_%s", i),
                                 String.format("varchar_%s", i),
+                                String.format("varchar2_%s", i),
+                                // multi-byte content exercises the NVARCHAR2 length rule
+                                String.format("崖山_%s", i),
                                 String.format("clob_%s", i),
                                 Date.valueOf(rowDate),
                                 Timestamp.valueOf(rowDateTime),

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_yashandb_source_to_sink.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/resources/jdbc_yashandb_source_to_sink.conf
@@ -41,7 +41,7 @@ sink {
     user = "SYS"
     password = "Cod-2022"
     query = """INSERT INTO SYS.E2E_TABLE_SINK
-             (YAS_TINYINT, YAS_SMALLINT, YAS_INT, YAS_BIGINT, YAS_FLOAT, YAS_DOUBLE, YAS_NUMBER, YAS_CHAR, YAS_VARCHAR, YAS_CLOB, YAS_DATE, YAS_TIMESTAMP, YAS_BOOLEAN)
-             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+             (YAS_TINYINT, YAS_SMALLINT, YAS_INT, YAS_BIGINT, YAS_FLOAT, YAS_DOUBLE, YAS_NUMBER, YAS_CHAR, YAS_VARCHAR, YAS_VARCHAR2, YAS_NVARCHAR2, YAS_CLOB, YAS_DATE, YAS_TIMESTAMP, YAS_BOOLEAN)
+             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
   }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11685.

`YashanDbTypeConverter` has cases for `CHAR`/`VARCHAR` and `NCHAR`/`NVARCHAR`, but not for the Oracle-compatible synonyms `VARCHAR2` and `NVARCHAR2`. Reading a YashanDB table containing such columns falls through to the `default` branch and fails:

```
ErrorCode:[COMMON-17], ErrorDescription:['YashanDB' unsupported convert type 'VARCHAR2' of 'test' to SeaTunnel data type.]
```

Per the YashanDB character type documentation, `VARCHAR2` is an alias of `VARCHAR` and `NVARCHAR2` is an alias of `NVARCHAR`, where an `NVARCHAR` declaration length is a character count stored at two bytes per character. Each synonym therefore joins the branch of the type it aliases, so it behaves identically:

| Type | Aliases | Converter branch |
| --- | --- | --- |
| `VARCHAR2` | `VARCHAR` | joins `CHAR`/`VARCHAR` → `charTo4ByteLength` |
| `NVARCHAR2` | `NVARCHAR` | joins `NCHAR`/`NVARCHAR` → `doubleByteTo4ByteLength` |

`convert()` sets `sourceType` centrally from `typeDefine.getColumnType()`, so the declared type name is preserved automatically and no per-branch handling is needed.

`reconvert()` (sink direction) is unchanged: it continues to emit `VARCHAR` for `STRING` columns.

### Does this PR introduce _any_ user-facing change?

Yes, in the sense that a previously failing configuration now works: YashanDB tables containing `VARCHAR2` or `NVARCHAR2` columns can now be read, and those columns map to SeaTunnel `STRING`.

No config option, default value, or existing type mapping changes. The added cases are purely additive — `CHAR`, `VARCHAR`, `NCHAR` and `NVARCHAR` behave exactly as before — so this is backward compatible.

### How was this patch tested?

**Unit test.** Extended `YashanDbTypeConverterTest#testConvertCharTypes` with `VARCHAR2` and `NVARCHAR2` cases.

The lengths used reflect the real catalog contract rather than the declared type text. `YashanDbCatalog#buildColumn` populates `BasicTypeDefine#length` from `COLUMN_LENGTH`, which is aliased from `cols.data_length` for every type — a byte count. The `cols.char_length` branch in the same query only feeds the `FULL_TYPE_NAME` display string, not the length. So a declared `NVARCHAR2(100)` reaches the converter as `length=200`, and `doubleByteTo4ByteLength` maps that to 400, i.e. 100 characters at 4 bytes.

```
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=YashanDbTypeConverterTest
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
```

Reverting only the `YashanDbTypeConverter` change makes the test fail with the reported error, confirming it is a genuine regression test:

```
[ERROR] testConvertCharTypes  Time elapsed: 0.089 s  <<< ERROR!
org.apache.seatunnel.common.exception.SeaTunnelRuntimeException: ErrorCode:[COMMON-17],
ErrorDescription:['YashanDB' unsupported convert type 'VARCHAR2' of 'test' to SeaTunnel data type.]
```

**E2E test.** Added `YAS_VARCHAR2 VARCHAR2(200)` and `YAS_NVARCHAR2 NVARCHAR2(100)` to `JdbcYashanDbIT`, along with the matching field list and the explicit insert column list in `jdbc_yashandb_source_to_sink.conf`. The `NVARCHAR2` column is populated with multi-byte content so the double-byte length rule is exercised end to end rather than only through ASCII data.

I could not run this suite locally — Docker is unavailable in my environment — so the `yasdb/yashandb:23.4.7.100` container path is validated by CI rather than by me. `./mvnw test-compile` on `connector-jdbc-e2e-part-7` passes.

`./mvnw spotless:apply` was run over both modules.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependency
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — not applicable, no option or documented behaviour changed
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR — not applicable, change is backward compatible
* [x] If you are contributing the connector code, please check that the following files are updated — not applicable, no new connector; E2E coverage added to the existing `JdbcYashanDbIT`
