### PR TITLE
[Docs][Connector-V2] Improve Databend connector docs

### DIFF
--- a/docs/en/connectors/sink/Databend.md
+++ b/docs/en/connectors/sink/Databend.md
@@ -4,7 +4,7 @@ import ChangeLog from '../changelog/connector-databend.md';
 
 > Databend sink connector
 
-## Supported Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -12,10 +12,10 @@ import ChangeLog from '../changelog/connector-databend.md';
 
 ## Key Features
 
-- [ ] [Support Multi-table Writing](../../introduction/concepts/connector-v2-features.md)
-- [x] [Exactly-Once](../../introduction/concepts/connector-v2-features.md)
-- [x] [CDC](../../introduction/concepts/connector-v2-features.md)
-- [x] [Parallelism](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
@@ -32,6 +32,15 @@ The Databend sink internally implements bulk data import through stage attachmen
 ### For SeaTunnel Zeta
 
 > 1. You need to download the [Databend JDBC driver jar package](https://github.com/databendlabs/databend-jdbc/) and add it to the directory `${SEATUNNEL_HOME}/lib/`.
+
+## Supported DataSource Info
+
+In order to use the Databend connector, the following dependencies are required.
+They can be downloaded via install-plugin.sh or from the Maven central repository.
+
+| Datasource | Supported Versions | Dependency                                                                             |
+|------------|--------------------|----------------------------------------------------------------------------------------|
+| Databend   | 1.2.x and above    | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-databend) |
 
 ## Sink Options
 
@@ -52,6 +61,7 @@ The Databend sink internally implements bulk data import through stage attachmen
 | jdbc_config         | Map | No | - | Additional JDBC connection configuration, such as connection timeout parameters             |
 | conflict_key        | String | No | - | Conflict key for CDC mode, used to determine the primary key for conflict resolution |
 | enable_delete       | Boolean | No | false | Whether to allow delete operations in CDC mode |
+| common-options      |  | No | - | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details. |
 
 ### schema_save_mode [Enum]
 
@@ -161,7 +171,54 @@ Set `conflict_key` to the primary-key column used to merge update/delete events.
 `enable_delete = true` only when DELETE events should remove rows from Databend.
 If `conflict_key` is not configured, the sink writes normal insert-style batches.
 
+The following end-to-end example feeds CDC row kinds (`INSERT`, `UPDATE_BEFORE`,
+`UPDATE_AFTER`, `DELETE`) into Databend. The sink merges updates and applies deletes
+against the rows identified by `conflict_key`.
+
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  checkpoint.interval = 1000
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    schema = {
+      fields {
+        id = "int"
+        name = "string"
+        position = "string"
+        age = "int"
+        score = "double"
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [1, "Alice", "Engineer", 30, 95.5]
+      },
+      {
+        kind = INSERT
+        fields = [2, "Bob", "Developer", 25, 85.0]
+      },
+      {
+        kind = UPDATE_BEFORE
+        fields = [2, "Bob", "Developer", 25, 85.0]
+      },
+      {
+        kind = UPDATE_AFTER
+        fields = [2, "Bob", "Senior Developer", 25, 87.0]
+      },
+      {
+        kind = DELETE
+        fields = [2, "Bob", "Senior Developer", 25, 87.0]
+      }
+    ]
+  }
+}
+
 sink {
   Databend {
     url = "jdbc:databend://databend:8000/default?ssl=false"
@@ -169,7 +226,7 @@ sink {
     password = ""
     database = "default"
     table = "sink_table"
-    
+
     # Enable CDC mode
     batch_size = 1
     conflict_key = "id"

--- a/docs/en/connectors/source/Databend.md
+++ b/docs/en/connectors/source/Databend.md
@@ -4,7 +4,7 @@ import ChangeLog from '../changelog/connector-databend.md';
 
 > Databend source connector
 
-## Supported Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -13,11 +13,11 @@ import ChangeLog from '../changelog/connector-databend.md';
 
 ## Key Features
 
-- [x] [Batch Processing](../../introduction/concepts/connector-v2-features.md)
-- [ ] [Stream Processing](../../introduction/concepts/connector-v2-features.md)
-- [x] [Parallelism](../../introduction/concepts/connector-v2-features.md)
-- [ ] [Support User-defined Sharding](../../introduction/concepts/connector-v2-features.md)
-- [ ] [Support Multi-table Reading](../../introduction/concepts/connector-v2-features.md)
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
 
@@ -33,11 +33,14 @@ A source connector for reading data from Databend.
 
 > 1. You need to download the [Databend JDBC driver jar package](https://github.com/databendlabs/databend-jdbc/) and add it to the directory `${SEATUNNEL_HOME}/lib/`.
 
-## Supported Data Source Information
+## Supported DataSource Info
 
-| Data Source | Supported Version | Driver | URL | Maven |
-|-------------|-------------------|--------|-----|-------|
-| Databend | 1.2.x and above | - | - | - |
+In order to use the Databend connector, the following dependencies are required.
+They can be downloaded via install-plugin.sh or from the Maven central repository.
+
+| Datasource | Supported Versions | Dependency                                                                             |
+|------------|--------------------|----------------------------------------------------------------------------------------|
+| Databend   | 1.2.x and above    | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-databend) |
 
 ## Data Type Mapping
 
@@ -72,9 +75,10 @@ Basic Configuration:
 | table | String | No | - | Databend table name |
 | query | String | No | - | Databend query statement. If set, it overrides database and table settings |
 | sql | String | No | - | Alias-style custom SQL statement. If both `sql` and `query` are set, `sql` takes precedence |
-| fetch_size | Integer | No | 1 | Number of records to fetch from Databend at once. Set it higher for large reads |
+| fetch_size | Integer | No | 1 | Number of records to fetch from Databend at once. Set it higher for large reads. Set to `0` to use the JDBC driver default |
 | ssl | Boolean | No | false | Whether to use SSL for the Databend connection |
 | jdbc_config | Map | No | - | Additional JDBC connection configuration, such as load balancing strategies |
+| common-options |  | No | - | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details. |
 
 You must configure either `sql`, `query`, or both `database` and `table`. When more than one of them is configured, the read SQL is chosen in this order: `sql`, then `query`, then `SELECT * FROM database.table`. The connector does not currently support `table_list`, so configure one Databend source block for each table.
 

--- a/docs/zh/connectors/sink/Databend.md
+++ b/docs/zh/connectors/sink/Databend.md
@@ -33,6 +33,14 @@ Databend sink 内部通过 stage attachment 实现数据的批量导入。
 
 > 1. 你需要下载 [Databend JDBC driver jar package](https://github.com/databendlabs/databend-jdbc/) 并添加到目录 `${SEATUNNEL_HOME}/lib/`.
 
+## 支持的数据源信息
+
+为了使用 Databend 连接器，需要以下依赖项。它们可以通过 install-plugin.sh 或从 Maven 中央存储库下载。
+
+| 数据源   | 支持的版本        | 依赖                                                                                   |
+|----------|-------------------|----------------------------------------------------------------------------------------|
+| Databend | 1.2.x 及以上版本  | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-databend) |
+
 ## Sink 选项
 
 | 名称                  | 类型 | 是否必须 | 默认值 | 描述                                 |
@@ -52,6 +60,7 @@ Databend sink 内部通过 stage attachment 实现数据的批量导入。
 | jdbc_config         | Map | 否 | - | 额外的 JDBC 连接配置，如连接超时参数等             |
 | conflict_key        | String | 否 | - | cdc 模式下的冲突键，用于确定冲突解决的主键 |
 | enable_delete       | Boolean | 否 | false | cdc 模式下是否允许删除操作 |
+| common-options      |  | 否 | - | Sink 插件通用参数，详见 [Sink 常用选项](../common-options/sink-common-options.md)。 |
 
 ### schema_save_mode [Enum]
 
@@ -161,7 +170,53 @@ sink {
 Databend 中的数据时，才需要设置 `enable_delete = true`。
 如果不配置 `conflict_key`，sink 会按普通批量插入方式写入。
 
+下面的端到端示例将 CDC 行类型（`INSERT`、`UPDATE_BEFORE`、`UPDATE_AFTER`、`DELETE`）
+写入 Databend。sink 会根据 `conflict_key` 指定的主键合并更新并执行删除。
+
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+  checkpoint.interval = 1000
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    schema = {
+      fields {
+        id = "int"
+        name = "string"
+        position = "string"
+        age = "int"
+        score = "double"
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [1, "Alice", "Engineer", 30, 95.5]
+      },
+      {
+        kind = INSERT
+        fields = [2, "Bob", "Developer", 25, 85.0]
+      },
+      {
+        kind = UPDATE_BEFORE
+        fields = [2, "Bob", "Developer", 25, 85.0]
+      },
+      {
+        kind = UPDATE_AFTER
+        fields = [2, "Bob", "Senior Developer", 25, 87.0]
+      },
+      {
+        kind = DELETE
+        fields = [2, "Bob", "Senior Developer", 25, 87.0]
+      }
+    ]
+  }
+}
+
 sink {
   Databend {
     url = "jdbc:databend://databend:8000/default?ssl=false"
@@ -169,7 +224,7 @@ sink {
     password = ""
     database = "default"
     table = "sink_table"
-    
+
     # 开启 CDC 写入模式
     batch_size = 1
     conflict_key = "id"

--- a/docs/zh/connectors/source/Databend.md
+++ b/docs/zh/connectors/source/Databend.md
@@ -34,9 +34,11 @@ import ChangeLog from '../changelog/connector-databend.md';
 
 ## 支持的数据源信息
 
-| 数据源 | 支持版本 | 驱动 | Url | Maven |
-|--------|----------|------|-----|-------|
-| Databend | 1.2.x 及以上版本 | - | - | - |
+为了使用 Databend 连接器，需要以下依赖项。它们可以通过 install-plugin.sh 或从 Maven 中央存储库下载。
+
+| 数据源   | 支持的版本        | 依赖                                                                                   |
+|----------|-------------------|----------------------------------------------------------------------------------------|
+| Databend | 1.2.x 及以上版本  | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-databend) |
 
 ## 数据类型映射
 
@@ -71,9 +73,10 @@ import ChangeLog from '../changelog/connector-databend.md';
 | table | String | 否 | - | Databend 表名称 |
 | query | String | 否 | - | Databend 查询语句。如果设置，会覆盖 database 和 table 的设置 |
 | sql | String | 否 | - | 自定义 SQL 语句。若同时配置 `sql` 和 `query`，优先使用 `sql` |
-| fetch_size | Integer | 否 | 1 | 每次从 Databend 拉取的记录数。读取大量数据时可以适当调大 |
+| fetch_size | Integer | 否 | 1 | 每次从 Databend 拉取的记录数。读取大量数据时可以适当调大。设为 `0` 使用 JDBC 驱动默认值 |
 | ssl | Boolean | 否 | false | 是否使用 SSL 连接 Databend |
 | jdbc_config | Map | 否 | - | 额外的 JDBC 连接配置，如加载均衡策略等 |
+| common-options |  | 否 | - | 源插件常用参数，详见 [源通用选项](../common-options/source-common-options.md). |
 
 必须配置 `sql`、`query`、或同时配置 `database` 和 `table`。如果同时配置了多个读取入口，实际读取 SQL 的优先级是：`sql`、`query`、最后是 `SELECT * FROM database.table`。当前连接器不支持 `table_list`，如果要读多张表，请为每张表分别配置一个 Databend source。
 


### PR DESCRIPTION
## Purpose of this PR

The Databend source and sink documentation had several gaps and inconsistencies compared with the connector code and the conventions used across the connector-v2 docs. This PR cleans them up based on the connector code (`DatabendSourceFactory`, `DatabendSinkFactory`, `DatabendSinkConfig`) and the connector e2e examples.

## Changes

- **Section headings & feature labels**: Standardized the `## Support Those Engines` and `## Supported DataSource Info` headings, and switched the EN Key Feature labels to the canonical lowercase forms used across connector-v2 docs (`batch`, `stream`, `exactly-once`, `cdc`, `parallelism`, `support user-defined split`, `support multiple table read` / `support multiple table write`, `timer flush`). The `[x]`/`[ ]` markings are unchanged and match the implementation (e.g. exactly-once via the sink's two-phase committer, CDC via `conflict_key`/`enable_delete`, no multi-table write).
- **Supported DataSource Info**: Fixed the malformed source table (empty `Driver`/`URL`/`Maven` columns) and added the missing sink section, both with the standard `Datasource | Supported Versions | Dependency` shape and the `connector-databend` Maven download link.
- **common-options**: Added the missing `common-options` rows to the source and sink option tables, linking to the common-options docs.
- **CDC example**: Expanded the sink CDC example from a sink-only snippet into an end-to-end flow that emits `INSERT`/`UPDATE_BEFORE`/`UPDATE_AFTER`/`DELETE` row kinds, demonstrating `conflict_key` merge and `enable_delete` behavior.
- **fetch_size**: Noted that `fetch_size = 0` falls back to the JDBC driver default, matching the option description in code.

## Notes

- Both EN and ZH (`docs/en/connectors/{source,sink}/Databend.md` and `docs/zh/connectors/{source,sink}/Databend.md`) are updated and kept consistent.
- The option list was verified against the connector `OptionRule` and `DatabendSinkConfig` (including the CDC-only `conflict_key` / `enable_delete` options that are read from config).
- Documentation only; no code or version numbers were changed.
