### PR TITLE
[Bug] [Connector-V2] Support Dameng NCHAR type

### DIFF
--- a/docs/en/connectors/source/Jdbc.md
+++ b/docs/en/connectors/source/Jdbc.md
@@ -274,6 +274,7 @@ If one dialect not supported by SeaTunnel, it will use the default dialect `Gene
 | IRIS      | Inceptor     | Highgo   |
 | YashanDB  |              |          |
 
+Dameng `NCHAR` source columns are mapped to SeaTunnel `STRING`.
 
 ## Parallel Reader
 

--- a/docs/zh/connectors/source/Jdbc.md
+++ b/docs/zh/connectors/source/Jdbc.md
@@ -274,6 +274,8 @@ int_type_narrowing = false
 | IRIS      | Inceptor | Highgo |
 | YashanDB  |          |          |
 
+达梦 `NCHAR` 源字段会映射为 SeaTunnel `STRING`。
+
 ## 并行读取器
 
 任务 `parallelism` 决定最多可以同时运行多少个 Reader；分片配置决定实际有多少个独立 split 可以分配给 Reader。

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -66,6 +66,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_CHARACTER = "CHARACTER";
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
+    public static final String DM_NCHAR = "NCHAR";
     public static final String DM_NVARCHAR = "NVARCHAR";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
@@ -203,8 +204,9 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
+            case DM_NCHAR:
             case DM_NVARCHAR:
-                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
+                builder.sourceType(String.format("%s(%s)", dmType, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverterTest.java
@@ -363,6 +363,22 @@ public class DmdbTypeConverterTest {
     }
 
     @Test
+    public void testConvertNchar() {
+        BasicTypeDefine<Object> typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("nchar(2)")
+                        .dataType("nchar")
+                        .length(2L)
+                        .build();
+        Column column = DmdbTypeConverter.INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(8, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType().toLowerCase());
+    }
+
+    @Test
     public void testConvertText() {
         BasicTypeDefine<Object> typeDefine =
                 BasicTypeDefine.builder()


### PR DESCRIPTION
### Purpose of this pull request

Closes #11688.

Dameng `NCHAR` columns currently fall through `DmdbTypeConverter`'s unsupported-type branch because only `NVARCHAR` is enumerated. This adds the missing `NCHAR` mapping to SeaTunnel `STRING`, preserves the concrete source type, and adds regression coverage.

### Does this PR introduce _any_ user-facing change?

Yes. Dameng `NCHAR` source columns that previously failed schema conversion with `COMMON-17` are now mapped to SeaTunnel `STRING`. The English and Chinese JDBC source documentation describe the mapping.

### How was this patch tested?

The new regression test failed on the unchanged base with:

```text
ErrorCode:[COMMON-17], ErrorDescription:['Dameng' unsupported convert type 'nchar' of 'test' to SeaTunnel data type.]
```

It passes after the fix. The following checks also pass:

```bash
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc '-Dtest=DmdbTypeConverterTest#testConvertNchar' -Dskip.spotless=true
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc '-Dtest=DmdbTypeConverterTest' -Dskip.spotless=true
./mvnw spotless:check
./mvnw -DskipTests verify
```

### Check list

* [x] No new Jar binary package is added.
* [x] The English and Chinese JDBC connector documentation is updated.
* [x] No incompatible change is introduced, so `incompatible-changes.md` does not need an update.
* [x] No new connector registration is introduced, so plugin mapping, distribution POM, CI label scope, E2E registration, and `plugin_config` do not need updates.

### Scope

* 4 files changed, +22 / -1 lines.
* No dependency, generated, vendored, or public API changes.
