### PR TITLE
[Docs][Connector-V2] Clarify Kafka avro format vs Confluent Schema Registry

### DIFF
--- a/docs/en/connectors/source/Kafka.md
+++ b/docs/en/connectors/source/Kafka.md
@@ -634,6 +634,8 @@ Note: the `key` field in NATIVE format is base64-encoded bytes.
 
 Kafka Source supports: `json`, `text`, `canal_json`, `debezium_json`, `ogg_json`, `avro`, `protobuf`, and `NATIVE`. Use `NATIVE` when you need access to Kafka-level metadata (headers, key, partition, timestamp) as part of the record.
 
+`format = avro` expects raw Avro-encoded messages. Unlike `protobuf` (see [Protobuf with Schema Registry wire format](#protobuf-with-schema-registry-wire-format)), there is no `strip_schema_registry_header`-equivalent option for `avro`: if a topic was produced by a Confluent `KafkaAvroSerializer` and its messages carry the Confluent Schema Registry wire-format header (magic byte + schema id), `format = avro` does not strip that header before deserializing, so reading will fail or produce corrupted data. `avro_schema` only supplies the writer schema for plain (non-registry) Avro messages.
+
 ### How do I configure SASL/Kerberos authentication?
 
 Pass authentication settings via `kafka.*` properties in the connector configuration:

--- a/docs/zh/connectors/source/Kafka.md
+++ b/docs/zh/connectors/source/Kafka.md
@@ -627,6 +627,8 @@ transform {
 
 支持：`json`、`text`、`canal_json`、`debezium_json`、`ogg_json`、`avro`、`protobuf` 和 `NATIVE`。当需要将 Kafka 元数据（headers、key、partition、timestamp）作为记录字段使用时，选择 `NATIVE` 格式。
 
+`format = avro` 仅支持原始（未经 Schema Registry 封装）的 Avro 消息。与 `protobuf`（参见 [Protobuf with Schema Registry wire format](#protobuf-with-schema-registry-wire-format)）不同，`avro` 没有对应 `strip_schema_registry_header` 的选项：如果 topic 是由 Confluent `KafkaAvroSerializer` 写入、消息中带有 Confluent Schema Registry 线格式头部（magic byte + schema id），`format = avro` 不会在反序列化前去除该头部，因此会读取失败或得到损坏的数据。`avro_schema` 仅用于为普通（非 Schema Registry）Avro 消息提供 writer schema。
+
 ### 如何配置 SASL/Kerberos 认证？
 
 通过 `kafka.*` 属性传入认证参数：


### PR DESCRIPTION
### Purpose of this pull request

A user asked (via a support-bot Q&A export I was reviewing for documentation gaps) whether
SeaTunnel's Kafka source `avro` format supports Confluent Schema-Registry-encoded Avro messages
("confluent-avro"). The existing FAQ entry lists `avro` as a supported format but doesn't clarify
this, so the question keeps coming up.

Verified against current source: `MessageFormat.AVRO` deserializes via `AvroDeserializationSchema`
(`connector-kafka/.../serialize` and `.../source/KafkaSourceConfig.java`, `case AVRO:`), which has no
schema-registry-header-stripping logic. This is different from `PROTOBUF`, which explicitly supports
it via `strip_schema_registry_header` / `SchemaRegistryAwareProtobufDeserializationSchema` (see the
existing "Protobuf with Schema Registry wire format" section in the same doc). Concretely: if a topic
was produced with Confluent's `KafkaAvroSerializer`, each message carries a 5-byte wire-format prefix
(magic byte + schema id) before the Avro payload. `format = avro` does not strip that prefix, so
deserialization will fail or produce corrupted data.

Extended the existing "What message formats does Kafka Source support?" FAQ entry (`docs/en` and
`docs/zh`) to state this limitation explicitly, at the same level of detail as the existing
Protobuf-with-Schema-Registry section, and cross-linked to it.

### Does this PR introduce _any_ user-facing change?

No functional change. Documentation-only addition.

### How was this patch tested?

Documentation-only change, so `./mvnw spotless:apply` is a no-op (spotless in this repo only formats
`<java>` and `<pom>`, not markdown). The technical claim was verified directly against current `dev`
HEAD source:
- `seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/config/MessageFormat.java`
  -- confirms the enum values, including the absence of a distinct Confluent-Avro variant.
- `seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceConfig.java`
  -- confirms the `AVRO` case only consults `avro_schema` / catalog schema, with no schema-registry
  header handling, versus the `PROTOBUF` case which explicitly branches on
  `STRIP_SCHEMA_REGISTRY_HEADER`.
- Confirmed the cross-reference anchor `#protobuf-with-schema-registry-wire-format` matches the
  existing `### Protobuf with Schema Registry wire format` heading in both `docs/en` and `docs/zh`.

### Check list

* [x] No new JAR binary package is added.
* [x] English and Chinese documentation both updated.
* [x] No incompatible configuration or API change is introduced (docs-only).
* [x] N/A -- documentation-only change, no test coverage applicable.