### PR TITLE
[Fix][Connector-V2] Upgrade shaded Doris thrift-service to 1.0.1

### DIFF
--- a/seatunnel-shade/seatunnel-thrift-service/pom.xml
+++ b/seatunnel-shade/seatunnel-thrift-service/pom.xml
@@ -26,7 +26,7 @@
     <name>SeaTunnel : Shade : Thrift-Service</name>
 
     <properties>
-        <thrift-service.version>1.0.0</thrift-service.version>
+        <thrift-service.version>1.0.1</thrift-service.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Purpose of this pull request

 Doris connector inherits the same thrift schema fixes that 1.0.1 ships over 1.0.0.

Concretely:

- Bump `org.apache.doris:thrift-service` from `1.0.0` to `1.0.1` in `seatunnel-shade/seatunnel-thrift-service/pom.xml`.
- Scope is intentionally limited to the shaded module property. No Java sources are touched.

### Does this PR introduce _any_ user-facing change?

No. This is a shaded internal dependency bump. The final relocated artifact name (`seatunnel-thrift-service.jar`) and its public surface remain identical, and the Doris connector keeps importing the same relocated classes. No configuration keys, defaults, or public APIs change.

If a downstream deployer overrides `<thrift-service.version>` from a custom `pom.xml`, that override keeps taking precedence and is unaffected.

No entry is needed in `docs/en/introduction/concepts/incompatible-changes.md`.

### How was this patch tested?

Validated on top of `apache/seatunnel` `dev` HEAD `00ca1bc02d`:

```bash
./mvnw -q -pl seatunnel-shade/seatunnel-thrift-service -am spotless:apply
```

```bash
./mvnw -q -pl seatunnel-shade/seatunnel-thrift-service -am   -DskipTests -Dmaven.gitcommitid.skip=true install
```

Both commands finish with exit code 0, confirming that the new artifact `seatunnel-thrift-service-1.0.1.jar` resolves from Maven Central (the only published versions are 1.0.0 and 1.0.1) and that the shaded relocation configuration in the module is still valid against the bumped dependency.

Because the change is a pure version bump inside a shaded module, the existing Doris connector unit tests (which exercise thrift classes through the relocated namespace) remain the contract. No new test cases are required.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — N/A, this is a version bump of an existing shaded dependency. License metadata in the POM is unchanged.
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — N/A, no user-facing feature added.
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR. — N/A, fully backward compatible shaded bump.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) — N/A.
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml) — N/A, the shaded artifact is consumed transitively via the Doris connector.
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml) — N/A.
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/) — N/A, version bump only; existing Doris e2e tests cover the contract.
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config) — N/A.