### PR TITLE
[Fix][Connector-V2] Cap decimal scale to what Doris 1.x accepts

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/AbstractDorisTypeConverter.java
@@ -83,6 +83,9 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
     public static final Integer DEFAULT_SCALE = 0;
     public static final Integer MAX_SCALE = 10;
 
+    /** Maximum decimal scale supported by Doris 1.x, whose DECIMAL is DecimalV2 (max 27, 9). */
+    public static final Integer MAX_DECIMALV2_SCALE = 9;
+
     public static final Integer MAX_DATETIME_SCALE = 6;
 
     // Min value of LARGEINT is -170141183460469231731687303715884105728, it will use 39 bytes in
@@ -242,6 +245,18 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
                 IDENTIFIER, column.getDataType().getSqlType().name(), column.getName());
     }
 
+    /**
+     * Maximum decimal scale accepted by the target Doris version.
+     *
+     * <p>DECIMALV3 only requires the scale to not exceed the precision, which the caller already
+     * enforces, so the default imposes no further limit. Doris 1.x is stricter and overrides this.
+     *
+     * @return the largest scale that may be emitted for a decimal column
+     */
+    protected int getMaxDecimalScale() {
+        return MAX_PRECISION.intValue();
+    }
+
     protected BasicTypeDefine sampleReconvert(
             Column column, BasicTypeDefine.BasicTypeDefineBuilder builder) {
 
@@ -296,7 +311,7 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
                 int scale = decimalType.getScale();
                 if (precision <= 0) {
                     precision = MAX_PRECISION.intValue();
-                    scale = MAX_SCALE;
+                    scale = Math.min(MAX_SCALE, getMaxDecimalScale());
                     log.warn(
                             "The decimal column {} type decimal({},{}) is out of range, "
                                     + "which is precision less than 0, "
@@ -318,6 +333,20 @@ public abstract class AbstractDorisTypeConverter implements TypeConverter<BasicT
                     builder.dataType(DORIS_VARCHAR);
                     builder.columnType(String.format("%s(%s)", DORIS_VARCHAR, 200));
                     break;
+                }
+
+                if (scale > getMaxDecimalScale()) {
+                    log.warn(
+                            "The decimal column {} type decimal({},{}) is out of range, "
+                                    + "which exceeds the maximum scale of {} supported by this "
+                                    + "Doris version, it will be converted to decimal({},{})",
+                            column.getName(),
+                            decimalType.getPrecision(),
+                            decimalType.getScale(),
+                            getMaxDecimalScale(),
+                            precision,
+                            getMaxDecimalScale());
+                    scale = getMaxDecimalScale();
                 }
 
                 if (scale < 0) {

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConverterV1.java
@@ -46,6 +46,16 @@ public class DorisTypeConverterV1 extends AbstractDorisTypeConverter {
         return IDENTIFIER;
     }
 
+    /**
+     * Doris 1.x decimals are DecimalV2, which is limited to a scale of 9 regardless of the
+     * precision. Emitting a larger scale makes the generated DDL fail with "Scale of decimal must
+     * between 0 and 9".
+     */
+    @Override
+    protected int getMaxDecimalScale() {
+        return MAX_DECIMALV2_SCALE;
+    }
+
     @Override
     public Column convert(BasicTypeDefine typeDefine) {
         return convert(typeDefine, true);

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV1Test.java
@@ -489,6 +489,8 @@ public class DorisTypeConvertorV1Test {
         Column column =
                 PhysicalColumn.builder().name("test").dataType(new DecimalType(0, 0)).build();
 
+        // Doris 1.x decimals are DecimalV2, so the fallback scale is capped at 9 rather than
+        // MAX_SCALE.
         BasicTypeDefine<?> typeDefine = DorisTypeConverterV1.INSTANCE.reconvert(column);
         Assertions.assertEquals(column.getName(), typeDefine.getName());
         Assertions.assertEquals(
@@ -496,7 +498,7 @@ public class DorisTypeConvertorV1Test {
                         "%s(%s,%s)",
                         DorisTypeConverterV1.DORIS_DECIMALV3,
                         DorisTypeConverterV1.MAX_PRECISION,
-                        DorisTypeConverterV1.MAX_SCALE),
+                        9),
                 typeDefine.getColumnType());
         Assertions.assertEquals(DorisTypeConverterV1.DORIS_DECIMALV3, typeDefine.getDataType());
 
@@ -517,6 +519,18 @@ public class DorisTypeConvertorV1Test {
         Assertions.assertEquals(
                 String.format("%s(%s)", DorisTypeConverterV1.DORIS_VARCHAR, 200),
                 typeDefine.getColumnType());
+
+        // A scale above 9 is valid for DECIMALV3 but rejected by Doris 1.x with
+        // "Scale of decimal must between 0 and 9", so it must be capped.
+        column = PhysicalColumn.builder().name("test").dataType(new DecimalType(20, 10)).build();
+
+        typeDefine = DorisTypeConverterV1.INSTANCE.reconvert(column);
+        Assertions.assertEquals(column.getName(), typeDefine.getName());
+        Assertions.assertEquals(DorisTypeConverterV1.DORIS_DECIMALV3, typeDefine.getDataType());
+        Assertions.assertEquals(
+                String.format("%s(%s,%s)", DorisTypeConverterV1.DORIS_DECIMALV3, 20, 9),
+                typeDefine.getColumnType());
+        Assertions.assertEquals(9, typeDefine.getScale());
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/datatype/DorisTypeConvertorV2Test.java
@@ -779,6 +779,18 @@ public class DorisTypeConvertorV2Test {
         Assertions.assertEquals(
                 String.format("%s(%s)", DorisTypeConverterV2.DORIS_VARCHAR, 200),
                 typeDefine.getColumnType());
+
+        // DECIMALV3 only requires scale <= precision, so a scale above 9 is kept as declared.
+        // This is the behaviour the Doris 1.x cap must not change.
+        column = PhysicalColumn.builder().name("test").dataType(new DecimalType(20, 10)).build();
+
+        typeDefine = DorisTypeConverterV2.INSTANCE.reconvert(column);
+        Assertions.assertEquals(column.getName(), typeDefine.getName());
+        Assertions.assertEquals(DorisTypeConverterV2.DORIS_DECIMALV3, typeDefine.getDataType());
+        Assertions.assertEquals(
+                String.format("%s(%s,%s)", DorisTypeConverterV2.DORIS_DECIMALV3, 20, 10),
+                typeDefine.getColumnType());
+        Assertions.assertEquals(10, typeDefine.getScale());
     }
 
     @Test


### PR DESCRIPTION
### Purpose of this pull request

Fixes #10924.

When Doris auto-creates a table, a decimal column with a scale above 9 produces DDL that Doris 1.x rejects:

```
CatalogException: ErrorCode:[API-03], ErrorDescription:[Catalog initialize failed]
- create table statement execute failed
Scale of decimal must between 0 and 9. Scale was set to: 10
```

**Root cause.** `AbstractDorisTypeConverter#sampleReconvert` validates the scale only against the precision:

```java
if (scale < 0) {
    scale = 0;
} else if (scale > precision) {
    scale = precision;
}
```

That is the DECIMALV3 rule — scale must not exceed precision. Doris 1.x decimals are DecimalV2, which is fixed at `DECIMAL(27, 9)` and caps the scale at **9 regardless of the precision**. A MySQL `DECIMAL(20,10)` therefore passes the check (10 ≤ 20) and reaches Doris unchanged.

The same gap exists in the `precision <= 0` fallback, which assigns `MAX_SCALE` (10) — already one over the Doris 1.x limit.

**Fix.** Add an overridable `getMaxDecimalScale()` and cap the emitted scale with it:

- the default returns `MAX_PRECISION`, so DECIMALV3 imposes no limit beyond the existing `scale <= precision` rule and **`DorisTypeConverterV2` behaviour is unchanged**
- `DorisTypeConverterV1` overrides it with 9

The cap is applied before the existing precision-based clamp, and an out-of-range scale is logged with the same warning style used by the neighbouring branches.

I deliberately scoped this to the scale. `DorisTypeConverterV1` also inherits `MAX_PRECISION = 38` even though DecimalV2 tops out at 27, and `sampleReconvert` hardcodes the `DECIMALV3` type name on the Doris 1.x path too. Both look questionable, but neither is needed to fix the reported failure and I could not verify either against a real Doris 1.x instance, so I left them alone rather than guess. Happy to open follow-up issues if maintainers agree they are problems.

### Does this PR introduce _any_ user-facing change?

Yes, for Doris 1.x only: a decimal column whose scale exceeds 9 is now emitted as `DECIMALV3(p,9)` instead of producing DDL that fails. Values are truncated to 9 decimal places rather than the job failing at table creation, which matches how the surrounding code already handles out-of-range precision and scale (clamp plus a warning log).

Doris 2.x and later are unaffected — `DorisTypeConverterV2` does not override `getMaxDecimalScale()`, and the default keeps the previous behaviour exactly.

No config option or default value changes.

### How was this patch tested?

Unit tests in both converter tests:

- `DorisTypeConvertorV1Test#testReconvertDecimal` — added a `DecimalType(20, 10)` case asserting the emitted type is `DECIMALV3(20,9)`, and updated the existing `DecimalType(0, 0)` fallback assertion from scale 10 to 9. That existing assertion encoded the buggy value, so it had to change; it is called out here rather than folded in silently.
- `DorisTypeConvertorV2Test#testReconvertDecimal` — added the same `DecimalType(20, 10)` case asserting `DECIMALV3(20,10)` is preserved, pinning the V2 behaviour so a future change to the cap cannot silently alter it.

The assertions use the literal `9` rather than the new constant, so a wrong constant value would still be caught.

```
./mvnw test -pl seatunnel-connectors-v2/connector-doris -Dtest='DorisTypeConvertorV1Test,DorisTypeConvertorV2Test'
Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
```

Reverting only the two main-code files makes V1 fail while V2 stays green, which confirms both that the test reproduces the bug and that V2 is untouched:

```
[ERROR] DorisTypeConvertorV1Test.testReconvertDecimal:496
        expected: <DECIMALV3(38,9)> but was: <DECIMALV3(38,10)>
[INFO]  DorisTypeConvertorV2Test  Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
```

No E2E test was added. `connector-doris-e2e` exists, but its containers run a modern Doris, and this failure only occurs on the Doris 1.x path — reproducing it end to end would mean adding a Doris 1.x container purely for this case. The defect is entirely in pure type-mapping logic that the unit tests cover directly. I do not have a Doris 1.x instance to verify against, so the DecimalV2 `(27, 9)` limit is taken from the Doris documentation and the error message in the issue rather than from my own reproduction.

`./mvnw spotless:apply` was run over the module.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependency
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — not applicable, no option or documented behaviour changed
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR — not applicable, the change turns a hard failure into the clamp-and-warn behaviour already used for out-of-range precision
* [x] If you are contributing the connector code, please check that the following files are updated — not applicable, no new connector
