### PR TITLE
[Fix][Connector-V2] Support Dameng NCHAR type conversion in JDBC connector

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -64,6 +64,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_CHAR = "CHAR";
 
     public static final String DM_CHARACTER = "CHARACTER";
+    public static final String DM_NCHAR = "NCHAR";
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
@@ -194,6 +195,13 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
             case DM_CHAR:
             case DM_CHARACTER:
                 builder.sourceType(String.format("%s(%s)", DM_CHAR, typeDefine.getLength()));
+                builder.dataType(BasicType.STRING_TYPE);
+                builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
+                break;
+            case DM_NCHAR:
+                // NCHAR is the fixed-length national character type, the counterpart of NVARCHAR.
+                // Keep the declared type name so it is not reported as CHAR.
+                builder.sourceType(String.format("%s(%s)", DM_NCHAR, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
@@ -347,6 +347,22 @@ public class DmdbTypeConverterTest {
     }
 
     @Test
+    public void testNchar() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("nchar(2)")
+                        .dataType("nchar")
+                        .length(2L)
+                        .build();
+        Column column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(8, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
+    }
+
+    @Test
     public void testNvarchar() {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDmIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcDmIT.java
@@ -81,6 +81,7 @@ public class JdbcDmIT extends AbstractJdbcIT {
                     + "\n"
                     + "    DM_CHAR             CHAR,\n"
                     + "    DM_CHARACTER        CHARACTER,\n"
+                    + "    DM_NCHAR            NCHAR(50),\n"
                     + "    DM_VARCHAR          VARCHAR,\n"
                     + "    DM_VARCHAR2         VARCHAR2,\n"
                     + "    DM_TEXT             TEXT,\n"
@@ -159,6 +160,7 @@ public class JdbcDmIT extends AbstractJdbcIT {
                     "DM_DOUBLE",
                     "DM_CHAR",
                     "DM_CHARACTER",
+                    "DM_NCHAR",
                     "DM_VARCHAR",
                     "DM_VARCHAR2",
                     "DM_TEXT",
@@ -199,6 +201,9 @@ public class JdbcDmIT extends AbstractJdbcIT {
                                 Double.parseDouble("1.1"),
                                 'f',
                                 'f',
+                                // DM_NCHAR: multi-byte content exercises the national
+                                // character path
+                                String.format("达梦_%s", i),
                                 String.format("f1_%s", i),
                                 String.format("f1_%s", i),
                                 String.format("f1_%s", i),

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/resources/jdbc_dm_source_and_sink.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-5/src/test/resources/jdbc_dm_source_and_sink.conf
@@ -41,9 +41,9 @@ sink {
     password = "SYSDBA"
     query = """
 INSERT INTO SYSDBA.e2e_table_sink (DM_BIT, DM_INT, DM_INTEGER, DM_PLS_INTEGER, DM_TINYINT, DM_BYTE, DM_SMALLINT, DM_BIGINT, DM_NUMERIC, DM_NUMBER,
- DM_DECIMAL, DM_DEC, DM_REAL, DM_FLOAT, DM_DOUBLE_PRECISION, DM_DOUBLE, DM_CHAR, DM_CHARACTER, DM_VARCHAR, DM_VARCHAR2, DM_TEXT, DM_LONG,
+ DM_DECIMAL, DM_DEC, DM_REAL, DM_FLOAT, DM_DOUBLE_PRECISION, DM_DOUBLE, DM_CHAR, DM_CHARACTER, DM_NCHAR, DM_VARCHAR, DM_VARCHAR2, DM_TEXT, DM_LONG,
  DM_LONGVARCHAR, DM_CLOB, DM_TIMESTAMP, DM_DATETIME, DM_DATE, DM_BLOB, DM_BINARY, DM_VARBINARY, DM_LONGVARBINARY, DM_IMAGE, DM_BFILE)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
   }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11688.

`DmdbTypeConverter` has cases for `CHAR`, `CHARACTER`, `VARCHAR`, `VARCHAR2` and `NVARCHAR`, but no case for `NCHAR`. Reading a Dameng table containing `NCHAR` columns falls through to the `default` branch and fails:

```
ErrorCode:[COMMON-17], ErrorDescription:['Dameng' unsupported convert type 'nchar' of 'test' to SeaTunnel data type.]
```

In a multi-table job the catalog aggregates these into `COMMON-21` and the whole job fails before any data is read.

`NCHAR` is the fixed-length national character type and the counterpart of the already supported variable-length `NVARCHAR`. Supporting one but not the other looks like an oversight rather than an intentional restriction.

**Length rule.** Every character type in this converter — `CHAR`, `CHARACTER`, `VARCHAR`, `VARCHAR2` and `NVARCHAR` — uses `charTo4ByteLength`. `NCHAR` follows the same rule, so the change introduces no new length behaviour and needs no assumption about how Dameng reports lengths. That matters here because Dameng's `LENGTH_IN_CHAR` parameter makes byte-vs-character length a database-level setting, so I deliberately avoided reasoning that depends on it.

**Source type.** `NCHAR` gets its own case rather than joining the `CHAR`/`CHARACTER` branch, because that branch rewrites `sourceType` to the `CHAR` constant. Sharing it would report `NCHAR` columns as `CHAR(n)` and lose the national character type name.

### Does this PR introduce _any_ user-facing change?

Yes, in the sense that a previously failing configuration now works: Dameng tables containing `NCHAR` columns can now be read by the JDBC source, and those columns map to SeaTunnel `STRING`.

No config option, default value, or existing type mapping changes. The added case is purely additive, so this is backward compatible.

### How was this patch tested?

**Unit test.** Added `DmdbTypeConverterTest#testNchar`, mirroring the existing `testNvarchar`, asserting the mapped data type, column length and source type.

```
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=DmdbTypeConverterTest
Tests run: 35, Failures: 0, Errors: 0, Skipped: 0
```

Reverting only the `DmdbTypeConverter` change makes it fail with the reported error, confirming it is a genuine regression test:

```
[ERROR] testNchar  Time elapsed: 0.09 s  <<< ERROR!
org.apache.seatunnel.common.exception.SeaTunnelRuntimeException: ErrorCode:[COMMON-17],
ErrorDescription:['Dameng' unsupported convert type 'nchar' of 'test' to SeaTunnel data type.]
```

**E2E test.** Added a `DM_NCHAR NCHAR(50)` column to `JdbcDmIT`, together with the matching `fieldNames` entry, row value and the explicit insert column list in `jdbc_dm_source_and_sink.conf`. The column is populated with multi-byte content so the national character path is exercised end to end. `JdbcDmUpsetIT` declares its own table and is unaffected.

I could not run this suite locally — Docker is unavailable in my environment — so the `laglangyue/dmdb8` container path is validated by CI rather than by me. `./mvnw test-compile` on `connector-jdbc-e2e-part-5` passes, and the `CREATE_SQL` columns, `fieldNames`, row array, insert column list and placeholder count are all consistent at 34 entries.

`./mvnw spotless:apply` was run over both modules.

### Note on overlap with #11684

#11684 adds `NVARCHAR2` support and also touches `JdbcDmIT` and `jdbc_dm_source_and_sink.conf`. The converter changes sit in different branches of the switch and do not overlap, but the two PRs both extend the same E2E table, so whichever merges second will need a trivial rebase. I'm happy to rebase this one whenever #11684 lands — or to combine them if a maintainer would prefer a single PR covering the whole national character family.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependency
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — not applicable, no option or documented behaviour changed
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR — not applicable, change is backward compatible
* [x] If you are contributing the connector code, please check that the following files are updated — not applicable, no new connector; E2E coverage added to the existing `JdbcDmIT`
