### PR TITLE
[Docs][Connector-V2] Improve Airtable Github Gitlab Notion and OneSignal connector docs

### DIFF
--- a/docs/en/connectors/sink/Airtable.md
+++ b/docs/en/connectors/sink/Airtable.md
@@ -15,64 +15,32 @@ Used to write data to Airtable.
 - [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Sink Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| token                       | String  | Yes      | -             |
-| base_id                     | String  | Yes      | -             |
-| table                       | String  | Yes      | -             |
-| api_base_url                | String  | No       | https://api.airtable.com |
-| typecast                    | boolean | No       | false         |
-| batch_size                  | int     | No       | 10            |
-| request_interval_ms         | int     | No       | 220           |
-| rate_limit_backoff_ms       | int     | No       | 30000         |
-| rate_limit_max_retries      | int     | No       | 3             |
-| common-options              |         | No       | -             |
+| Name                     | Type    | Required | Default Value          | Description |
+|--------------------------|---------|----------|------------------------|-------------|
+| token                    | String  | Yes      | -                      | Airtable personal access token. Create one at https://airtable.com/create/tokens. The connector sends it as `Authorization: Bearer <token>`. |
+| base_id                  | String  | Yes      | -                      | The ID of the Airtable base (starts with `app`). |
+| table                    | String  | Yes      | -                      | The table name or table ID to write to. |
+| api_base_url             | String  | No       | https://api.airtable.com | Airtable API base URL. The connector appends `/v0/<base_id>/<table>` automatically. |
+| typecast                 | boolean | No       | false                  | If true, Airtable will automatically convert values to match the field type. Default false. |
+| batch_size               | int     | No       | 10                     | Number of records per API request. Maximum 10 per Airtable API limit. Default 10. |
+| request_interval_ms      | int     | No       | 220                    | Minimum interval in milliseconds between API requests. Default 220ms (to stay within Airtable's 5 requests/second limit). Must be `>= 0`. |
+| rate_limit_backoff_ms    | int     | No       | 30000                  | Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms. Must be `>= 0`. |
+| rate_limit_max_retries   | int     | No       | 3                      | Maximum number of retries after receiving a 429 response. Default 3. Must be `>= 0`. |
+| common-options           |         | No       | -                      | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md). |
 
-### token [String]
+## Usage Notes
 
-Airtable personal access token. You can create one at https://airtable.com/create/tokens.
+- `token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector writes to one fixed `base_id` and `table`. It does not route records to different Airtable tables by upstream table name. For multi-table pipelines, configure separate sink entries or route data before the Airtable sink.
+- Each input record becomes one Airtable record. Field names in the upstream schema must match the Airtable column names, otherwise set `typecast = true` to let Airtable auto-convert.
+- Airtable enforces a 5 requests/second rate limit per token. The default `request_interval_ms = 220` keeps a single connector within that limit. Configure `rate_limit_backoff_ms` and `rate_limit_max_retries` to control how the connector reacts to HTTP 429 responses.
+- The connector does not batch with a timer; rows are sent when the buffered count reaches `batch_size` or when the writer closes.
 
-### base_id [String]
+## Task Examples
 
-The ID of the Airtable base (starts with `app`).
-
-### table [String]
-
-The table name or table ID to write to.
-
-### api_base_url [String]
-
-Airtable API base URL. Default is `https://api.airtable.com`.
-
-### typecast [boolean]
-
-If true, Airtable will automatically convert values to match the field type. Default false.
-
-### batch_size [int]
-
-Number of records per API request. Maximum 10 per Airtable API limit. Default 10.
-
-### request_interval_ms [int]
-
-Minimum interval in milliseconds between API requests. Default 220ms.
-
-### rate_limit_backoff_ms [int]
-
-Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms.
-
-### rate_limit_max_retries [int]
-
-Maximum number of retries after receiving a 429 response. Default 3.
-
-### common options
-
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
-
-## Example
-
-Write rows to an Airtable table:
+### Write Rows To Airtable
 
 ```hocon
 env {
@@ -109,6 +77,86 @@ sink {
     typecast = true
     batch_size = 10
     request_interval_ms = 220
+  }
+}
+```
+
+### Write Rows From A Source With Field Name Mapping
+
+When upstream field names already match Airtable column names:
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        Name = string
+        Email = string
+        Score = int
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", "alice@example.com", 95]
+      },
+      {
+        kind = INSERT
+        fields = ["Bob", "bob@example.com", 88]
+      }
+    ]
+  }
+}
+
+sink {
+  Airtable {
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Contacts"
+    typecast = false
+    batch_size = 10
+  }
+}
+```
+
+### Pointing At A Self-Hosted Airtable
+
+Override `api_base_url` when running against a self-hosted or proxied Airtable-compatible API:
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        Name = string
+        Age = int
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", 30]
+      }
+    ]
+  }
+}
+
+sink {
+  Airtable {
+    api_base_url = "https://airtable.internal.example.com"
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Shipments"
   }
 }
 ```

--- a/docs/en/connectors/sink/Cassandra.md
+++ b/docs/en/connectors/sink/Cassandra.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-cassandra.md';
 
 > Cassandra sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Write data to Apache Cassandra in batch mode.
@@ -15,11 +21,17 @@ columns are written, and every configured field must exist in the target table.
 The connector does not create keyspaces, tables, or missing columns. Prepare the target Cassandra
 schema before starting the job.
 
-## Key features
+## Supported DataSource Info
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| Cassandra  | Universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-cassandra) |
+
+## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Sink Options
 
 | Name              | Type    | Required | Default     | Description |
 |-------------------|---------|----------|-------------|-------------|
@@ -99,7 +111,7 @@ Sink plugin common parameters. For details, see [Sink Common Options](../common-
 - `async_write = true` improves throughput, while `batch_size` controls how many rows are grouped
   before a flush.
 
-## Examples
+## Task Example
 
 ### Write to Cassandra
 

--- a/docs/en/connectors/sink/Datahub.md
+++ b/docs/en/connectors/sink/Datahub.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-datahub.md';
 
 > DataHub sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 The DataHub sink writes SeaTunnel rows to Alibaba Cloud DataHub.
@@ -25,7 +31,7 @@ Create the DataHub project and topic before running the SeaTunnel job. The
 DataHub topic schema must contain fields with the same names as the upstream
 SeaTunnel schema fields, because the sink writes values by field name.
 
-## Options
+## Sink Options
 
 | name           | type   | required | default value | description |
 |----------------|--------|----------|---------------|-------------|
@@ -36,7 +42,7 @@ SeaTunnel schema fields, because the sink writes values by field name.
 | topic          | string | yes      | -             | DataHub topic name. Supports placeholders in multi-table jobs. |
 | timeout        | int    | no       | 3000          | Maximum client connection timeout in milliseconds. |
 | retryTimes     | int    | no       | 3             | Maximum retry count when writing a record fails. |
-| common-options | config | no       | -             | Sink plugin common options. |
+| common-options | config | no       | -             | Sink plugin common options. See [Sink Common Options](../common-options/sink-common-options.md). |
 
 ### endpoint [string]
 
@@ -57,7 +63,7 @@ The DataHub project name.
 ### topic [string]
 
 The DataHub topic name. For multi-table writes, this value can contain
-placeholders, for example `${table}`. `${table_name}` is only kept as a
+placeholders such as `${table}`. `${table_name}` is only kept as a
 deprecated compatibility alias; use `${table}` for new jobs.
 
 The SeaTunnel field names must match the DataHub topic fields, because the sink
@@ -78,9 +84,11 @@ Sink plugin common parameters, please refer to
 For multi-table writes, `multi_table_sink_replica` can be used with the common
 sink options.
 
-## Examples
+## Task Example
 
-### Write one table to one topic
+### Write One Table to One Topic
+
+A simple batch job that writes records from a fake source to a single DataHub topic.
 
 ```hocon
 env {
@@ -113,7 +121,10 @@ sink {
 }
 ```
 
-### Write multiple input tables to matching topics
+### Write Multiple Input Tables to Matching Topics
+
+When the upstream source provides multiple tables, configure `topic` with the
+`${table}` placeholder so each input table is routed to a topic with the same name.
 
 ```hocon
 env {

--- a/docs/en/connectors/sink/InfluxDB.md
+++ b/docs/en/connectors/sink/InfluxDB.md
@@ -4,16 +4,24 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 > InfluxDB sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Write SeaTunnel rows to InfluxDB 1.x. The sink converts one row into one InfluxDB point, using
 `measurement`, `key_time`, and `key_tags` to decide the target measurement, timestamp, tags, and
 fields.
 
-## Key features
+## Key Features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Data Type Mapping
 
@@ -30,7 +38,7 @@ fields.
 
 Other SeaTunnel types are not supported by the current InfluxDB sink serializer.
 
-## Options
+## Sink Options
 
 | name                        | type   | required | default value         | description                                                                                   |
 |-----------------------------|--------|----------|-----------------------|-----------------------------------------------------------------------------------------------|
@@ -51,67 +59,64 @@ Other SeaTunnel types are not supported by the current InfluxDB sink serializer.
 | connect_timeout_ms          | long   | no       | 15000                 | Timeout for connecting to InfluxDB, in milliseconds.                                          |
 | query_timeout_sec           | int    | no       | 3                     | Read timeout used by the InfluxDB client, in seconds.                                         |
 | multi_table_sink_replica    | int    | no       | -                     | Replica count for multi-table sink writers.                                                   |
-| common-options              | config | no       | -                     | Sink plugin common options.                                                                   |
+| common-options              | config | no       | -                     | Sink plugin common options. See [Sink Common Options](../common-options/sink-common-options.md). |
 
-### url
+### url [string]
 
-the url to connect to influxDB e.g.
-
-```
-http://influxdb-host:8086
-```
+The URL to connect to InfluxDB, for example `http://influxdb-host:8086`.
 
 ### database [string]
 
-The name of `influxDB` database
+The name of the InfluxDB database that points are written to.
 
 ### measurement [string]
 
-The name of `influxDB` measurement. This option is optional. If it is omitted, the sink uses the
-input table full name as the measurement name, which is useful for multi-table writes.
-For multi-table input, make sure the generated table names are valid InfluxDB measurement names.
+The InfluxDB measurement name. When omitted, the sink uses the input table full name as the
+measurement — which is the common setting for multi-table writes. Make sure the generated
+table names are valid InfluxDB measurement names.
 
 ### username [string]
 
-`influxDB` user username
+The InfluxDB user name. Configure it together with `password` when the influxdb requires authentication.
 
 ### password [string]
 
-`influxDB` user password
+The InfluxDB user password. Configure it together with `username` when authentication is required.
 
 ### key_time [string]
 
-Specify field-name of the `influxDB` measurement timestamp in SeaTunnelRow. If not specified, use processing-time as timestamp
+The field name in the upstream row that supplies the InfluxDB point timestamp. When omitted, the
+sink uses the current processing time. Values configured here are accepted as numeric timestamps
+or as an ISO-8601 timestamp string.
 
 ### key_tags [array]
 
-Specify field-name of the `influxDB` measurement tags in SeaTunnelRow.
-If not specified, include all fields with `influxDB` measurement field
+The field names in the upstream row that should be written as InfluxDB tags. All other fields are
+written as point fields. When omitted, every field is written as a point field.
 
 ### batch_size [int]
 
-For batch writing, when the number of buffers reaches the number of `batch_size` or the time reaches `checkpoint.interval`, the data will be flushed into the influxDB
+Number of points buffered before flushing to InfluxDB. The default is `1024`. The buffer is also
+flushed at each checkpoint and when the writer closes.
 
 ### max_retries [int]
 
-The number of retries to flush failed
-
-If this option is not configured, the sink tries the write once and fails immediately if that write fails.
+Maximum retry count when the flush fails. When this option is not set, the sink writes once and
+fails immediately if that write fails.
 
 ### retry_backoff_multiplier_ms [int]
 
-Using as a multiplier for generating the next delay for backoff
+Backoff multiplier used between retry attempts, in milliseconds. Configure it together with
+`max_retry_backoff_ms` so the retry sleep interval is non-zero.
 
 ### max_retry_backoff_ms [int]
 
-The amount of time to wait before attempting to retry a request to `influxDB`
-
-When retry options are used, configure both `retry_backoff_multiplier_ms` and
-`max_retry_backoff_ms`; otherwise the retry sleep interval remains `0`.
+Maximum backoff between retry attempts, in milliseconds. Configure it together with
+`retry_backoff_multiplier_ms` so the retry sleep interval is non-zero.
 
 ### write_timeout [int]
 
-The write timeout used by the InfluxDB client.
+The write timeout used by the InfluxDB client, in seconds.
 
 ### rp [string]
 
@@ -119,9 +124,8 @@ Retention policy used when writing points.
 
 ### epoch [string]
 
-Time precision used by the InfluxDB client. For sink write precision, uppercase values `H`, `M`,
-`S`, `MS`, `U`, and `NS` are recognized by the current connector. The default `n` is treated as
-nanosecond precision.
+Time precision used by the InfluxDB client. Uppercase values `H`, `M`, `S`, `MS`, `U`, and `NS`
+are recognized for write precision. The default value `n` is treated as nanosecond precision.
 
 ### query_timeout_sec [int]
 
@@ -129,28 +133,29 @@ The read timeout used by the InfluxDB client, in seconds.
 
 ### connect_timeout_ms [long]
 
-the timeout for connecting to InfluxDB, in milliseconds
+The timeout for connecting to InfluxDB, in milliseconds. The default is `15000`.
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
 
-## Examples
+## Task Example
 
 ### Write One Measurement
 
+A simple sink that writes rows to a single named measurement.
+
 ```hocon
 sink {
-    InfluxDB {
-        url = "http://influxdb-host:8086"
-        database = "test"
-        measurement = "sink"
-        key_time = "time"
-        key_tags = ["label"]
-        batch_size = 1
-    }
+  InfluxDB {
+    url = "http://influxdb-host:8086"
+    database = "test"
+    measurement = "sink"
+    key_time = "time"
+    key_tags = ["label"]
+    batch_size = 1
+  }
 }
-
 ```
 
 ### Write Without Explicit Measurement
@@ -199,7 +204,7 @@ sink {
 }
 ```
 
-### Multiple Table
+### Multi-Table Write
 
 When `measurement` is omitted, each upstream table is written to a measurement named after that
 table. This is the usual setting for multi-table input.
@@ -216,7 +221,7 @@ source {
     url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
     username = "root"
     password = "******"
-    
+
     table-names = ["seatunnel.role","seatunnel.user","galileo.Bucket"]
   }
 }

--- a/docs/en/connectors/sink/Mqtt.md
+++ b/docs/en/connectors/sink/Mqtt.md
@@ -4,15 +4,24 @@ import ChangeLog from '../changelog/connector-mqtt.md';
 
 > MQTT sink connector
 
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
 ## Description
 
-Used to write data to an MQTT broker. Supports MQTT 3.1.1 protocol via the Eclipse Paho client library.
+Write data to an MQTT broker. Supports MQTT 3.1.1 protocol via the Eclipse Paho client library.
 
-This connector is suitable for publishing SeaTunnel pipeline data to IoT endpoints and lightweight message brokers. Messages are serialized as JSON or plain text and published to a configurable MQTT topic.
+This connector is suitable for publishing SeaTunnel pipeline data to IoT endpoints and lightweight
+message brokers. Messages are serialized as JSON or plain text and published to a configurable MQTT
+topic.
 
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 **Delivery Semantics Notice**:
@@ -22,40 +31,34 @@ client disconnections. Setting `clean_session=false` lets the broker keep sessio
 the sink currently generates a unique client id for each writer and does not expose a `client_id` option. For recovery
 from job restarts, rely on upstream replay and MQTT QoS rather than a stable sink client id.
 
-## Supported Engines
+## Sink Options
 
-> SeaTunnel Zeta<br/>
-> Flink<br/>
-> Spark<br/>
-
-## Options
-
-|       name            |  type   | required | default value |
-|-----------------------|---------|----------|---------------|
-| url                   | string  | yes      | -             |
-| topic                 | string  | yes      | -             |
-| username              | string  | no       | -             |
-| password              | string  | no       | -             |
-| qos                   | int     | no       | 1             |
-| format                | string  | no       | json          |
-| field_delimiter       | string  | no       | ,             |
-| batch_size            | int     | no       | 1             |
-| retry_timeout         | int     | no       | 5000          |
-| connection_timeout    | int     | no       | 30            |
-| clean_session         | boolean | no       | true          |
-| common-options        |         | no       | -             |
+|       name            |  type   | required | default value | description                                                                                                          |
+|-----------------------|---------|----------|---------------|----------------------------------------------------------------------------------------------------------------------|
+| url                   | string  | yes      | -             | MQTT broker connection URL. Must include protocol, host, and port, for example `tcp://broker.example.com:1883`.       |
+| topic                 | string  | yes      | -             | MQTT topic to publish messages to, for example `iot/sensors/temperature`.                                             |
+| username              | string  | no       | -             | MQTT broker username. Leave unset for anonymous access.                                                              |
+| password              | string  | no       | -             | MQTT broker password. Leave unset for anonymous access.                                                              |
+| qos                   | int     | no       | 1             | MQTT Quality of Service level. `0` is at-most-once, `1` is at-least-once.                                            |
+| format                | string  | no       | json          | Serialization format. `json` serializes each row as a JSON object; `text` serializes each row as delimited text.     |
+| field_delimiter       | string  | no       | ,             | Field delimiter used when `format = "text"`, for example `,`, `|`, or `\t`.                                          |
+| batch_size            | int     | no       | 1             | Number of messages to buffer before sending to the broker. The buffer is also flushed at each checkpoint.            |
+| retry_timeout         | int     | no       | 5000          | Maximum time in milliseconds to retry publishing on transient network failures before failing the task.             |
+| connection_timeout    | int     | no       | 30            | MQTT connection establishment timeout in seconds.                                                                    |
+| clean_session         | boolean | no       | true          | Whether to use a clean MQTT session. `true` discards any previous session state; `false` retains session state.      |
+| common-options        | config  | no       | -             | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md).                  |
 
 ### url [string]
 
 The MQTT broker connection URL. Must include protocol, host, and port.
 
-Example: `tcp://broker.example.com:1883`
+Example: `tcp://broker.example.com:1883`.
 
 ### topic [string]
 
 The MQTT topic to publish messages to.
 
-Example: `iot/sensors/temperature`
+Example: `iot/sensors/temperature`.
 
 ### username [string]
 
@@ -69,31 +72,32 @@ The password for MQTT broker authentication. Leave unset for anonymous access.
 
 The MQTT Quality of Service level for published messages.
 
-- `0` — At most once (fire and forget)
-- `1` — At least once (acknowledged delivery, default)
+- `0` — At most once (fire and forget).
+- `1` — At least once (acknowledged delivery, default).
 
 ### format [string]
 
 The serialization format for outgoing messages. Supported values:
 
-- `json` — Serialize each row as a JSON object (default)
-- `text` — Serialize each row as delimited plain text (delimiter controlled by `field_delimiter`)
+- `json` — Serialize each row as a JSON object (default).
+- `text` — Serialize each row as delimited plain text (delimiter controlled by `field_delimiter`).
 
 ### field_delimiter [string]
 
 The field delimiter used when `format` is set to `text`. Default is `,`.
 
-Examples: `,`, `|`, `\t`
+Examples: `,`, `|`, `\t`.
 
 ### batch_size [int]
 
-Number of messages to buffer before sending to the broker. Default is `1` (send each message immediately).
-
-Higher values improve throughput by reducing per-message overhead. Buffered messages are automatically flushed at each checkpoint and when the writer closes.
+Number of messages to buffer before sending to the broker. The default is `1` (send each message
+immediately). Higher values improve throughput by reducing per-message overhead. Buffered messages
+are automatically flushed at each checkpoint and when the writer closes.
 
 ### retry_timeout [int]
 
-Maximum time in milliseconds to retry publishing on transient network failures before failing the task. The writer polls the connection state with exponential backoff during this window.
+Maximum time in milliseconds to retry publishing on transient network failures before failing the
+task. The writer polls the connection state with exponential backoff during this window.
 
 ### connection_timeout [int]
 
@@ -101,7 +105,7 @@ The MQTT connection establishment timeout in seconds.
 
 ### clean_session [boolean]
 
-Whether to use a clean MQTT session. Default is `true`.
+Whether to use a clean MQTT session. The default is `true`.
 
 - `true` — Broker discards any previous session state. Suitable for stateless operation (recommended for most use cases).
 - `false` — Broker retains session state for the generated writer client id while the writer is running. This can help with transient disconnects, but it may cause broker-side state accumulation and does not provide a stable client id across job restarts.
@@ -114,19 +118,19 @@ Sink plugin common parameters, please refer to [Sink Common Options](../common-o
 
 The MQTT Sink sends messages synchronously to guarantee delivery ordering. Typical throughput:
 
-- QoS 0: ~10,000 messages/sec (local network)
-- QoS 1: ~5,000 messages/sec (requires broker ACK)
+- QoS 0: ~10,000 messages/sec (local network).
+- QoS 1: ~5,000 messages/sec (requires broker ACK).
 
 To improve throughput:
 
-- Increase `batch_size` to reduce per-message overhead (e.g., `batch_size = 100`)
-- Reduce `qos` to `0` if at-most-once delivery is acceptable
-- Increase SeaTunnel parallelism to distribute load across multiple MQTT clients
-- For very high throughput requirements, consider using the Kafka Sink instead
+- Increase `batch_size` to reduce per-message overhead (for example `batch_size = 100`).
+- Reduce `qos` to `0` if at-most-once delivery is acceptable.
+- Increase SeaTunnel parallelism to distribute load across multiple MQTT clients.
+- For very high throughput requirements, consider using the Kafka Sink instead.
 
-## Example
+## Task Example
 
-### Write JSON messages to MQTT
+### Write JSON Messages to MQTT
 
 ```hocon
 env {
@@ -163,7 +167,7 @@ sink {
 This job writes 16 rows to the `test/seatunnel/sink` topic. Each row is serialized as one JSON
 message because `format` is set to `json`.
 
-### Authenticated broker with text format
+### Authenticated Broker with Text Format
 
 ```hocon
 env {

--- a/docs/en/connectors/source/Airtable.md
+++ b/docs/en/connectors/source/Airtable.md
@@ -17,159 +17,62 @@ Used to read data from Airtable.
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| token                       | String  | Yes      | -             |
-| base_id                     | String  | Yes      | -             |
-| table                       | String  | Yes      | -             |
-| api_base_url                | String  | No       | https://api.airtable.com |
-| view                        | String  | No       | -             |
-| fields                      | List    | No       | -             |
-| filter_by_formula           | String  | No       | -             |
-| max_records                 | int     | No       | -             |
-| page_size                   | int     | No       | -             |
-| sort                        | String  | No       | -             |
-| cell_format                 | String  | No       | -             |
-| return_fields_by_field_id   | boolean | No       | -             |
-| record_metadata             | List    | No       | -             |
-| time_zone                   | String  | No       | -             |
-| user_locale                 | String  | No       | -             |
-| offset                      | String  | No       | -             |
-| headers                     | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| pageing                     | Config  | No       | -             |
-| request_interval_ms         | int     | No       | 220           |
-| rate_limit_backoff_ms       | int     | No       | 30000         |
-| rate_limit_max_retries      | int     | No       | 3             |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | text          |
-| content_field               | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| json_filed_missed_return_null | boolean | No     | false         |
-| common-options              | config  | No       | -             |
+| Name                        | Type    | Required | Default Value          | Description |
+|-----------------------------|---------|----------|------------------------|-------------|
+| token                       | String  | Yes      | -                      | Airtable personal access token. Create one at https://airtable.com/create/tokens. |
+| base_id                     | String  | Yes      | -                      | The ID of the Airtable base (starts with `app`). |
+| table                       | String  | Yes      | -                      | The table name or table ID to read from. |
+| api_base_url                | String  | No       | https://api.airtable.com | Airtable API base URL. |
+| view                        | String  | No       | -                      | The name or ID of a view in the table. Only records visible in this view will be returned. |
+| fields                      | List    | No       | -                      | A list of field names to include in the response. |
+| filter_by_formula           | String  | No       | -                      | An Airtable formula to filter records. See [Airtable formula reference](https://support.airtable.com/docs/formula-field-reference). |
+| max_records                 | int     | No       | -                      | Maximum total number of records to return. |
+| page_size                   | int     | No       | -                      | Number of records per page (1-100). |
+| sort                        | String  | No       | -                      | Sort definition as a JSON array, e.g. `[{"field":"Name","direction":"asc"}]`. |
+| cell_format                 | String  | No       | -                      | The format for cell values, either `json` or `string`. |
+| return_fields_by_field_id   | boolean | No       | -                      | If true, field keys in the response will be field IDs instead of field names. |
+| record_metadata             | List    | No       | -                      | Additional record metadata to return, e.g. `["commentCount"]`. |
+| time_zone                   | String  | No       | -                      | The time zone for formatting date/time values. |
+| user_locale                 | String  | No       | -                      | The user locale for formatting values. |
+| offset                      | String  | No       | -                      | Pagination offset returned by Airtable. Usually you do not need to set this manually because the connector follows Airtable pagination automatically. |
+| headers                     | Map     | No       | -                      | Extra HTTP headers. The connector automatically adds Airtable authorization and JSON content type headers. |
+| body                        | String  | No       | -                      | Advanced request body. Do not use it together with dedicated Airtable request options such as `fields`, `filter_by_formula`, `page_size`, or `sort` for the same Airtable API key. |
+| pageing                     | Config  | No       | -                      | HTTP pagination configuration inherited from the HTTP connector. For normal Airtable list-records reads, prefer Airtable's own pagination handled by the connector. |
+| request_interval_ms         | int     | No       | 220                    | Minimum interval in milliseconds between API requests. Default 220ms (to stay within Airtable's 5 requests/second limit). |
+| rate_limit_backoff_ms       | int     | No       | 30000                  | Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms. |
+| rate_limit_max_retries      | int     | No       | 3                      | Maximum number of retries after receiving a 429 response. Default 3. |
+| schema                      | Config  | No       | -                      | Output row structure. Required when `format = "json"`. See [Schema Feature](../../introduction/concepts/schema-feature.md). |
+| schema.fields               | Config  | No       | -                      | Field names and SeaTunnel data types used to parse the JSON response. |
+| format                      | String  | No       | text                   | The format of upstream data, supports `json` and `text`, default `text`. |
+| content_field               | String  | No       | -                      | JSONPath expression to extract data from the response. For Airtable, you typically use `$.records[*].fields` to extract the fields from each record. |
+| json_field                  | Config  | No       | -                      | Field-level JSONPath mapping. Use it with `schema` when each output field lives at a different JSON path. |
+| json_filed_missed_return_null | boolean | No     | false                  | When `true`, missing JSON fields return `null`; otherwise a missing field causes an error. |
+| enable_multi_lines          | boolean | No       | false                  | When `true`, multiple JSON objects separated by newlines in the response body are treated as separate records. |
+| connect_timeout_ms          | int     | No       | 12000                  | HTTP connection timeout in milliseconds. Default 12000ms. |
+| socket_timeout_ms           | int     | No       | 60000                  | HTTP socket timeout in milliseconds. Default 60000ms. |
+| common-options              | config  | No       | -                      | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md). |
 
-### token [String]
+## Usage Notes
 
-Airtable personal access token. You can create one at https://airtable.com/create/tokens.
+- `token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector automatically follows Airtable's `offset`-based pagination, so you usually do not need to set `offset` manually.
+- Airtable enforces a 5 requests/second rate limit per token. The default `request_interval_ms = 220` keeps a single connector within that limit. Configure `rate_limit_backoff_ms` and `rate_limit_max_retries` to control how the connector reacts to HTTP 429 responses.
+- Set `format = "json"` and configure `schema` when you want typed SeaTunnel rows.
+- Use `content_field = "$.records[*].fields"` to extract the fields of each record before parsing.
+- Use `json_field` only when each output field needs its own JSONPath expression.
 
-### base_id [String]
+## Task Examples
 
-The ID of the Airtable base (starts with `app`).
-
-### table [String]
-
-The table name or table ID to read from.
-
-### api_base_url [String]
-
-Airtable API base URL. Default is `https://api.airtable.com`.
-
-### view [String]
-
-The name or ID of a view in the table. Only records visible in this view will be returned.
-
-### fields [List]
-
-A list of field names to include in the response.
-
-### filter_by_formula [String]
-
-An Airtable formula to filter records. See [Airtable formula reference](https://support.airtable.com/docs/formula-field-reference).
-
-### max_records [int]
-
-Maximum total number of records to return.
-
-### page_size [int]
-
-Number of records per page (1-100).
-
-### sort [String]
-
-Sort definition as a JSON array, e.g. `[{"field":"Name","direction":"asc"}]`.
-
-### cell_format [String]
-
-The format for cell values, either `json` or `string`.
-
-### return_fields_by_field_id [boolean]
-
-If true, field keys in the response will be field IDs instead of field names.
-
-### record_metadata [List]
-
-Additional record metadata to return, e.g. `["commentCount"]`.
-
-### time_zone [String]
-
-The time zone for formatting date/time values.
-
-### user_locale [String]
-
-The user locale for formatting values.
-
-### offset [String]
-
-Pagination offset returned by Airtable. Usually you do not need to set this manually because the connector follows Airtable pagination automatically.
-
-### headers [Map]
-
-Extra HTTP headers. The connector automatically adds Airtable authorization and JSON content type headers.
-
-### body [String]
-
-Advanced request body. Do not use it together with dedicated Airtable request options such as `fields`, `filter_by_formula`, `page_size`, or `sort` for the same Airtable API key.
-
-### pageing [Config]
-
-HTTP pagination configuration inherited from the HTTP connector. For normal Airtable list-records reads, prefer Airtable's own pagination handled by the connector.
-
-### request_interval_ms [int]
-
-Minimum interval in milliseconds between API requests. Default 220ms (to stay within Airtable's 5 requests/second limit).
-
-### rate_limit_backoff_ms [int]
-
-Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms.
-
-### rate_limit_max_retries [int]
-
-Maximum number of retries after receiving a 429 response. Default 3.
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### format [String]
-
-The format of upstream data, supports `json` and `text`, default `text`.
-
-### content_field [String]
-
-JsonPath expression to extract data from the response. For Airtable, you typically use `$.records[*].fields` to extract the fields from each record.
-
-### json_field [Config]
-
-This parameter helps you configure the schema and must be used with schema.
-
-### json_filed_missed_return_null [boolean]
-
-When `true`, missing JSON fields return `null`; otherwise a missing field causes an error.
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
-
-## Example
-
-Read from an Airtable table and output raw text:
+### Read Records As Text
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
@@ -179,16 +82,27 @@ source {
     max_records = 10
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-Read with schema and extract record fields:
+### Read Records With Schema
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
     base_id = "appXXXXXXXX"
     table = "Shipments"
+    format = "json"
     content_field = "$.records[*].fields"
     filter_by_formula = "{Status} = 'Shipped'"
     schema = {
@@ -202,9 +116,16 @@ source {
 }
 ```
 
-Read a small page from Airtable:
+### Read With Pagination Control
+
+Use `page_size` together with `request_interval_ms` for predictable throughput:
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
@@ -219,6 +140,34 @@ source {
         Name = string
         Age = int
         Status = string
+      }
+    }
+  }
+}
+```
+
+### Read Fields With JSONPath
+
+When different fields live at different JSON paths:
+
+```hocon
+source {
+  Airtable {
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Shipments"
+    format = "json"
+    content_field = "$.records[*]"
+    json_field = {
+      Name = "$.fields.Name"
+      Status = "$.fields.Status"
+      CreatedAt = "$.createdTime"
+    }
+    schema = {
+      fields {
+        Name = string
+        Status = string
+        CreatedAt = string
       }
     }
   }

--- a/docs/en/connectors/source/Cassandra.md
+++ b/docs/en/connectors/source/Cassandra.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-cassandra.md';
 
 > Cassandra source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Read data from Apache Cassandra in batch mode.
@@ -16,7 +22,13 @@ The Cassandra source supports two read modes:
 The source gets column names and data types from the result set returned by the configured CQL, so
 the CQL should return the columns that downstream steps need.
 
-## Key features
+## Supported DataSource Info
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| Cassandra  | Universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-cassandra) |
+
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
@@ -49,7 +61,7 @@ the CQL should return the columns that downstream steps need.
 | set                 | ARRAY               |
 | map                 | MAP                 |
 
-## Options
+## Source Options
 
 | Name              | Type       | Required | Default     | Description |
 |-------------------|------------|----------|-------------|-------------|
@@ -131,7 +143,7 @@ Source plugin common parameters. For details, see [Source Common Options](../com
 - A single CQL query is read as one source split. Increasing job parallelism does not split one
   Cassandra table scan automatically.
 
-## Examples
+## Task Example
 
 ### Single-table read
 

--- a/docs/en/connectors/source/Github.md
+++ b/docs/en/connectors/source/Github.md
@@ -17,7 +17,7 @@ The Github source connector reads data from the GitHub REST API. It is built on 
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
 | name                        | type    | required | default value |
 |-----------------------------|---------|----------|---------------|
@@ -33,10 +33,22 @@ The Github source connector reads data from the GitHub REST API. It is built on 
 | json_field                  | Config  | No       | -             |
 | content_field               | String  | No       | -             |
 | pageing                     | Config  | No       | -             |
+| page_type                   | String  | No       | PageNumber    |
+| cursor_field                | String  | No       | -             |
+| cursor_response_field       | String  | No       | -             |
 | poll_interval_millis        | int     | No       | -             |
 | retry                       | int     | No       | -             |
 | retry_backoff_multiplier_ms | int     | No       | 100           |
 | retry_backoff_max_ms        | int     | No       | 10000         |
+| enable_multi_lines          | boolean | No       | false         |
+| keep_params_as_form         | boolean | No       | false         |
+| keep_page_param_as_http_param | boolean | No    | false         |
+| batch_size                  | int     | No       | 100           |
+| start_page_number           | long    | No       | 1             |
+| total_page_size             | long    | No       | 0             |
+| use_placeholder_replacement | boolean | No       | false         |
+| connect_timeout_ms          | int     | No       | 12000         |
+| socket_timeout_ms           | int     | No       | 60000         |
 | json_filed_missed_return_null | boolean | No     | false         |
 | common-options              | config  | No       | -             |
 
@@ -82,7 +94,19 @@ JSONPath expression used to select a JSON fragment before schema parsing, for ex
 
 ### pageing [Config]
 
-Pagination settings inherited from the HTTP connector. Keep the option name `pageing` in job configs.
+Pagination settings inherited from the HTTP connector. Keep the option name `pageing` in job configs. Configure `page_type = "Cursor"` for cursor-based GitHub pagination when needed.
+
+### page_type [String]
+
+Pagination type. Supported values are `PageNumber` (default) and `Cursor`. Use `Cursor` for endpoints that return a `next` cursor in the response.
+
+### cursor_field [String]
+
+The request parameter name that carries the cursor value. Used together with `page_type = "Cursor"`.
+
+### cursor_response_field [String]
+
+The JSONPath of the cursor in the response body. Used together with `page_type = "Cursor"`.
 
 ### poll_interval_millis [int]
 
@@ -100,6 +124,42 @@ Retry backoff multiplier in milliseconds.
 
 Maximum retry backoff in milliseconds.
 
+### enable_multi_lines [boolean]
+
+When `true`, multiple JSON objects separated by newlines in the response body are treated as separate records.
+
+### keep_params_as_form [boolean]
+
+When `true`, request parameters are sent as form-encoded body parameters instead of URL query parameters.
+
+### keep_page_param_as_http_param [boolean]
+
+When `true`, the page parameter remains in the request URL when paginating instead of being replaced inside the body.
+
+### batch_size [int]
+
+The number of records returned per page request when the total number of pages is unknown.
+
+### start_page_number [long]
+
+Which page number to start synchronizing from.
+
+### total_page_size [long]
+
+Total page size to read. `0` means use `batch_size` until the API stops returning new pages.
+
+### use_placeholder_replacement [boolean]
+
+When `true`, use `${field}` placeholder replacement for headers, parameters and body values; otherwise use key-based replacement.
+
+### connect_timeout_ms [int]
+
+HTTP connection timeout in milliseconds. Default 12000ms.
+
+### socket_timeout_ms [int]
+
+HTTP socket timeout in milliseconds. Default 60000ms.
+
 ### json_filed_missed_return_null [boolean]
 
 When `true`, missing JSON fields return `null`; otherwise a missing field causes an error.
@@ -108,11 +168,25 @@ When `true`, missing JSON fields return `null`; otherwise a missing field causes
 
 Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md).
 
-## Example
+## Usage Notes
 
-Read repositories from a GitHub organization:
+- `access_token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector always adds an `Authorization: Bearer <access_token>` header from `access_token`. Put other custom headers in `headers`.
+- Set `format = "json"` and define `schema` when you want typed SeaTunnel rows.
+- Use `content_field` when the GitHub response wraps records in a nested array such as `$.items[*]`.
+- For traditional page-number pagination, keep `page_type = "PageNumber"` and use `params` with `page` / `per_page`.
+- For cursor-based endpoints (such as the GitHub Events API), set `page_type = "Cursor"` and configure `cursor_field` / `cursor_response_field`.
+
+## Task Examples
+
+### Read Repositories From A GitHub Organization
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Github {
     url = "https://api.github.com/orgs/apache/repos"
@@ -131,11 +205,21 @@ source {
     }
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-Read paged GitHub API results:
+### Read Paged GitHub API Results
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Github {
     url = "https://api.github.com/orgs/apache/repos"
@@ -157,6 +241,33 @@ source {
         id = int
         name = string
         html_url = string
+      }
+    }
+  }
+}
+```
+
+### Stream GitHub Events
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Github {
+    url = "https://api.github.com/orgs/apache/events"
+    access_token = "ghp_xxxxxxxxxxxx"
+    method = "GET"
+    format = "json"
+    poll_interval_millis = 60000
+    schema = {
+      fields {
+        id = string
+        type = string
+        created_at = string
       }
     }
   }

--- a/docs/en/connectors/source/Gitlab.md
+++ b/docs/en/connectors/source/Gitlab.md
@@ -17,7 +17,7 @@ The Gitlab source connector reads data from the GitLab REST API. It is built on 
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
 | name                        | type    | required | default value |
 |-----------------------------|---------|----------|---------------|
@@ -33,10 +33,22 @@ The Gitlab source connector reads data from the GitLab REST API. It is built on 
 | json_field                  | Config  | No       | -             |
 | content_field               | String  | No       | -             |
 | pageing                     | Config  | No       | -             |
+| page_type                   | String  | No       | PageNumber    |
+| cursor_field                | String  | No       | -             |
+| cursor_response_field       | String  | No       | -             |
 | poll_interval_millis        | int     | No       | -             |
 | retry                       | int     | No       | -             |
 | retry_backoff_multiplier_ms | int     | No       | 100           |
 | retry_backoff_max_ms        | int     | No       | 10000         |
+| enable_multi_lines          | boolean | No       | false         |
+| keep_params_as_form         | boolean | No       | false         |
+| keep_page_param_as_http_param | boolean | No    | false         |
+| batch_size                  | int     | No       | 100           |
+| start_page_number           | long    | No       | 1             |
+| total_page_size             | long    | No       | 0             |
+| use_placeholder_replacement | boolean | No       | false         |
+| connect_timeout_ms          | int     | No       | 12000         |
+| socket_timeout_ms           | int     | No       | 60000         |
 | json_filed_missed_return_null | boolean | No     | false         |
 | common-options              | config  | No       | -             |
 
@@ -84,6 +96,18 @@ JSONPath expression used to select a JSON fragment before schema parsing, for ex
 
 Pagination settings inherited from the HTTP connector. Keep the option name `pageing` in job configs.
 
+### page_type [String]
+
+Pagination type. Supported values are `PageNumber` (default) and `Cursor`. Use `Cursor` for GitLab endpoints that return a `X-Next-Page` cursor header.
+
+### cursor_field [String]
+
+The request parameter name that carries the cursor value. Used together with `page_type = "Cursor"`.
+
+### cursor_response_field [String]
+
+The JSONPath of the cursor in the response body. Used together with `page_type = "Cursor"`.
+
 ### poll_interval_millis [int]
 
 This option is inherited from the HTTP connector, but Gitlab source currently supports batch mode only.
@@ -100,6 +124,42 @@ Retry backoff multiplier in milliseconds.
 
 Maximum retry backoff in milliseconds.
 
+### enable_multi_lines [boolean]
+
+When `true`, multiple JSON objects separated by newlines in the response body are treated as separate records.
+
+### keep_params_as_form [boolean]
+
+When `true`, request parameters are sent as form-encoded body parameters instead of URL query parameters.
+
+### keep_page_param_as_http_param [boolean]
+
+When `true`, the page parameter remains in the request URL when paginating instead of being replaced inside the body.
+
+### batch_size [int]
+
+The number of records returned per page request when the total number of pages is unknown.
+
+### start_page_number [long]
+
+Which page number to start synchronizing from.
+
+### total_page_size [long]
+
+Total page size to read. `0` means use `batch_size` until the API stops returning new pages.
+
+### use_placeholder_replacement [boolean]
+
+When `true`, use `${field}` placeholder replacement for headers, parameters and body values; otherwise use key-based replacement.
+
+### connect_timeout_ms [int]
+
+HTTP connection timeout in milliseconds. Default 12000ms.
+
+### socket_timeout_ms [int]
+
+HTTP socket timeout in milliseconds. Default 60000ms.
+
 ### json_filed_missed_return_null [boolean]
 
 When `true`, missing JSON fields return `null`; otherwise a missing field causes an error.
@@ -108,11 +168,25 @@ When `true`, missing JSON fields return `null`; otherwise a missing field causes
 
 Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md).
 
-## Example
+## Usage Notes
 
-Read projects from GitLab:
+- `access_token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector always adds a `PRIVATE-TOKEN` header from `access_token`. Put other custom headers in `headers`.
+- Set `format = "json"` and define `schema` when you want typed SeaTunnel rows.
+- Use `content_field` when the GitLab response wraps records in a nested array such as `$.items[*]`.
+- For traditional page-number pagination, keep `page_type = "PageNumber"` and use `params` with `page` / `per_page`.
+- The GitLab source supports batch mode only; `poll_interval_millis` does not enable streaming behavior.
+
+## Task Examples
+
+### Read Projects From GitLab
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Gitlab {
     url = "https://gitlab.com/api/v4/projects"
@@ -131,11 +205,21 @@ source {
     }
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-Read paged GitLab API results:
+### Read Paged GitLab API Results
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Gitlab {
     url = "https://gitlab.com/api/v4/projects"
@@ -157,6 +241,41 @@ source {
         id = int
         name = string
         path = string
+      }
+    }
+  }
+}
+```
+
+### Filter And Extract Fields With JSONPath
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Gitlab {
+    url = "https://gitlab.com/api/v4/projects"
+    access_token = "glpat-xxxxxxxxxxxx"
+    method = "GET"
+    params = {
+      owned = "true"
+      per_page = "50"
+    }
+    format = "json"
+    content_field = "$.[*]"
+    json_field = {
+      id = "$.id"
+      name = "$.name"
+      visibility = "$.visibility"
+    }
+    schema = {
+      fields {
+        id = int
+        name = string
+        visibility = string
       }
     }
   }

--- a/docs/en/connectors/source/InfluxDB.md
+++ b/docs/en/connectors/source/InfluxDB.md
@@ -4,12 +4,18 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 > InfluxDB source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Read data from InfluxDB 1.x by using an InfluxQL query. The connector supports a normal single
 query and an optional parallel scan mode that splits one query by an integer column range.
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
@@ -32,7 +38,7 @@ query and an optional parallel scan mode that splits one query by an integer col
 
 Other SeaTunnel types are not supported by the current InfluxDB source converter.
 
-## Options
+## Source Options
 
 | name               | type   | required | default value | description                                                                                      |
 |--------------------|--------|----------|---------------|--------------------------------------------------------------------------------------------------|
@@ -50,30 +56,24 @@ Other SeaTunnel types are not supported by the current InfluxDB source converter
 | epoch              | string | no       | n             | Time precision returned by InfluxDB. For example: `H`, `m`, `s`, `MS`, `u`, `n`.                 |
 | connect_timeout_ms | long   | no       | 15000         | Timeout for connecting to InfluxDB, in milliseconds.                                             |
 | query_timeout_sec  | int    | no       | 3             | Timeout for querying InfluxDB, in seconds.                                                       |
-| common-options     | config | no       | -             | Source plugin common options.                                                                    |
+| common-options     | config | no       | -             | Source plugin common options. See [Source Common Options](../common-options/source-common-options.md). |
 
-### url
+### url [string]
 
-the url to connect to influxDB e.g.
-
-```
-http://influxdb-host:8086
-```
+The URL to connect to InfluxDB, for example `http://influxdb-host:8086`.
 
 ### sql [string]
 
-The query sql used to search data
+The InfluxQL query used to read data. For example:
 
 ```
-select name,age from test
+select name, age from test
 ```
 
 ### schema [config]
 
-#### fields [Config]
-
-The schema information of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-e.g.
+The output schema of the source. See [Schema Feature](../../introduction/concepts/schema-feature.md)
+for the full grammar. For example:
 
 ```
 schema {
@@ -81,82 +81,83 @@ schema {
         name = string
         age = int
     }
-  }
+}
 ```
 
 ### database [string]
 
-The `influxDB` database
+The InfluxDB database name.
 
 ### username [string]
 
-the username of the influxDB when you select
+InfluxDB username used to authenticate the connection. Configure it together with `password`.
 
 ### password [string]
 
-the password of the influxDB when you select
+InfluxDB password used to authenticate the connection. Configure it together with `username`.
 
 ### split_column [string]
 
-The column used to split one query into multiple range queries.
+The integer column used to split one query into multiple range queries when parallel scan is
+enabled.
 
 > Tips:
-> - influxDB tags is not supported as a segmented primary key because the type of tags can only be a string
-> - influxDB time is not supported as a segmented primary key because the time field cannot participate in mathematical calculation
-> - Currently, `split_column` only supports integer data segmentation, and does not support `float`, `string`, `date` and other types.
+> - InfluxDB tags cannot be used as a split column because tags only support the string type.
+> - InfluxDB time cannot be used as a split column because the time field cannot participate in
+>   mathematical calculations.
+> - `split_column` currently only supports integer columns; `float`, `string`, `date`, and other
+>   types are not supported.
 > - `split_column`, `lower_bound`, `upper_bound`, and `partition_num` must be configured together.
-> - If the split query contains a filter, use lowercase `where` in `sql`, for example `select * from test where age > 0`. The current split parser is case-sensitive.
-> - `where` is an option in the validation rule, but the current split logic reads the filter from `sql`. Put the filter in `sql` instead of configuring a separate `where` value.
+> - If the split query has a filter, write the filter with a lowercase `where` directly inside
+>   `sql` (for example `select * from test where age > 0`). The current split parser is
+>   case-sensitive.
+> - `where` is part of the option validation rule but the split logic reads the filter from `sql`.
+>   Put the filter in `sql` instead of configuring a separate `where` value.
 
 ### upper_bound [int]
 
-upper bound of the `split_column`column
+Upper bound of the `split_column` column when parallel scan is enabled.
 
 ### lower_bound [int]
 
-lower bound of the `split_column` column
+Lower bound of the `split_column` column when parallel scan is enabled.
+
+The split column range is divided into `partition_num` parts. If `partition_num = 1`, the connector
+uses the whole range. If `partition_num` is less than `upper_bound - lower_bound`, the connector
+uses `(upper_bound - lower_bound)` partitions.
+
+For example, with `lower_bound = 1`, `upper_bound = 10`, `partition_num = 2`, and
+`sql = "select * from test where age > 0 and age < 10"`, the connector splits the query into:
 
 ```
-     split the $split_column range into $partition_num parts
-     if partition_num is 1, use the whole `split_column` range
-     if partition_num < (upper_bound - lower_bound), use (upper_bound - lower_bound) partitions
-     
-     eg: lower_bound = 1, upper_bound = 10, partition_num = 2
-     sql = "select * from test where age > 0 and age < 10"
-     
-     split result
-
-     split 1: select * from test where ($split_column >= 1 and $split_column < 6)  and (  age > 0 and age < 10 )
-     
-     split 2: select * from test where ($split_column >= 6 and $split_column < 11) and (  age > 0 and age < 10 )
-
+split 1: select * from test where ($split_column >= 1 and $split_column < 6)  and (  age > 0 and age < 10 )
+split 2: select * from test where ($split_column >= 6 and $split_column < 11) and (  age > 0 and age < 10 )
 ```
 
 ### partition_num [int]
 
-the `partition_num` of the InfluxDB when you select
-
-> Tips: Ensure that `upper_bound` minus `lower_bound` is divided `bypartition_num`, otherwise the query results will overlap
+Number of query splits. Configure it together with `lower_bound`, `upper_bound`, and
+`split_column`. Make sure `upper_bound - lower_bound` is divisible by `partition_num`; otherwise
+the query results overlap.
 
 ### epoch [string]
 
-returned time precision
-- Optional values: H, m, s, MS, u, n
-- default value: n
+Time precision returned by InfluxDB. Valid values include `H`, `m`, `s`, `MS`, `u`, and `n`. The
+default value is `n`.
 
 ### query_timeout_sec [int]
 
-the `query_timeout` of the InfluxDB when you select, in seconds
+Query timeout for the InfluxDB client, in seconds.
 
 ### connect_timeout_ms [long]
 
-the timeout for connecting to InfluxDB, in milliseconds
+Connection timeout for the InfluxDB client, in milliseconds.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
 
-## Examples
+## Task Example
 
 ### Read With Parallel Range Splits
 
@@ -167,7 +168,6 @@ env {
 }
 
 source {
-
     InfluxDB {
         url = "http://influxdb-host:8086"
         sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
@@ -190,7 +190,6 @@ source {
             }
         }
     }
-
 }
 
 sink {
@@ -207,7 +206,6 @@ env {
 }
 
 source {
-
     InfluxDB {
         url = "http://influxdb-host:8086"
         sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
@@ -226,7 +224,6 @@ source {
             }
         }
     }
-
 }
 
 sink {

--- a/docs/en/connectors/source/Notion.md
+++ b/docs/en/connectors/source/Notion.md
@@ -34,11 +34,23 @@ The Notion source connector reads data from the Notion API. It is based on the H
 | content_field               | String  | No       | -       | JSONPath used to select a nested part of the response before parsing it with `schema`. |
 | json_field                  | Config  | No       | -       | Field-level JSONPath mapping. Use it with `schema` when output fields come from different JSON paths. |
 | pageing                     | Config  | No       | -       | HTTP pagination settings inherited from the HTTP source connector. |
-| poll_interval_millis        | Int     | No       | -       | Request interval in milliseconds when the source is used in streaming mode. |
+| page_type                   | String  | No       | PageNumber | Pagination type. Supported values are `PageNumber` (default) and `Cursor`. Use `Cursor` for Notion endpoints that return a `next_cursor`. |
+| cursor_field                | String  | No       | -       | The request parameter name that carries the cursor value. Used together with `page_type = "Cursor"`. |
+| cursor_response_field       | String  | No       | -       | The JSONPath of the cursor in the response body. Used together with `page_type = "Cursor"`. |
+| poll_interval_millis        | Int     | No       | -       | Request interval in milliseconds when the source is used in streaming mode. Notion source currently supports batch mode only. |
 | retry                       | Int     | No       | -       | Maximum retry times when the HTTP request fails with an `IOException`. |
 | retry_backoff_multiplier_ms | Int     | No       | 100     | Retry backoff multiplier in milliseconds. |
 | retry_backoff_max_ms        | Int     | No       | 10000   | Maximum retry backoff in milliseconds. |
-| json_filed_missed_return_null | Boolean | No     | false   | Return null when a configured JSON field is missing. |
+| enable_multi_lines          | Boolean | No       | false   | When `true`, multiple JSON objects separated by newlines in the response body are treated as separate records. |
+| keep_params_as_form         | Boolean | No       | false   | When `true`, request parameters are sent as form-encoded body parameters instead of URL query parameters. |
+| keep_page_param_as_http_param | Boolean | No    | false   | When `true`, the page parameter remains in the request URL when paginating instead of being replaced inside the body. |
+| batch_size                  | Int     | No       | 100     | The number of records returned per page request when the total number of pages is unknown. |
+| start_page_number           | Long    | No       | 1       | Which page number to start synchronizing from. |
+| total_page_size             | Long    | No       | 0       | Total page size to read. `0` means use `batch_size` until the API stops returning new pages. |
+| use_placeholder_replacement | Boolean | No       | false   | When `true`, use `${field}` placeholder replacement for headers, parameters and body values; otherwise use key-based replacement. |
+| connect_timeout_ms          | Int     | No       | 12000   | HTTP connection timeout in milliseconds. Default 12000ms. |
+| socket_timeout_ms           | Int     | No       | 60000   | HTTP socket timeout in milliseconds. Default 60000ms. |
+| json_filed_missed_return_null | Boolean | No    | false   | Return null when a configured JSON field is missing. |
 | common-options              | Config  | No       | -       | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md). |
 
 :::tip
@@ -53,8 +65,10 @@ The Notion source connector reads data from the Notion API. It is based on the H
 - Use `content_field` when the Notion response wraps records in a nested array, such as `$.results.*`.
 - Use `json_field` only when each output field needs its own JSONPath expression.
 - `password` and `version` override the `Authorization` and `Notion-Version` headers. Put only other custom headers in `headers`.
+- For Notion list endpoints, prefer `page_type = "Cursor"` together with `cursor_field = "start_cursor"` and `cursor_response_field = "$.next_cursor"`.
+- The Notion source supports batch mode only. `poll_interval_millis` is exposed for HTTP-base compatibility but does not enable streaming behavior.
 
-## Task Example
+## Task Examples
 
 ### Read Users
 
@@ -89,6 +103,39 @@ source {
 
 sink {
   Console {
+  }
+}
+```
+
+### Search Pages With Cursor Pagination
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Notion {
+    url = "https://api.notion.com/v1/search"
+    password = "<notion-integration-token>"
+    version = "2022-06-28"
+    method = "POST"
+    body = "{\"page_size\": 100, \"filter\": {\"value\": \"page\", \"property\": \"object\"}}"
+    format = "json"
+    content_field = "$.results[*]"
+    page_type = "Cursor"
+    cursor_field = "start_cursor"
+    cursor_response_field = "$.next_cursor"
+    schema = {
+      fields {
+        id = string
+        object = string
+        created_time = string
+        last_edited_time = string
+        archived = boolean
+      }
+    }
   }
 }
 ```

--- a/docs/en/connectors/source/OneSignal.md
+++ b/docs/en/connectors/source/OneSignal.md
@@ -6,321 +6,162 @@ import ChangeLog from '../changelog/connector-http-onesignal.md';
 
 ## Description
 
-Used to read data from OneSignal.
+The OneSignal source connector reads data from the OneSignal REST API. It is built on the HTTP source connector and automatically sends `password` to OneSignal as the `Authorization: Basic <token>` request header, so you do not need to set `Authorization` yourself.
 
-## Key features
+Use this connector to ingest OneSignal resources such as apps, players, segments, or notifications as SeaTunnel rows.
+
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+| Name                        | Type    | Required | Default | Description |
+|-----------------------------|---------|----------|---------|-------------|
+| url                         | String  | Yes      | -       | OneSignal REST API endpoint. Common endpoints include `https://onesignal.com/api/v1/apps` and `https://onesignal.com/api/v1/players`. |
+| password                    | String  | Yes      | -       | OneSignal user auth key. The connector sends it as the HTTP `Authorization: Basic <password>` header. Create one at [OneSignal Accounts and Keys](https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key). |
+| method                      | String  | No       | get     | HTTP request method. Supported values are `GET` and `POST`. |
+| headers                     | Map     | No       | -       | Extra HTTP headers. Do not put `Authorization` here unless you want to override the header generated from `password`. |
+| params                      | Map     | No       | -       | HTTP query parameters, such as `limit`, `offset`, or other OneSignal API parameters. |
+| body                        | String  | No       | -       | HTTP request body. Useful for endpoints that accept a JSON payload. |
+| format                      | String  | No       | json    | Response format. Use `json` with `schema` to read OneSignal JSON as SeaTunnel rows with named fields. Use `text` to keep the raw response. |
+| schema                      | Config  | No       | -       | Output row structure. Required when `format = "json"`. See [Schema Feature](../../introduction/concepts/schema-feature.md). |
+| schema.fields               | Config  | No       | -       | Field names and SeaTunnel data types used to parse the JSON response. |
+| json_field                  | Config  | No       | -       | Field-level JSONPath mapping. Use it with `schema` when each output field lives at a different JSON path. |
+| content_field               | String  | No       | -       | JSONPath expression that selects a JSON fragment before `schema` parses it. For example, use `$.players[*]` to flatten a list response. |
+| pageing                     | Config  | No       | -       | HTTP pagination settings inherited from the HTTP source connector. OneSignal paged endpoints use `page` / `per_page` parameters. |
+| poll_interval_millis        | Int     | No       | -       | Request interval in milliseconds for streaming jobs. In batch mode the connector reads once and finishes. |
+| retry                       | Int     | No       | -       | Maximum retry count when an HTTP request fails with `IOException`. |
+| retry_backoff_multiplier_ms | Int     | No       | 100     | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | Int     | No       | 10000   | Maximum retry backoff in milliseconds. |
+| enable_multi_lines          | Boolean | No       | false   | When `true`, multiple JSON objects separated by newlines in the response body are treated as separate records. |
+| json_filed_missed_return_null | Boolean | No    | false   | When `true`, missing JSON fields return `null`; otherwise a missing field causes an error. |
+| common-options              | Config  | No       | -       | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md). |
 
-### url [String]
+## Usage Notes
 
-http request url
+- `password` is sensitive. Avoid hardcoding real keys in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector always adds an `Authorization` header from `password`. Put other custom headers in `headers`.
+- Set `format = "json"` and define `schema` when you want typed SeaTunnel rows.
+- Use `content_field` when OneSignal wraps records in a nested array such as `$.players[*]`.
+- Use `json_field` only when each output field needs its own JSONPath expression.
+- OneSignal paged endpoints accept `page` and `per_page` query parameters; configure them through `params` and `pageing`.
 
-### password [String]
+## Task Examples
 
-Auth key for login, you can get more detail at this link:
-
-https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key
-
-### method [String]
-
-http request method, only supports GET, POST method
-
-### params [Map]
-
-http params
-
-### body [String]
-
-http body
-
-### poll_interval_millis [int]
-
-request http api interval(millis) in stream mode
-
-### retry [int]
-
-The max retry times if request http return to `IOException`
-
-### retry_backoff_multiplier_ms [int]
-
-The retry-backoff times(millis) multiplier if request http failed
-
-### retry_backoff_max_ms [int]
-
-The maximum retry-backoff times(millis) if request http failed
-
-### format [String]
-
-the format of upstream data, now only support `json` `text`, default `json`.
-
-when you assign format is `json`, you should also assign schema option, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-you should assign schema as the following:
+### Read Apps
 
 ```hocon
-
-schema {
-    fields {
-        code = int
-        data = string
-        success = boolean
-    }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
 }
 
-```
-
-connector will generate data as the following:
-
-| code |    data     | success |
-|------|-------------|---------|
-| 200  | get success | true    |
-
-when you assign format is `text`, connector will do nothing for upstream data, for example:
-
-upstream data is the following:
-
-```json
-{
-  "code": 200,
-  "data": "get success",
-  "success": true
-}
-```
-
-connector will generate data as the following:
-
-|                         content                          |
-|----------------------------------------------------------|
-| {"code":  200, "data":  "get success", "success":  true} |
-
-### schema [Config]
-
-#### fields [Config]
-
-The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
-
-### content_json [String]
-
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
-
-If your return data looks something like this.
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
+source {
+  OneSignal {
+    url = "https://onesignal.com/api/v1/apps"
+    password = "<onesignal-user-auth-key>"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        id = string
+        name = string
+        gcm_key = string
+        chrome_key = string
+        site_name = string
+        created_at = string
+        updated_at = string
+        players = int
+        messageable_players = int
       }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
     }
-  },
-  "expensive": 10
+  }
+}
+
+sink {
+  Console {
+  }
 }
 ```
 
-You can configure `content_field = "$.store.book.*"` and the result returned looks like this:
+### Read Players With Pagination
 
-```json
-[
-  {
-    "category": "reference",
-    "author": "Nigel Rees",
-    "title": "Sayings of the Century",
-    "price": 8.95
-  },
-  {
-    "category": "fiction",
-    "author": "Evelyn Waugh",
-    "title": "Sword of Honour",
-    "price": 12.99
-  }
-]
-```
-
-Then you can get the desired result with a simpler schema,like
+Use `params` together with `pageing` to walk through paged OneSignal endpoints:
 
 ```hocon
-Http {
-  url = "http://mockserver:1080/contentjson/mock"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  OneSignal {
+    url = "https://onesignal.com/api/v1/players"
+    password = "<onesignal-user-auth-key>"
+    method = "GET"
+    params = {
+      app_id = "<your-app-id>"
+      limit = "50"
+      offset = "0"
+    }
+    pageing = {
+      page_field = "offset"
+      start_page_number = 0
+      page_step = 50
+      total_page_size = 10
+      use_placeholder_replacement = false
+    }
+    format = "json"
+    content_field = "$.players[*]"
+    schema = {
+      fields {
+        id = string
+        identifier = string
+        device_type = int
+        sessions = int
+        language = string
+        game_version = string
+      }
     }
   }
 }
 ```
 
-Here is an example:
+### Extract Fields With JSONPath
 
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
-
-### json_field [Config]
-
-This parameter helps you configure the schema,so this parameter must be used with schema.
-
-If your data looks something like this:
-
-```json
-{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    }
-  },
-  "expensive": 10
-}
-```
-
-You can get the contents of 'book' by configuring the task as follows:
+Use `json_field` when each output field lives at a different JSON path:
 
 ```hocon
 source {
-  Http {
-    url = "http://mockserver:1080/jsonpath/mock"
+  OneSignal {
+    url = "https://onesignal.com/api/v1/apps"
+    password = "<onesignal-user-auth-key>"
     method = "GET"
     format = "json"
     json_field = {
-      category = "$.store.book[*].category"
-      author = "$.store.book[*].author"
-      title = "$.store.book[*].title"
-      price = "$.store.book[*].price"
+      id = "$.id"
+      name = "$.name"
+      players = "$.players"
+      site_name = "$.site_name"
     }
     schema = {
       fields {
-        category = string
-        author = string
-        title = string
-        price = string
+        id = string
+        name = string
+        players = int
+        site_name = string
       }
     }
   }
-}
-```
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
-
-### common options
-
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
-
-## Example
-
-```hocon
-
-OneSignal {
-    url = "https://onesignal.com/api/v1/apps"
-    password = "SeaTunnel-test"
-    schema = {
-       fields {
-         id = string
-         name = string
-         gcm_key = string
-         chrome_key = string
-         chrome_web_key = string
-         chrome_web_origin = string
-         chrome_web_gcm_sender_id = string
-         chrome_web_default_notification_icon = string
-         chrome_web_sub_domain = string
-         apns_env = string
-         apns_certificates = string
-         apns_p8 = string
-         apns_team_id = string
-         apns_key_id = string
-         apns_bundle_id = string
-         safari_apns_certificate = string
-         safari_site_origin = string
-         safari_push_id = string
-         safari_icon_16_16 = string
-         safari_icon_32_32 = string
-         safari_icon_64_64 = string
-         safari_icon_128_128 = string
-         safari_icon_256_256 = string
-         site_name = string
-         created_at = string
-         updated_at = string
-         players = int
-         messageable_players = int
-         basic_auth_key = string
-         additional_data_is_root_payload = string
-       }
-    }   
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-

--- a/docs/zh/connectors/sink/Airtable.md
+++ b/docs/zh/connectors/sink/Airtable.md
@@ -15,64 +15,32 @@ import ChangeLog from '../changelog/connector-http-airtable.md';
 - [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## Sink 选项
 
-| 参数名 | 类型 | 必须 | 默认值 |
-|--------|------|------|--------|
-| token                       | String  | 是 | -             |
-| base_id                     | String  | 是 | -             |
-| table                       | String  | 是 | -             |
-| api_base_url                | String  | 否 | https://api.airtable.com |
-| typecast                    | boolean | 否 | false         |
-| batch_size                  | int     | 否 | 10            |
-| request_interval_ms         | int     | 否 | 220           |
-| rate_limit_backoff_ms       | int     | 否 | 30000         |
-| rate_limit_max_retries      | int     | 否 | 3             |
-| common-options              |         | 否 | -             |
+| 参数名                     | 类型    | 必须 | 默认值                    | 描述                                                                                          |
+|--------------------------|---------|----|------------------------|---------------------------------------------------------------------------------------------|
+| token                    | String  | 是  | -                      | Airtable 个人访问令牌。可在 https://airtable.com/create/tokens 创建。连接器会将其作为 `Authorization: Bearer <token>` 发送。 |
+| base_id                  | String  | 是  | -                      | Airtable Base ID（以 `app` 开头）。                                                                      |
+| table                    | String  | 是  | -                      | 要写入的表名或表 ID。                                                                                  |
+| api_base_url             | String  | 否  | https://api.airtable.com | Airtable API 基础 URL，连接器会自动追加 `/v0/<base_id>/<table>`。                                            |
+| typecast                 | boolean | 否  | false                  | 如果为 true，Airtable 会自动将值转换为匹配的字段类型，默认 false。                                                          |
+| batch_size               | int     | 否  | 10                     | 每次 API 请求的记录数，受 Airtable API 限制最大为 10，默认 10。                                                       |
+| request_interval_ms      | int     | 否  | 220                    | API 请求之间的最小间隔（毫秒），默认 220ms（以保持在 Airtable 每秒 5 次请求的限制内），必须 `>= 0`。                                       |
+| rate_limit_backoff_ms    | int     | 否  | 30000                  | 收到 429（限流）响应时的基础退避时间（毫秒），默认 30000ms，必须 `>= 0`。                                                      |
+| rate_limit_max_retries   | int     | 否  | 3                      | 收到 429 响应后的最大重试次数，默认 3，必须 `>= 0`。                                                                  |
+| common-options           |         | 否  | -                      | Sink 插件通用参数，详见 [Sink Common Options](../common-options/sink-common-options.md)。                         |
 
-### token [String]
+## 使用提示
 
-Airtable 个人访问令牌。可在 https://airtable.com/create/tokens 创建。
+- `token` 是敏感信息，请避免在共享的任务文件中硬编码真实令牌。可使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
+- 连接器只会写入到固定的 `base_id` 和 `table`，不会按上游表名将记录路由到不同的 Airtable 表。多表写入场景需要配置多个 sink，或在上游提前路由。
+- 每条输入记录会变成一条 Airtable 记录。上游字段名需要与 Airtable 列名一致，否则可以开启 `typecast = true` 让 Airtable 自动转换。
+- Airtable 对每个令牌限速为 5 次/秒。默认 `request_interval_ms = 220` 可保证单个连接器不超过该限制。可通过 `rate_limit_backoff_ms` 和 `rate_limit_max_retries` 控制遇到 HTTP 429 时的退避与重试行为。
+- 连接器不基于时间定时刷新，缓冲达到 `batch_size` 或写入器关闭时即会发送。
 
-### base_id [String]
+## 任务示例
 
-Airtable Base ID（以 `app` 开头）。
-
-### table [String]
-
-要写入的表名或表 ID。
-
-### api_base_url [String]
-
-Airtable API 基础 URL，默认 `https://api.airtable.com`。
-
-### typecast [boolean]
-
-如果为 true，Airtable 会自动将值转换为匹配的字段类型。默认 false。
-
-### batch_size [int]
-
-每次 API 请求的记录数，受 Airtable API 限制最大为 10。默认 10。
-
-### request_interval_ms [int]
-
-API 请求之间的最小间隔（毫秒），默认 220ms。
-
-### rate_limit_backoff_ms [int]
-
-收到 429（限流）响应时的基础退避时间（毫秒），默认 30000ms。
-
-### rate_limit_max_retries [int]
-
-收到 429 响应后的最大重试次数，默认 3。
-
-### common options
-
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
-
-## 示例
-
-将数据写入 Airtable 表：
+### 写入 Airtable 表
 
 ```hocon
 env {
@@ -109,6 +77,86 @@ sink {
     typecast = true
     batch_size = 10
     request_interval_ms = 220
+  }
+}
+```
+
+### 按列名映射字段写入
+
+当上游字段名与 Airtable 列名一致时可直接写入：
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        Name = string
+        Email = string
+        Score = int
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", "alice@example.com", 95]
+      },
+      {
+        kind = INSERT
+        fields = ["Bob", "bob@example.com", 88]
+      }
+    ]
+  }
+}
+
+sink {
+  Airtable {
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Contacts"
+    typecast = false
+    batch_size = 10
+  }
+}
+```
+
+### 写入自托管 Airtable
+
+可通过 `api_base_url` 指向自托管或代理的 Airtable 兼容接口：
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        Name = string
+        Age = int
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", 30]
+      }
+    ]
+  }
+}
+
+sink {
+  Airtable {
+    api_base_url = "https://airtable.internal.example.com"
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Shipments"
   }
 }
 ```

--- a/docs/zh/connectors/sink/Cassandra.md
+++ b/docs/zh/connectors/sink/Cassandra.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-cassandra.md';
 
 > Cassandra 接收器连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 以批处理方式将数据写入 Apache Cassandra。
@@ -13,11 +19,17 @@ sink 会把数据写入已经存在的 Cassandra 表。如果不配置 `fields`�
 
 连接器不会自动创建 keyspace、表或缺失字段。启动任务前请先准备好目标 Cassandra 表结构。
 
+## 支持的数据源信息
+
+| 数据源      | 支持版本 | 依赖 |
+|-----------|--------|------|
+| Cassandra | 通用    | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-cassandra) |
+
 ## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## Sink 选项
 
 | 名称              | 类型    | 是否必填 | 默认值      | 描述 |
 |-------------------|---------|----------|-------------|------|
@@ -94,7 +106,7 @@ Sink 插件通用参数，详情请参考 [Sink 常用选项](../common-options/
 - `fields` 适合上游数据有额外字段、只想写入其中一部分字段的场景；它不是建表配置。
 - `async_write = true` 可以提升吞吐，`batch_size` 用来控制每次 flush 前聚合的行数。
 
-## 示例
+## 任务示例
 
 ### 写入 Cassandra
 

--- a/docs/zh/connectors/sink/Datahub.md
+++ b/docs/zh/connectors/sink/Datahub.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-datahub.md';
 
 > DataHub Sink 连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 DataHub Sink 用于将 SeaTunnel 数据写入阿里云 DataHub。
@@ -11,7 +17,7 @@ DataHub Sink 用于将 SeaTunnel 数据写入阿里云 DataHub。
 该连接器支持单表写入和多表写入。多表写入时，可以在 `topic` 中使用
 `${table}` 这类占位符，将不同输入表的数据写入不同的 DataHub Topic。
 
-## 主要特性
+## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
@@ -22,18 +28,18 @@ DataHub Sink 用于将 SeaTunnel 数据写入阿里云 DataHub。
 
 运行 SeaTunnel 任务前，请先创建 DataHub 项目和 Topic。DataHub Topic 的结构中需要包含和上游 SeaTunnel schema 同名的字段，因为该 Sink 会按字段名写入数据。
 
-## 选项
+## Sink 选项
 
-| 名称           | 类型   | 必填 | 默认值 | 描述 |
-|----------------|--------|------|--------|------|
-| endpoint       | string | 是   | -      | DataHub 服务地址。 |
-| accessId       | string | 是   | -      | 访问 DataHub 使用的阿里云 Access ID。 |
-| accessKey      | string | 是   | -      | 访问 DataHub 使用的阿里云 Access Key。 |
-| project        | string | 是   | -      | DataHub 项目名称。 |
-| topic          | string | 是   | -      | DataHub Topic 名称，多表写入时支持占位符。 |
-| timeout        | int    | 否   | 3000   | 客户端连接最大超时时间，单位为毫秒。 |
-| retryTimes     | int    | 否   | 3      | 写入记录失败时的最大重试次数。 |
-| common-options | config | 否   | -      | Sink 插件通用参数。 |
+| 名称             | 类型     | 必填 | 默认值 | 描述                                                              |
+|----------------|--------|----|-----|-----------------------------------------------------------------|
+| endpoint       | string | 是  | -   | DataHub 服务地址。                                                   |
+| accessId       | string | 是  | -   | 访问 DataHub 使用的阿里云 Access ID。                                  |
+| accessKey      | string | 是  | -   | 访问 DataHub 使用的阿里云 Access Key。                                 |
+| project        | string | 是  | -   | DataHub 项目名称。                                                  |
+| topic          | string | 是  | -   | DataHub Topic 名称，多表写入时支持占位符。                                  |
+| timeout        | int    | 否  | 3000 | 客户端连接最大超时时间，单位为毫秒。                                            |
+| retryTimes     | int    | 否  | 3   | 写入记录失败时的最大重试次数。                                                |
+| common-options | config | 否  | -   | Sink 插件通用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
 ### endpoint [string]
 
@@ -68,12 +74,14 @@ SeaTunnel 字段名需要和 DataHub Topic 中的字段名一致，因为 sink �
 
 ### 通用选项
 
-Sink 插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。
+Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
 多表写入时，可以配合通用参数中的 `multi_table_sink_replica` 使用。
 
-## 示例
+## 任务示例
 
 ### 单表写入单个 Topic
+
+将 fake source 的记录写入单个 DataHub topic 的简单批量任务。
 
 ```hocon
 env {
@@ -107,6 +115,8 @@ sink {
 ```
 
 ### 多表写入匹配的 Topic
+
+当上游 source 提供多个表时，可以使用 `${table}` 占位符配置 `topic`，让每个输入表路由到同名的 topic。
 
 ```hocon
 env {

--- a/docs/zh/connectors/sink/InfluxDB.md
+++ b/docs/zh/connectors/sink/InfluxDB.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 > InfluxDB Sink 连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 将 SeaTunnel 行数据写入 InfluxDB 1.x。Sink 会把一行数据转换成一个 InfluxDB point，并通过
@@ -12,7 +18,9 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 ## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 数据类型映射
 
@@ -29,10 +37,10 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 当前 InfluxDB sink 序列化器不支持其他 SeaTunnel 类型。
 
-## 选项
+## Sink 选项
 
 | 参数名                         | 类型     | 必须 | 默认值          | 描述                                                       |
-|-----------------------------|--------|----|--------------|----------------------------------------------------------|
+|------------------------------|--------|----|--------------|----------------------------------------------------------|
 | url                         | string | 是  | -            | InfluxDB 连接 URL，例如 `http://influxdb-host:8086`。          |
 | database                    | string | 是  | -            | InfluxDB 数据库名称。                                           |
 | measurement                 | string | 否  | 输入表完整名称      | InfluxDB measurement 名称。不配置时使用输入表名。                     |
@@ -50,66 +58,62 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 | connect_timeout_ms          | long   | 否  | 15000        | 连接 InfluxDB 的超时时间，单位毫秒。                                  |
 | query_timeout_sec           | int    | 否  | 3            | InfluxDB 客户端读超时时间，单位秒。                                   |
 | multi_table_sink_replica    | int    | 否  | -            | 多表写入时的 sink writer 副本数。                                  |
-| common-options              | config | 否  | -            | Sink 插件通用参数。                                             |
+| common-options              | config | 否  | -            | Sink 插件通用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
-### url
+### url [string]
 
-连接到 influxDB 的 url，例如
-
-```
-http://influxdb-host:8086
-```
+连接到 InfluxDB 的 URL，例如 `http://influxdb-host:8086`。
 
 ### database [string]
 
-`influxDB` 数据库的名称
+InfluxDB 数据库的名称。
 
 ### measurement [string]
 
-`influxDB` measurement 的名称。这个配置是可选项；不配置时，sink 会使用输入表完整名称作为
-measurement 名称，这在多表写入场景很有用。
+InfluxDB measurement 的名称。该项可省略；不配置时，sink 会使用输入表完整名称作为
+measurement 名称，这在多表写入场景中很常见。
 多表输入时，请确保生成的表名可以作为合法的 InfluxDB measurement 名称。
 
 ### username [string]
 
-`influxDB` 用户名
+InfluxDB 用户名。
 
 ### password [string]
 
-`influxDB` 用户密码
+InfluxDB 用户密码。
 
 ### key_time [string]
 
-在 SeaTunnelRow 中指定 `influxDB` measurement 时间戳的字段名。如果未指定，则使用处理时间作为时间戳
+指定 SeaTunnelRow 中作为 InfluxDB measurement 时间戳的字段名。
+如果未指定，则使用处理时间作为时间戳；支持数值类型或 ISO-8601 时间戳字符串。
 
 ### key_tags [array]
 
-在 SeaTunnelRow 中指定 `influxDB` measurement 标签的字段名。
-如果未指定，则包含所有字段作为 `influxDB` measurement 字段
+指定 SeaTunnelRow 中作为 InfluxDB measurement tag 的字段名。
+如果未指定，所有字段都会作为 InfluxDB measurement field。
 
 ### batch_size [int]
 
-对于批量写入，当缓冲区数量达到 `batch_size` 数量或时间达到 `checkpoint.interval` 时，数据将被刷新到 influxDB
+批量写入时，当缓冲数量达到 `batch_size` 或时间达到 `checkpoint.interval` 时，数据会刷新到 InfluxDB。
+默认值为 `1024`，在每个 checkpoint 和 writer 关闭时也会触发 flush。
 
 ### max_retries [int]
 
-刷新失败的重试次数
-
-不配置该选项时，sink 只尝试写入一次，失败后直接报错。
+写入失败时的最大重试次数。不配置该选项时，sink 只尝试写入一次，失败后直接报错。
 
 ### retry_backoff_multiplier_ms [int]
 
-用作生成下一个退避延迟的乘数
+用作生成下一次重试退避延迟的乘数，单位毫秒。
+须配合 `max_retry_backoff_ms` 一起配置，否则重试等待时间仍为 `0`。
 
 ### max_retry_backoff_ms [int]
 
-在尝试重新请求 `influxDB` 之前等待的时间量
-
-使用重试配置时，建议同时配置 `retry_backoff_multiplier_ms` 和 `max_retry_backoff_ms`；否则重试等待时间仍为 `0`。
+两次重试之间的最大等待时间，单位毫秒。
+须配合 `retry_backoff_multiplier_ms` 一起配置，否则重试等待时间仍为 `0`。
 
 ### write_timeout [int]
 
-InfluxDB 客户端写入超时时间。
+InfluxDB 客户端写入超时时间，单位秒。
 
 ### rp [string]
 
@@ -126,31 +130,32 @@ InfluxDB 客户端读超时时间，单位秒。
 
 ### connect_timeout_ms [long]
 
-连接到 InfluxDB 的超时时间，以毫秒为单位
+连接 InfluxDB 的超时时间，单位毫秒。默认值为 `15000`。
 
 ### 通用选项
 
-Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 详见
+Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 详见。
 
-## 示例
+## 任务示例
 
-### 写入一个 measurement
+### 写入一个 Measurement
+
+将行数据写入指定 measurement 的简单示例。
 
 ```hocon
 sink {
-    InfluxDB {
-        url = "http://influxdb-host:8086"
-        database = "test"
-        measurement = "sink"
-        key_time = "time"
-        key_tags = ["label"]
-        batch_size = 1
-    }
+  InfluxDB {
+    url = "http://influxdb-host:8086"
+    database = "test"
+    measurement = "sink"
+    key_time = "time"
+    key_tags = ["label"]
+    batch_size = 1
+  }
 }
-
 ```
 
-### 不显式配置 measurement
+### 不显式配置 Measurement
 
 不配置 `measurement` 时，sink 会使用输入表完整名称作为 measurement 名称。
 
@@ -212,7 +217,7 @@ source {
     url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
     username = "root"
     password = "******"
-    
+
     table-names = ["seatunnel.role","seatunnel.user","galileo.Bucket"]
   }
 }

--- a/docs/zh/connectors/sink/Mqtt.md
+++ b/docs/zh/connectors/sink/Mqtt.md
@@ -4,15 +4,22 @@ import ChangeLog from '../changelog/connector-mqtt.md';
 
 > MQTT Sink 连接器
 
+## 引擎支持
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
 ## 描述
 
 用于把数据写入 MQTT broker。该连接器基于 Eclipse Paho 客户端库，支持 MQTT 3.1.1 协议。
 
 它适合把 SeaTunnel 作业中的数据发布到物联网设备、边缘网关或轻量消息 broker。消息可以按 JSON 或纯文本格式序列化，并写入指定的 MQTT topic。
 
-## 主要特性
+## 关键特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::caution 投递语义
@@ -23,40 +30,34 @@ import ChangeLog from '../changelog/connector-mqtt.md';
 
 :::
 
-## 支持引擎
+## Sink 选项
 
-> SeaTunnel Zeta<br/>
-> Flink<br/>
-> Spark<br/>
-
-## 选项
-
-| 名称                 | 类型      | 是否必须 | 默认值  |
-|--------------------|---------|------|------|
-| url                | string  | 是    | -    |
-| topic              | string  | 是    | -    |
-| username           | string  | 否    | -    |
-| password           | string  | 否    | -    |
-| qos                | int     | 否    | 1    |
-| format             | string  | 否    | json |
-| field_delimiter    | string  | 否    | ,    |
-| batch_size         | int     | 否    | 1    |
-| retry_timeout      | int     | 否    | 5000 |
-| connection_timeout | int     | 否    | 30   |
-| clean_session      | boolean | 否    | true |
-| common-options     |         | 否    | -    |
+| 名称                 | 类型      | 是否必须 | 默认值  | 描述                                                              |
+|--------------------|---------|------|------|-----------------------------------------------------------------|
+| url                | string  | 是    | -    | MQTT broker 连接地址，必须包含协议、主机和端口，例如 `tcp://broker.example.com:1883`。 |
+| topic              | string  | 是    | -    | 要发布消息的 MQTT topic，例如 `iot/sensors/temperature`。                |
+| username           | string  | 否    | -    | MQTT broker 认证用户名。匿名访问时可以不配置。                                   |
+| password           | string  | 否    | -    | MQTT broker 认证密码。匿名访问时可以不配置。                                   |
+| qos                | int     | 否    | 1    | 发布消息时使用的 MQTT QoS 等级。`0` 表示最多一次，`1` 表示至少一次。                  |
+| format             | string  | 否    | json | 输出消息的序列化格式。`json` 把每一行序列化为 JSON 对象；`text` 按分隔符拼接为纯文本。          |
+| field_delimiter    | string  | 否    | ,    | 当 `format = "text"` 时使用的字段分隔符，例如 `,`、`|`、`\t`。                  |
+| batch_size         | int     | 否    | 1    | 发送到 broker 前缓存的消息数量；每个 checkpoint 和 writer 关闭时也会自动 flush。        |
+| retry_timeout      | int     | 否    | 5000 | 发布消息遇到临时网络故障时，最多重试多久，单位为毫秒。                                  |
+| connection_timeout | int     | 否    | 30   | 建立 MQTT 连接的超时时间，单位为秒。                                          |
+| clean_session      | boolean | 否    | true | 是否使用 clean MQTT session。`true` 丢弃之前的会话状态，`false` 保留会话状态。       |
+| common-options     | config  | 否    | -    | Sink 插件通用参数，详见 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
 ### url [string]
 
 MQTT broker 连接地址，必须包含协议、主机和端口。
 
-示例：`tcp://broker.example.com:1883`
+示例：`tcp://broker.example.com:1883`。
 
 ### topic [string]
 
 要发布消息的 MQTT topic。
 
-示例：`iot/sensors/temperature`
+示例：`iot/sensors/temperature`。
 
 ### username [string]
 
@@ -84,12 +85,11 @@ MQTT broker 认证密码。匿名访问时可以不配置。
 
 当 `format = "text"` 时使用的字段分隔符。默认值为 `,`。
 
-示例：`,`, `|`, `\t`
+示例：`,`、`|`、`\t`。
 
 ### batch_size [int]
 
 发送到 broker 前缓存的消息数量。默认值为 `1`，表示每条消息都会立即发送。
-
 调大该值可以减少逐条发送的开销，提升吞吐。缓存中的消息会在 checkpoint 和 writer 关闭时自动 flush。
 
 ### retry_timeout [int]
@@ -107,20 +107,25 @@ MQTT broker 认证密码。匿名访问时可以不配置。
 - `true`：broker 会丢弃之前的会话状态，适合大多数无状态写入场景。
 - `false`：broker 可以在 writer 运行期间保留自动生成的 client id 对应的会话状态。它有助于处理短暂断连，但可能造成 broker 端状态堆积，也不提供跨作业重启的稳定 client id。
 
-### common options
+### 通用选项
 
 Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
 
 ## 性能建议
 
-MQTT Sink 会同步发送消息，以保持写入顺序。可以通过下面方式提升吞吐：
+MQTT Sink 会同步发送消息，以保持写入顺序。典型吞吐：
+
+- QoS 0：~10,000 条消息/秒（局域网）。
+- QoS 1：~5,000 条消息/秒（需要 broker ACK）。
+
+可以通过下面方式提升吞吐：
 
 - 适当调大 `batch_size`，例如设置为 `100`，减少逐条发送开销。
 - 如果业务可以接受最多一次投递，把 `qos` 设置为 `0`。
 - 提高 SeaTunnel 作业并行度，让多个 MQTT client 分担写入。
 - 如果需要非常高的吞吐，可以考虑使用 Kafka Sink。
 
-## 示例
+## 任务示例
 
 ### 写入 JSON 消息到 MQTT
 

--- a/docs/zh/connectors/source/Airtable.md
+++ b/docs/zh/connectors/source/Airtable.md
@@ -17,159 +17,62 @@ import ChangeLog from '../changelog/connector-http-airtable.md';
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 源选项
 
-| 参数名 | 类型 | 必须 | 默认值 |
-|--------|------|------|--------|
-| token                       | String  | 是 | -             |
-| base_id                     | String  | 是 | -             |
-| table                       | String  | 是 | -             |
-| api_base_url                | String  | 否 | https://api.airtable.com |
-| view                        | String  | 否 | -             |
-| fields                      | List    | 否 | -             |
-| filter_by_formula           | String  | 否 | -             |
-| max_records                 | int     | 否 | -             |
-| page_size                   | int     | 否 | -             |
-| sort                        | String  | 否 | -             |
-| cell_format                 | String  | 否 | -             |
-| return_fields_by_field_id   | boolean | 否 | -             |
-| record_metadata             | List    | 否 | -             |
-| time_zone                   | String  | 否 | -             |
-| user_locale                 | String  | 否 | -             |
-| offset                      | String  | 否 | -             |
-| headers                     | Map     | 否 | -             |
-| body                        | String  | 否 | -             |
-| pageing                     | Config  | 否 | -             |
-| request_interval_ms         | int     | 否 | 220           |
-| rate_limit_backoff_ms       | int     | 否 | 30000         |
-| rate_limit_max_retries      | int     | 否 | 3             |
-| schema                      | Config  | 否 | -             |
-| schema.fields               | Config  | 否 | -             |
-| format                      | String  | 否 | text          |
-| content_field               | String  | 否 | -             |
-| json_field                  | Config  | 否 | -             |
-| json_filed_missed_return_null | boolean | 否 | false       |
-| common-options              | config  | 否 | -             |
+| 参数名 | 类型 | 必须 | 默认值 | 描述 |
+|--------|------|------|--------|------|
+| token                       | String  | 是 | -                      | Airtable 个人访问令牌。可在 https://airtable.com/create/tokens 创建。 |
+| base_id                     | String  | 是 | -                      | Airtable Base ID（以 `app` 开头）。 |
+| table                       | String  | 是 | -                      | 要读取的表名或表 ID。 |
+| api_base_url                | String  | 否 | https://api.airtable.com | Airtable API 基础 URL。 |
+| view                        | String  | 否 | -                      | 视图名称或 ID，仅返回该视图中可见的记录。 |
+| fields                      | List    | 否 | -                      | 要包含在响应中的字段名列表。 |
+| filter_by_formula           | String  | 否 | -                      | Airtable 公式表达式，用于过滤记录。参考 [Airtable 公式文档](https://support.airtable.com/docs/formula-field-reference)。 |
+| max_records                 | int     | 否 | -                      | 返回的最大记录总数。 |
+| page_size                   | int     | 否 | -                      | 每页记录数（1-100）。 |
+| sort                        | String  | 否 | -                      | 排序定义 JSON 数组，例如 `[{"field":"Name","direction":"asc"}]`。 |
+| cell_format                 | String  | 否 | -                      | 单元格值格式，`json` 或 `string`。 |
+| return_fields_by_field_id   | boolean | 否 | -                      | 如果为 true，响应中的字段键将使用字段 ID 而非字段名。 |
+| record_metadata             | List    | 否 | -                      | 要返回的额外记录元数据，例如 `["commentCount"]`。 |
+| time_zone                   | String  | 否 | -                      | 用于格式化日期/时间值的时区。 |
+| user_locale                 | String  | 否 | -                      | 用于格式化值的用户区域设置。 |
+| offset                      | String  | 否 | -                      | Airtable 返回的分页偏移量。通常不需要手动配置，连接器会自动继续读取 Airtable 后续分页。 |
+| headers                     | Map     | 否 | -                      | 额外的 HTTP 请求头。连接器会自动添加 Airtable 认证头和 JSON 内容类型请求头。 |
+| body                        | String  | 否 | -                      | 高级请求体配置。不要把它和 `fields`、`filter_by_formula`、`page_size`、`sort` 等专用 Airtable 请求选项配置成同一个 Airtable API 字段。 |
+| pageing                     | Config  | 否 | -                      | 继承自 HTTP 连接器的分页配置。普通 Airtable 读取建议优先使用连接器内置的 Airtable 分页处理。 |
+| request_interval_ms         | int     | 否 | 220                    | API 请求之间的最小间隔（毫秒），默认 220ms（以保持在 Airtable 每秒 5 次请求的限制内）。 |
+| rate_limit_backoff_ms       | int     | 否 | 30000                  | 收到 429（限流）响应时的基础退避时间（毫秒），默认 30000ms。 |
+| rate_limit_max_retries      | int     | 否 | 3                      | 收到 429 响应后的最大重试次数，默认 3。 |
+| schema                      | Config  | 否 | -                      | 输出数据结构，`format = "json"` 时必填。详见 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
+| schema.fields               | Config  | 否 | -                      | 字段名与 SeaTunnel 数据类型，用于解析 JSON 响应。 |
+| format                      | String  | 否 | text                   | 上游数据的格式，支持 `json` 和 `text`，默认 `text`。 |
+| content_field               | String  | 否 | -                      | 用于从响应中提取数据的 JsonPath 表达式。对于 Airtable，通常使用 `$.records[*].fields` 来提取每条记录的字段。 |
+| json_field                  | Config  | 否 | -                      | 字段级 JSONPath 映射，与 `schema` 配合使用。 |
+| json_filed_missed_return_null | boolean | 否 | false                | 配置的 JSON 字段缺失时是否返回 `null`，否则报错。 |
+| enable_multi_lines          | boolean | 否 | false                  | 是否启用多行模式，将响应体中按换行分隔的多个 JSON 对象视为独立记录。 |
+| connect_timeout_ms          | int     | 否 | 12000                  | HTTP 连接超时时间（毫秒），默认 12000ms。 |
+| socket_timeout_ms           | int     | 否 | 60000                  | HTTP 套接字超时时间（毫秒），默认 60000ms。 |
+| common-options              | config  | 否 | -                      | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。 |
 
-### token [String]
+## 使用提示
 
-Airtable 个人访问令牌。可在 https://airtable.com/create/tokens 创建。
+- `token` 是敏感信息，请避免在共享的任务文件中硬编码真实令牌。可使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
+- 连接器会自动按 Airtable `offset` 分页继续读取，通常不需要手动设置 `offset`。
+- Airtable 对每个令牌限速为 5 次/秒。默认 `request_interval_ms = 220` 可保证单个连接器不超过该限制。可通过 `rate_limit_backoff_ms` 和 `rate_limit_max_retries` 控制遇到 HTTP 429 时的退避与重试行为。
+- 若希望输出带字段名的数据行，请将 `format` 设置为 `json` 并配置 `schema`。
+- 使用 `content_field = "$.records[*].fields"` 在解析前先抽取记录的字段部分。
+- 只有当不同字段位于不同 JSON 路径时，才需要使用 `json_field`。
 
-### base_id [String]
+## 任务示例
 
-Airtable Base ID（以 `app` 开头）。
-
-### table [String]
-
-要读取的表名或表 ID。
-
-### api_base_url [String]
-
-Airtable API 基础 URL，默认 `https://api.airtable.com`。
-
-### view [String]
-
-视图名称或 ID，仅返回该视图中可见的记录。
-
-### fields [List]
-
-要包含在响应中的字段名列表。
-
-### filter_by_formula [String]
-
-Airtable 公式表达式，用于过滤记录。参考 [Airtable 公式文档](https://support.airtable.com/docs/formula-field-reference)。
-
-### max_records [int]
-
-返回的最大记录总数。
-
-### page_size [int]
-
-每页记录数（1-100）。
-
-### sort [String]
-
-排序定义 JSON 数组，例如 `[{"field":"Name","direction":"asc"}]`。
-
-### cell_format [String]
-
-单元格值格式，`json` 或 `string`。
-
-### return_fields_by_field_id [boolean]
-
-如果为 true，响应中的字段键将使用字段 ID 而非字段名。
-
-### record_metadata [List]
-
-要返回的额外记录元数据，例如 `["commentCount"]`。
-
-### time_zone [String]
-
-用于格式化日期/时间值的时区。
-
-### user_locale [String]
-
-用于格式化值的用户区域设置。
-
-### offset [String]
-
-Airtable 返回的分页偏移量。通常不需要手动配置，连接器会自动继续读取 Airtable 后续分页。
-
-### headers [Map]
-
-额外的 HTTP 请求头。连接器会自动添加 Airtable 认证头和 JSON 内容类型请求头。
-
-### body [String]
-
-高级请求体配置。不要把它和 `fields`、`filter_by_formula`、`page_size`、`sort` 等专用 Airtable 请求选项配置成同一个 Airtable API 字段。
-
-### pageing [Config]
-
-继承自 HTTP 连接器的分页配置。普通 Airtable 读取建议优先使用连接器内置的 Airtable 分页处理。
-
-### request_interval_ms [int]
-
-API 请求之间的最小间隔（毫秒），默认 220ms（以保持在 Airtable 每秒 5 次请求的限制内）。
-
-### rate_limit_backoff_ms [int]
-
-收到 429（限流）响应时的基础退避时间（毫秒），默认 30000ms。
-
-### rate_limit_max_retries [int]
-
-收到 429 响应后的最大重试次数，默认 3。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### format [String]
-
-上游数据的格式，支持 `json` 和 `text`，默认 `text`。
-
-### content_field [String]
-
-用于从响应中提取数据的 JsonPath 表达式。对于 Airtable，通常使用 `$.records[*].fields` 来提取每条记录的字段。
-
-### json_field [Config]
-
-此参数帮助您配置模式，必须与 schema 一起使用。
-
-### json_filed_missed_return_null [boolean]
-
-设置为 `true` 时，JSON 字段缺失会返回 `null`；否则字段缺失会报错。
-
-### common options
-
-源插件通用参数，请参考 [Source Common Options](../common-options/source-common-options.md)。
-
-## 示例
-
-读取 Airtable 表并输出原始文本：
+### 读取记录并以文本形式输出
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
@@ -179,16 +82,27 @@ source {
     max_records = 10
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-指定 schema 并提取记录字段：
+### 指定 Schema 并提取字段
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
     base_id = "appXXXXXXXX"
     table = "Shipments"
+    format = "json"
     content_field = "$.records[*].fields"
     filter_by_formula = "{Status} = 'Shipped'"
     schema = {
@@ -202,9 +116,16 @@ source {
 }
 ```
 
-读取 Airtable 的小批量分页数据：
+### 按页读取并控制吞吐
+
+通过 `page_size` 与 `request_interval_ms` 控制分页读取的吞吐：
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Airtable {
     token = "patXXXXXXXX.XXXXXXXX"
@@ -219,6 +140,34 @@ source {
         Name = string
         Age = int
         Status = string
+      }
+    }
+  }
+}
+```
+
+### 通过 JSONPath 抽取字段
+
+当不同字段位于不同 JSON 路径时，使用 `json_field`：
+
+```hocon
+source {
+  Airtable {
+    token = "patXXXXXXXX.XXXXXXXX"
+    base_id = "appXXXXXXXX"
+    table = "Shipments"
+    format = "json"
+    content_field = "$.records[*]"
+    json_field = {
+      Name = "$.fields.Name"
+      Status = "$.fields.Status"
+      CreatedAt = "$.createdTime"
+    }
+    schema = {
+      fields {
+        Name = string
+        Status = string
+        CreatedAt = string
       }
     }
   }

--- a/docs/zh/connectors/source/Cassandra.md
+++ b/docs/zh/connectors/source/Cassandra.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-cassandra.md';
 
 > Cassandra 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 以批处理方式从 Apache Cassandra 读取数据。
@@ -14,6 +20,12 @@ Cassandra source 支持两种读取方式：
 - 使用 `tables_configs` 读取多张表，每个条目里配置一个 `cql`。
 
 连接器会根据 CQL 返回结果里的列名和数据类型生成下游数据结构，所以 CQL 应该返回下游真正需要的列。
+
+## 支持的数据源信息
+
+| 数据源      | 支持版本 | 依赖 |
+|-----------|--------|------|
+| Cassandra | 通用    | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-cassandra) |
 
 ## 关键特性
 
@@ -48,7 +60,7 @@ Cassandra source 支持两种读取方式：
 | set               | ARRAY              |
 | map               | MAP                |
 
-## 选项
+## Source 选项
 
 | 名称              | 类型       | 是否必填 | 默认值      | 描述 |
 |-------------------|------------|----------|-------------|------|
@@ -124,7 +136,7 @@ Source 插件通用参数，详情请参考 [Source 常用选项](../common-opti
 - 这是批处理 source。它读取当前查询结果后就会结束。
 - 一个 CQL 查询会作为一个 source split 读取。调大任务并行度不会自动把单张 Cassandra 表拆成多个扫描任务。
 
-## 示例
+## 任务示例
 
 ### 单表读取
 

--- a/docs/zh/connectors/source/Github.md
+++ b/docs/zh/connectors/source/Github.md
@@ -33,10 +33,22 @@ Github 源连接器用于读取 GitHub REST API 数据。它基于 HTTP 源连�
 | json_field                  | Config  | 否   | -      |
 | content_field               | String  | 否   | -      |
 | pageing                     | Config  | 否   | -      |
+| page_type                   | String  | 否   | PageNumber |
+| cursor_field                | String  | 否   | -      |
+| cursor_response_field       | String  | 否   | -      |
 | poll_interval_millis        | int     | 否   | -      |
 | retry                       | int     | 否   | -      |
 | retry_backoff_multiplier_ms | int     | 否   | 100    |
 | retry_backoff_max_ms        | int     | 否   | 10000  |
+| enable_multi_lines          | boolean | 否   | false  |
+| keep_params_as_form         | boolean | 否   | false  |
+| keep_page_param_as_http_param | boolean | 否 | false  |
+| batch_size                  | int     | 否   | 100    |
+| start_page_number           | long    | 否   | 1      |
+| total_page_size             | long    | 否   | 0      |
+| use_placeholder_replacement | boolean | 否   | false  |
+| connect_timeout_ms          | int     | 否   | 12000  |
+| socket_timeout_ms           | int     | 否   | 60000  |
 | json_filed_missed_return_null | boolean | 否 | false  |
 | common-options              | config  | 否   | -      |
 
@@ -82,7 +94,19 @@ HTTP 请求体。只有目标 API 接口支持请求体时才需要配置。
 
 ### pageing [Config]
 
-继承自 HTTP 连接器的分页配置。任务配置中请保持 `pageing` 这个拼写。
+继承自 HTTP 连接器的分页配置。任务配置中请保持 `pageing` 这个拼写。必要时可配合 `page_type = "Cursor"` 使用游标分页。
+
+### page_type [String]
+
+分页类型，支持 `PageNumber`（默认）和 `Cursor`。对于响应中包含 `next` 游标的接口，请使用 `Cursor`。
+
+### cursor_field [String]
+
+携带游标值的请求参数名称，与 `page_type = "Cursor"` 一起使用。
+
+### cursor_response_field [String]
+
+响应体中游标所在的 JSONPath，与 `page_type = "Cursor"` 一起使用。
 
 ### poll_interval_millis [int]
 
@@ -100,6 +124,42 @@ HTTP 请求因 `IOException` 失败时的最大重试次数。
 
 最大重试退避时间，单位毫秒。
 
+### enable_multi_lines [boolean]
+
+是否启用多行模式，将响应体中按换行分隔的多个 JSON 对象视为独立记录。
+
+### keep_params_as_form [boolean]
+
+是否将请求参数作为表单参数发送，而不是 URL 查询参数。
+
+### keep_page_param_as_http_param [boolean]
+
+分页时是否将分页参数保留在 URL 中，而不是在请求体内替换。
+
+### batch_size [int]
+
+当总页数未知时，每次请求返回的记录数。
+
+### start_page_number [long]
+
+从哪一页开始读取。
+
+### total_page_size [long]
+
+要读取的总页数。`0` 表示按照 `batch_size` 一直读取，直到 API 不再返回新页。
+
+### use_placeholder_replacement [boolean]
+
+是否使用 `${field}` 占位符替换 headers、params 和 body 中的字段值，否则按键名替换。
+
+### connect_timeout_ms [int]
+
+HTTP 连接超时时间（毫秒），默认 12000ms。
+
+### socket_timeout_ms [int]
+
+HTTP 套接字超时时间（毫秒），默认 60000ms。
+
 ### json_filed_missed_return_null [boolean]
 
 设置为 `true` 时，JSON 字段缺失会返回 `null`；否则字段缺失会报错。
@@ -108,11 +168,25 @@ HTTP 请求因 `IOException` 失败时的最大重试次数。
 
 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md)。
 
-## 示例
+## 使用提示
 
-读取 GitHub 组织下的仓库：
+- `access_token` 是敏感信息，请避免在共享的任务文件中硬编码真实令牌。可使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
+- 连接器始终会根据 `access_token` 添加 `Authorization: Bearer <access_token>` 请求头，请把其他自定义请求头放在 `headers` 中。
+- 需要按字段读取时，把 `format` 设置为 `json` 并配置 `schema`。
+- 当 GitHub 把记录嵌套在数组中时，使用 `content_field` 抽取数组元素。
+- 使用页码分页时，保持 `page_type = "PageNumber"`，并通过 `params` 配置 `page` / `per_page`。
+- 对于 GitHub Events 这类游标分页接口，请设置 `page_type = "Cursor"` 并配置 `cursor_field` 与 `cursor_response_field`。
+
+## 任务示例
+
+### 读取 GitHub 组织下的仓库
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Github {
     url = "https://api.github.com/orgs/apache/repos"
@@ -131,11 +205,21 @@ source {
     }
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-读取分页的 GitHub API 结果：
+### 读取分页的 GitHub API 结果
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Github {
     url = "https://api.github.com/orgs/apache/repos"
@@ -157,6 +241,33 @@ source {
         id = int
         name = string
         html_url = string
+      }
+    }
+  }
+}
+```
+
+### 流式读取 GitHub 事件
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Github {
+    url = "https://api.github.com/orgs/apache/events"
+    access_token = "ghp_xxxxxxxxxxxx"
+    method = "GET"
+    format = "json"
+    poll_interval_millis = 60000
+    schema = {
+      fields {
+        id = string
+        type = string
+        created_at = string
       }
     }
   }

--- a/docs/zh/connectors/source/Gitlab.md
+++ b/docs/zh/connectors/source/Gitlab.md
@@ -33,10 +33,22 @@ Gitlab 源连接器用于读取 GitLab REST API 数据。它基于 HTTP 源连�
 | json_field                  | Config  | 否   | -      |
 | content_field               | String  | 否   | -      |
 | pageing                     | Config  | 否   | -      |
+| page_type                   | String  | 否   | PageNumber |
+| cursor_field                | String  | 否   | -      |
+| cursor_response_field       | String  | 否   | -      |
 | poll_interval_millis        | int     | 否   | -      |
 | retry                       | int     | 否   | -      |
 | retry_backoff_multiplier_ms | int     | 否   | 100    |
 | retry_backoff_max_ms        | int     | 否   | 10000  |
+| enable_multi_lines          | boolean | 否   | false  |
+| keep_params_as_form         | boolean | 否   | false  |
+| keep_page_param_as_http_param | boolean | 否 | false  |
+| batch_size                  | int     | 否   | 100    |
+| start_page_number           | long    | 否   | 1      |
+| total_page_size             | long    | 否   | 0      |
+| use_placeholder_replacement | boolean | 否   | false  |
+| connect_timeout_ms          | int     | 否   | 12000  |
+| socket_timeout_ms           | int     | 否   | 60000  |
 | json_filed_missed_return_null | boolean | 否 | false  |
 | common-options              | config  | 否   | -      |
 
@@ -84,6 +96,18 @@ HTTP 请求体。只有目标 API 接口支持请求体时才需要配置。
 
 继承自 HTTP 连接器的分页配置。任务配置中请保持 `pageing` 这个拼写。
 
+### page_type [String]
+
+分页类型，支持 `PageNumber`（默认）和 `Cursor`。对于响应中包含 `X-Next-Page` 游标的接口，请使用 `Cursor`。
+
+### cursor_field [String]
+
+携带游标值的请求参数名称，与 `page_type = "Cursor"` 一起使用。
+
+### cursor_response_field [String]
+
+响应体中游标所在的 JSONPath，与 `page_type = "Cursor"` 一起使用。
+
 ### poll_interval_millis [int]
 
 该选项继承自 HTTP 连接器，但 Gitlab 源连接器当前只支持批处理模式。
@@ -100,6 +124,42 @@ HTTP 请求因 `IOException` 失败时的最大重试次数。
 
 最大重试退避时间，单位毫秒。
 
+### enable_multi_lines [boolean]
+
+是否启用多行模式，将响应体中按换行分隔的多个 JSON 对象视为独立记录。
+
+### keep_params_as_form [boolean]
+
+是否将请求参数作为表单参数发送，而不是 URL 查询参数。
+
+### keep_page_param_as_http_param [boolean]
+
+分页时是否将分页参数保留在 URL 中，而不是在请求体内替换。
+
+### batch_size [int]
+
+当总页数未知时，每次请求返回的记录数。
+
+### start_page_number [long]
+
+从哪一页开始读取。
+
+### total_page_size [long]
+
+要读取的总页数。`0` 表示按照 `batch_size` 一直读取，直到 API 不再返回新页。
+
+### use_placeholder_replacement [boolean]
+
+是否使用 `${field}` 占位符替换 headers、params 和 body 中的字段值，否则按键名替换。
+
+### connect_timeout_ms [int]
+
+HTTP 连接超时时间（毫秒），默认 12000ms。
+
+### socket_timeout_ms [int]
+
+HTTP 套接字超时时间（毫秒），默认 60000ms。
+
 ### json_filed_missed_return_null [boolean]
 
 设置为 `true` 时，JSON 字段缺失会返回 `null`；否则字段缺失会报错。
@@ -108,11 +168,25 @@ HTTP 请求因 `IOException` 失败时的最大重试次数。
 
 源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md)。
 
-## 示例
+## 使用提示
 
-读取 GitLab 项目：
+- `access_token` 是敏感信息，请避免在共享的任务文件中硬编码真实令牌。可使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
+- 连接器始终会根据 `access_token` 添加 `PRIVATE-TOKEN` 请求头，请把其他自定义请求头放在 `headers` 中。
+- 需要按字段读取时，把 `format` 设置为 `json` 并配置 `schema`。
+- 当 GitLab 把记录嵌套在数组中时，使用 `content_field` 抽取数组元素。
+- 使用页码分页时，保持 `page_type = "PageNumber"`，并通过 `params` 配置 `page` / `per_page`。
+- Gitlab 源连接器当前只支持批处理模式，`poll_interval_millis` 不会启用流式行为。
+
+## 任务示例
+
+### 读取 GitLab 项目
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Gitlab {
     url = "https://gitlab.com/api/v4/projects"
@@ -131,11 +205,21 @@ source {
     }
   }
 }
+
+sink {
+  Console {
+  }
+}
 ```
 
-读取分页的 GitLab API 结果：
+### 读取分页的 GitLab API 结果
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Gitlab {
     url = "https://gitlab.com/api/v4/projects"
@@ -157,6 +241,41 @@ source {
         id = int
         name = string
         path = string
+      }
+    }
+  }
+}
+```
+
+### 过滤并通过 JSONPath 抽取字段
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Gitlab {
+    url = "https://gitlab.com/api/v4/projects"
+    access_token = "glpat-xxxxxxxxxxxx"
+    method = "GET"
+    params = {
+      owned = "true"
+      per_page = "50"
+    }
+    format = "json"
+    content_field = "$.[*]"
+    json_field = {
+      id = "$.id"
+      name = "$.name"
+      visibility = "$.visibility"
+    }
+    schema = {
+      fields {
+        id = int
+        name = string
+        visibility = string
       }
     }
   }

--- a/docs/zh/connectors/source/InfluxDB.md
+++ b/docs/zh/connectors/source/InfluxDB.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 > InfluxDB 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 通过 InfluxQL 查询从 InfluxDB 1.x 读取数据。连接器支持普通单查询，也支持按一个整数列范围切分查询，
@@ -32,47 +38,42 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 当前 InfluxDB source 转换器不支持其他 SeaTunnel 类型。
 
-## 选项
+## Source 选项
 
 | 参数名                | 类型     | 必须 | 默认值   | 描述                                                                            |
-|--------------------|--------|----|-------|-------------------------------------------------------------------------------|
-| url                | string | 是  | -     | InfluxDB 连接 URL                                                               |
-| sql                | string | 是  | -     | 用于搜索数据的查询 SQL                                                                 |
-| schema             | config | 是  | -     | 上游数据的模式信息。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| database           | string | 是  | -     | InfluxDB 数据库                                                                  |
+|---------------------|--------|----|-------|-------------------------------------------------------------------------------|
+| url                | string | 是  | -     | InfluxDB 连接 URL，例如 `http://influxdb-host:8086`。                                |
+| sql                | string | 是  | -     | 用于读取数据的 InfluxQL 查询。                                                            |
+| schema             | config | 是  | -     | 上游数据的 schema 信息。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
+| database           | string | 是  | -     | InfluxDB 数据库名称。                                                                  |
 | username           | string | 否  | -     | InfluxDB 用户名。必须和 `password` 一起配置。                                                |
 | password           | string | 否  | -     | InfluxDB 密码。必须和 `username` 一起配置。                                                |
 | lower_bound        | int    | 否  | -     | 启用并行范围读取时，`split_column` 的下界。                                                   |
 | upper_bound        | int    | 否  | -     | 启用并行范围读取时，`split_column` 的上界。                                                   |
 | partition_num      | int    | 否  | 0     | 查询切分数量。`0` 表示不切分，直接执行原始 `sql`。                                              |
-| split_column       | string | 否  | -     | 分割列                                                                           |
+| split_column       | string | 否  | -     | 用于并行切分的整数列。                                                                    |
 | where              | string | 否  | -     | 预留的 source 配置项。当前切分逻辑直接从 `sql` 中读取小写 `where` 关键字。                              |
 | epoch              | string | 否  | n     | 返回的时间精度，例如：`H`、`m`、`s`、`MS`、`u`、`n`。                                     |
-| connect_timeout_ms | long   | 否  | 15000 | 连接 InfluxDB 的超时时间（毫秒）                                                         |
-| query_timeout_sec  | int    | 否  | 3     | 查询超时时间（秒）                                                                     |
-| common-options     | config | 否  | -     | 源插件通用参数                                                                       |
+| connect_timeout_ms | long   | 否  | 15000 | 连接 InfluxDB 的超时时间（毫秒）。                                                         |
+| query_timeout_sec  | int    | 否  | 3     | 查询 InfluxDB 的超时时间（秒）。                                                          |
+| common-options     | config | 否  | -     | Source 插件通用参数，详见 [Source 通用选项](../common-options/source-common-options.md)。 |
 
-### url
+### url [string]
 
-连接到 InfluxDB 的 URL，例如：
-
-```
-http://influxdb-host:8086
-```
+连接到 InfluxDB 的 URL，例如 `http://influxdb-host:8086`。
 
 ### sql [string]
 
-用于搜索数据的查询 SQL
+用于读取数据的 InfluxQL 查询，例如：
 
 ```
-select name,age from test
+select name, age from test
 ```
 
 ### schema [config]
 
-#### fields [Config]
-
-上游数据的模式信息，例如：
+上游数据的 schema 信息，更多语法参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
+例如：
 
 ```
 schema {
@@ -80,28 +81,28 @@ schema {
         name = string
         age = int
     }
-  }
+}
 ```
 
 ### database [string]
 
-InfluxDB 数据库
+InfluxDB 数据库名称。
 
 ### username [string]
 
-InfluxDB 用户名
+InfluxDB 用户名。必须和 `password` 一起配置。
 
 ### password [string]
 
-InfluxDB 密码
+InfluxDB 密码。必须和 `username` 一起配置。
 
 ### split_column [string]
 
-用于把一次查询切分成多个范围查询的列。
+用于把一次查询切分成多个范围查询的整数列。启用并行范围读取时必须配置。
 
 > 提示：
-> - InfluxDB tags 不支持作为分割主键，因为 tags 的类型只能是字符串
-> - InfluxDB time 不支持作为分割主键，因为 time 字段无法参与数学计算
+> - InfluxDB tags 不支持作为分割主键，因为 tags 的类型只能是字符串。
+> - InfluxDB time 不支持作为分割主键，因为 time 字段无法参与数学计算。
 > - 目前，`split_column` 仅支持整数数据分割，不支持 `float`、`string`、`date` 等类型。
 > - `split_column`、`lower_bound`、`upper_bound`、`partition_num` 需要一起配置。
 > - 如果切分读取的 SQL 中包含过滤条件，请在 `sql` 里使用小写 `where`，例如 `select * from test where age > 0`。当前切分解析逻辑区分大小写。
@@ -109,53 +110,46 @@ InfluxDB 密码
 
 ### upper_bound [int]
 
-`split_column` 列的上界
+`split_column` 列的上界。启用并行范围读取时使用。
 
 ### lower_bound [int]
 
-`split_column` 列的下界
+`split_column` 列的下界。启用并行范围读取时使用。
+
+连接器会把 `split_column` 范围切成 `partition_num` 份；若 `partition_num = 1`，则使用整段范围；若
+`partition_num` 小于 `upper_bound - lower_bound`，则按 `upper_bound - lower_bound` 切分。
+
+例如 `lower_bound = 1`、`upper_bound = 10`、`partition_num = 2`、
+`sql = "select * from test where age > 0 and age < 10"` 会被切分成：
 
 ```
-     将 $split_column 范围分成 $partition_num 部分
-     如果 partition_num 为 1，使用整个 `split_column` 范围
-     如果 partition_num < (upper_bound - lower_bound)，使用 (upper_bound - lower_bound) 个分区
-     
-     例如：lower_bound = 1, upper_bound = 10, partition_num = 2
-     sql = "select * from test where age > 0 and age < 10"
-     
-     分割结果
-
-     分割 1: select * from test where ($split_column >= 1 and $split_column < 6)  and (  age > 0 and age < 10 )
-     
-     分割 2: select * from test where ($split_column >= 6 and $split_column < 11) and (  age > 0 and age < 10 )
-
+split 1: select * from test where ($split_column >= 1 and $split_column < 6)  and (  age > 0 and age < 10 )
+split 2: select * from test where ($split_column >= 6 and $split_column < 11) and (  age > 0 and age < 10 )
 ```
 
 ### partition_num [int]
 
-InfluxDB 的分区数量
+查询切分数量。须与 `lower_bound`、`upper_bound`、`split_column` 一起配置。
 
-> 提示：确保 `upper_bound` 减去 `lower_bound` 能被 `partition_num` 整除，否则查询结果会重叠
+> 提示：确保 `upper_bound - lower_bound` 能被 `partition_num` 整除，否则查询结果会重叠。
 
 ### epoch [string]
 
-返回的时间精度
-- 可选值：H, m, s, MS, u, n
-- 默认值：n
+InfluxDB 返回的时间精度。可选值：`H`、`m`、`s`、`MS`、`u`、`n`，默认值为 `n`。
 
 ### query_timeout_sec [int]
 
-InfluxDB 的查询超时时间（秒）
+InfluxDB 客户端的查询超时时间，单位为秒。
 
 ### connect_timeout_ms [long]
 
-连接到 InfluxDB 的超时时间（毫秒）
+连接到 InfluxDB 的超时时间，单位为毫秒。
 
 ### 通用选项
 
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
+Source 插件通用参数，请参考 [Source 通用选项](../common-options/source-common-options.md) 详见。
 
-## 示例
+## 任务示例
 
 ### 使用并行范围读取
 
@@ -166,7 +160,6 @@ env {
 }
 
 source {
-
     InfluxDB {
         url = "http://influxdb-host:8086"
         sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
@@ -189,7 +182,6 @@ source {
             }
         }
     }
-
 }
 
 sink {
@@ -206,7 +198,6 @@ env {
 }
 
 source {
-
     InfluxDB {
         url = "http://influxdb-host:8086"
         sql = "select label, c_string, c_double, c_bigint, c_float, c_int, c_smallint, c_boolean from source"
@@ -225,7 +216,6 @@ source {
             }
         }
     }
-
 }
 
 sink {

--- a/docs/zh/connectors/source/Notion.md
+++ b/docs/zh/connectors/source/Notion.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-http-notion.md';
 
 ## 描述
 
-Notion 源连接器用于从 Notion API 读取数据。它基于 HTTP 源连接器实现，并会根据 `password` 和 `version` 配置自动添加 `Authorization: Bearer <password>` 与 `Notion-Version: <version>` 请求头。
+Notion 源连接器用于读取 Notion API 数据。它基于 HTTP 源连接器实现，并会根据配置自动添加 `Authorization: Bearer <password>` 和 `Notion-Version: <version>` 请求头。
 
 ## 主要特性
 
@@ -15,48 +15,62 @@ Notion 源连接器用于从 Notion API 读取数据。它基于 HTTP 源连接�
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义切分](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
 ## 源选项
 
-| 名称                          | 类型      | 是否必需 | 默认值   | 描述 |
-|-----------------------------|---------|------|-------|------|
-| url                         | String  | 是    | -     | Notion API 请求 URL，例如 `https://api.notion.com/v1/users`。 |
-| password                    | String  | 是    | -     | Notion 集成 Token。连接器会把它作为 `Authorization` Bearer Token 发送。 |
-| version                     | String  | 是    | -     | Notion API 版本，例如 `2022-06-28`。连接器会把它作为 `Notion-Version` 请求头发送。 |
-| method                      | String  | 否    | get   | HTTP 请求方法。支持 `GET` 和 `POST`。 |
-| headers                     | Map     | 否    | -     | 额外 HTTP 请求头。`Authorization` 和 `Notion-Version` 会由 `password` 与 `version` 设置。 |
-| params                      | Map     | 否    | -     | 随请求发送的查询参数。 |
-| body                        | String  | 否    | -     | HTTP 请求体，通常与 `method = "POST"` 一起使用。 |
-| format                      | String  | 否    | text  | 响应格式。读取 Notion JSON 并转换为 SeaTunnel 字段时使用 `json`；返回原始响应内容时使用 `text`。 |
-| schema                      | Config  | 否    | -     | 输出结构。`format = "json"` 时需要配置。 |
-| schema.fields               | Config  | 否    | -     | 用于解析 JSON 响应的字段名和 SeaTunnel 数据类型。 |
-| content_field               | String  | 否    | -     | JSONPath 表达式，用于先选取响应中的嵌套内容，再按 `schema` 解析。 |
-| json_field                  | Config  | 否    | -     | 字段级 JSONPath 映射。当不同输出字段来自不同 JSON 路径时，与 `schema` 一起使用。 |
-| pageing                     | Config  | 否    | -     | 继承自 HTTP 源连接器的分页配置。 |
-| poll_interval_millis        | Int     | 否    | -     | 以流模式使用时，两次请求之间的间隔毫秒数。 |
-| retry                       | Int     | 否    | -     | HTTP 请求发生 `IOException` 时的最大重试次数。 |
-| retry_backoff_multiplier_ms | Int     | 否    | 100   | 重试退避时间倍数，单位毫秒。 |
-| retry_backoff_max_ms        | Int     | 否    | 10000 | 最大重试退避时间，单位毫秒。 |
-| json_filed_missed_return_null | Boolean | 否  | false | 配置的 JSON 字段不存在时返回 null。 |
-| common-options              | Config  | 否    | -     | 源插件通用参数，详情请参考 [Source 通用选项](../common-options/source-common-options.md)。 |
+| 参数名                      | 类型    | 必须 | 默认值    | 描述                                                                                          |
+|-----------------------------|---------|----|--------|---------------------------------------------------------------------------------------------|
+| url                         | String  | 是  | -      | Notion API 请求地址，例如 `https://api.notion.com/v1/users`。                                              |
+| password                    | String  | 是  | -      | Notion 集成令牌，连接器会将其作为 `Authorization` Bearer token 发送。                                              |
+| version                     | String  | 是  | -      | Notion API 版本号，例如 `2022-06-28`，连接器会将其作为 `Notion-Version` 请求头发送。                                       |
+| method                      | String  | 否  | get    | HTTP 请求方法，支持 `GET` 和 `POST`。                                                                       |
+| headers                     | Map     | 否  | -      | 额外的 HTTP 请求头。`Authorization` 和 `Notion-Version` 会由 `password` 和 `version` 自动添加。                      |
+| params                      | Map     | 否  | -      | 请求附带的查询参数。                                                                                      |
+| body                        | String  | 否  | -      | HTTP 请求体，通常与 `method = "POST"` 一起使用。                                                                |
+| format                      | String  | 否  | text   | 响应格式，`json` 时需要配合 `schema`；`text` 时返回原始响应。                                                       |
+| schema                      | Config  | 否  | -      | 输出数据结构，`format = "json"` 时必填。                                                                       |
+| schema.fields               | Config  | 否  | -      | 字段名与 SeaTunnel 数据类型，用于解析 JSON 响应。                                                                |
+| content_field               | String  | 否  | -      | 在 `schema` 解析之前先通过 JSONPath 抽取一段 JSON。                                                            |
+| json_field                  | Config  | 否  | -      | 字段级 JSONPath 映射，与 `schema` 配合使用。                                                                |
+| pageing                     | Config  | 否  | -      | HTTP 分页配置，继承自 HTTP 源连接器。                                                                          |
+| page_type                   | String  | 否  | PageNumber | 分页类型，支持 `PageNumber`（默认）和 `Cursor`。对于返回 `next_cursor` 的 Notion 接口请使用 `Cursor`。                       |
+| cursor_field                | String  | 否  | -      | 携带游标值的请求参数名称，与 `page_type = "Cursor"` 一起使用。                                                         |
+| cursor_response_field       | String  | 否  | -      | 响应体中游标所在的 JSONPath，与 `page_type = "Cursor"` 一起使用。                                                     |
+| poll_interval_millis        | int     | 否  | -      | 流模式下的请求间隔（毫秒）。Notion 源连接器当前只支持批处理模式。                                                            |
+| retry                       | int     | 否  | -      | HTTP 请求返回 `IOException` 时的最大重试次数。                                                              |
+| retry_backoff_multiplier_ms | int     | 否  | 100    | HTTP 请求失败时的重试退避倍数（毫秒）。                                                                          |
+| retry_backoff_max_ms        | int     | 否  | 10000  | HTTP 请求失败时的最大重试退避时间（毫秒）。                                                                        |
+| enable_multi_lines          | boolean | 否  | false  | 是否启用多行模式，将响应体中按换行分隔的多个 JSON 对象视为独立记录。                                                            |
+| keep_params_as_form         | boolean | 否  | false  | 是否将请求参数作为表单参数发送，而不是 URL 查询参数。                                                                   |
+| keep_page_param_as_http_param | boolean | 否 | false | 分页时是否将分页参数保留在 URL 中，而不是在请求体内替换。                                                                  |
+| batch_size                  | int     | 否  | 100    | 当总页数未知时，每次请求返回的记录数。                                                                              |
+| start_page_number           | long    | 否  | 1      | 从哪一页开始读取。                                                                                       |
+| total_page_size             | long    | 否  | 0      | 要读取的总页数。`0` 表示按照 `batch_size` 一直读取，直到 API 不再返回新页。                                              |
+| use_placeholder_replacement | boolean | 否  | false  | 是否使用 `${field}` 占位符替换 headers、params 和 body 中的字段值，否则按键名替换。                                            |
+| connect_timeout_ms          | int     | 否  | 12000  | HTTP 连接超时时间（毫秒），默认 12000ms。                                                                       |
+| socket_timeout_ms           | int     | 否  | 60000  | HTTP 套接字超时时间（毫秒），默认 60000ms。                                                                      |
+| json_filed_missed_return_null | boolean | 否 | false  | 配置的 JSON 字段缺失时是否返回 `null`，否则报错。                                                                  |
+| common-options              | config  | 否  | -      | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。                                       |
 
-:::tip 提示
+:::tip
 
-`password` 是敏感的 Notion 集成 Token。请避免在共享作业文件中硬编码真实 Token，优先使用 SeaTunnel 变量替换或部署环境的密钥管理方式注入。
+`password` 是敏感的 Notion 集成令牌，请避免在共享的任务文件中硬编码真实令牌。可使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
 
 :::
 
-## 使用说明
+## 使用提示
 
-- 如果希望把 Notion JSON 响应解析成带类型的 SeaTunnel 行，请设置 `format = "json"` 并配置 `schema`。
-- 当 Notion 响应把记录包在嵌套数组中时，可以使用 `content_field`，例如 `$.results.*`。
-- 只有当每个输出字段都需要单独的 JSONPath 表达式时，才需要使用 `json_field`。
-- `password` 和 `version` 会覆盖 `Authorization` 与 `Notion-Version` 请求头，`headers` 中只需要放其他自定义请求头。
+- 需要按字段读取时，把 `format` 设置为 `json` 并配置 `schema`。
+- 当 Notion 把记录嵌套在数组中（例如 `results`）时，使用 `content_field` 抽取数组元素。
+- 只有当不同字段位于不同 JSON 路径时，才需要使用 `json_field`。
+- `password` 和 `version` 会覆盖 `Authorization` 和 `Notion-Version` 请求头，请把其他自定义请求头放在 `headers` 中。
+- 对于 Notion 列表类接口，建议使用 `page_type = "Cursor"` 配合 `cursor_field = "start_cursor"` 与 `cursor_response_field = "$.next_cursor"`。
+- Notion 源连接器当前只支持批处理模式，`poll_interval_millis` 仅为兼容 HTTP 基类而保留，不会启用流式行为。
 
 ## 任务示例
 
-### 读取用户列表
+### 读取 Users
 
 ```hocon
 env {
@@ -93,7 +107,40 @@ sink {
 }
 ```
 
-### 使用 JSONPath 提取字段
+### 搜索 Pages（游标分页）
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Notion {
+    url = "https://api.notion.com/v1/search"
+    password = "<notion-integration-token>"
+    version = "2022-06-28"
+    method = "POST"
+    body = "{\"page_size\": 100, \"filter\": {\"value\": \"page\", \"property\": \"object\"}}"
+    format = "json"
+    content_field = "$.results[*]"
+    page_type = "Cursor"
+    cursor_field = "start_cursor"
+    cursor_response_field = "$.next_cursor"
+    schema = {
+      fields {
+        id = string
+        object = string
+        created_time = string
+        last_edited_time = string
+        archived = boolean
+      }
+    }
+  }
+}
+```
+
+### 通过 JSONPath 抽取字段
 
 ```hocon
 source {

--- a/docs/zh/connectors/source/OneSignal.md
+++ b/docs/zh/connectors/source/OneSignal.md
@@ -6,118 +6,158 @@ import ChangeLog from '../changelog/connector-http-onesignal.md';
 
 ## 描述
 
-用于从 OneSignal 读取数据。
+OneSignal 源连接器用于从 OneSignal 的 REST API 读取数据。它基于 HTTP 源连接器实现，并把 `password` 自动转换为 `Authorization: Basic <password>` 请求头，因此不需要在 `headers` 中再手动配置 `Authorization`。
+
+使用该连接器可以把 OneSignal 中的 App、Players、Segments、Notifications 等资源读取为 SeaTunnel 行数据。
 
 ## 关键特性
 
 - [x] [批](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 源选项
 
 | 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                          |
 |-----------------------------|---------|----|-------|---------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                 |
-| password                    | String  | 是  | -     | 认证密钥用于登录                                                                                    |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法                                                                   |
-| schema                      | Config  | 否  | -     | HTTP 和 SeaTunnel 数据结构映射。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                   |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                      |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                     |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                    |
-| json_field                  | Config  | 否  | -     | JSON 字段配置                                                                                   |
-| content_json                | String  | 否  | -     | 内容 JSON 配置                                                                                  |
-| poll_interval_millis        | int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                     |
-| retry                       | int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 的最大重试次数                                                          |
-| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                       |
-| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                     |
-| enable_multi_lines          | boolean | 否  | false | 是否启用多行模式                                                                                    |
-| common-options              | config  | 否  | -     | 源插件通用参数                                                                                     |
+| url                         | String  | 是  | -     | OneSignal REST API 地址，常见接口如 `https://onesignal.com/api/v1/apps`、`https://onesignal.com/api/v1/players`。          |
+| password                    | String  | 是  | -     | OneSignal 用户 Auth Key，连接器会将其作为 `Authorization: Basic <password>` 请求头发送。可在 [OneSignal 账号与密钥](https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key) 中创建。 |
+| method                      | String  | 否  | get   | HTTP 请求方法，支持 `GET` 和 `POST`。                                                                 |
+| headers                     | Map     | 否  | -     | 额外的 HTTP 请求头。除非需要覆盖由 `password` 生成的头，否则不要在这里配置 `Authorization`。                                  |
+| params                      | Map     | 否  | -     | HTTP 查询参数，例如 `limit`、`offset` 等 OneSignal API 参数。                                                  |
+| body                        | String  | 否  | -     | HTTP 请求体，对支持 JSON 负载的接口有用。                                                                      |
+| format                      | String  | 否  | json  | 响应格式，`json` 时需要配合 `schema`；`text` 时返回原始响应。                                                       |
+| schema                      | Config  | 否  | -     | 输出数据结构，`format = "json"` 时必填。详见 [Schema 特性](../../introduction/concepts/schema-feature.md)。                 |
+| schema.fields               | Config  | 否  | -     | 字段名与 SeaTunnel 数据类型，用于解析 JSON 响应。                                                                |
+| json_field                  | Config  | 否  | -     | 字段级 JSONPath 映射，与 `schema` 配合使用。                                                                |
+| content_field               | String  | 否  | -     | 在 `schema` 解析之前先通过 JSONPath 抽取一段 JSON，例如 `$.players[*]` 可展开列表响应。                                  |
+| pageing                     | Config  | 否  | -     | HTTP 分页配置，继承自 HTTP 源连接器。OneSignal 分页接口通常使用 `page` / `per_page` 参数。                                |
+| poll_interval_millis        | int     | 否  | -     | 流式任务下两次请求之间的间隔（毫秒）。批模式下连接器读取一次后即结束。                                                            |
+| retry                       | int     | 否  | -     | HTTP 请求返回 `IOException` 时的最大重试次数。                                                              |
+| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）。                                                                          |
+| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）。                                                                        |
+| enable_multi_lines          | boolean | 否  | false | 是否启用多行模式，将响应体中按换行分隔的多个 JSON 对象视为独立记录。                                                            |
+| json_filed_missed_return_null | boolean | 否 | false | 配置的 JSON 字段缺失时是否返回 `null`，否则报错。                                                                 |
+| common-options              | config  | 否  | -     | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。                                       |
 
-### url [String]
+## 使用提示
 
-HTTP 请求 URL
+- `password` 是敏感信息，请避免在共享的任务文件中硬编码真实密钥。可以使用 SeaTunnel 变量替换或部署平台的密钥管理机制。
+- 连接器始终会根据 `password` 添加 `Authorization` 请求头，请把其他自定义请求头放在 `headers` 中。
+- 需要按字段读取时，把 `format` 设置为 `json` 并配置 `schema`。
+- 当 OneSignal 把记录嵌套在数组中（例如 `players` 列表）时，使用 `content_field` 抽取数组元素。
+- 只有当不同字段位于不同 JSON 路径时，才需要使用 `json_field`。
+- OneSignal 分页接口使用 `page` 和 `per_page` 查询参数，可以通过 `params` 与 `pageing` 配合来逐页读取。
 
-### password [String]
+## 任务示例
 
-认证密钥用于登录，您可以在以下链接获取更多详情：
+### 读取 App 列表
 
-https://documentation.onesignal.com/docs/accounts-and-keys#user-auth-key
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-### method [String]
+source {
+  OneSignal {
+    url = "https://onesignal.com/api/v1/apps"
+    password = "<onesignal-user-auth-key>"
+    method = "GET"
+    format = "json"
+    schema = {
+      fields {
+        id = string
+        name = string
+        gcm_key = string
+        chrome_key = string
+        site_name = string
+        created_at = string
+        updated_at = string
+        players = int
+        messageable_players = int
+      }
+    }
+  }
+}
 
-HTTP 请求方法，仅支持 GET、POST 方法
+sink {
+  Console {
+  }
+}
+```
 
-### params [Map]
+### 读取 Players 列表（分页）
 
-HTTP 参数
+通过 `params` 配合 `pageing` 读取 OneSignal 分页接口：
 
-### body [String]
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-HTTP 请求体
+source {
+  OneSignal {
+    url = "https://onesignal.com/api/v1/players"
+    password = "<onesignal-user-auth-key>"
+    method = "GET"
+    params = {
+      app_id = "<your-app-id>"
+      limit = "50"
+      offset = "0"
+    }
+    pageing = {
+      page_field = "offset"
+      start_page_number = 0
+      page_step = 50
+      total_page_size = 10
+      use_placeholder_replacement = false
+    }
+    format = "json"
+    content_field = "$.players[*]"
+    schema = {
+      fields {
+        id = string
+        identifier = string
+        device_type = int
+        sessions = int
+        language = string
+        game_version = string
+      }
+    }
+  }
+}
+```
 
-### poll_interval_millis [int]
+### 通过 JSONPath 抽取字段
 
-流模式下请求 HTTP API 的间隔（毫秒）
-
-### retry [int]
-
-如果 HTTP 请求返回 `IOException` 的最大重试次数
-
-### retry_backoff_multiplier_ms [int]
-
-HTTP 请求失败时的重试退避倍数（毫秒）
-
-### retry_backoff_max_ms [int]
-
-HTTP 请求失败时的最大重试退避时间（毫秒）
-
-### format [String]
-
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
-
-### schema [Config]
-
-#### fields [Config]
-
-上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
-
-### content_json [String]
-
-此参数可以获取一些 JSON 数据。
-
-### json_field [Config]
-
-此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
-
-### 通用选项
-
-源插件通用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见。
-
-## 示例
+当不同字段位于不同 JSON 路径时，使用 `json_field`：
 
 ```hocon
 source {
   OneSignal {
     url = "https://onesignal.com/api/v1/apps"
-    password = "SeaTunnel-test"
+    password = "<onesignal-user-auth-key>"
+    method = "GET"
+    format = "json"
+    json_field = {
+      id = "$.id"
+      name = "$.name"
+      players = "$.players"
+      site_name = "$.site_name"
+    }
     schema = {
-       fields {
-         id = string
-         name = string
-         gcm_key = string
-         chrome_key = string
-         created_at = string
-         updated_at = string
-         players = int
-         messageable_players = int
-         basic_auth_key = string
-       }
-    }   
+      fields {
+        id = string
+        name = string
+        players = int
+        site_name = string
+      }
+    }
   }
 }
 ```
@@ -125,4 +165,3 @@ source {
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## Description

This PR improves the user-facing documentation for the following V2 connectors, covering both the English and Chinese doc sets:

- Airtable (source and sink)
- Github (source)
- Gitlab (source)
- Notion (source)
- OneSignal (source)

The branch also includes the prior batch's connector doc improvements that were already merged into this branch (Cassandra, Datahub, InfluxDB, and MQTT), so the PR currently shows the full set of changes for both batches.

### Airtable

- Added the description column to the source and sink option tables.
- Listed the missing HTTP base options for the source: `enable_multi_lines`, `connect_timeout_ms`, `socket_timeout_ms`.
- Documented `token`/`base_id`/`table` requirements, the 5 req/sec Airtable rate limit, and `offset`-based pagination behaviour.
- Rewrote the source examples to include a complete job (`env` + `source` + `sink`) and added a JSONPath extraction example.
- Aligned the sink options table with `AirtableSinkFactory`, including `multi_table_sink_replica`, and added a self-hosted Airtable example.

### Github

- Added the missing HTTP base options: `page_type`, `cursor_field`, `cursor_response_field`, `enable_multi_lines`, `keep_params_as_form`, `keep_page_param_as_http_param`, `batch_size`, `start_page_number`, `total_page_size`, `use_placeholder_replacement`, `connect_timeout_ms`, `socket_timeout_ms`.
- Added a streaming example using `poll_interval_millis` and clarified batch vs. streaming behaviour.
- Added a JSONPath extraction example and clarified `Authorization` header handling.

### Gitlab

- Same set of HTTP base options added.
- Added a filter + JSONPath extraction example for GitLab projects.
- Clarified that Gitlab source supports batch mode only.

### Notion

- Added `version`, `page_type`, `cursor_field`, `cursor_response_field`, and the rest of the HTTP base options.
- Added a cursor-paginated search example using `/v1/search`.
- Clarified that the Notion source supports batch mode only and that `poll_interval_millis` is exposed for HTTP base compatibility.

### OneSignal

- Rewrote the doc. The previous version contained copy from the generic HTTP connector (an `Http { ... }` example for `content_json`/`json_field`) and an unformatted example block.
- Added the missing options (`headers`, `enable_multi_lines`, `connect_timeout_ms`, `socket_timeout_ms`) and aligned the table with the implementation.
- Added three task examples: read apps, read players with pagination, and JSONPath extraction.
- Added a security note about the `password` (OneSignal user auth key).

### Cassandra / Datahub / InfluxDB / MQTT

These connectors were already improved in an earlier commit on this branch. See the prior commit `519ff4112` for the per-connector details.

### General

- Both English and Chinese versions are updated; the Chinese version keeps terminology consistent with the existing convention (e.g. `批处理` / `流处理` / `精确一次`).
- No support-version metadata is added.
- No source files were changed; only `docs/en/connectors` and `docs/zh/connectors` Markdown files.

## Verification

- Inspected each connector's factory / options Java files to confirm the documented options exist.
- Cross-checked examples against the matching e2e configs under `seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/`.
- Verified all internal links to `../common-options/*` and `../../introduction/concepts/*` resolve to existing files.