### PR TITLE
[Fix][E2E] Stabilize JDBC HANA and OpenGauss tests

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHanaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcHanaIT.java
@@ -36,6 +36,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerLoggerFactory;
 
+import com.github.dockerjava.api.model.HostConfig;
 import lombok.SneakyThrows;
 
 import java.sql.Date;
@@ -271,6 +272,18 @@ public class JdbcHanaIT extends AbstractJdbcIT {
                         .withCommand("--master-password", PASSWORD, "--agree-to-sap-license")
                         .withLogConsumer(
                                 new Slf4jLogConsumer(DockerLoggerFactory.getLogger(HANA_IMAGE)))
+                        .withCreateContainerCmdModifier(
+                                cmd -> {
+                                    // HANA requires move_pages and mbind during startup on GitHub
+                                    // runners.
+                                    HostConfig hostConfig = cmd.getHostConfig();
+                                    if (hostConfig == null) {
+                                        hostConfig = HostConfig.newHostConfig();
+                                        cmd.withHostConfig(hostConfig);
+                                    }
+                                    hostConfig.withSecurityOpts(
+                                            Lists.newArrayList("seccomp=unconfined"));
+                                })
                         .waitingFor(
                                 Wait.forLogMessage(".*Startup finished!.*", 1)
                                         .withStartupTimeout(Duration.of(5, ChronoUnit.MINUTES)));

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOpenGaussIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/JdbcOpenGaussIT.java
@@ -55,7 +55,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.given;
 
 @Slf4j
 public class JdbcOpenGaussIT extends AbstractJdbcIT {
@@ -351,6 +354,8 @@ public class JdbcOpenGaussIT extends AbstractJdbcIT {
                         .withNetwork(NETWORK)
                         .withNetworkAliases(OPEN_GAUSS_ALIASES)
                         .withEnv("GS_PASSWORD", PASSWORD)
+                        // The official OpenGauss image requires privileged mode for CI startup.
+                        .withPrivilegedMode(true)
                         .waitingFor(
                                 Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(5)))
                         .withLogConsumer(
@@ -360,6 +365,38 @@ public class JdbcOpenGaussIT extends AbstractJdbcIT {
                 Lists.newArrayList(String.format("%s:%s", OPEN_GAUSS_PORT, OPEN_GAUSS_PORT)));
 
         return container;
+    }
+
+    /**
+     * Waits until OpenGauss can authenticate a real SQL session inside the container.
+     *
+     * <p>The first host-port readiness signal can arrive before OpenGauss accepts authenticated
+     * sessions, which makes downstream SeaTunnel JDBC catalog creation fail with EOF.
+     */
+    @Override
+    protected void beforeStartUP() {
+        given().ignoreExceptions()
+                .await()
+                .atMost(120, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Container.ExecResult result =
+                                    dbServer.execInContainer(
+                                            "gsql",
+                                            "-h",
+                                            "localhost",
+                                            "-p",
+                                            String.valueOf(OPEN_GAUSS_PORT),
+                                            "-d",
+                                            DATABASE,
+                                            "-U",
+                                            USERNAME,
+                                            "-W",
+                                            PASSWORD,
+                                            "-c",
+                                            "select 1");
+                            Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+                        });
     }
 
     @Override


### PR DESCRIPTION
### Purpose

Stabilize unrelated JDBC E2E failures observed while checking apache/seatunnel#11538. The failures are not caused by the dry-run sample changes in that PR; they come from JDBC E2E container startup/readiness behavior.

### Changes

- Configure the SAP HANA test container with `seccomp=unconfined`, matching the HANA container startup error that requests seccomp permissions for `move_pages` and `mbind`.
- Start the OpenGauss test container in privileged mode, matching the official image startup requirement.
- Add an OpenGauss `gsql select 1` readiness check before the JDBC E2E base class starts creating schemas/tables, so host-port readiness does not race ahead of authenticated SQL readiness.

### Verification

- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6,seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7 spotless:apply`
- `./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-6,seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7 -DskipTests -DskipIT -Dskip.spotless=true test-compile`

A wider `-am test-compile` did not reach these modules locally because `seatunnel-config-shade` failed earlier with missing shaded Typesafe Config classes. GitHub CI remains the final E2E verifier.
