### PR TITLE
[Docs][Connector-V2] Improve TDengine Hive Elasticsearch Pulsar and OceanBase connector docs

### DIFF
--- a/docs/en/connectors/sink/Elasticsearch.md
+++ b/docs/en/connectors/sink/Elasticsearch.md
@@ -2,282 +2,271 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 
 # Elasticsearch
 
+> Elasticsearch sink connector
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Output data to `Elasticsearch`.
+
+:::tip
+
+Engine Supported: `ElasticSearch version is >= 2.x and <= 8.x`.
+
+:::
 
 ## Key features
 
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-:::tip
+## Sink Options
 
-Engine Supported
+| Name                     | Type    | Required | Default Value                     | Description                                                                                                                                                                                                                                       |
+|--------------------------|---------|----------|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| hosts                    | Array   | Yes      | -                                 | Elasticsearch cluster HTTP address, format `host:port`, allowing multiple hosts, for example `["host1:9200", "host2:9200"]`.                                                                                                                       |
+| index                    | String  | Yes      | -                                 | Elasticsearch index name. Supports placeholders that reference upstream field names, for example `seatunnel_${age}` (also requires `schema_save_mode = "IGNORE"`). The referenced field must exist in the upstream row, otherwise the placeholder is left as-is. |
+| index_type               | String  | No       | -                                 | Elasticsearch index type. It is recommended not to specify this on Elasticsearch 6 and above.                                                                                                                                                      |
+| primary_keys             | List    | No       | -                                 | Primary key fields used to generate the document `_id`. Required for CDC sources to produce deterministic document IDs.                                                                                                                            |
+| key_delimiter            | String  | No       | `_`                               | Delimiter used to join `primary_keys` into a composite `_id`, for example `$` produces document IDs like `KEY1$KEY2$KEY3`.                                                                                                                          |
+| schema_save_mode         | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST      | How to handle the existing index structure on the target before the synchronization task starts. See `schema_save_mode` below.                                                                                                                    |
+| data_save_mode           | Enum    | No       | APPEND_DATA                       | How to handle existing documents on the target before writing new data. See `data_save_mode` below.                                                                                                                                                |
+| auth_type                | String  | No       | basic                             | Authentication method: `basic`, `api_key`, or `api_key_encoded`. Defaults to `basic` for backward compatibility.                                                                                                                                    |
+| username                 | String  | No       | -                                 | Username for HTTP basic authentication (X-Pack username).                                                                                                                                                                                          |
+| password                 | String  | No       | -                                 | Password for HTTP basic authentication (X-Pack password).                                                                                                                                                                                          |
+| auth.api_key_id          | String  | No       | -                                 | API key ID for `auth_type = "api_key"`.                                                                                                                                                                                                            |
+| auth.api_key             | String  | No       | -                                 | API key secret for `auth_type = "api_key"`.                                                                                                                                                                                                        |
+| auth.api_key_encoded     | String  | No       | -                                 | Base64-encoded API key (`base64(id:api_key)`) for `auth_type = "api_key_encoded"`. Either `auth.api_key_id` + `auth.api_key` OR `auth.api_key_encoded` should be set, but not both.                                                                |
+| max_retry_count          | Int     | No       | 3                                 | Maximum retry count for a single bulk request.                                                                                                                                                                                                     |
+| max_batch_size           | Int     | No       | 10                                | Maximum number of documents included in a single bulk request.                                                                                                                                                                                     |
+| tls_verify_certificate   | Boolean | No       | true                              | Enable certificate validation for HTTPS endpoints.                                                                                                                                                                                                 |
+| tls_verify_hostname      | Boolean | No       | true                              | Enable hostname validation for HTTPS endpoints.                                                                                                                                                                                                   |
+| tls_keystore_path        | String  | No       | -                                 | Path to the PEM or JKS key store. Must be readable by the user running SeaTunnel.                                                                                                                                                                  |
+| tls_keystore_password    | String  | No       | -                                 | Key password for `tls_keystore_path`.                                                                                                                                                                                                              |
+| tls_truststore_path      | String  | No       | -                                 | Path to the PEM or JKS trust store. Must be readable by the user running SeaTunnel.                                                                                                                                                                |
+| tls_truststore_password  | String  | No       | -                                 | Key password for `tls_truststore_path`.                                                                                                                                                                                                            |
+| vectorization_fields     | Array   | No       | -                                 | Field names that require vector conversion. Requires Elasticsearch 7.3 or later.                                                                                                                                                                    |
+| vector_dimensions        | Int     | No       | 0                                 | Vector dimension for `vectorization_fields`. Requires Elasticsearch 7.3 or later.                                                                                                                                                                  |
+| multi_table_sink_replica | Int     | No       | 1                                 | Number of sink writer replicas used per table in a multi-table sink job. Keep the default unless one table needs more parallelism.                                                                                                                  |
+| common-options           |         | No       | -                                 | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                                                          |
 
-* supported  `ElasticSearch version is >= 2.x and <= 8.x`
+### hosts [Array]
 
-:::
+Elasticsearch cluster HTTP address, format `host:port`, allowing multiple
+hosts, for example `["host1:9200", "host2:9200"]`.
 
-## Options
+### index [String]
 
-| name                    | type    | required |        default value         |
-|-------------------------|---------|----------|------------------------------|
-| hosts                   | array   | yes      | -                            |
-| index                   | string  | yes      | -                            |
-| schema_save_mode        | string  | yes      | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode          | string  | yes      | APPEND_DATA                  |
-| index_type              | string  | no       |                              |
-| primary_keys            | list    | no       |                              |
-| key_delimiter           | string  | no       | `_`                          |
-| auth_type               | string  | no       | basic                        |
-| username                | string  | no       |                              |
-| password                | string  | no       |                              |
-| auth.api_key_id         | string  | no       | -                            |
-| auth.api_key            | string  | no       | -                            |
-| auth.api_key_encoded    | string  | no       | -                            |
-| max_retry_count         | int     | no       | 3                            |
-| max_batch_size          | int     | no       | 10                           |
-| tls_verify_certificate  | boolean | no       | true                         |
-| tls_verify_hostname    | boolean | no       | true                         |
-| tls_keystore_path       | string  | no       | -                            |
-| tls_keystore_password   | string  | no       | -                            |
-| tls_truststore_path     | string  | no       | -                            |
-| tls_truststore_password | string  | no       | -                            |
-| common-options          |         | no       | -                            |
-| vectorization_fields    | array   | no       | -                            |
-| vector_dimensions       | int     | no       | -                            |
-### hosts [array]
+Elasticsearch index name. The value supports placeholders that reference
+upstream field names, for example `seatunnel_${age}` (also requires
+`schema_save_mode = "IGNORE"`). The referenced field must exist in the
+upstream row, otherwise the placeholder is treated as a literal value.
 
-`Elasticsearch` cluster http address, the format is `host:port` , allowing multiple hosts to be specified. Such as `["host1:9200", "host2:9200"]`.
+### index_type [String]
 
-### index [string]
+Elasticsearch index type. It is recommended not to specify this on
+Elasticsearch 6 and above.
 
-`Elasticsearch`  `index` name.Index support contains variables of field name,such as `seatunnel_${age}`(Need to configure schema_save_mode="IGNORE"),and the field must appear at seatunnel row.
-If not, we will treat it as a normal index.
+### primary_keys [List]
 
-### index_type [string]
+Primary key fields used to generate the document `_id`. Required for CDC sources
+to produce deterministic document IDs.
 
-`Elasticsearch` index type, it is recommended not to specify in elasticsearch 6 and above
+### key_delimiter [String]
 
-### primary_keys [list]
+Delimiter used to join `primary_keys` into a composite `_id`. The default `_`
+produces IDs like `KEY1_KEY2_KEY3`. Use `$` to produce `KEY1$KEY2$KEY3`.
 
-Primary key fields used to generate the document `_id`, this is cdc required options.
+### auth_type [String]
 
-### key_delimiter [string]
+Authentication method used by the connector:
 
-Delimiter for composite keys ("_" by default), e.g., "$" would result in document `_id` "KEY1$KEY2$KEY3".
+- `basic` (default): HTTP Basic authentication using `username` and `password`.
+- `api_key`: API key authentication using `auth.api_key_id` + `auth.api_key`.
+- `api_key_encoded`: API key authentication using `auth.api_key_encoded`.
 
-## Authentication
+### username / password [String]
 
-The Elasticsearch connector supports multiple authentication methods to connect to secured Elasticsearch clusters. You can choose the appropriate authentication method based on your Elasticsearch security configuration.
+X-Pack credentials for HTTP basic authentication. Used when `auth_type =
+"basic"` (default).
 
-### auth_type [enum]
+### auth.api_key_id / auth.api_key / auth.api_key_encoded [String]
 
-Specifies the authentication method to use. Supported values:
-- `basic` (default): HTTP Basic Authentication using username and password
-- `api_key`: Elasticsearch API Key authentication using separate ID and key
-- `api_key_encoded`: Elasticsearch API Key authentication using encoded key
+API key credentials for `auth_type = "api_key"` or `auth_type =
+"api_key_encoded"`. Either `auth.api_key_id` + `auth.api_key` OR
+`auth.api_key_encoded` should be set, but not both.
 
-If not specified, defaults to `basic` for backward compatibility.
+### max_retry_count [Int]
 
-### Basic Authentication
+Maximum retry count for a single bulk request when the upstream cluster is
+unavailable.
 
-Basic authentication uses HTTP Basic Authentication with username and password credentials.
+### max_batch_size [Int]
 
-#### username [string]
+Maximum number of documents included in a single bulk request.
 
-Username for basic authentication (x-pack username).
+### tls_verify_certificate [Boolean]
 
-#### password [string]
+Enable certificate validation for HTTPS endpoints. Set to `false` to disable
+certificate validation (typically only used in development).
 
-Password for basic authentication (x-pack password).
+### tls_verify_hostname [Boolean]
 
-### vectorization_fields [array]
-Field names that require vector conversion, supported by Elasticsearch 7.3 and later versions
+Enable hostname validation for HTTPS endpoints. Set to `false` to disable
+hostname validation (typically only used in development).
 
-### vector_dimensions [int]
-Vector dimension, supported by Elasticsearch 7.3 and later versions
+### tls_keystore_path / tls_keystore_password [String]
 
-**Example:**
-```hocon
-sink {
-    Elasticsearch {
-        hosts = ["https://localhost:9200"]
-        auth_type = "basic"
-        username = "elastic"
-        password = "your_password"
-        index = "my_index"
-    }
-}
-```
+Path to the PEM or JKS key store and its password. The file must be readable by
+the user running SeaTunnel.
 
-### API Key Authentication
+### tls_truststore_path / tls_truststore_password [String]
 
-API Key authentication provides a more secure way to authenticate with Elasticsearch using API keys.
+Path to the PEM or JKS trust store and its password. The file must be readable
+by the user running SeaTunnel.
 
-#### auth.api_key_id [string]
+### vectorization_fields [Array]
 
-The API key ID generated by Elasticsearch.
+Field names that require vector conversion. Requires Elasticsearch 7.3 or later.
 
-#### auth.api_key [string]
+### vector_dimensions [Int]
 
-The API key secret generated by Elasticsearch.
+Vector dimension for `vectorization_fields`. Requires Elasticsearch 7.3 or later.
 
-#### auth.api_key_encoded [string]
+### multi_table_sink_replica [Int]
 
-Base64 encoded API key in the format `base64(id:api_key)`. This is an alternative to specifying `auth.api_key_id` and `auth.api_key` separately.
-
-**Note:** You can use either `auth.api_key_id` + `auth.api_key` OR `auth.api_key_encoded`, but not both.
-
-**Example with separate ID and key:**
-```hocon
-sink {
-    Elasticsearch {
-        hosts = ["https://localhost:9200"]
-        auth_type = "api_key"
-        auth.api_key_id = "your_api_key_id"
-        auth.api_key = "your_api_key_secret"
-        index = "my_index"
-    }
-}
-```
-
-**Example with encoded key:**
-```hocon
-sink {
-    Elasticsearch {
-        hosts = ["https://localhost:9200"]
-        auth_type = "api_key_encoded"
-        auth.api_key_encoded = "eW91cl9hcGlfa2V5X2lkOnlvdXJfYXBpX2tleV9zZWNyZXQ="
-        index = "my_index"
-    }
-}
-```
-
-
-
-### max_retry_count [int]
-
-one bulk request max try size
-
-### max_batch_size [int]
-
-batch bulk doc max size
-
-### tls_verify_certificate [boolean]
-
-Enable certificates validation for HTTPS endpoints
-
-### tls_verify_hostname [boolean]
-
-Enable hostname validation for HTTPS endpoints
-
-### tls_keystore_path [string]
-
-The path to the PEM or JKS key store. This file must be readable by the operating system user running SeaTunnel.
-
-### tls_keystore_password [string]
-
-The key password for the key store specified
-
-### tls_truststore_path [string]
-
-The path to PEM or JKS trust store. This file must be readable by the operating system user running SeaTunnel.
-
-### tls_truststore_password [string]
-
-The key password for the trust store specified
+Number of sink writer replicas used per table in a multi-table sink job. Keep
+the default value unless one table needs more sink writer parallelism.
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
 
-### schema_save_mode
+### schema_save_mode [Enum]
 
-Before the synchronous task is turned on, different treatment schemes are selected for the existing surface structure of the target side.
-Option introduction：  
-`RECREATE_SCHEMA` ：Will create when the table does not exist, delete and rebuild when the table is saved  
-`CREATE_SCHEMA_WHEN_NOT_EXIST` ：Will Created when the table does not exist, skipped when the table is saved  
-`ERROR_WHEN_SCHEMA_NOT_EXIST` ：Error will be reported when the table does not exist  
-`IGNORE` ：Ignore the treatment of the table
+How to handle the existing index structure on the target before the
+synchronization task starts.
 
-### data_save_mode
+- `RECREATE_SCHEMA`: Drop and recreate the index when it already exists.
+- `CREATE_SCHEMA_WHEN_NOT_EXIST`: Create the index when it does not exist,
+  skip when it already exists.
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`: Report an error when the index does not exist.
+- `IGNORE`: Skip the index handling.
 
-Before the synchronous task is turned on, different processing schemes are selected for data existing data on the target side.
-Option introduction：  
-`DROP_DATA`： Preserve database structure and delete data  
-`APPEND_DATA`：Preserve database structure, preserve data  
-`ERROR_WHEN_DATA_EXISTS`：When there is data, an error is reported
+### data_save_mode [Enum]
 
-## Examples
+How to handle existing documents on the target before writing new data.
 
-Simple
+- `DROP_DATA`: Preserve index structure and delete data.
+- `APPEND_DATA`: Preserve index structure and preserve data.
+- `ERROR_WHEN_DATA_EXISTS`: Report an error when there is existing data.
 
-```conf
+## Timer Flush on Zeta
+
+This engine-level feature is supported only by Zeta. Spark and Flink do not
+inject `FlushSignal` records. On Zeta, configure `sink.flush.interval` in the
+`env` block to flush pending bulk requests before `max_batch_size` is reached.
+
+:::tip
+
+Elasticsearch timer flush does not provide 2PC exactly-once semantics. The
+Elasticsearch Sink currently provides at-least-once delivery, and retries can
+produce duplicate writes when document IDs are not deterministic.
+
+:::
+
+```hocon
+env {
+  job.mode = "STREAMING"
+  checkpoint.interval = 300000
+  sink.flush.interval = 5000
+}
+
+sink {
+  Elasticsearch {
+    hosts = ["localhost:9200"]
+    index = "seatunnel-index"
+    max_batch_size = 10000
+  }
+}
+```
+
+## Task Example
+
+### Simple
+
+```hocon
 sink {
     Elasticsearch {
         hosts = ["localhost:9200"]
         index = "seatunnel-${age}"
-        schema_save_mode="IGNORE"
+        schema_save_mode = "IGNORE"
     }
 }
-
 ```
-Multi-table writing
 
-```conf
+### Multi-table writing
+
+```hocon
 sink {
     Elasticsearch {
         hosts = ["localhost:9200"]
         index = "${table_name}"
-        schema_save_mode="IGNORE"
+        schema_save_mode = "IGNORE"
+        multi_table_sink_replica = 1
     }
 }
 ```
 
-vector-field writing
+### Vector field writing
 
-```conf
+```hocon
 sink {
     Elasticsearch {
         hosts = ["localhost:9200"]
         index = "${table_name}"
-        schema_save_mode="IGNORE"
-        vectorization_fields = ["review_embedding"]  
-        vector_dimensions = 1024 
+        schema_save_mode = "IGNORE"
+        vectorization_fields = ["review_embedding"]
+        vector_dimensions = 1024
     }
 }
 ```
 
-CDC(Change data capture) event
+### CDC (Change Data Capture) event
 
-```conf
+```hocon
 sink {
     Elasticsearch {
         hosts = ["localhost:9200"]
         index = "seatunnel-${age}"
-        schema_save_mode="IGNORE"
-        # cdc required options
-        primary_keys = ["key1", "key2", ...]
+        schema_save_mode = "IGNORE"
+        primary_keys = ["key1", "key2"]
     }
 }
-
 ```
-CDC(Change data capture) event Multi-table writing
 
-```conf
+### CDC multi-table writing
+
+```hocon
 sink {
     Elasticsearch {
         hosts = ["localhost:9200"]
         index = "${table_name}"
-        schema_save_mode="IGNORE"
+        schema_save_mode = "IGNORE"
         primary_keys = ["${primary_key}"]
     }
 }
 ```
 
-SSL (Disable certificates validation)
+### SSL (Disable certificate validation)
 
 ```hocon
 sink {
@@ -285,13 +274,12 @@ sink {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-        
         tls_verify_certificate = false
     }
 }
 ```
 
-SSL (Disable hostname validation)
+### SSL (Disable hostname validation)
 
 ```hocon
 sink {
@@ -299,13 +287,12 @@ sink {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-        
         tls_verify_hostname = false
     }
 }
 ```
 
-SSL (Enable certificates validation)
+### SSL (Enable certificate validation)
 
 ```hocon
 sink {
@@ -313,14 +300,13 @@ sink {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-        
         tls_keystore_path = "${your elasticsearch home}/config/certs/http.p12"
         tls_keystore_password = "${your password}"
     }
 }
 ```
 
-SAVE_MODE
+### Save Mode
 
 ```hocon
 sink {
@@ -328,23 +314,21 @@ sink {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-        
         schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
         data_save_mode = "APPEND_DATA"
     }
 }
 ```
 
-### Schema Evolution
+## Schema Evolution
 
-CDC collection supports a limited number of schema changes. The currently supported schema changes include:
+CDC collection supports a limited number of schema changes. The currently
+supported schema changes include:
 
-* Adding columns.
+- Adding columns.
 
-### Schema Evolution
 ```hocon
 env {
-  # You can set engine configuration here
   parallelism = 5
   job.mode = "STREAMING"
   checkpoint.interval = 5000
@@ -372,8 +356,8 @@ sink {
     tls_verify_hostname = false
     index = "schema_change_index"
     index_type = "_doc"
-    "schema_save_mode" = "CREATE_SCHEMA_WHEN_NOT_EXIST"
-    "data_save_mode" = "APPEND_DATA"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
   }
 }
 ```

--- a/docs/en/connectors/sink/Hive.md
+++ b/docs/en/connectors/sink/Hive.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-hive.md';
 
 > Hive sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Write data to Hive.
@@ -20,7 +26,7 @@ If you use SeaTunnel Engine, You need put seatunnel-hadoop3-3.1.4-uber.jar and h
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 
-By default, we use 2PC commit to ensure `exactly-once`
+By default, we use 2PC commit to ensure `exactly-once`.
 
 - [x] file format
   - [x] text
@@ -31,110 +37,159 @@ By default, we use 2PC commit to ensure `exactly-once`
 - [x] compress codec
   - [x] lzo
 
-## Options
+## Sink Options
 
-| name                                  | type    | required | default value  |
-|---------------------------------------|---------|----------|----------------|
-| table_name                            | string  | yes      | -              |
-| metastore_uri                         | string  | yes      | -              |
-| compress_codec                        | string  | no       | none           |
-| hdfs_site_path                        | string  | no       | -              |
-| hive_site_path                        | string  | no       | -              |
-| hive.hadoop.conf                      | Map     | no       | -              |
-| hive.hadoop.conf-path                 | string  | no       | -              |
-| krb5_path                             | string  | no       | /etc/krb5.conf |
-| kerberos_principal                    | string  | no       | -              |
-| kerberos_keytab_path                  | string  | no       | -              |
-| abort_drop_partition_metadata         | boolean | no       | true           |
-| parquet_avro_write_timestamp_as_int96 | boolean | no       | false          |
-| overwrite                             | boolean | no       | false          |
-| data_save_mode                        | enum    | no       | APPEND_DATA    |
-| schema_save_mode                      | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| save_mode_create_template             | string  | no       | -              |
-| common-options                        |         | no       | -              |
+| Name                                | Type    | Required | Default Value                     | Description                                                                                                                                                                                                                                                                                                                                       |
+|-------------------------------------|---------|----------|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| table_name                          | String  | Yes      | -                                 | Target Hive table name, for example `db1.table1`. When the source is in multi-table mode, you can use `${database_name}.${table_name}` to generate the table name; `${database_name}` and `${table_name}` are replaced with the values from the upstream `CatalogTable`.                                                                       |
+| metastore_uri                       | String  | Yes      | -                                 | Hive metastore URI. Supports comma-separated multiple URIs for HA/failover (whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris` and uses `RetryingMetaStoreClient` to retry/failover between URIs.                                                                                                          |
+| compress_codec                      | String  | No       | none                              | The compression codec of files. Supported codecs: `lzo`, `none` for text/csv/json. For orc/parquet the compression type is automatically recognized from the file metadata.                                                                                                                                                                     |
+| hdfs_site_path                      | String  | No       | -                                 | The path of `hdfs-site.xml`, used to load HA configuration of namenodes.                                                                                                                                                                                                                                                                          |
+| hive_site_path                      | String  | No       | -                                 | The path of `hive-site.xml`.                                                                                                                                                                                                                                                                                                                       |
+| hive.hadoop.conf                    | Map     | No       | -                                 | Properties in hadoop conf (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`).                                                                                                                                                                                                                                                                    |
+| hive.hadoop.conf-path               | String  | No       | -                                 | The specified loading path for `core-site.xml`, `hdfs-site.xml`, `hive-site.xml`.                                                                                                                                                                                                                                                                  |
+| remote_user                         | String  | No       | -                                 | Hadoop remote user name used when connecting to HDFS/Hive storage without Kerberos credentials.                                                                                                                                                                                                                                                   |
+| krb5_path                           | String  | No       | /etc/krb5.conf                     | The path of `krb5.conf`, used for Kerberos authentication.                                                                                                                                                                                                                                                                                        |
+| kerberos_principal                  | String  | No       | -                                 | The principal of Kerberos authentication.                                                                                                                                                                                                                                                                                                         |
+| kerberos_keytab_path                | String  | No       | -                                 | The keytab file path of Kerberos authentication.                                                                                                                                                                                                                                                                                                  |
+| abort_drop_partition_metadata       | Boolean | No       | false                             | Drop partition metadata from the Hive Metastore during an abort operation. Only affects metastore metadata; the data in the partition is always deleted (data generated during the synchronization process).                                                                                                                                   |
+| parquet_avro_write_timestamp_as_int96 | Boolean | No       | false                             | Support writing Parquet INT96 from a timestamp. Only valid for Parquet files.                                                                                                                                                                                                                                                                     |
+| overwrite                           | Boolean | No       | false                             | Use overwrite mode when inserting data into Hive. For non-partitioned tables, the existing data in the table is deleted before inserting new data. For partitioned tables, the data in the relevant partition is deleted before inserting new data.                                                                                            |
+| data_save_mode                      | Enum    | No       | APPEND_DATA                       | How to handle existing data on the target before writing new data. `APPEND_DATA` keeps existing data and appends new records. `DROP_DATA` behaves like `overwrite = true` and is the recommended option when you want to fully replace the table. `CUSTOM_PROCESSING` and `ERROR_WHEN_DATA_EXISTS` are not recommended unless you have specific requirements. |
+| schema_save_mode                    | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST       | How to handle the existing table structure on the target before the synchronization task starts. See `schema_save_mode` below for valid values.                                                                                                                                                                                                  |
+| save_mode_create_template           | String  | No       | -                                 | Template used to auto-create the Hive table. Available template variables: `${database}`, `${table}`, `${rowtype_fields}`, `${rowtype_partition_fields}`, `${table_location}`.                                                                                                                                                                    |
+| common-options                      |         | No       | -                                 | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                                                                                                                                                       |
 
-### table_name [string]
+### table_name [String]
 
-Target Hive table name eg: db1.table1, and if the source is multiple mode, you can use `${database_name}.${table_name}` to generate the table name, it will replace the `${database_name}` and `${table_name}` with the value of the CatalogTable generate from the source.
+Target Hive table name, for example `db1.table1`. When the source is in
+multi-table mode, you can use `${database_name}.${table_name}` to generate the
+table name; `${database_name}` and `${table_name}` are replaced with the
+values from the upstream `CatalogTable`.
 
-### metastore_uri [string]
+### metastore_uri [String]
 
-Hive metastore uri. Supports comma-separated multiple URIs for HA/failover (whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris` and uses Hive `RetryingMetaStoreClient` (if available) to retry/failover between URIs. This is client-side endpoint failover; make sure your metastores share/replicate the same backend to keep metadata consistent.
+Hive metastore URI. Supports comma-separated multiple URIs for HA/failover
+(whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris`
+and uses `RetryingMetaStoreClient` (if available) to retry/failover between
+URIs. This is client-side endpoint failover; make sure your metastores
+share/replicate the same backend to keep metadata consistent.
 
-### hdfs_site_path [string]
+### hdfs_site_path [String]
 
-The path of `hdfs-site.xml`, used to load ha configuration of namenodes
+The path of `hdfs-site.xml`, used to load HA configuration of namenodes.
 
-### hive_site_path [string]
+### hive_site_path [String]
 
-The path of `hive-site.xml`
+The path of `hive-site.xml`.
 
-### hive.hadoop.conf [map]
+### hive.hadoop.conf [Map]
 
-Properties in hadoop conf('core-site.xml', 'hdfs-site.xml', 'hive-site.xml')
+Properties in hadoop conf (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`).
 
-### hive.hadoop.conf-path [string]
+### hive.hadoop.conf-path [String]
 
-The specified loading path for the 'core-site.xml', 'hdfs-site.xml', 'hive-site.xml' files
+The specified loading path for `core-site.xml`, `hdfs-site.xml`, `hive-site.xml`
+files.
 
-### krb5_path [string]
+### remote_user [String]
 
-The path of `krb5.conf`, used to authentication kerberos
+Hadoop remote user name used when connecting to HDFS/Hive storage without
+Kerberos credentials.
 
-The path of `hive-site.xml`, used to authentication hive metastore
+### krb5_path [String]
 
-### kerberos_principal [string]
+The path of `krb5.conf`, used for Kerberos authentication.
 
-The principal of kerberos
+### kerberos_principal [String]
 
-### kerberos_keytab_path [string]
+The principal of Kerberos authentication.
 
-The keytab path of kerberos
+### kerberos_keytab_path [String]
 
-### abort_drop_partition_metadata [boolean]
+The keytab file path of Kerberos authentication.
 
-Flag to decide whether to drop partition metadata from Hive Metastore during an abort operation. Note: this only affects the metadata in the metastore, the data in the partition will always be deleted(data generated during the synchronization process).
+### abort_drop_partition_metadata [Boolean]
 
-### parquet_avro_write_timestamp_as_int96 [boolean]
+Whether to drop partition metadata from the Hive Metastore during an abort
+operation. Note: this only affects the metadata in the metastore, the data in
+the partition will always be deleted (data generated during the synchronization
+process).
 
-Support writing Parquet INT96 from a timestamp, only valid for parquet files.
+The default value is `false`.
 
-### overwrite [boolean]
+### parquet_avro_write_timestamp_as_int96 [Boolean]
 
-Flag to decide whether to use overwrite mode when inserting data into Hive. If set to true, for non-partitioned tables, the existing data in the table will be deleted before inserting new data. For partitioned tables, the data in the relevant partition will be deleted before inserting new data.
+Support writing Parquet INT96 from a timestamp. Only valid for Parquet files.
 
-- Batch mode (BATCH): Delete existing data in the target path before commit (for non-partitioned tables, delete the table directory; for partitioned tables, delete the related partition directories), then write new data.
-- Streaming mode (STREAMING): In streaming jobs with checkpointing enabled, `commit()` is invoked after each completed checkpoint. To avoid deleting on every checkpoint (which would wipe previously committed files), SeaTunnel deletes each target directory (table directory / partition directory) at most once (empty commits will skip deletion). On recovery, the delete step is best-effort and may be skipped to avoid deleting already committed data, so streaming overwrite is not a strict snapshot overwrite.
+### overwrite [Boolean]
 
-### data_save_mode [enum]
+Whether to use overwrite mode when inserting data into Hive.
 
-Select how to handle existing data on the target before writing new data.
+- For non-partitioned tables, the existing data in the table is deleted before
+  inserting new data.
+- For partitioned tables, the data in the relevant partition is deleted before
+  inserting new data.
 
-- APPEND_DATA (default): Keep existing data and append new records.
-- DROP_DATA: Behaves the same as overwrite=true. Before commit, delete the existing data in the target path (for non-partitioned tables, delete the table directory; for partitioned tables, delete the related partition directories), then write new data.
-- CUSTOM_PROCESSING / ERROR_WHEN_DATA_EXISTS: Currently not recommended for Hive sink unless you have specific requirements.
+Behavior by job mode:
 
-Note: overwrite=true and data_save_mode=DROP_DATA are equivalent. Use either one; do not set both.
+- **Batch mode (`BATCH`)**: Delete existing data in the target path before
+  commit (for non-partitioned tables, delete the table directory; for
+  partitioned tables, delete the related partition directories), then write new
+  data.
+- **Streaming mode (`STREAMING`)**: In streaming jobs with checkpointing
+  enabled, `commit()` is invoked after each completed checkpoint. To avoid
+  deleting on every checkpoint (which would wipe previously committed files),
+  SeaTunnel deletes each target directory (table directory / partition
+  directory) at most once (empty commits will skip deletion). On recovery, the
+  delete step is best-effort and may be skipped to avoid deleting already
+  committed data, so streaming overwrite is not a strict snapshot overwrite.
 
-### schema_save_mode [enum]
+### data_save_mode [Enum]
 
-Before starting the synchronization task, different processing schemes are selected for the existing table structure on the target side.
+How to handle existing data on the target before writing new data.
+
+- `APPEND_DATA` (default): Keep existing data and append new records.
+- `DROP_DATA`: Behaves the same as `overwrite = true`. Before commit, delete
+  the existing data in the target path (for non-partitioned tables, delete the
+  table directory; for partitioned tables, delete the related partition
+  directories), then write new data.
+- `CUSTOM_PROCESSING` / `ERROR_WHEN_DATA_EXISTS`: Currently not recommended for
+  Hive sink unless you have specific requirements.
+
+Note: `overwrite = true` and `data_save_mode = "DROP_DATA"` are equivalent. Use
+either one; do not set both.
+
+For batch jobs, use either `overwrite = true` or `data_save_mode = "DROP_DATA"`
+when the target Hive table should be replaced by the current run. For normal
+append jobs, keep the default `data_save_mode = "APPEND_DATA"`.
+
+### schema_save_mode [Enum]
+
+How to handle the existing table structure on the target before the
+synchronization task starts.
 
 **Default value**: `CREATE_SCHEMA_WHEN_NOT_EXIST`
 
 Option values:
-- `RECREATE_SCHEMA`: Will create when the table does not exist, delete and rebuild when the table exists
-- `CREATE_SCHEMA_WHEN_NOT_EXIST`: Will create when the table does not exist, skip when the table exists
-- `ERROR_WHEN_SCHEMA_NOT_EXIST`: Error will be reported when the table does not exist
-- `IGNORE`: Ignore the treatment of the table
 
+- `RECREATE_SCHEMA`: Create the table when it does not exist, drop and rebuild
+  it when the table exists.
+- `CREATE_SCHEMA_WHEN_NOT_EXIST`: Create the table when it does not exist,
+  skip when the table exists.
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`: Report an error when the table does not exist.
+- `IGNORE`: Skip table handling.
 
+### save_mode_create_template [String]
 
-### save_mode_create_template [string]
+Use templates to automatically create Hive tables; the connector renders the
+upstream row type into the template. Available template variables:
+`${database}`, `${table}`, `${rowtype_fields}`, `${rowtype_partition_fields}`,
+`${table_location}`.
 
-We use templates to automatically create Hive tables, which will create corresponding table creation statements based on the type of upstream data and schema type, and the default template can be modified according to the situation. Available template variables: ${database}, ${table}, ${rowtype_fields}, ${rowtype_partition_fields}, ${table_location}.
+**Default value**: When not specified, the connector uses a default
+non-partitioned PARQUET table template:
 
-**Default value**: When not specified, uses a default PARQUET non-partitioned table template:
 ```sql
 CREATE TABLE IF NOT EXISTS `${database}`.`${table}` (
   ${rowtype_fields}
@@ -145,85 +200,65 @@ LOCATION '${table_location}'
 
 ### common options
 
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
 
-## Example
+## Task Example
 
-```bash
-
-  Hive {
-    table_name = "default.seatunnel_orc"
-    metastore_uri = "thrift://namenode001:9083"
-  }
-
-```
-
-Metastore URI failover example (multiple URIs):
-
-```bash
-  Hive {
-    table_name = "default.seatunnel_orc"
-    metastore_uri = "thrift://metastore-1:9083,thrift://metastore-2:9083"
-  }
-```
-
-### example 1
+### Example 1: Single table read & write
 
 We have a source table like this:
 
-```bash
+```sql
 create table test_hive_source(
-     test_tinyint                          TINYINT,
-     test_smallint                       SMALLINT,
-     test_int                                INT,
-     test_bigint                           BIGINT,
-     test_boolean                       BOOLEAN,
-     test_float                             FLOAT,
-     test_double                         DOUBLE,
-     test_string                           STRING,
-     test_binary                          BINARY,
-     test_timestamp                  TIMESTAMP,
-     test_decimal                       DECIMAL(8,2),
-     test_char                             CHAR(64),
-     test_varchar                        VARCHAR(64),
-     test_date                             DATE,
-     test_array                            ARRAY<INT>,
-     test_map                              MAP<STRING, FLOAT>,
-     test_struct                           STRUCT<street:STRING, city:STRING, state:STRING, zip:INT>
-     )
+     test_tinyint   TINYINT,
+     test_smallint  SMALLINT,
+     test_int       INT,
+     test_bigint    BIGINT,
+     test_boolean   BOOLEAN,
+     test_float     FLOAT,
+     test_double    DOUBLE,
+     test_string    STRING,
+     test_binary    BINARY,
+     test_timestamp TIMESTAMP,
+     test_decimal   DECIMAL(8,2),
+     test_char      CHAR(64),
+     test_varchar   VARCHAR(64),
+     test_date      DATE,
+     test_array     ARRAY<INT>,
+     test_map       MAP<STRING, FLOAT>,
+     test_struct    STRUCT<street:STRING, city:STRING, state:STRING, zip:INT>
+)
 PARTITIONED BY (test_par1 STRING, test_par2 STRING);
-
 ```
 
-We need read data from the source table and write to another table:
+We read from this source table and write to a sink table:
 
-```bash
+```sql
 create table test_hive_sink_text_simple(
-     test_tinyint                          TINYINT,
-     test_smallint                       SMALLINT,
-     test_int                                INT,
-     test_bigint                           BIGINT,
-     test_boolean                       BOOLEAN,
-     test_float                             FLOAT,
-     test_double                         DOUBLE,
-     test_string                           STRING,
-     test_binary                          BINARY,
-     test_timestamp                  TIMESTAMP,
-     test_decimal                       DECIMAL(8,2),
-     test_char                             CHAR(64),
-     test_varchar                        VARCHAR(64),
-     test_date                             DATE
-     )
+     test_tinyint   TINYINT,
+     test_smallint  SMALLINT,
+     test_int       INT,
+     test_bigint    BIGINT,
+     test_boolean   BOOLEAN,
+     test_float     FLOAT,
+     test_double    DOUBLE,
+     test_string    STRING,
+     test_binary    BINARY,
+     test_timestamp TIMESTAMP,
+     test_decimal   DECIMAL(8,2),
+     test_char      CHAR(64),
+     test_varchar   VARCHAR(64),
+     test_date      DATE
+)
 PARTITIONED BY (test_par1 STRING, test_par2 STRING);
-
 ```
 
-The job config file can like this:
-
-```
+```hocon
 env {
   parallelism = 3
-  job.name="test_hive_source_to_hive"
+  job.name = "test_hive_source_to_hive"
+  job.mode = "BATCH"
 }
 
 source {
@@ -234,21 +269,46 @@ source {
 }
 
 sink {
-  # choose stdout output plugin to output data to console
-
   Hive {
     table_name = "test_hive.test_hive_sink_text_simple"
     metastore_uri = "thrift://ctyun7:9083"
     hive.hadoop.conf = {
       bucket = "s3a://mybucket"
-      fs.s3a.aws.credentials.provider="com.amazonaws.auth.InstanceProfileCredentialsProvider"
+      fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
     }
+  }
 }
 ```
 
-### example2: Kerberos
+### Example 2: Kerberos
 
-```bash
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        pk_id = bigint
+        name = string
+        score = int
+      }
+      primaryKey {
+        name = "pk_id"
+        columnNames = [pk_id]
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "A", 100] },
+      { kind = INSERT, fields = [2, "B", 100] },
+      { kind = INSERT, fields = [3, "C", 100] }
+    ]
+  }
+}
+
 sink {
   Hive {
     table_name = "default.test_hive_sink_on_hdfs_with_kerberos"
@@ -268,263 +328,27 @@ Description:
 - `kerberos_keytab_path`: The keytab file path for Kerberos authentication.
 - `krb5_path`: The path to the `krb5.conf` file used for Kerberos authentication.
 
-Run the case:
+### Example 3: Multiple tables (multi-table write)
 
-```bash
+When the source produces multiple tables, use `${database_name}.${table_name}`
+placeholders so each upstream table is written to a matching Hive table.
+
+```hocon
 env {
-  parallelism = 1
-  job.mode = "BATCH"
-}
-
-source {
-  FakeSource {
-    schema = {
-      fields {
-        pk_id = bigint
-        name = string
-        score = int
-      }
-      primaryKey {
-        name = "pk_id"
-        columnNames = [pk_id]
-      }
-    }
-    rows = [
-      {
-        kind = INSERT
-        fields = [1, "A", 100]
-      },
-      {
-        kind = INSERT
-        fields = [2, "B", 100]
-      },
-      {
-        kind = INSERT
-        fields = [3, "C", 100]
-      }
-    ]
-  }
-}
-
-sink {
-  Hive {
-    table_name = "default.test_hive_sink_on_hdfs_with_kerberos"
-    metastore_uri = "thrift://metastore:9083"
-    hive_site_path = "/tmp/hive-site.xml"
-    kerberos_principal = "hive/metastore.seatunnel@EXAMPLE.COM"
-    kerberos_keytab_path = "/tmp/hive.keytab"
-    krb5_path = "/tmp/krb5.conf"
-  }
-}
-```
-
-## Hive on s3
-
-### Step 1
-
-Create the lib dir for hive of emr.
-
-```shell
-mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
-```
-
-### Step 2
-
-Get the jars from maven center to the lib.
-
-```shell
-cd ${SEATUNNEL_HOME}/plugins/Hive/lib
-wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.6.5/hadoop-aws-2.6.5.jar
-wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
-```
-
-### Step 3
-
-Copy the jars from your environment on emr to the lib dir.
-
-```shell
-cp /usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly-2.60.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
-cp /usr/share/aws/emr/hadoop-state-pusher/lib/hadoop-common-3.3.6-amzn-1.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
-cp /usr/share/aws/emr/hadoop-state-pusher/lib/javax.inject-1.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
-cp /usr/share/aws/emr/hadoop-state-pusher/lib/aopalliance-1.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
-```
-
-### Step 4
-
-Run the case.
-
-```shell
-env {
-  parallelism = 1
-  job.mode = "BATCH"
-}
-
-source {
-  FakeSource {
-    schema = {
-      fields {
-        pk_id = bigint
-        name = string
-        score = int
-      }
-      primaryKey {
-        name = "pk_id"
-        columnNames = [pk_id]
-      }
-    }
-    rows = [
-      {
-        kind = INSERT
-        fields = [1, "A", 100]
-      },
-      {
-        kind = INSERT
-        fields = [2, "B", 100]
-      },
-      {
-        kind = INSERT
-        fields = [3, "C", 100]
-      }
-    ]
-  }
-}
-
-sink {
-  Hive {
-    table_name = "test_hive.test_hive_sink_on_s3"
-    metastore_uri = "thrift://ip-192-168-0-202.cn-north-1.compute.internal:9083"
-    hive.hadoop.conf-path = "/home/ec2-user/hadoop-conf"
-    hive.hadoop.conf = {
-       bucket="s3://ws-package"
-       fs.s3a.aws.credentials.provider="com.amazonaws.auth.InstanceProfileCredentialsProvider"
-    }
-  }
-}
-```
-
-## Hive on oss
-
-### Step 1
-
-Create the lib dir for hive of emr.
-
-```shell
-mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
-```
-
-### Step 2
-
-Get the jars from maven center to the lib.
-
-```shell
-cd ${SEATUNNEL_HOME}/plugins/Hive/lib
-wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
-```
-
-### Step 3
-
-Copy the jars from your environment on emr to the lib dir and delete the conflicting jar.
-
-```shell
-cp -r /opt/apps/JINDOSDK/jindosdk-current/lib/jindo-*.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
-rm -f ${SEATUNNEL_HOME}/lib/hadoop-aliyun-*.jar
-```
-
-### Step 4
-
-Run the case.
-
-```shell
-env {
-  parallelism = 1
-  job.mode = "BATCH"
-}
-
-source {
-  FakeSource {
-    schema = {
-      fields {
-        pk_id = bigint
-        name = string
-        score = int
-      }
-      primaryKey {
-        name = "pk_id"
-        columnNames = [pk_id]
-      }
-    }
-    rows = [
-      {
-        kind = INSERT
-        fields = [1, "A", 100]
-      },
-      {
-        kind = INSERT
-        fields = [2, "B", 100]
-      },
-      {
-        kind = INSERT
-        fields = [3, "C", 100]
-      }
-    ]
-  }
-}
-
-sink {
-  Hive {
-    table_name = "test_hive.test_hive_sink_on_oss"
-    metastore_uri = "thrift://master-1-1.c-1009b01725b501f2.cn-wulanchabu.emr.aliyuncs.com:9083"
-    hive.hadoop.conf-path = "/tmp/hadoop"
-    hive.hadoop.conf = {
-        bucket="oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
-    }
-  }
-}
-```
-
-### example 2
-
-We have multiple source table like this:
-
-```bash
-create table test_1(
-)
-PARTITIONED BY (xx);
-
-create table test_2(
-)
-PARTITIONED BY (xx);
-...
-```
-
-We need read data from these source tables and write to another tables:
-
-The job config file can like this:
-
-```
-env {
-  # You can set flink configuration here
   parallelism = 3
-  job.name="test_hive_source_to_hive"
+  job.mode = "BATCH"
 }
 
 source {
   Hive {
-    tables_configs = [
-      {
-        table_name = "test_hive.test_1"
-        metastore_uri = "thrift://ctyun6:9083"
-      },
-      {
-        table_name = "test_hive.test_2"
-        metastore_uri = "thrift://ctyun7:9083"
-      }
+    table_list = [
+      { table_name = "test_hive.test_1", metastore_uri = "thrift://ctyun6:9083" },
+      { table_name = "test_hive.test_2", metastore_uri = "thrift://ctyun7:9083" }
     ]
   }
 }
 
 sink {
-  # choose stdout output plugin to output data to console
   Hive {
     table_name = "${database_name}.${table_name}"
     metastore_uri = "thrift://ctyun7:9083"
@@ -532,9 +356,11 @@ sink {
 }
 ```
 
-## Auto Table Creation Examples
+### Example 4: Auto Table Creation
 
-### Example 1: Basic Auto Table Creation
+Use `save_mode_create_template` together with `schema_save_mode =
+"CREATE_SCHEMA_WHEN_NOT_EXIST"` to let the connector create the Hive table on
+the fly:
 
 ```hocon
 env {
@@ -583,53 +409,136 @@ sink {
   }
 }
 ```
+
+## Hive on s3
+
+### Step 1: Create the lib dir for Hive
+
+```shell
+mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
+```
+
+### Step 2: Download jars from Maven Central
+
+```shell
+cd ${SEATUNNEL_HOME}/plugins/Hive/lib
+wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.6.5/hadoop-aws-2.6.5.jar
+wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
+```
+
+### Step 3: Copy EMR jars into the lib dir
+
+```shell
+cp /usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly-2.60.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
+cp /usr/share/aws/emr/hadoop-state-pusher/lib/hadoop-common-3.3.6-amzn-1.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
+cp /usr/share/aws/emr/hadoop-state-pusher/lib/javax.inject-1.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
+cp /usr/share/aws/emr/hadoop-state-pusher/lib/aopalliance-1.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
+```
+
+### Step 4: Run the job
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Hive {
+    table_name = "test_hive.test_hive_sink_on_s3"
+    metastore_uri = "thrift://ip-192-168-0-202.cn-north-1.compute.internal:9083"
+    hive.hadoop.conf-path = "/home/ec2-user/hadoop-conf"
+    hive.hadoop.conf = {
+      bucket = "s3://ws-package"
+      fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+    }
+  }
+}
+```
+
+## Hive on oss
+
+### Step 1: Create the lib dir for Hive
+
+```shell
+mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
+```
+
+### Step 2: Download jars from Maven Central
+
+```shell
+cd ${SEATUNNEL_HOME}/plugins/Hive/lib
+wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
+```
+
+### Step 3: Copy JindoSDK jars and remove conflicting Hadoop Aliyun jars
+
+```shell
+cp -r /opt/apps/JINDOSDK/jindosdk-current/lib/jindo-*.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
+rm -f ${SEATUNNEL_HOME}/lib/hadoop-aliyun-*.jar
+```
+
+### Step 4: Run the job
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        pk_id = bigint
+        name = string
+        score = int
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "A", 100] },
+      { kind = INSERT, fields = [2, "B", 100] },
+      { kind = INSERT, fields = [3, "C", 100] }
+    ]
+  }
+}
+
+sink {
+  Hive {
+    table_name = "test_hive.test_hive_sink_on_oss"
+    metastore_uri = "thrift://master-1-1.c-1009b01725b501f2.cn-wulanchabu.emr.aliyuncs.com:9083"
+    hive.hadoop.conf-path = "/tmp/hadoop"
+    hive.hadoop.conf = {
+      bucket = "oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
+    }
+  }
+}
+```
+
 ## FAQ
-
-### What file formats does Hive Sink support?
-
-Hive Sink supports `ORC`, `PARQUET`, `TEXT`, `JSON`, and `SEQUENCE` file formats. Specify the format with the `file_format_type` parameter. Ensure the Hive table's `STORED AS` clause matches the configured format.
-
-### Does Hive Sink support partitioned tables?
-
-Yes. For partitioned tables, specify the partition fields using `partition_by`. SeaTunnel writes data into the correct partition directories automatically:
-
-```hocon
-sink {
-  Hive {
-    table_name = "mydb.sales"
-    metastore_uri = "thrift://hive-metastore:9083"
-    partition_by = ["dt", "region"]
-  }
-}
-```
-
-### How do I connect to a Kerberized Hadoop cluster?
-
-Provide the Kerberos keytab and principal in the connector configuration:
-
-```hocon
-sink {
-  Hive {
-    table_name = "mydb.events"
-    metastore_uri = "thrift://hive-metastore:9083"
-    kerberos_principal = "hive/host@REALM.COM"
-    kerberos_keytab_path = "/etc/security/keytabs/hive.keytab"
-    krb5_path = "/etc/krb5.conf"
-  }
-}
-```
 
 ### Why do I see many small files in my Hive table?
 
-Small files are created when job parallelism is high or batches are small. To reduce small file counts:
+Small files are created when job parallelism is high or batches are small. To
+reduce small file counts:
 
 - Lower the job `parallelism` setting in the `env` block.
-- Increase `batch_size` so each task writes larger files.
-- Run a periodic compaction using Hive's `ALTER TABLE ... CONCATENATE` or a Spark merge job.
+- Run a periodic compaction using Hive's `ALTER TABLE ... CONCATENATE` or a
+  Spark merge job.
 
 ### Does Hive Sink support schema evolution?
 
-Hive Sink reads the current table schema from the Hive Metastore. If columns are added to the upstream, they will only appear in Hive after the table DDL is updated. SeaTunnel does not automatically `ALTER TABLE` Hive schemas.
+The Hive sink writes the upstream schema into the target table. If columns are
+added to the upstream, they will only appear in Hive after the table DDL is
+updated; SeaTunnel does not automatically run `ALTER TABLE` on Hive schemas.
+
+### What is the difference between `overwrite` and `data_save_mode`?
+
+`overwrite = true` and `data_save_mode = "DROP_DATA"` behave the same way: the
+target directory (table directory for non-partitioned tables, partition
+directories for partitioned tables) is deleted before the new data is written.
+Use either one, but not both. `data_save_mode = "APPEND_DATA"` (the default)
+keeps existing data and appends new rows.
 
 ## Changelog
 

--- a/docs/en/connectors/sink/OceanBase.md
+++ b/docs/en/connectors/sink/OceanBase.md
@@ -12,17 +12,33 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Key Features
 
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+> Exactly-once uses XA transactions. Enable it with `is_exactly_once = true`,
+> `max_retries = 0`, and a valid OceanBase XA data source class from the
+> OceanBase JDBC driver.
 
 ## Description
 
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once semantics.
+Write data to OceanBase through JDBC. The sink supports batch and streaming
+jobs, CDC row kinds, generated SQL, save modes, multi-table writes, and
+exactly-once semantics when XA transactions are configured.
+
+:::tip
+
+The connector uses the `Jdbc` plugin under the hood with the
+`com.oceanbase.jdbc.Driver` driver. The `compatible_mode` option is required
+to switch between the MySQL and Oracle dialect implementations.
+
+:::
 
 ## Supported DataSource Info
 
-| Datasource |       Supported versions       |          Driver           |                 Url                  |                                     Maven                                     |
-|------------|--------------------------------|---------------------------|--------------------------------------|-------------------------------------------------------------------------------|
+| Datasource | Supported versions       | Driver                   | Url                                  | Maven                                                                       |
+|------------|--------------------------|--------------------------|--------------------------------------|-----------------------------------------------------------------------------|
 | OceanBase  | All OceanBase server versions. | com.oceanbase.jdbc.Driver | jdbc:oceanbase://localhost:2883/test | [Download](https://mvnrepository.com/artifact/com.oceanbase/oceanbase-client) |
 
 ## Database Dependency
@@ -32,84 +48,127 @@ Write data through jdbc. Support Batch mode and Streaming mode, support concurre
 
 ## Data Type Mapping
 
-### Mysql Mode
+### MySQL Mode
 
-|                                                          Mysql Data type                                                          |                                                                 SeaTunnel Data type                                                                 |
-|-----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| BIT(1)<br/>INT UNSIGNED                                                                                                           | BOOLEAN                                                                                                                                             |
-| TINYINT<br/>TINYINT UNSIGNED<br/>SMALLINT<br/>SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR | INT                                                                                                                                                 |
-| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                                                      | BIGINT                                                                                                                                              |
-| BIGINT UNSIGNED                                                                                                                   | DECIMAL(20,0)                                                                                                                                       |
-| DECIMAL(x,y)(Get the designated column's specified column size.<38)                                                               | DECIMAL(x,y)                                                                                                                                        |
-| DECIMAL(x,y)(Get the designated column's specified column size.>38)                                                               | DECIMAL(38,18)                                                                                                                                      |
-| DECIMAL UNSIGNED                                                                                                                  | DECIMAL((Get the designated column's specified column size)+1,<br/>(Gets the designated column's number of digits to right of the decimal point.))) |
-| FLOAT<br/>FLOAT UNSIGNED                                                                                                          | FLOAT                                                                                                                                               |
-| DOUBLE<br/>DOUBLE UNSIGNED                                                                                                        | DOUBLE                                                                                                                                              |
-| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON                                                       | STRING                                                                                                                                              |
-| DATE                                                                                                                              | DATE                                                                                                                                                |
-| TIME                                                                                                                              | TIME                                                                                                                                                |
-| DATETIME<br/>TIMESTAMP                                                                                                            | TIMESTAMP                                                                                                                                           |
-| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINAR<br/>BIT(n)                                                  | BYTES                                                                                                                                               |
-| GEOMETRY<br/>UNKNOWN                                                                                                              | Not supported yet                                                                                                                                   |
+| Mysql Data type                                                                                | SeaTunnel Data type                                                                                                                |
+|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| BIT(1)<br/>INT UNSIGNED                                                                        | BOOLEAN                                                                                                                            |
+| TINYINT<br/>TINYINT UNSIGNED<br/>SMALLINT<br/>SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR | INT |
+| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                   | BIGINT                                                                                                                             |
+| BIGINT UNSIGNED                                                                                | DECIMAL(20,0)                                                                                                                      |
+| DECIMAL(x,y) (column size < 38)                                                                | DECIMAL(x,y)                                                                                                                       |
+| DECIMAL(x,y) (column size >= 38)                                                               | DECIMAL(38,18)                                                                                                                     |
+| DECIMAL UNSIGNED                                                                               | DECIMAL((column size + 1), (right-of-decimal digits))                                                                             |
+| FLOAT<br/>FLOAT UNSIGNED                                                                       | FLOAT                                                                                                                              |
+| DOUBLE<br/>DOUBLE UNSIGNED                                                                     | DOUBLE                                                                                                                             |
+| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON                     | STRING                                                                                                                             |
+| DATE                                                                                           | DATE                                                                                                                               |
+| TIME                                                                                           | TIME                                                                                                                               |
+| DATETIME<br/>TIMESTAMP                                                                         | TIMESTAMP                                                                                                                          |
+| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINARY<br/>BIT(n)              | BYTES                                                                                                                              |
+| GEOMETRY<br/>UNKNOWN                                                                           | Not supported yet                                                                                                                  |
 
 ### Oracle Mode
 
-|                     Oracle Data type                      | SeaTunnel Data type |
-|-----------------------------------------------------------|---------------------|
-| Number(p), p <= 9                                         | INT                 |
-| Number(p), p <= 18                                        | BIGINT              |
-| Number(p), p > 18                                         | DECIMAL(38,18)      |
-| REAL<br/> BINARY_FLOAT                                    | FLOAT               |
-| BINARY_DOUBLE                                             | DOUBLE              |
-| CHAR<br/>NCHAR<br/>NVARCHAR2<br/>NCLOB<br/>CLOB<br/>ROWID | STRING              |
-| DATE                                                      | DATE                |
-| TIMESTAMP<br/>TIMESTAMP WITH LOCAL TIME ZONE              | TIMESTAMP           |
-| BLOB<br/>RAW<br/>LONG RAW<br/>BFILE                       | BYTES               |
-| UNKNOWN                                                   | Not supported yet   |
+| Oracle Data type                                              | SeaTunnel Data type |
+|---------------------------------------------------------------|---------------------|
+| Number(p), p <= 9                                             | INT                 |
+| Number(p), p <= 18                                            | BIGINT              |
+| Number(p), p > 18                                             | DECIMAL(38,18)      |
+| REAL<br/>BINARY_FLOAT                                         | FLOAT               |
+| BINARY_DOUBLE                                                 | DOUBLE              |
+| CHAR<br/>NCHAR<br/>NVARCHAR2<br/>NCLOB<br/>CLOB<br/>ROWID     | STRING              |
+| DATE                                                          | DATE                |
+| TIMESTAMP<br/>TIMESTAMP WITH LOCAL TIME ZONE                  | TIMESTAMP           |
+| BLOB<br/>RAW<br/>LONG RAW<br/>BFILE                           | BYTES               |
+| UNKNOWN                                                       | Not supported yet   |
 
 ## Sink Options
 
-|                   Name                    |  Type   | Required | Default |                                                                                                                  Description                                                                                                                   |
-|-------------------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:oceanbase://localhost:2883/test                                                                                                                                                          |
-| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source, should be `com.oceanbase.jdbc.Driver`.                                                                                                                                          |
-| username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                  |
-| password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                   |
-| query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
-| compatible_mode                           | String  | Yes      | -       | The compatible mode of OceanBase, can be 'mysql' or 'oracle'.                                                                                                                                                                                  |
-| database                                  | String  | No       | -       | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                       |
-| table                                     | String  | No       | -       | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                           |
-| primary_keys                              | Array   | No       | -       | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql.                                                                                                                            |
-| connection_check_timeout_sec              | Int     | No       | 30      | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                            |
-| max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
-| batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
-| generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
-| max_commit_attempts                       | Int     | No       | 3       | The number of retries for transaction commit failures                                                                                                                                                                                          |
-| transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
-| auto_commit                               | Boolean | No       | true    | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
-| properties                                | Map     | No       | -       | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL. |
-| common-options                            |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                                    |
-| enable_upsert                             | Boolean | No       | true    | Enable upsert by primary_keys exist, If the task has no key duplicate data, setting this parameter to `false` can speed up data import                                                                                                         |
+| Name                              | Type    | Required | Default                          | Description                                                                                                                                                                                                                                                          |
+|-----------------------------------|---------|----------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                               | String  | Yes      | -                                | The URL of the JDBC connection, for example `jdbc:oceanbase://localhost:2883/test`.                                                                                                                                                                                  |
+| driver                            | String  | Yes      | -                                | The JDBC class name used to connect to the remote data source. Must be `com.oceanbase.jdbc.Driver`.                                                                                                                                                                  |
+| username                          | String  | No       | -                                | Connection instance username.                                                                                                                                                                                                                                        |
+| password                          | String  | No       | -                                | Connection instance password.                                                                                                                                                                                                                                         |
+| query                             | String  | No       | -                                | SQL used to write upstream data to OceanBase, for example `INSERT ...`. When `generate_sink_sql = false`, `query` is required. Save mode options do not run in custom `query` mode.                                                                                  |
+| compatible_mode                   | String  | Yes      | -                                | The compatible mode of OceanBase. Must be `mysql` or `oracle`.                                                                                                                                                                                                       |
+| database                          | String  | No       | -                                | Database used when `generate_sink_sql = true`. This option is required when generated SQL is enabled.                                                                                                                                                                |
+| table                             | String  | No       | -                                | Target table used when `generate_sink_sql = true`. Supports placeholders such as `${schema_name}` and `${table_name}` for multi-table writes.                                                                                                                       |
+| primary_keys                      | Array   | No       | -                                | Used to support operations such as `insert`, `delete`, and `update` when SQL is generated automatically.                                                                                                                                                              |
+| connection_check_timeout_sec      | Int     | No       | 30                               | Time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                                                      |
+| max_retries                       | Int     | No       | 0                                | The number of retries to submit a failed batch (`executeBatch`).                                                                                                                                                                                                    |
+| batch_size                        | Int     | No       | 1000                             | For batch writing, when buffered record count reaches `batch_size`, data is flushed to OceanBase. If `batch_interval_ms > 0`, elapsed time can also trigger a flush.                                                                                                |
+| batch_interval_ms                 | Long    | No       | 0                                | Write-triggered flush interval in milliseconds. `0` disables time-based flushing. When greater than 0, the writer checks elapsed time on each record and flushes synchronously when the interval is reached.                                                       |
+| is_exactly_once                   | Boolean | No       | false                            | Whether to enable exactly-once semantics through XA transactions. If enabled, set `xa_data_source_class_name` and keep `max_retries = 0`.                                                                                                                            |
+| generate_sink_sql                 | Boolean | No       | false                            | Generate SQL statements based on the database table you want to write to.                                                                                                                                                                                            |
+| xa_data_source_class_name         | String  | No       | -                                | XA data source class name from the OceanBase JDBC driver. Required when `is_exactly_once = true`.                                                                                                                                                                    |
+| max_commit_attempts               | Int     | No       | 3                                | The number of retries for transaction commit failures.                                                                                                                                                                                                               |
+| transaction_timeout_sec           | Int     | No       | -1                               | The timeout after the transaction is opened. `-1` means never time out. Note that setting a timeout may affect exactly-once semantics.                                                                                                                                |
+| auto_commit                       | Boolean | No       | true                             | Whether automatic transaction commit is enabled.                                                                                                                                                                                                                     |
+| field_ide                         | String  | No       | -                                | Controls field name case conversion. Available values: `ORIGINAL`, `UPPERCASE`, `LOWERCASE`.                                                                                                                                                                          |
+| properties                        | Map     | No       | -                                | Additional connection configuration parameters. When properties and the URL have the same parameters, the priority depends on the driver implementation; for example, MySQL drivers give `properties` priority over the URL.                                        |
+| schema_save_mode                  | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST      | Controls how the target table structure is handled before the job starts. See [schema_save_mode](#schema_save_mode) below.                                                                                                                                          |
+| data_save_mode                    | Enum    | No       | APPEND_DATA                      | Controls how existing target table data is handled before the job starts. See [data_save_mode](#data_save_mode) below.                                                                                                                                               |
+| custom_sql                        | String  | No       | -                                | SQL executed before synchronization when `data_save_mode = CUSTOM_PROCESSING`. Not executed in custom `query` mode.                                                                                                                                                 |
+| enable_upsert                     | Boolean | No       | true                             | Enable upsert by `primary_keys`. If the task has no key duplicate data, setting this to `false` can speed up data import.                                                                                                                                           |
+| is_primary_key_updated            | Boolean | No       | true                             | Whether primary key fields are included when generated update statements are built.                                                                                                                                                                                  |
+| support_upsert_by_insert_only     | Boolean | No       | false                            | Whether to support upsert behavior through insert-only statements for compatible dialects.                                                                                                                                                                          |
+| multi_table_sink_replica          | Int     | No       | 1                                | Number of sink writer replicas used when writing multiple tables.                                                                                                                                                                                                   |
+| common-options                    |         | No       | -                                | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                                                                          |
+
+### schema_save_mode
+
+Controls how the target table structure is handled before the job starts.
+
+- `RECREATE_SCHEMA`: Drop the table and recreate it.
+- `CREATE_SCHEMA_WHEN_NOT_EXIST` (default): Create the table when it does not
+  exist, skip when it exists.
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`: Report an error when the table does not exist.
+- `IGNORE`: Skip table handling.
+
+### data_save_mode
+
+Controls how existing target table data is handled before the job starts.
+
+- `DROP_DATA`: Preserve the database structure and delete the data.
+- `APPEND_DATA` (default): Preserve both the database structure and the data.
+- `CUSTOM_PROCESSING`: Run a user-provided `custom_sql` before the job starts.
+- `ERROR_WHEN_DATA_EXISTS`: Report an error when data already exists.
 
 ### Tips
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
+> Configure `compatible_mode = "mysql"` for OceanBase MySQL mode and
+> `compatible_mode = "oracle"` for OceanBase Oracle mode.
+>
+> Use `query` when you want to provide the full write SQL yourself. Use
+> `generate_sink_sql = true` together with `database` and `table` when you want
+> SeaTunnel to generate INSERT/UPSERT SQL and apply save mode settings.
+>
+> To consume CDC data, use generated SQL and configure `primary_keys`;
+> otherwise UPDATE and DELETE events cannot be mapped safely.
 
 ## Task Example
 
 ### Simple
 
-> This example defines a SeaTunnel synchronization task that automatically generates data through FakeSource and sends it to JDBC Sink. FakeSource generates a total of 16 rows of data (row.num=16), with each row having two fields, name (string type) and age (int type). The final target table is test_table will also be 16 rows of data in the table. Before run this job, you need create database test and table test_table in your mysql. And if you have not yet installed and deployed SeaTunnel, you need to follow the instructions in [Install SeaTunnel](../../getting-started/locally/deployment.md) to install and deploy SeaTunnel. And then follow the instructions in [Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md) to run this job.
+> This example defines a SeaTunnel job that automatically generates data through
+> FakeSource and sends it to the OceanBase sink. `FakeSource` generates 16 rows
+> in total (row.num=16), each with two fields: `name` (string) and `age` (int).
+> The target table `test_table` will also contain 16 rows. Before running this
+> job, create the `test` database and `test_table` in your OceanBase cluster.
+> If you have not yet installed and deployed SeaTunnel, follow the
+> [Install SeaTunnel](../../getting-started/locally/deployment.md) and
+> [Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md)
+> guides.
 
-```
-# Defining the runtime environment
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"
 }
 
 source {
-  # This is a example source plugin **only for test and demonstrate the feature source plugin**
   FakeSource {
     parallelism = 1
     plugin_output = "fake"
@@ -121,67 +180,117 @@ source {
       }
     }
   }
-  # If you would like to get more information about how to configure seatunnel and see full list of source plugins,
-  # please go to https://seatunnel.apache.org/docs/connector-v2/source
 }
 
 transform {
-  # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-    # please go to https://seatunnel.apache.org/docs/transform-v2
 }
 
 sink {
-    jdbc {
-        url = "jdbc:oceanbase://localhost:2883/test"
-        driver = "com.oceanbase.jdbc.Driver"
-        username = "root"
-        password = "123456"
-        compatible_mode = "mysql"
-        query = "insert into test_table(name,age) values(?,?)"
-    }
-  # If you would like to get more information about how to configure seatunnel and see full list of sink plugins,
-  # please go to https://seatunnel.apache.org/docs/connector-v2/sink
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root"
+    password = "123456"
+    compatible_mode = "mysql"
+    query = "insert into test_table(name,age) values(?,?)"
+  }
 }
 ```
 
 ### Generate Sink SQL
 
-> This example  not need to write complex sql statements, you can configure the database name table name to automatically generate add statements for you
+> Use this option when you do not want to write complex SQL by hand; SeaTunnel
+> generates the INSERT statement for you.
 
-```
+```hocon
 sink {
-    jdbc {
-        url = "jdbc:oceanbase://localhost:2883/test"
-        driver = "com.oceanbase.jdbc.Driver"
-        username = "root"
-        password = "123456"
-        compatible_mode = "mysql"
-        # Automatically generate sql statements based on database table names
-        generate_sink_sql = true
-        database = test
-        table = test_table
-    }
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root"
+    password = "123456"
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = test
+    table = test_table
+  }
 }
 ```
 
-### CDC(Change Data Capture) Event
+### Generated SQL With Save Mode
 
-> CDC change data is also supported by us In this case, you need config database, table and primary_keys.
-
-```
+```hocon
 sink {
-    jdbc {
-        url = "jdbc:oceanbase://localhost:3306/test"
-        driver = "com.oceanbase.jdbc.Driver"
-        username = "root"
-        password = "123456"
-        compatible_mode = "mysql"
-        generate_sink_sql = true
-        # You need to configure both database and table
-        database = test
-        table = sink_table
-        primary_keys = ["id","name"]
-    }
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "sink_table"
+    primary_keys = ["id"]
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
+  }
+}
+```
+
+### CDC (Change Data Capture) Event
+
+> CDC change data is supported. Configure `database`, `table`, and
+> `primary_keys`.
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:3306/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root"
+    password = "123456"
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = test
+    table = sink_table
+    primary_keys = ["id", "name"]
+  }
+}
+```
+
+### Oracle-Compatible Mode
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "INSERT INTO SINK_TABLE (ID, NAME, CREATE_TIME) VALUES (?, ?, ?)"
+  }
+}
+```
+
+### Multiple Table Write
+
+Use placeholders in `table` when upstream rows carry table identity.
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:oceanbase://localhost:2883/test"
+    driver = "com.oceanbase.jdbc.Driver"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    generate_sink_sql = true
+    database = "test"
+    table = "${table_name}_sink"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
 }
 ```
 

--- a/docs/en/connectors/sink/Pulsar.md
+++ b/docs/en/connectors/sink/Pulsar.md
@@ -8,15 +8,19 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 > Spark<br/>
 > Flink<br/>
-> Seatunnel Zeta<br/>
+> SeaTunnel Zeta<br/>
+
+## Description
+
+The Pulsar sink writes SeaTunnel rows to Apache Pulsar topics. It can write to
+one configured topic, or route multi-table records by the table id carried in
+each row.
 
 ## Key features
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-
-## Description
-
-Sink connector for Apache Pulsar.
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Supported DataSource Info
 
@@ -26,35 +30,40 @@ Sink connector for Apache Pulsar.
 
 ## Sink Options
 
-|         Name         |  Type  | Required |       Default       |                                                   Description                                                    |
-|----------------------|--------|----------|---------------------|------------------------------------------------------------------------------------------------------------------|
-| topic                | String | Yes      | -                   | sink pulsar topic                                                                                                |
-| client.service-url   | String | Yes      | -                   | Service URL provider for Pulsar service.                                                                         |
-| admin.service-url    | String | Yes      | -                   | The Pulsar service HTTP URL for the admin endpoint.                                                              |
-| auth.plugin-class    | String | No       | -                   | Name of the authentication plugin.                                                                               |
-| auth.params          | String | No       | -                   | Parameters for the authentication plugin.                                                                        |
-| format               | String | No       | json                | Data format. The default format is json. Optional text format.                                                   |
-| field_delimiter      | String | No       | ,                   | Customize the field delimiter for data format.                                                                   |
-| semantics            | Enum   | No       | AT_LEAST_ONCE       | Consistency semantics for writing to pulsar.                                                                     |
-| transaction_timeout  | Int    | No       | 600                 | The transaction timeout is specified as 10 minutes by default.                                                   |
-| pulsar.config        | Map    | No       | -                   | In addition to the above parameters that must be specified by the Pulsar producer client.                        |
-| message.routing.mode | Enum   | No       | RoundRobinPartition | Default routing mode for messages to partition.                                                                  |
-| partition_key_fields | array  | No       | -                   | Configure which fields are used as the key of the pulsar message.                                                |
-| common-options       | config | no       | -                   | Source plugin common parameters, please refer to [Source Common Options](../common-options/sink-common-options.md) for details. |
+| Name                     | Type   | Required | Default             | Description                                                                                                      |
+|--------------------------|--------|----------|---------------------|------------------------------------------------------------------------------------------------------------------|
+| topic                    | String | No       | -                   | Target Pulsar topic. Required for normal single-table writes. Optional only when multi-table rows carry table ids. |
+| client.service-url       | String | Yes      | -                   | Pulsar client service URL, for example `pulsar://localhost:6650`.                                                 |
+| admin.service-url        | String | Yes      | -                   | Pulsar admin HTTP URL, for example `http://localhost:8080`.                                                       |
+| auth.plugin-class        | String | No       | -                   | Pulsar authentication plugin class name.                                                                         |
+| auth.params              | String | No       | -                   | Parameters for the authentication plugin. Configure it together with `auth.plugin-class`.                         |
+| format                   | String | No       | json                | Data format. The default format is json. Optional text and avro format.                                                                        |
+| field_delimiter          | String | No       | ,                   | Field delimiter used when `format = "text"`.                                                                     |
+| semantics                | Enum   | No       | AT_LEAST_ONCE       | Write consistency. Valid values: `NON`, `AT_LEAST_ONCE`, `EXACTLY_ONCE`.                                         |
+| transaction_timeout      | Int    | No       | 600                 | Pulsar transaction timeout in seconds. Used by `EXACTLY_ONCE`.                                                    |
+| pulsar.config            | Map    | No       | -                   | Extra producer properties passed to the Pulsar producer client.                                                   |
+| message.routing.mode     | Enum   | No       | RoundRobinPartition | Routing mode for partitioned topics. Valid values: `SinglePartition`, `RoundRobinPartition`.                     |
+| partition_key_fields     | Array  | No       | -                   | Fields used to build the Pulsar message key.                                                                     |
+| multi_table_sink_replica | Int    | No       | 1                   | Writer replica count for multi-table writes.                                                                     |
+| common-options           | Config | No       | -                   | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md).              |
 
 ## Parameter Interpretation
 
+### topic [String]
+
+The default Pulsar topic used by the sink.
+
+For single-table pipelines, configure `topic`. For multi-table pipelines, the sink uses `SeaTunnelRow.getTableId()` as the target topic when the row has a table id, and falls back to `topic` only when the row does not carry one.
+
+If neither the row table id nor `topic` is available, the sink fails fast with a configuration error.
+
 ### client.service-url [String]
 
-Service URL provider for Pulsar service.
-To connect to Pulsar using client libraries, you need to specify a Pulsar protocol URL.
-You can assign Pulsar protocol URLs to specific clusters and use the Pulsar scheme.
-
-For example, `localhost`: `pulsar://localhost:6650,localhost:6651`.
+Pulsar client service URL. Use the Pulsar protocol, for example `pulsar://localhost:6650`.
 
 ### admin.service-url [String]
 
-The Pulsar service HTTP URL for the admin endpoint.
+Pulsar admin HTTP URL.
 
 For example, `http://my-broker.example.com:8080`, or `https://my-broker.example.com:8443` for TLS.
 
@@ -66,93 +75,77 @@ Name of the authentication plugin.
 
 Parameters for the authentication plugin.
 
-For example, `key1:val1,key2:val2`
+For example, `key1:val1,key2:val2`.
 
 ### format [String]
 
-Data format. The default format is json. Optional text format. The default field separator is ",".
-If you customize the delimiter, add the "field_delimiter" option.
+Data format. The default format is `json`. Optional text and avro format. You can also use `text`. When using `text`, configure `field_delimiter` if the default comma delimiter is not suitable.
+When using avro format, the Avro schema is derived from the upstream row type; no sink-side `schema` option is required.
 
 ### field_delimiter [String]
 
-Customize the field delimiter for data format.The default field_delimiter is ','.
+Field delimiter used by the `text` format. The default value is `,`.
 
 ### semantics [Enum]
 
-Consistency semantics for writing to pulsar.
-Available options are EXACTLY_ONCE,NON,AT_LEAST_ONCE, default AT_LEAST_ONCE.
-If semantic is specified as EXACTLY_ONCE, we will use 2pc to guarantee the message is sent to pulsar exactly once.
-If semantic is specified as NON, we will directly send the message to pulsar, the data may duplicat/lost if
-job restart/retry or network error.
+Write consistency semantics.
+
+- `AT_LEAST_ONCE`: the default. Messages may be duplicated after job restart or retry.
+- `EXACTLY_ONCE`: writes messages through Pulsar transactions. The Pulsar cluster must enable transaction support, and `transaction_timeout` should be greater than the checkpoint interval.
+- `NON`: sends messages directly without checkpoint coordination. Data may be duplicated or lost after restart, retry, or network errors.
 
 ### transaction_timeout [Int]
 
-The transaction timeout is specified as 10 minutes by default.
-If the transaction does not commit within the specified timeout, the transaction will be automatically aborted.
-So you need to ensure that the timeout is greater than the checkpoint interval.
+Pulsar transaction timeout in seconds. The default value is `600`.
+
+This option is only used when `semantics = "EXACTLY_ONCE"`. If a transaction is not committed before the timeout, Pulsar aborts it automatically.
 
 ### pulsar.config [Map]
 
-In addition to the above parameters that must be specified by the Pulsar producer client,
-the user can also specify multiple non-mandatory parameters for the producer client,
-covering all the producer parameters specified in the official Pulsar document.
+Extra Pulsar producer properties. These properties are passed to the Pulsar producer client.
 
 ### message.routing.mode [Enum]
 
-Default routing mode for messages to partition.
-Available options are SinglePartition,RoundRobinPartition.
-If you choose SinglePartition, If no key is provided, The partitioned producer will randomly pick one single partition and publish all the messages into that partition, If a key is provided on the message, the partitioned producer will hash the key and assign message to a particular partition.
-If you choose RoundRobinPartition, If no key is provided, the producer will publish messages across all partitions in round-robin fashion to achieve maximum throughput.
-Please note that round-robin is not done per individual message but rather it's set to the same boundary of batching delay, to ensure batching is effective.
+Routing mode for partitioned topics.
 
-### partition_key_fields [String]
+- `SinglePartition`: without a message key, one partition is selected and all messages are sent to it. With a key, Pulsar hashes the key and sends the message to the selected partition.
+- `RoundRobinPartition`: without a message key, messages are sent across partitions in round-robin order. Pulsar applies round-robin routing at the batching-delay boundary, not per individual message.
 
-Configure which fields are used as the key of the pulsar message.
+### partition_key_fields [Array]
 
-For example, if you want to use value of fields from upstream data as key, you can assign field names to this property.
+Fields used to build the Pulsar message key.
 
-Upstream data is the following:
+For example, if the upstream row has `name` and `age`, setting `partition_key_fields = ["name"]` builds a JSON key such as `{"name":"Jack"}`. The selected fields must exist in the upstream schema.
 
-| name | age |     data      |
-|------|-----|---------------|
-| Jack | 16  | data-example1 |
-| Mary | 23  | data-example2 |
+### multi_table_sink_replica [Int]
 
-If name is set as the key, then the hash value of the name column will determine which partition the message is sent to.
-
-If not set partition key fields, the null message key will be sent to.
-
-The format of the message key is json, If name is set as the key, for example '{"name":"Jack"}'.
-
-The selected field must be an existing field in the upstream.
+Replica count for multi-table sink writers. It applies to all target topics in the multi-table sink.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/sink-common-options.md) for details.
+Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
 
 ## Task Example
 
-### Simple
-
-> This example defines a SeaTunnel synchronization task that automatically generates data through FakeSource and sends it to Pulsar Sink. FakeSource generates a total of 16 rows of data (row.num=16), with each row having two fields, name (string type) and age (int type). The final target topic is test_topic will also be 16 rows of data in the topic. And if you have not yet installed and deployed SeaTunnel, you need to follow the instructions in [Install SeaTunnel](../../getting-started/locally/deployment.md) to install and deploy SeaTunnel. And then follow the instructions in [Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md) to run this job.
+### Write FakeSource To Pulsar
 
 ```hocon
-# Defining the runtime environment
 env {
-  # You can set flink configuration here
-  execution.parallelism = 1
+  parallelism = 1
   job.mode = "BATCH"
 }
 
 source {
   FakeSource {
-    parallelism = 1
     plugin_output = "fake"
-    row.num = 16
+    row.num = 10
     schema = {
       fields {
-        name = "string"
-        age = "int"
+        c_string = string
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_timestamp = timestamp
       }
     }
   }
@@ -160,13 +153,64 @@ source {
 
 sink {
   Pulsar {
-  	topic = "example"
-    client.service-url = "localhost:pulsar://localhost:6650"
-    admin.service-url = "http://my-broker.example.com:8080"
-    plugin_output = "test"
+    topic = "topic_test"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    format = json
     pulsar.config = {
-        sendTimeoutMs = 30000
+      sendTimeoutMs = 30000
     }
+  }
+}
+```
+
+### Write With Message Key
+
+```hocon
+sink {
+  Pulsar {
+    topic = "orders"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    partition_key_fields = ["order_id"]
+    message.routing.mode = "SinglePartition"
+    format = json
+  }
+}
+```
+
+### Exactly-Once Write
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 10000
+}
+
+sink {
+  Pulsar {
+    topic = "orders"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    semantics = "EXACTLY_ONCE"
+    transaction_timeout = 600
+    format = json
+  }
+}
+```
+
+### Multi-Table Write
+
+When upstream rows carry table ids, the sink can route each row to the topic with the same table id. In this mode, `topic` can be omitted.
+
+```hocon
+sink {
+  Pulsar {
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    multi_table_sink_replica = 2
+    format = json
   }
 }
 ```

--- a/docs/en/connectors/sink/TDengine.md
+++ b/docs/en/connectors/sink/TDengine.md
@@ -4,75 +4,207 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 > TDengine sink connector
 
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Used to write data to TDengine. You need to create stable before running seatunnel task
+Write data to TDengine.
 
-## Key features
+Create the target database and super table before running the SeaTunnel job. The
+sink can write one input table to one super table, or use placeholders such as
+`${table_name}` in `stable` for multi-table writes.
+
+The input row must follow TDengine's super table write shape: the first field is
+the target sub table name, the middle fields are normal columns, and the last
+fields are TAGS values. The connector reads the number of TAGS fields from the
+target super table metadata.
+
+For example, if the target super table has two TAGS fields, the last two input
+fields are treated as TAGS values, and the first input field is treated as the
+sub table name.
+
+:::tip
+
+By default the sink uses 2PC commit to guarantee `exactly-once`. The Zeta
+engine must have checkpointing enabled for streaming jobs.
+
+:::
+
+## Key Features
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Sink Options
 
-| name         | type   | required | default value |
-|--------------|--------|----------|---------------|
-| url          | string | yes      | -             |
-| username     | string | yes      | -             |
-| password     | string | yes      | -             |
-| database     | string | yes      |               |
-| stable       | string | yes      | -             |
-| timezone     | string | no       | UTC           |
-| write_columns| list   | no       | -             |
+| Name           | Type   | Required | Default Value | Description                                                                                                                                                                       |
+|----------------|--------|----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url            | String | Yes      | -             | The TDengine REST JDBC URL, for example `jdbc:TAOS-RS://localhost:6041/`.                                                                                                          |
+| username       | String | Yes      | -             | The username used to connect to TDengine.                                                                                                                                         |
+| password       | String | Yes      | -             | The password used to connect to TDengine.                                                                                                                                         |
+| database       | String | Yes      | -             | The TDengine database name.                                                                                                                                                       |
+| stable         | String | Yes      | -             | The TDengine super table name. For multi-table writes, this value can contain placeholders, for example `${table_name}`.                                                            |
+| timezone       | String | No       | UTC           | The TDengine server timezone used for timestamp conversion.                                                                                                                       |
+| write_columns  | List   | No       | -             | The normal TDengine column names to insert. If it is not set, TDengine uses the column order of the target super table. Do not include the first input field that contains the sub table name, and do not include TAGS columns; the connector adds TAGS values from the end of the input row automatically. |
+| common-options |        | No       | -             | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                       |
 
-### url [string]
+### url [String]
 
-the url of the TDengine when you select the TDengine
-
-e.g.
+The TDengine REST JDBC URL.
 
 ```
 jdbc:TAOS-RS://localhost:6041/
 ```
 
-### username [string]
+### username [String]
 
-the username of the TDengine when you select
+The username used to connect to TDengine.
 
-### password [string]
+### password [String]
 
-the password of the TDengine when you select
+The password used to connect to TDengine.
 
-### database [string]
+### database [String]
 
-the database of the TDengine when you select
+The TDengine database name.
 
-### stable [string]
+### stable [String]
 
-the stable of the TDengine when you select
+The TDengine super table name. For multi-table writes, this value can contain
+placeholders, for example `${table_name}`. The placeholder is resolved against
+the upstream `CatalogTable` generated by the source.
 
-### timezone [string]
+### timezone [String]
 
-the timeznoe of the TDengine sever, it's important to the ts field
+The TDengine server timezone used for timestamp conversion. The default value is
+`UTC`. Make sure this matches the timezone configured on the TDengine server so
+timestamp columns are written consistently.
 
-### write_columns [list]
-The field names to be inserted into TDengine. If not set, all fields will be written. The plugin will automatically append TAGS columns, so please do not include TAGS columns in this option.
+### write_columns [List]
 
-## Example
+The normal TDengine column names to insert. If it is not set, TDengine uses the
+column order of the target super table. Do not include the first input field
+that contains the sub table name, and do not include TAGS columns; the connector
+adds TAGS values from the end of the input row automatically.
 
-### sink
+### common options
+
+Sink plugin common parameters, please refer to
+[Sink Common Options](../common-options/sink-common-options.md) for details.
+For multi-table writes, `multi_table_sink_replica` can be used with the common
+sink options.
+
+## Task Example
+
+### Write to one super table
 
 ```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    schema = {
+      fields {
+        ts = timestamp
+        voltage = float
+        current = float
+        power = float
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["2023-04-22T14:38:05", 219.0, 0.31, 68.2]
+      }
+    ]
+  }
+}
+
 sink {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power2"
-          stable : "meters2"
-          timezone: UTC
-          write_columns: ["ts", "voltage", "current", "power"]
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+    write_columns = ["ts", "voltage", "current", "power"]
+  }
+}
+```
+
+### Write multiple input tables to matching super tables
+
+```hocon
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        schema = {
+          table = "meters3"
+          fields {
+            device_id = "string"
+            event_time = "timestamp"
+            metric1 = "float"
+            metric2 = "int"
+            metric3 = "float"
+            status_flag = "boolean"
+            notes = "string"
+            location_tag = "string"
+            group_tag = "int"
+          }
         }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["d2001", "2023-04-22T14:38:05", 10.3, 219, 0.31, true, "nc", "California.SanFrancisco", 2]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "meters4"
+          fields {
+            device_id = "string"
+            event_time = "timestamp"
+            metric1 = "float"
+            metric2 = "int"
+            metric3 = "float"
+            status_flag = "boolean"
+            notes = "string"
+            location_tag = "string"
+            group_tag = "int"
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["d1005", "2023-04-22T14:38:05", 110.3, 219, 0.31, true, "nc", "California.SanFrancisco", 2]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "${table_name}"
+    timezone = "UTC"
+  }
 }
 ```
 

--- a/docs/en/connectors/source/Elasticsearch.md
+++ b/docs/en/connectors/source/Elasticsearch.md
@@ -4,11 +4,17 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 
 > Elasticsearch source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Used to read data from Elasticsearch.
 
-support version >= 2.x and <= 8.x.
+Supports Elasticsearch versions `>= 2.x` and `<= 8.x`.
 
 ## Key features
 
@@ -16,74 +22,72 @@ support version >= 2.x and <= 8.x.
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
-- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-| name                    | type    | required | default value                                                  |
-|-------------------------|---------|----------|----------------------------------------------------------------|
-| hosts                   | array   | yes      | -                                                              |
-| auth_type               | string  | no       | basic                                                          |
-| username                | string  | no       | -                                                              |
-| password                | string  | no       | -                                                              |
-| auth.api_key_id         | string  | no       | -                                                              |
-| auth.api_key            | string  | no       | -                                                              |
-| auth.api_key_encoded    | string  | no       | -                                                              |
-| index                   | string  | no       | If the index list does not exist, the index must be configured |
-| index_list              | array   | no       | used to define a multiple table task                           |
-| source                  | array   | no       | -                                                              |
-| query                   | json    | no       | {"match_all": {}}                                              |
-| search_type             | enum    | no       | Query type, SQL or DSL, default DSL                            |
-| search_api_type         | enum    | no       | Pagination API type, SCROLL or PIT, default SCROLL             |
-| sql_query               | json    | no       | SQL query, required when search_type is SQL                    |
-| scroll_time             | string  | no       | 1m                                                             |
-| scroll_size             | int     | no       | 100                                                            |
-| tls_verify_certificate  | boolean | no       | true                                                           |
-| tls_verify_hostname     | boolean | no       | true                                                           |
-| array_column            | map     | no       |                                                                |
-| tls_keystore_path       | string  | no       | -                                                              |
-| tls_keystore_password   | string  | no       | -                                                              |
-| tls_truststore_path     | string  | no       | -                                                              |
-| tls_truststore_password | string  | no       | -                                                              |
-| pit_keep_alive          | long    | no       | 60000 (1 minute)                                               |
-| pit_batch_size          | int     | no       | 100                                                            |
-| runtime_fields          | array   | no       | -                                                              |
-| slice_max               | int     | no       | 1 (SCROLL: ES >= 5.0, PIT: ES >= 7.10)                        |
-| common-options          |         | no       | -                                                              |
+| Name                     | Type    | Required | Default Value | Description                                                                                                                                                                                                                                                |
+|--------------------------|---------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| hosts                    | Array   | Yes      | -             | Elasticsearch cluster HTTP address, format `host:port`, allowing multiple hosts, for example `["host1:9200", "host2:9200"]`.                                                                                                                                |
+| auth_type                | String  | No       | basic         | Authentication method: `basic`, `api_key`, or `api_key_encoded`. Defaults to `basic` for backward compatibility.                                                                                                                                           |
+| username                 | String  | No       | -             | Username for HTTP basic authentication (X-Pack username).                                                                                                                                                                                                   |
+| password                 | String  | No       | -             | Password for HTTP basic authentication (X-Pack password).                                                                                                                                                                                                   |
+| auth.api_key_id          | String  | No       | -             | API key ID for `auth_type = "api_key"`.                                                                                                                                                                                                                     |
+| auth.api_key             | String  | No       | -             | API key secret for `auth_type = "api_key"`.                                                                                                                                                                                                                 |
+| auth.api_key_encoded     | String  | No       | -             | Base64-encoded API key (`base64(id:api_key)`) for `auth_type = "api_key_encoded"`. Either `auth.api_key_id` + `auth.api_key` OR `auth.api_key_encoded` should be set, but not both.                                                                       |
+| index                    | String  | No       | -             | Elasticsearch index name. Required when `index_list` is not configured. Supports `*` fuzzy matching.                                                                                                                                                       |
+| index_list               | Array   | No       | -             | Define a multi-index synchronization task. Use this when different indexes need their own `query`, `source`, `schema`, or paging options.                                                                                                                    |
+| source                   | Array   | No       | -             | Fields to read from the document. The `_id` field can be exposed by listing it explicitly. If not set, fields are automatically derived from the index mapping.                                                                                            |
+| query                    | Json    | No       | `{"match_all": {}}` | Elasticsearch DSL query used to control which documents are read.                                                                                                                                                                                       |
+| search_type              | Enum    | No       | DSL           | Query type, available values: `DSL` (default) or `SQL`.                                                                                                                                                                                                     |
+| search_api_type          | Enum    | No       | SCROLL        | Pagination API type: `SCROLL` (default) or `PIT` (Point-in-Time).                                                                                                                                                                                            |
+| sql_query                | String  | No       | -             | SQL query, required when `search_type = "SQL"`.                                                                                                                                                                                                            |
+| scroll_time              | String  | No       | 1m            | Amount of time Elasticsearch keeps the search context alive for scroll requests.                                                                                                                                                                           |
+| scroll_size              | Int     | No       | 100           | Maximum number of hits returned per Elasticsearch scroll request.                                                                                                                                                                                          |
+| pit_keep_alive           | Long    | No       | 60000         | Lifetime (in milliseconds) of a PIT search context.                                                                                                                                                                                                         |
+| pit_batch_size           | Int     | No       | 100           | Maximum number of hits returned per PIT search request.                                                                                                                                                                                                     |
+| tls_verify_certificate   | Boolean | No       | true          | Enable certificate validation for HTTPS endpoints.                                                                                                                                                                                                          |
+| tls_verify_hostname      | Boolean | No       | true          | Enable hostname validation for HTTPS endpoints.                                                                                                                                                                                                            |
+| array_column             | Map     | No       | -             | Mark fields as array columns because Elasticsearch has no array type. Example: `{c_array = "array<tinyint>"}`.                                                                                                                                              |
+| tls_keystore_path        | String  | No       | -             | Path to the PEM or JKS key store. Must be readable by the user running SeaTunnel.                                                                                                                                                                            |
+| tls_keystore_password    | String  | No       | -             | Key password for `tls_keystore_path`.                                                                                                                                                                                                                       |
+| tls_truststore_path      | String  | No       | -             | Path to the PEM or JKS trust store. Must be readable by the user running SeaTunnel.                                                                                                                                                                         |
+| tls_truststore_password  | String  | No       | -             | Key password for `tls_truststore_path`.                                                                                                                                                                                                                     |
+| runtime_fields           | Array   | No       | -             | Runtime fields computed at query time (Elasticsearch 7.11+). See [Runtime Fields](#runtime-fields) below.                                                                                                                                                  |
+| slice_max                | Int     | No       | 1             | Split a single index into multiple slices for parallel reads. Only effective for `SCROLL` / `PIT`. `SCROLL` slicing requires ES 5.0+; `PIT` slicing requires ES 7.10+. Ignored when `search_type = "SQL"`.                                                  |
+| common-options           |         | No       | -             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                                           |
 
+### hosts [Array]
 
-
-### hosts [array]
-
-Elasticsearch cluster http address, the format is `host:port`, allowing multiple hosts to be specified. Such as `["host1:9200", "host2:9200"]`.
+Elasticsearch cluster HTTP address, format `host:port`, allowing multiple
+hosts, for example `["host1:9200", "host2:9200"]`.
 
 ## Authentication
 
-The Elasticsearch connector supports multiple authentication methods to connect to secured Elasticsearch clusters. You can choose the appropriate authentication method based on your Elasticsearch security configuration.
+The Elasticsearch connector supports multiple authentication methods. Choose
+the appropriate one based on your Elasticsearch security configuration.
 
-### auth_type [enum]
+### auth_type [String]
 
 Specifies the authentication method to use. Supported values:
-- `basic` (default): HTTP Basic Authentication using username and password
-- `api_key`: Elasticsearch API Key authentication using separate ID and key
-- `api_key_encoded`: Elasticsearch API Key authentication using encoded key
+
+- `basic` (default): HTTP Basic authentication using `username` and `password`.
+- `api_key`: API key authentication using `auth.api_key_id` + `auth.api_key`.
+- `api_key_encoded`: API key authentication using `auth.api_key_encoded`.
 
 If not specified, defaults to `basic` for backward compatibility.
 
 ### Basic Authentication
 
-Basic authentication uses HTTP Basic Authentication with username and password credentials.
+#### username [String]
 
-#### username [string]
+Username for HTTP basic authentication (X-Pack username).
 
-Username for basic authentication (x-pack username).
+#### password [String]
 
-#### password [string]
+Password for HTTP basic authentication (X-Pack password).
 
-Password for basic authentication (x-pack password).
-
-**Example:**
 ```hocon
 source {
     Elasticsearch {
@@ -98,23 +102,22 @@ source {
 
 ### API Key Authentication
 
-API Key authentication provides a more secure way to authenticate with Elasticsearch using API keys.
-
-#### auth.api_key_id [string]
+#### auth.api_key_id [String]
 
 The API key ID generated by Elasticsearch.
 
-#### auth.api_key [string]
+#### auth.api_key [String]
 
 The API key secret generated by Elasticsearch.
 
-#### auth.api_key_encoded [string]
+#### auth.api_key_encoded [String]
 
-Base64 encoded API key in the format `base64(id:api_key)`. This is an alternative to specifying `auth.api_key_id` and `auth.api_key` separately.
+Base64-encoded API key in the format `base64(id:api_key)`. Alternative to
+specifying `auth.api_key_id` and `auth.api_key` separately.
 
-**Note:** You can use either `auth.api_key_id` + `auth.api_key` OR `auth.api_key_encoded`, but not both.
+**Note:** You can use either `auth.api_key_id` + `auth.api_key` OR
+`auth.api_key_encoded`, but not both.
 
-**Example with separate ID and key:**
 ```hocon
 source {
     Elasticsearch {
@@ -127,7 +130,6 @@ source {
 }
 ```
 
-**Example with encoded key:**
 ```hocon
 source {
     Elasticsearch {
@@ -139,90 +141,106 @@ source {
 }
 ```
 
+### index [String]
 
+Elasticsearch index name. Supports `*` fuzzy matching.
 
-### index [string]
+Either `index` or `index_list` must be configured. Use `index` for a single
+index or an index pattern, and use `index_list` when different indexes need
+their own `query`, `source`, `schema`, or paging options.
 
-Elasticsearch index name, support * fuzzy matching.
+### source [Array]
 
-### source [array]
+Fields to read from the document. You can expose the document `_id` by
+listing it explicitly. When sinking `_id` to another index, an alias is
+required because of Elasticsearch limits. If `source` is not configured, the
+fields are automatically derived from the index mapping.
 
-The fields of index.
-You can get the document id by specifying the field `_id`.If sink _id to other index,you need specify an alias for _id due to the Elasticsearch limit.
-If you don't config source, it is automatically retrieved from the mapping of the index.
+### query [Json]
 
-### array_column [map]
-
-The fields of array type.
-Since there is no array index in es,so need assign array type,just like `{c_array = "array<tinyint>"}`.
-
-### query [json]
-
-Elasticsearch DSL.
-You can control the range of data read.
+Elasticsearch DSL used to control the range of data read. The default is
+`{"match_all": {}}`.
 
 ### scroll_time [String]
 
-Amount of time Elasticsearch will keep the search context alive for scroll requests.
+Amount of time Elasticsearch keeps the search context alive for scroll
+requests.
 
-### scroll_size [int]
+### scroll_size [Int]
 
 Maximum number of hits to be returned with each Elasticsearch scroll request.
 
-### index_list [array]
+### index_list [Array]
 
-The `index_list` is used to define multi-index synchronization tasks. It is an array that contains the parameters required for single-table synchronization, such as `query`, `source/schema`, `scroll_size`, and `scroll_time`. It is recommended that `index_list` and `query` should not be configured at the same level simultaneously. Please refer to the upcoming multi-table synchronization example for more details.
+Define a multi-index synchronization task. It is an array that contains the
+parameters required for single-table synchronization, such as `query`,
+`source`, `schema`, `scroll_size`, and `scroll_time`. `index_list` and a
+root-level `query` should not be configured at the same time.
 
-### tls_verify_certificate [boolean]
+### search_type [String]
 
-Enable certificates validation for HTTPS endpoints
-
-### tls_verify_hostname [boolean]
-
-Enable hostname validation for HTTPS endpoints
-
-### tls_keystore_path [string]
-
-The path to the PEM or JKS key store. This file must be readable by the operating system user running SeaTunnel.
-
-### tls_keystore_password [string]
-
-The key password for the key store specified
-
-### tls_truststore_path [string]
-
-The path to PEM or JKS trust store. This file must be readable by the operating system user running SeaTunnel.
-
-### tls_truststore_password [string]
-
-The key password for the trust store specified
-
-### search_type
 Query type, available values:
-- DSL: Use Domain Specific Language query (default)
-- SQL: Use SQL query
 
-### search_api_type
+- `DSL` (default): Use the Domain Specific Language query.
+- `SQL`: Use a SQL query.
+
+### search_api_type [String]
+
 Pagination API type, available values:
-- SCROLL: Use Scroll API for pagination (default)
-- PIT: Use Point in Time (PIT) API for pagination
 
-### pit_keep_alive [long]
-The amount of time (in milliseconds) for which the PIT should be keep alive
+- `SCROLL` (default): Use the Scroll API for pagination.
+- `PIT`: Use the Point-in-Time (PIT) API for pagination.
 
-### pit_batch_size  [int]
-Maximum number of hits to be returned with each PIT search request
+### pit_keep_alive [Long]
 
-### runtime_fields [array]
+The amount of time (in milliseconds) the PIT should be kept alive.
 
-Runtime fields to be computed at query time (Elasticsearch 7.11+). Each runtime field should contain:
-- **name**: The name of the runtime field
-- **type**: The data type (boolean, date, double, geo_point, ip, keyword, long)
-- **script**: Painless script to compute the field value
-- **script_lang** (optional): Script language (default: painless)
-- **script_params** (optional): Script parameters
+### pit_batch_size [Int]
 
-Example:
+Maximum number of hits returned per PIT search request.
+
+### tls_verify_certificate [Boolean]
+
+Enable certificate validation for HTTPS endpoints.
+
+### tls_verify_hostname [Boolean]
+
+Enable hostname validation for HTTPS endpoints.
+
+### tls_keystore_path [String]
+
+Path to the PEM or JKS key store. Must be readable by the user running
+SeaTunnel.
+
+### tls_keystore_password [String]
+
+Key password for `tls_keystore_path`.
+
+### tls_truststore_path [String]
+
+Path to the PEM or JKS trust store. Must be readable by the user running
+SeaTunnel.
+
+### tls_truststore_password [String]
+
+Key password for `tls_truststore_path`.
+
+### array_column [Map]
+
+Mark fields as array columns because Elasticsearch has no array type. Example:
+`{c_array = "array<tinyint>"}`.
+
+### runtime_fields [Array]
+
+Runtime fields computed at query time (Elasticsearch 7.11+). Each runtime
+field should contain:
+
+- **name**: Name of the runtime field.
+- **type**: Data type (boolean, date, double, geo_point, ip, keyword, long).
+- **script**: Painless script to compute the field value.
+- **script_lang** (optional): Script language (default: painless).
+- **script_params** (optional): Script parameters.
+
 ```hocon
 runtime_fields = [
   {
@@ -238,58 +256,79 @@ runtime_fields = [
 ]
 ```
 
-**Runtime Fields Use Cases:**
+Common use cases:
 
-1. **Date Extraction**: Extract day of week, month, year from timestamps
-2. **Calculations**: Compute derived values like total price, tax amount
-3. **String Operations**: Concatenate fields, extract substrings
-4. **Conditional Logic**: Categorize data based on conditions
-5. **Data Transformation**: Convert units, format values on-the-fly
+- Date extraction (day of week, month, year from timestamps).
+- Calculations (derived values like total price, tax amount).
+- String operations (concatenation, substrings).
+- Conditional logic (categorize data based on conditions).
+- Data transformation (unit conversions, formatting).
 
-**Performance Considerations:**
-- Runtime fields are computed at query time, which may impact performance for large datasets
-- Best suited for ad-hoc analysis, prototyping, and infrequent queries
-- Keep scripts simple to minimize performance impact
-- Consider indexing frequently used computed fields
+Performance considerations:
 
-**Limitations:**
-- Requires Elasticsearch 7.11 or higher
-- Only Painless scripts are supported
-- May be slower than indexed fields for large-scale queries
+- Runtime fields are computed at query time and may impact performance for
+  large datasets.
+- Best suited for ad-hoc analysis, prototyping, and infrequent queries.
+- Keep scripts simple to minimize performance impact.
+- Consider indexing frequently used computed fields.
 
-### slice_max [int]
-Split a single index into multiple slices for parallel reads. Only effective for SCROLL/PIT. Set to a value greater than 1 to enable slicing.
+Limitations:
 
-**Version requirements:**
-- SCROLL slicing (sliced scroll) requires Elasticsearch 5.0 or higher.
-- PIT slicing requires Elasticsearch 7.10 or higher (PIT was introduced in 7.10.0).
+- Requires Elasticsearch 7.11 or higher.
+- Only Painless scripts are supported.
+- May be slower than indexed fields for large-scale queries.
 
-**Trade-off:** slicing improves throughput but may reduce snapshot consistency across slices. For strong consistency, prefer PIT with a shared snapshot or set `slice_max = 1`. For append-only or low-write workloads, slicing is usually acceptable.
+### slice_max [Int]
+
+Split a single index into multiple slices for parallel reads. Only effective
+for `SCROLL` / `PIT`. Set to a value greater than 1 to enable slicing.
+
+Version requirements:
+
+- `SCROLL` slicing (sliced scroll) requires Elasticsearch 5.0 or higher.
+- `PIT` slicing requires Elasticsearch 7.10 or higher (PIT was introduced
+  in 7.10.0).
+
+Trade-offs:
+
+- Slicing improves throughput but may reduce snapshot consistency across
+  slices. For strong consistency, prefer `PIT` with a shared snapshot or
+  set `slice_max = 1`.
+- For append-only or low-write workloads, slicing is usually acceptable.
+- `slice_max` is ignored when `search_type = "SQL"`, because Elasticsearch
+  SQL search does not support slicing.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+Source plugin common parameters, please refer to
+[Source Common Options](../common-options/source-common-options.md) for
+details.
 
-## Examples
+## Task Example
 
-Demo 1
+### Demo 1: Read from a single index pattern with column projection
 
-> This case will read data from indices matching the seatunnel-* pattern based on a query. The query will only return documents containing the id, name, age, tags, and phones fields. In this example, the source field configuration is used to specify which fields should be read, and the array_column is used to indicate that tags and phones should be treated as arrays.
+> Read documents matching the `seatunnel-*` pattern. The query restricts to
+> documents containing the `id`, `name`, `age`, `tags`, and `phones` fields.
+> `source` selects the fields to read, and `array_column` marks `tags` and
+> `phones` as array fields.
 
 ```hocon
 Elasticsearch {
     hosts = ["localhost:9200"]
     index = "seatunnel-*"
-    array_column = {tags = "array<string>",phones = "array<string>"}
-    source = ["_id","name","age","tags","phones"]
-    query = {"range":{"firstPacket":{"gte":1669225429990,"lte":1669225429990}}}
+    array_column = { tags = "array<string>", phones = "array<string>" }
+    source = ["_id", "name", "age", "tags", "phones"]
+    query = {"range": {"firstPacket": {"gte": 1669225429990, "lte": 1669225429990}}}
 }
 ```
 
-Demo 2 : Multi-table synchronization
+### Demo 2: Multi-table synchronization
 
-> This example demonstrates how to read different data from ``read_index1`` and ``read_index2`` and write separately to ``read_index1_copy``,``read_index2_copy``.
-> in `read_index1`,I used source to specify the fields to be read and  specify which fields are array fields using the 'array_column'.
+> Read different data from `read_index1` and `read_index2` and write to
+> `read_index1_copy` and `read_index2_copy`. For `read_index1`, `source`
+> selects the fields to read and `array_column` marks `c_array` as an
+> array field.
 
 ```hocon
 source {
@@ -304,37 +343,20 @@ source {
            index = "read_index1"
            query = {"range": {"c_int": {"gte": 10, "lte": 20}}}
            source = [
-           c_map,
-           c_array,
-           c_string,
-           c_boolean,
-           c_tinyint,
-           c_smallint,
-           c_bigint,
-           c_float,
-           c_double,
-           c_decimal,
-           c_bytes,
-           c_int,
-           c_date,
-           c_timestamp]
+             c_map, c_array, c_string, c_boolean, c_tinyint, c_smallint,
+             c_bigint, c_float, c_double, c_decimal, c_bytes, c_int,
+             c_date, c_timestamp
+           ]
            array_column = {
-           c_array = "array<tinyint>"
+             c_array = "array<tinyint>"
            }
-       }
+       },
        {
            index = "read_index2"
            query = {"match_all": {}}
-           source = [
-           c_int2,
-           c_date2,
-           c_null
-           ]
-
+           source = [c_int2, c_date2, c_null]
        }
-
     ]
-
   }
 }
 
@@ -348,18 +370,15 @@ sink {
     password = "elasticsearch"
     tls_verify_certificate = false
     tls_verify_hostname = false
-
     index = "${table_name}_copy"
     index_type = "st"
-    "schema_save_mode"="CREATE_SCHEMA_WHEN_NOT_EXIST"
-    "data_save_mode"="APPEND_DATA"
+    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+    data_save_mode = "APPEND_DATA"
   }
 }
 ```
 
-
-
-Demo 3 : SSL (Disable certificates validation)
+### Demo 3: SSL (Disable certificate validation)
 
 ```hocon
 source {
@@ -367,13 +386,12 @@ source {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-
         tls_verify_certificate = false
     }
 }
 ```
 
-Demo 4 :SSL (Disable hostname validation)
+### Demo 4: SSL (Disable hostname validation)
 
 ```hocon
 source {
@@ -381,13 +399,12 @@ source {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-
         tls_verify_hostname = false
     }
 }
 ```
 
-Demo 5 :SSL (Enable certificates validation)
+### Demo 5: SSL (Enable certificate validation)
 
 ```hocon
 source {
@@ -395,15 +412,16 @@ source {
         hosts = ["https://localhost:9200"]
         username = "elastic"
         password = "elasticsearch"
-
         tls_keystore_path = "${your elasticsearch home}/config/certs/http.p12"
         tls_keystore_password = "${your password}"
     }
 }
 ```
 
-Demo 6 : sql query
-notes: sql does not support map and array types
+### Demo 6: SQL query
+
+> Note: SQL search does not support map and array types.
+
 ```hocon
 source {
   Elasticsearch {
@@ -419,7 +437,8 @@ source {
 }
 ```
 
-Demo7:  PIT
+### Demo 7: PIT
+
 ```hocon
 source {
   Elasticsearch {
@@ -428,22 +447,19 @@ source {
     password = "elasticsearch"
     tls_verify_certificate = false
     tls_verify_hostname = false
-
     index = "st_index"
     query = {"range": {"c_int": {"gte": 10, "lte": 20}}}
-
-    # Use DSL query with PIT API
     search_type = DSL
     search_api_type = PIT
-    pit_keep_alive = 60000  # 1 minute in milliseconds
+    pit_keep_alive = 60000
     pit_batch_size = 100
   }
 }
 ```
 
-Demo 8: Runtime Fields (Elasticsearch 7.11+)
+### Demo 8: Runtime Fields (Elasticsearch 7.11+)
 
-> This example demonstrates how to use runtime fields to compute values at query time without reindexing data.
+> Compute values at query time without reindexing data.
 
 ```hocon
 source {
@@ -453,25 +469,21 @@ source {
     password = "elasticsearch"
     tls_verify_certificate = false
     tls_verify_hostname = false
-    
+
     index = "sales_data"
-    
-    # Define runtime fields for dynamic computation
+
     runtime_fields = [
       {
-        # Calculate total amount
         name = "total_amount"
         type = "double"
         script = "emit(doc['quantity'].value * doc['price'].value)"
       },
       {
-        # Extract day of week from timestamp
         name = "day_of_week"
         type = "keyword"
         script = "emit(doc['order_date'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
       },
       {
-        # Categorize orders
         name = "order_category"
         type = "keyword"
         script = """
@@ -486,7 +498,6 @@ source {
         """
       },
       {
-        # Calculate with parameters
         name = "price_with_tax"
         type = "double"
         script = "emit(doc['price'].value * (1 + params.tax_rate))"
@@ -495,19 +506,12 @@ source {
         }
       }
     ]
-    
-    # Include runtime fields in the output
+
     source = [
-      "product_id",
-      "quantity",
-      "price",
-      "order_date",
-      "total_amount",
-      "day_of_week",
-      "order_category",
-      "price_with_tax"
+      "product_id", "quantity", "price", "order_date",
+      "total_amount", "day_of_week", "order_category", "price_with_tax"
     ]
-    
+
     schema = {
       fields {
         product_id = string
@@ -529,7 +533,8 @@ sink {
 }
 ```
 
-Demo 9: PIT with slicing
+### Demo 9: PIT with slicing
+
 ```hocon
 source {
   Elasticsearch {
@@ -538,16 +543,12 @@ source {
     password = "elasticsearch"
     tls_verify_certificate = false
     tls_verify_hostname = false
-
     index = "st_index"
     query = {"range": {"c_int": {"gte": 10, "lte": 20}}}
-
     search_type = DSL
     search_api_type = PIT
     pit_keep_alive = 60000
     pit_batch_size = 100
-
-    # Enable slicing for parallel reads
     slice_max = 2
   }
 }

--- a/docs/en/connectors/source/Hive.md
+++ b/docs/en/connectors/source/Hive.md
@@ -4,11 +4,18 @@ import ChangeLog from '../changelog/connector-hive.md';
 
 > Hive source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Read data from Hive.
 
-When using markdown format, SeaTunnel can parse markdown files stored in Hive tables and extract structured data with elements like headings, paragraphs, lists, code blocks, and tables. Each element is converted to a row with the following schema:
+When using markdown format, SeaTunnel can parse markdown files stored in Hive tables and extract structured data with elements like headings, paragraphs, lists, code blocks, and tables. Each extracted element is converted to a document-element row with the following schema:
+
 - `element_id`: Unique identifier for the element
 - `element_type`: Type of the element (Heading, Paragraph, ListItem, etc.)
 - `heading_level`: Level of heading (1-6, null for non-heading elements)
@@ -46,214 +53,267 @@ Read all the data in a split in a pollNext call. What splits are read will be sa
   - [x] json
   - [x] markdown
 
-## Options
+## Source Options
 
-|         name          |  type  | required | default value  |
-|-----------------------|--------|----------|----------------|
-| table_name            | string | yes      | -              |
-| use_regex             | boolean| no       | false          |
-| metastore_uri         | string | yes      | -              |
-| krb5_path             | string | no       | /etc/krb5.conf |
-| kerberos_principal    | string | no       | -              |
-| kerberos_keytab_path  | string | no       | -              |
-| hdfs_site_path        | string | no       | -              |
-| hive_site_path        | string | no       | -              |
-| hive.hadoop.conf      | Map    | no       | -              |
-| hive.hadoop.conf-path | string | no       | -              |
-| read_partitions       | list   | no       | -              |
-| read_columns          | list   | no       | -              |
-| compress_codec        | string | no       | none           |
-| common-options        |        | no       | -              |
+| Name                 | Type    | Required | Default Value  | Description                                                                                                                                                                                                                                  |
+|----------------------|---------|----------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| table_name           | String  | No       | Required for single-table mode | Hive table name in `db.table` form. When `use_regex = true`, the value uses the `databasePattern.tablePattern` form (Hive has no schema) to match multiple tables from the Hive metastore.                                                    |
+| table_list           | Array   | No       | -              | List of Hive table configurations for multi-table reading. Each item can contain `table_name`, `metastore_uri`, `use_regex`, `read_partitions`, `read_columns`, and the same authentication/Hadoop options as the root connector block.     |
+| tables_configs       | Array   | No       | -              | Deprecated multi-table configuration list. New jobs should use `table_list` instead.                                                                                                                                                          |
+| use_regex            | Boolean | No       | false          | Treat `table_name` as a regular expression for matching multiple tables (whole database / subset). This also works inside each entry of `table_list` / `tables_configs`.                                                                       |
+| metastore_uri        | String  | No       | Required for single-table mode | Hive metastore URI. Supports comma-separated multiple URIs for HA/failover (whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris` and uses `RetryingMetaStoreClient` for retry/failover.                            |
+| krb5_path            | String  | No       | /etc/krb5.conf | The path of `krb5.conf`, used for Kerberos authentication.                                                                                                                                                                                    |
+| kerberos_principal   | String  | No       | -              | The principal of Kerberos authentication.                                                                                                                                                                                                    |
+| kerberos_keytab_path | String  | No       | -              | The keytab file path of Kerberos authentication.                                                                                                                                                                                              |
+| hdfs_site_path       | String  | No       | -              | The path of `hdfs-site.xml`, used to load HA configuration of namenodes.                                                                                                                                                                       |
+| hive_site_path       | String  | No       | -              | The path of `hive-site.xml`.                                                                                                                                                                                                                  |
+| hive.hadoop.conf     | Map     | No       | -              | Properties in hadoop conf (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`).                                                                                                                                                               |
+| hive.hadoop.conf-path| String  | No       | -              | The specified loading path for `core-site.xml`, `hdfs-site.xml`, `hive-site.xml`.                                                                                                                                                             |
+| remote_user          | String  | No       | -              | Hadoop remote user name used when connecting to HDFS/Hive storage without Kerberos credentials.                                                                                                                                                |
+| read_partitions      | List    | No       | -              | The target partitions to read from the Hive table. If it is not configured, all partitions are read. Every partition in the list must have the same directory depth.                                                                        |
+| read_columns         | List    | No       | -              | The read column list of the data source; use it to implement field projection.                                                                                                                                                                |
+| compress_codec       | String  | No       | none           | The compression codec of files. Supported codecs: `lzo`, `none` for text/json/csv. For orc/parquet, the compression type is automatically recognized and no additional setting is required.                                                  |
+| common-options       |         | No       | -              | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                              |
 
-### table_name [string]
+### table_name [String]
 
-Target Hive table name eg: `db1.table1`. When `use_regex = true`, this field uses `databasePattern.tablePattern` (Hive has no schema) to match multiple tables from Hive metastore.
+Target Hive table name, for example `db1.table1`. When `use_regex = true`, this
+field uses `databasePattern.tablePattern` (Hive has no schema) to match multiple
+tables from the Hive metastore.
 
-### use_regex [boolean]
+For a single-table source, configure `table_name` and `metastore_uri` at the root
+level. For multi-table reading, configure `table_list`. `tables_configs` is still
+accepted for compatibility, but `table_list` is preferred.
 
-Whether to treat `table_name` as a regular expression pattern for matching multiple tables (whole database / subset). This also works inside each entry of `table_list` / `tables_configs`.
+### table_list [Array]
+
+List of Hive table configurations for multi-table reading. Each item can contain
+`table_name`, `metastore_uri`, `use_regex`, `read_partitions`, `read_columns`, and
+the same authentication/Hadoop options as the root connector block.
+
+### tables_configs [Array]
+
+Deprecated multi-table configuration list. New jobs should use `table_list`.
+
+### use_regex [Boolean]
+
+Whether to treat `table_name` as a regular expression pattern for matching
+multiple tables (whole database / subset). This also works inside each entry of
+`table_list` / `tables_configs`.
 
 Regex syntax notes:
-- The dot (`.`) is treated as the separator between database and table patterns (Hive only supports `database.table`).
-- Only one unescaped dot is allowed (as the database/table separator). If you need to use dot (`.`) in a regular expression (e.g. `.*`), you must escape it as `\.` (in a HOCON string, write `\\.`).
+
+- The dot (`.`) is treated as the separator between database and table patterns
+  (Hive only supports `database.table`).
+- Only one unescaped dot is allowed (as the database/table separator). If you
+  need to use dot (`.`) in a regular expression (e.g. `.*`), you must escape it
+  as `\.` (in a HOCON string, write `\\.`).
 - Examples: `db0.\.*`, `db1.user_table_[0-9]+`, `db[1-2].(app|web)order_\.*`.
-- In SeaTunnel job config (HOCON string), backslashes need escaping. For example, the regex `db0.\.*` should be configured as `db0.\\.*`.
-- `db0.\.*` matches all tables in database `db0` (whole database synchronization).
+- In a SeaTunnel job config (HOCON string), backslashes need escaping. For
+  example, the regex `db0.\.*` should be configured as `db0.\\.*`.
+- `db0.\.*` matches all tables in database `db0` (whole database
+  synchronization).
 - `\.*.\.*` matches all tables in all databases (whole Hive synchronization).
 
-### metastore_uri [string]
+### metastore_uri [String]
 
-Hive metastore uri. Supports comma-separated multiple URIs for HA/failover (whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris` and uses Hive `RetryingMetaStoreClient` (if available) to retry/failover between URIs. This is client-side endpoint failover; make sure your metastores share/replicate the same backend to keep metadata consistent.
+Hive metastore URI. Supports comma-separated multiple URIs for HA/failover
+(whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris`
+and uses Hive `RetryingMetaStoreClient` (if available) to retry/failover between
+URIs. This is client-side endpoint failover; make sure your metastores
+share/replicate the same backend to keep metadata consistent.
 
-### hdfs_site_path [string]
+### remote_user [String]
 
-The path of `hdfs-site.xml`, used to load ha configuration of namenodes
+Hadoop remote user name used when connecting to HDFS/Hive storage without
+Kerberos credentials.
 
-### hive.hadoop.conf [map]
+### hdfs_site_path [String]
 
-Properties in hadoop conf('core-site.xml', 'hdfs-site.xml', 'hive-site.xml')
+The path of `hdfs-site.xml`, used to load HA configuration of namenodes.
 
-### hive.hadoop.conf-path [string]
+### hive_site_path [String]
 
-The specified loading path for the 'core-site.xml', 'hdfs-site.xml', 'hive-site.xml' files
+The path of `hive-site.xml`. Use this when the file is not on the default classpath.
 
-### read_partitions [list]
+### hive.hadoop.conf [Map]
 
-The target partitions that user want to read from hive table, if user does not set this parameter, it will read all the data from hive table.
+Properties in hadoop conf (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`).
 
-**Tips: Every partition in partitions list should have the same directory depth. For example, a hive table has two partitions: par1 and par2, if user sets it like as the following:**
-**read_partitions = [par1=xxx, par1=yyy/par2=zzz], it is illegal**
+### hive.hadoop.conf-path [String]
 
-### krb5_path [string]
+The specified loading path for `core-site.xml`, `hdfs-site.xml`, `hive-site.xml`
+files.
 
-The path of `krb5.conf`, used to authentication kerberos
+### read_partitions [List]
 
-### kerberos_principal [string]
+The target partitions that the user wants to read from the Hive table. If the
+user does not set this parameter, all data in the Hive table is read.
 
-The principal of kerberos authentication
+**Tips: Every partition in the partition list should have the same directory
+depth. For example, a Hive table has two partitions: `par1` and `par2`. The
+following configuration is illegal:**
 
-### kerberos_keytab_path [string]
+```
+read_partitions = [par1=xxx, par1=yyy/par2=zzz]
+```
 
-The keytab file path of kerberos authentication
+### krb5_path [String]
 
-### read_columns [list]
+The path of `krb5.conf`, used for Kerberos authentication.
 
-The read column list of the data source, user can use it to implement field projection.
+### kerberos_principal [String]
 
-### compress_codec [string]
+The principal of Kerberos authentication.
 
-The compress codec of files and the details that supported as the following shown:
+### kerberos_keytab_path [String]
 
-- txt: `lzo` `none`
-- json: `lzo` `none`
-- csv: `lzo` `none`
-- orc/parquet:  
-  automatically recognizes the compression type, no additional settings required.
+The keytab file path of Kerberos authentication.
+
+### read_columns [List]
+
+The read column list of the data source; the user can use it to implement field
+projection.
+
+### compress_codec [String]
+
+The compression codec of files:
+
+- `text`/`json`/`csv`: `lzo`, `none`
+- `orc`/`parquet`: automatically recognizes the compression type, no additional
+  settings required.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details
+Source plugin common parameters, please refer to
+[Source Common Options](../common-options/source-common-options.md) for details.
 
-## Example
+## Task Example
 
 ### Example 1: Single table
 
-```bash
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
+source {
   Hive {
     table_name = "default.seatunnel_orc"
     metastore_uri = "thrift://namenode001:9083"
   }
+}
 
+sink {
+  Console {}
+}
 ```
 
 ### Example 2: Metastore URI failover
 
-```bash
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
   Hive {
     table_name = "default.seatunnel_orc"
     metastore_uri = "thrift://metastore-1:9083,thrift://metastore-2:9083"
   }
+}
 ```
 
 ### Example 3: Multiple tables
-> Note: Hive is a structured data source and should be use 'table_list', and 'tables_configs' will be removed in the future.
-> You can also set `use_regex = true` in each table config to match multiple tables.
 
-```bash
+> Note: Hive is a structured data source and should use `table_list`; `tables_configs` will be removed in the future. You can also set `use_regex = true` in each table config to match multiple tables.
 
-  Hive {
-    table_list = [
-        {
-          table_name = "default.seatunnel_orc_1"
-          metastore_uri = "thrift://namenode001:9083"
-        },
-        {
-          table_name = "default.seatunnel_orc_2"
-          metastore_uri = "thrift://namenode001:9083"
-        }
-    ]
-  }
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-```
-
-```bash
-
-  Hive {
-    tables_configs = [
-        {
-          table_name = "default.seatunnel_orc_1"
-          metastore_uri = "thrift://namenode001:9083"
-        },
-        {
-          table_name = "default.seatunnel_orc_2"
-          metastore_uri = "thrift://namenode001:9083"
-        }
-    ]
-  }
-
-```
-
-### Example 3: Regex matching (whole database / subset)
-
-```bash
-  Hive {
-    metastore_uri = "thrift://namenode001:9083"
-
-    # 1) Whole database: all tables in database `a`
-    table_name = "a.\\.*"
-    use_regex = true
-  }
-```
-
-```bash
-  Hive {
-    metastore_uri = "thrift://namenode001:9083"
-
-    # 2) Whole Hive: all tables in all databases
-    table_name = "\\.*.\\.*"
-    use_regex = true
-  }
-```
-
-```bash
-  Hive {
-    metastore_uri = "thrift://namenode001:9083"
-
-    # 3) Subset: tables matching `tmp_.*` in database `a`
-    #    Note: escape the dot wildcard as `\.` (in HOCON string, write `\\.`) because unescaped dots are treated as separators
-    table_name = "a.tmp_\\.*"
-    use_regex = true
-  }
-```
-
-### Example 4 : Kerberos
-
-```bash
 source {
   Hive {
-    table_name = "default.test_hive_sink_on_hdfs_with_kerberos"
-    metastore_uri = "thrift://metastore:9083"
-    hive.hadoop.conf-path = "/tmp/hadoop"
-    plugin_output = hive_source
-    hive_site_path = "/tmp/hive-site.xml"
-    kerberos_principal = "hive/metastore.seatunnel@EXAMPLE.COM"
-    kerberos_keytab_path = "/tmp/hive.keytab"
-    krb5_path = "/tmp/krb5.conf"
+    table_list = [
+      {
+        table_name = "default.seatunnel_orc_1"
+        metastore_uri = "thrift://namenode001:9083"
+      },
+      {
+        table_name = "default.seatunnel_orc_2"
+        metastore_uri = "thrift://namenode001:9083"
+      }
+    ]
   }
 }
 ```
 
-Description:
+Deprecated `tables_configs` form (still accepted for backward compatibility):
 
-- `hive_site_path`: The path to the `hive-site.xml` file.
-- `kerberos_principal`: The principal for Kerberos authentication.
-- `kerberos_keytab_path`: The keytab file path for Kerberos authentication.
-- `krb5_path`: The path to the `krb5.conf` file used for Kerberos authentication.
+```hocon
+source {
+  Hive {
+    tables_configs = [
+      {
+        table_name = "default.seatunnel_orc_1"
+        metastore_uri = "thrift://namenode001:9083"
+      },
+      {
+        table_name = "default.seatunnel_orc_2"
+        metastore_uri = "thrift://namenode001:9083"
+      }
+    ]
+  }
+}
+```
 
-Run the case:
+### Example 4: Regex matching (whole database / subset)
 
-```bash
+Whole database (`a`):
+
+```hocon
+source {
+  Hive {
+    metastore_uri = "thrift://namenode001:9083"
+    table_name = "a.\\.*"
+    use_regex = true
+  }
+}
+```
+
+Whole Hive (all databases):
+
+```hocon
+source {
+  Hive {
+    metastore_uri = "thrift://namenode001:9083"
+    table_name = "\\.*.\\.*"
+    use_regex = true
+  }
+}
+```
+
+Subset (tables matching `tmp_.*` in database `a`). Note: escape the dot
+wildcard as `\.` (in a HOCON string, write `\\.`) because unescaped dots are
+treated as separators.
+
+```hocon
+source {
+  Hive {
+    metastore_uri = "thrift://namenode001:9083"
+    table_name = "a.tmp_\\.*"
+    use_regex = true
+  }
+}
+```
+
+### Example 5: Kerberos
+
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"
@@ -264,7 +324,6 @@ source {
     table_name = "default.test_hive_sink_on_hdfs_with_kerberos"
     metastore_uri = "thrift://metastore:9083"
     hive.hadoop.conf-path = "/tmp/hadoop"
-    plugin_output = hive_source
     hive_site_path = "/tmp/hive-site.xml"
     kerberos_principal = "hive/metastore.seatunnel@EXAMPLE.COM"
     kerberos_keytab_path = "/tmp/hive.keytab"
@@ -277,58 +336,34 @@ sink {
     plugin_input = hive_source
     rules {
       row_rules = [
-        {
-          rule_type = MAX_ROW
-          rule_value = 3
-        }
-      ],
+        { rule_type = MAX_ROW, rule_value = 3 }
+      ]
       field_rules = [
-        {
-          field_name = pk_id
-          field_type = bigint
-          field_value = [
-            {
-              rule_type = NOT_NULL
-            }
-          ]
-        },
-        {
-          field_name = name
-          field_type = string
-          field_value = [
-            {
-              rule_type = NOT_NULL
-            }
-          ]
-        },
-        {
-          field_name = score
-          field_type = int
-          field_value = [
-            {
-              rule_type = NOT_NULL
-            }
-          ]
-        }
+        { field_name = pk_id, field_type = bigint, field_value = [{ rule_type = NOT_NULL }] },
+        { field_name = name, field_type = string, field_value = [{ rule_type = NOT_NULL }] },
+        { field_name = score, field_type = int, field_value = [{ rule_type = NOT_NULL }] }
       ]
     }
   }
 }
 ```
 
+Description of the Kerberos options:
+
+- `hive_site_path`: The path to the `hive-site.xml` file.
+- `kerberos_principal`: The principal for Kerberos authentication.
+- `kerberos_keytab_path`: The keytab file path for Kerberos authentication.
+- `krb5_path`: The path to the `krb5.conf` file used for Kerberos authentication.
+
 ## Hive on s3
 
-### Step 1
-
-Create the lib dir for hive of emr.
+### Step 1: Create the lib dir for Hive
 
 ```shell
 mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
 ```
 
-### Step 2
-
-Get the jars from maven center to the lib.
+### Step 2: Download jars from Maven Central
 
 ```shell
 cd ${SEATUNNEL_HOME}/plugins/Hive/lib
@@ -336,9 +371,7 @@ wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.6.5/hadoop-aw
 wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
 ```
 
-### Step 3
-
-Copy the jars from your environment on emr to the lib dir.
+### Step 3: Copy EMR jars into the lib dir
 
 ```shell
 cp /usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly-2.60.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
@@ -347,11 +380,9 @@ cp /usr/share/aws/emr/hadoop-state-pusher/lib/javax.inject-1.jar ${SEATUNNEL_HOM
 cp /usr/share/aws/emr/hadoop-state-pusher/lib/aopalliance-1.0.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
 ```
 
-### Step 4
+### Step 4: Run the job
 
-Run the case.
-
-```shell
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"
@@ -363,8 +394,8 @@ source {
     metastore_uri = "thrift://ip-192-168-0-202.cn-north-1.compute.internal:9083"
     hive.hadoop.conf-path = "/home/ec2-user/hadoop-conf"
     hive.hadoop.conf = {
-       bucket="s3://ws-package"
-       fs.s3a.aws.credentials.provider="com.amazonaws.auth.InstanceProfileCredentialsProvider"
+      bucket = "s3://ws-package"
+      fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
     }
     read_columns = ["pk_id", "name", "score"]
   }
@@ -376,8 +407,8 @@ sink {
     metastore_uri = "thrift://ip-192-168-0-202.cn-north-1.compute.internal:9083"
     hive.hadoop.conf-path = "/home/ec2-user/hadoop-conf"
     hive.hadoop.conf = {
-       bucket="s3://ws-package"
-       fs.s3a.aws.credentials.provider="com.amazonaws.auth.InstanceProfileCredentialsProvider"
+      bucket = "s3://ws-package"
+      fs.s3a.aws.credentials.provider = "com.amazonaws.auth.InstanceProfileCredentialsProvider"
     }
   }
 }
@@ -385,37 +416,29 @@ sink {
 
 ## Hive on oss
 
-### Step 1
-
-Create the lib dir for hive of emr.
+### Step 1: Create the lib dir for Hive
 
 ```shell
 mkdir -p ${SEATUNNEL_HOME}/plugins/Hive/lib
 ```
 
-### Step 2
-
-Get the jars from maven center to the lib.
+### Step 2: Download jars from Maven Central
 
 ```shell
 cd ${SEATUNNEL_HOME}/plugins/Hive/lib
 wget https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar
 ```
 
-### Step 3
-
-Copy the jars from your environment on emr to the lib dir and delete the conflicting jar.
+### Step 3: Copy JindoSDK jars and remove conflicting Hadoop Aliyun jars
 
 ```shell
 cp -r /opt/apps/JINDOSDK/jindosdk-current/lib/jindo-*.jar ${SEATUNNEL_HOME}/plugins/Hive/lib
 rm -f ${SEATUNNEL_HOME}/lib/hadoop-aliyun-*.jar
 ```
 
-### Step 4
+### Step 4: Run the job
 
-Run the case.
-
-```shell
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"
@@ -427,7 +450,7 @@ source {
     metastore_uri = "thrift://master-1-1.c-1009b01725b501f2.cn-wulanchabu.emr.aliyuncs.com:9083"
     hive.hadoop.conf-path = "/tmp/hadoop"
     hive.hadoop.conf = {
-        bucket="oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
+      bucket = "oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
     }
   }
 }
@@ -438,7 +461,7 @@ sink {
     metastore_uri = "thrift://master-1-1.c-1009b01725b501f2.cn-wulanchabu.emr.aliyuncs.com:9083"
     hive.hadoop.conf-path = "/tmp/hadoop"
     hive.hadoop.conf = {
-        bucket="oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
+      bucket = "oss://emr-osshdfs.cn-wulanchabu.oss-dls.aliyuncs.com"
     }
   }
 }

--- a/docs/en/connectors/source/OceanBase.md
+++ b/docs/en/connectors/source/OceanBase.md
@@ -18,15 +18,26 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
 ## Description
 
-Read external data source data through JDBC.
+Read OceanBase data through JDBC. OceanBase can run in MySQL-compatible mode
+or Oracle-compatible mode, so every OceanBase job should set `compatible_mode`
+to `mysql` or `oracle`.
+
+:::tip
+
+The connector uses the `Jdbc` plugin under the hood with the
+`com.oceanbase.jdbc.Driver` driver. The `compatible_mode` option is required
+to switch between the MySQL and Oracle dialect implementations.
+
+:::
 
 ## Supported DataSource Info
 
-| Datasource |       Supported versions       |          Driver           |                 Url                  |                                     Maven                                     |
-|------------|--------------------------------|---------------------------|--------------------------------------|-------------------------------------------------------------------------------|
+| Datasource | Supported versions       | Driver                   | Url                                  | Maven                                                                       |
+|------------|--------------------------|--------------------------|--------------------------------------|-----------------------------------------------------------------------------|
 | OceanBase  | All OceanBase server versions. | com.oceanbase.jdbc.Driver | jdbc:oceanbase://localhost:2883/test | [Download](https://mvnrepository.com/artifact/com.oceanbase/oceanbase-client) |
 
 ## Database Dependency
@@ -36,73 +47,99 @@ Read external data source data through JDBC.
 
 ## Data Type Mapping
 
-### Mysql Mode
+### MySQL Mode
 
-|                                        Mysql Data type                                        |                                                                 SeaTunnel Data type                                                                 |
-|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| BIT(1)<br/>TINYINT(1)                                                                         | BOOLEAN                                                                                                                                             |
-| TINYINT                                                                                       | BYTE                                                                                                                                                |
-| TINYINT<br/>TINYINT UNSIGNED                                                                  | SMALLINT                                                                                                                                            |
-| SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR           | INT                                                                                                                                                 |
-| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                  | BIGINT                                                                                                                                              |
-| BIGINT UNSIGNED                                                                               | DECIMAL(20,0)                                                                                                                                       |
-| DECIMAL(x,y)(Get the designated column's specified column size.<38)                           | DECIMAL(x,y)                                                                                                                                        |
-| DECIMAL(x,y)(Get the designated column's specified column size.>38)                           | DECIMAL(38,18)                                                                                                                                      |
-| DECIMAL UNSIGNED                                                                              | DECIMAL((Get the designated column's specified column size)+1,<br/>(Gets the designated column's number of digits to right of the decimal point.))) |
-| FLOAT<br/>FLOAT UNSIGNED                                                                      | FLOAT                                                                                                                                               |
-| DOUBLE<br/>DOUBLE UNSIGNED                                                                    | DOUBLE                                                                                                                                              |
-| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON<br/>ENUM          | STRING                                                                                                                                              |
-| DATE                                                                                          | DATE                                                                                                                                                |
-| TIME                                                                                          | TIME                                                                                                                                                |
-| DATETIME<br/>TIMESTAMP                                                                        | TIMESTAMP                                                                                                                                           |
-| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINAR<br/>BIT(n)<br/>GEOMETRY | BYTES                                                                                                                                               |
+| Mysql Data type                                                                                | SeaTunnel Data type                                                                                                                |
+|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| BIT(1)<br/>TINYINT(1)                                                                          | BOOLEAN                                                                                                                            |
+| TINYINT                                                                                        | BYTE                                                                                                                               |
+| TINYINT<br/>TINYINT UNSIGNED                                                                   | SMALLINT                                                                                                                           |
+| SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR            | INT                                                                                                                                |
+| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                   | BIGINT                                                                                                                             |
+| BIGINT UNSIGNED                                                                                | DECIMAL(20,0)                                                                                                                      |
+| DECIMAL(x,y) (column size < 38)                                                                | DECIMAL(x,y)                                                                                                                       |
+| DECIMAL(x,y) (column size >= 38)                                                               | DECIMAL(38,18)                                                                                                                     |
+| DECIMAL UNSIGNED                                                                               | DECIMAL((column size + 1), (right-of-decimal digits))                                                                             |
+| FLOAT<br/>FLOAT UNSIGNED                                                                       | FLOAT                                                                                                                              |
+| DOUBLE<br/>DOUBLE UNSIGNED                                                                     | DOUBLE                                                                                                                             |
+| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON<br/>ENUM             | STRING                                                                                                                             |
+| DATE                                                                                           | DATE                                                                                                                               |
+| TIME                                                                                           | TIME                                                                                                                               |
+| DATETIME<br/>TIMESTAMP                                                                         | TIMESTAMP                                                                                                                          |
+| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINARY<br/>BIT(n)<br/>GEOMETRY  | BYTES                                                                                                                              |
 
 ### Oracle Mode
 
-|                                          Oracle Data type                                           | SeaTunnel Data type |
-|-----------------------------------------------------------------------------------------------------|---------------------|
-| Integer                                                                                             | DECIMAL(38,0)       |
-| Number(p), p <= 9                                                                                   | INT                 |
-| Number(p), p <= 18                                                                                  | BIGINT              |
-| Number(p), p > 18                                                                                   | DECIMAL(38,18)      |
-| Number(p,s)                                                                                         | DECIMAL(p,s)        |
-| Float                                                                                               | DECIMAL(38,18)      |
-| REAL<br/> BINARY_FLOAT                                                                              | FLOAT               |
-| BINARY_DOUBLE                                                                                       | DOUBLE              |
+| Oracle Data type                                                                                | SeaTunnel Data type |
+|-------------------------------------------------------------------------------------------------|---------------------|
+| Integer                                                                                         | DECIMAL(38,0)       |
+| Number(p), p <= 9                                                                               | INT                 |
+| Number(p), p <= 18                                                                              | BIGINT              |
+| Number(p), p > 18                                                                               | DECIMAL(38,18)      |
+| Number(p,s)                                                                                     | DECIMAL(p,s)        |
+| Float                                                                                           | DECIMAL(38,18)      |
+| REAL<br/>BINARY_FLOAT                                                                           | FLOAT               |
+| BINARY_DOUBLE                                                                                   | DOUBLE              |
 | CHAR<br/>NCHAR<br/>VARCHAR<br/>VARCHAR2<br/>NVARCHAR2<br/>NCLOB<br/>CLOB<br/>LONG<br/>XML<br/>ROWID | STRING              |
-| DATE                                                                                                | TIMESTAMP           |
-| TIMESTAMP<br/>TIMESTAMP WITH LOCAL TIME ZONE                                                        | TIMESTAMP           |
-| BLOB<br/>RAW<br/>LONG RAW<br/>BFILE                                                                 | BYTES               |
-| UNKNOWN                                                                                             | Not supported yet   |
+| DATE                                                                                            | TIMESTAMP           |
+| TIMESTAMP<br/>TIMESTAMP WITH LOCAL TIME ZONE                                                    | TIMESTAMP           |
+| BLOB<br/>RAW<br/>LONG RAW<br/>BFILE                                                             | BYTES               |
+| UNKNOWN                                                                                         | Not supported yet   |
 
 ## Source Options
 
-|             Name             |    Type    | Required |     Default     |                                                                                                                              Description                                                                                                                              |
-|------------------------------|------------|----------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                          | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: jdbc:oceanbase://localhost:2883/test                                                                                                                                                                                 |
-| driver                       | String     | Yes      | -               | The jdbc class name used to connect to the remote data source, should be `com.oceanbase.jdbc.Driver`.                                                                                                                                                                 |
-| username                         | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                         |
-| password                     | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                          |
-| compatible_mode              | String     | Yes      | -               | The compatible mode of OceanBase, can be 'mysql' or 'oracle'.                                                                                                                                                                                                         |
-| query                        | String     | Yes      | -               | Query statement                                                                                                                                                                                                                                                       |
-| connection_check_timeout_sec | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete                                                                                                                                                                    |
-| partition_column             | String     | No       | -               | The column name for parallelism's partition, only support numeric type column and string type column.                                                                                                                                                                 |
-| partition_lower_bound        | BigDecimal | No       | -               | The partition_column min value for scan, if not set SeaTunnel will query database get min value.                                                                                                                                                                      |
-| partition_upper_bound        | BigDecimal | No       | -               | The partition_column max value for scan, if not set SeaTunnel will query database get max value.                                                                                                                                                                      |
-| partition_num                | Int        | No       | job parallelism | The number of partition count, only support positive integer. Default value is job parallelism.                                                                                                                                                                       |
-| fetch_size                   | Int        | No       | 0               | For queries that return a large number of objects, you can configure <br/> the row fetch size used in the query to improve performance by <br/> reducing the number database hits required to satisfy the selection criteria.<br/> Zero means use jdbc default value. |
-| properties                   | Map        | No       | -               | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL.                        |
-| common-options               |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details                                                                                                                                                     |
+| Name                                  | Type       | Required | Default          | Description                                                                                                                                                                                              |
+|---------------------------------------|------------|----------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                                   | String     | Yes      | -                | The URL of the JDBC connection, for example `jdbc:oceanbase://localhost:2883/test`.                                                                                                                       |
+| driver                                | String     | Yes      | -                | The JDBC class name used to connect to the remote data source. Must be `com.oceanbase.jdbc.Driver`.                                                                                                       |
+| username                              | String     | No       | -                | Connection instance username.                                                                                                                                                                            |
+| password                              | String     | No       | -                | Connection instance password.                                                                                                                                                                            |
+| compatible_mode                       | String     | Yes      | -                | The compatible mode of OceanBase. Must be `mysql` or `oracle`.                                                                                                                                          |
+| query                                 | String     | No       | -                | Query statement. Configure one of `query`, `table_path`, or `table_list`.                                                                                                                                |
+| table_path                            | String     | No       | -                | Full table path used instead of `query`, for example `test.source`.                                                                                                                                     |
+| table_list                            | Array      | No       | -                | List of tables to read. Use it for multi-table reads. Each item can contain `table_path`, `query`, `partition_column`, and other table-level settings.                                                   |
+| where_condition                       | String     | No       | -                | Common row filter for all tables or queries. Must start with `where`, for example `where id > 100`.                                                                                                      |
+| connection_check_timeout_sec          | Int        | No       | 30               | Time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                          |
+| partition_column                      | String     | No       | -                | Column name for parallelism partitioning. Only numeric or string columns are supported.                                                                                                                  |
+| partition_lower_bound                 | BigDecimal | No       | -                | Minimum value for `partition_column`. If not set, SeaTunnel queries the database to get it.                                                                                                              |
+| partition_upper_bound                 | BigDecimal | No       | -                | Maximum value for `partition_column`. If not set, SeaTunnel queries the database to get it.                                                                                                              |
+| partition_num                         | Int        | No       | job parallelism  | Number of partitions. Only positive integers are supported. When reading by `table_path`, prefer `split.size` to control split size.                                                                    |
+| fetch_size                            | Int        | No       | 0                | Row fetch size used in queries. `0` means use the JDBC default value.                                                                                                                                   |
+| split.size                            | Int        | No       | 8096             | Number of rows in one split when reading by `table_path`.                                                                                                                                               |
+| split.even-distribution.factor.lower-bound | Double | No      | 0.05             | Lower bound used to judge whether split-key values are evenly distributed.                                                                                                                              |
+| split.even-distribution.factor.upper-bound | Double | No      | 100              | Upper bound used to judge whether split-key values are evenly distributed.                                                                                                                              |
+| split.sample-sharding.threshold       | Int        | No       | 1000             | Estimated shard count threshold that triggers sample-based sharding for uneven data.                                                                                                                    |
+| split.inverse-sampling.rate           | Int        | No       | 1000             | Sampling rate denominator used by sample-based sharding.                                                                                                                                                |
+| split.allow-sampling                  | Boolean    | No       | true             | Whether to allow sample-based sharding.                                                                                                                                                                 |
+| split.string_split_mode               | String     | No       | sample           | String split algorithm. Available values: `sample`, `charset_based`.                                                                                                                                   |
+| split.string-strategy                 | String     | No       | -                | String partition strategy. Available values: `none`, `hash`, `range`, `auto`.                                                                                                                           |
+| split.string_split_mode_collate       | String     | No       | -                | Collation used when `split.string_split_mode = charset_based`.                                                                                                                                          |
+| use_select_count                      | Boolean    | No       | false            | Use `SELECT COUNT(*)` during dynamic chunk split. Mainly used by Oracle-compatible read scenarios.                                                                                                      |
+| skip_analyze                          | Boolean    | No       | false            | Skip table count analysis during dynamic chunk split. Mainly used by Oracle-compatible read scenarios.                                                                                                  |
+| use_regex                             | Boolean    | No       | false            | Treat `table_path` as a regular expression when matching tables.                                                                                                                                        |
+| decimal_type_narrowing                | Boolean    | No       | true             | In Oracle-compatible mode, narrow decimal values to `INT` or `BIGINT` when it can be done without losing precision.                                                                                     |
+| int_type_narrowing                    | Boolean    | No       | true             | In MySQL-compatible mode, narrow `TINYINT(1)` to `BOOLEAN` when it can be done without losing precision.                                                                                                |
+| dialect                               | String     | No       | -                | Appointed JDBC dialect. OceanBase is usually detected from the URL, so this is only needed for special compatibility cases.                                                                             |
+| properties                            | Map        | No       | -                | Additional connection configuration parameters. When properties and the URL have the same parameters, the priority depends on the driver implementation; for example, MySQL drivers give `properties` priority over the URL. |
+| common-options                        |            | No       | -                | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                       |
 
 ### Tips
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
+> Configure one of `query`, `table_path`, or `table_list`.
+>
+> If `partition_column` is not set and SeaTunnel cannot find a suitable primary
+> key or unique key from the table metadata, the source runs with one reader.
+> If a supported split column is available, SeaTunnel can read in parallel.
+>
+> For OceanBase MySQL mode, JDBC connection URLs usually include MySQL-compatible
+> parameters such as `rewriteBatchedStatements=true`. For OceanBase Oracle mode,
+> use the Oracle-compatible tenant and set `compatible_mode = "oracle"`.
 
 ## Task Example
 
 ### Simple
 
-```
+```hocon
 env {
   parallelism = 2
   job.mode = "BATCH"
@@ -121,7 +158,7 @@ source {
 
 transform {
     # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-    # please go to https://seatunnel.apache.org/docs/transform/sql
+    # please go to https://seatunnel.apache.org/docs/transforms/sql
 }
 
 sink {
@@ -131,13 +168,15 @@ sink {
 
 ### Parallel
 
-> Read your query table in parallel with the shard field you configured and the shard data. You can do this if you want to read the whole table
+> Read your query table in parallel with the shard field you configured and the
+> shard data. Use this when you want to read the whole table.
 
-```
+```hocon
 env {
   parallelism = 10
   job.mode = "BATCH"
 }
+
 source {
   Jdbc {
     driver = "com.oceanbase.jdbc.Driver"
@@ -146,12 +185,11 @@ source {
     password = ""
     compatible_mode = "mysql"
     query = "select * from source"
-    # Parallel sharding reads fields
     partition_column = "id"
-    # Number of fragments
     partition_num = 10
   }
 }
+
 sink {
   Console {}
 }
@@ -159,9 +197,10 @@ sink {
 
 ### Parallel Boundary
 
-> It is more efficient to read your data source according to the upper and lower boundaries you configured
+> It is more efficient to read your data source according to the upper and
+> lower boundaries you configured.
 
-```
+```hocon
 source {
   Jdbc {
     driver = "com.oceanbase.jdbc.Driver"
@@ -172,10 +211,61 @@ source {
     query = "select * from source"
     partition_column = "id"
     partition_num = 10
-    # Read start boundary
     partition_lower_bound = 1
-    # Read end boundary
     partition_upper_bound = 500
+  }
+}
+```
+
+### Table Path
+
+Use `table_path` when you want SeaTunnel to discover table metadata and split
+the table automatically.
+
+```hocon
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_path = "test.source"
+    split.size = 8096
+  }
+}
+```
+
+### Oracle-Compatible Mode
+
+```hocon
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/TESTUSER"
+    username = "TESTUSER@test"
+    password = ""
+    compatible_mode = "oracle"
+    query = "SELECT ID, NAME, CREATE_TIME FROM SOURCE"
+  }
+}
+```
+
+### Multiple Table Read
+
+```hocon
+source {
+  Jdbc {
+    driver = "com.oceanbase.jdbc.Driver"
+    url = "jdbc:oceanbase://localhost:2883/test"
+    username = "root@test"
+    password = ""
+    compatible_mode = "mysql"
+    table_list = [
+      { table_path = "test.source_1" },
+      { table_path = "test.source_2" }
+    ]
+    where_condition = "where id > 100"
   }
 }
 ```

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -4,6 +4,10 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 > Apache Pulsar source connector
 
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Source connector for Apache Pulsar.
@@ -16,52 +20,61 @@ Source connector for Apache Pulsar.
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-| Name                     | Type    | Required | Default Value | Description                                                                                                      |
-|--------------------------|---------|----------|---------------|------------------------------------------------------------------------------------------------------------------|
-| topic                    | String  | No       | -             | Topic name(s) to read. Supports comma-separated list. **Note: only one of `topic`, `topic-pattern`, `tables_configs`** |
-| topic-pattern            | String  | No       | -             | Regular expression for topic names. **Note: only one of `topic`, `topic-pattern`, `tables_configs`**            |
-| table_path               | String  | No       | -             | Logical table identifier for multi-table mode                                                                    |
-| tables_configs           | Array   | No       | -             | Multi-table configuration. Each item can override global defaults. **Note: only one of `topic`, `topic-pattern`, `tables_configs`** |
-| topic-discovery.interval | Long    | No       | -1            | Interval (ms) to discover new partitions. Non-positive disables discovery. Only works with `topic-pattern`      |
-| subscription.name        | String  | No       | -             | Consumer subscription name. Can be defined globally or per item in multi-table mode                              |
-| client.service-url       | String  | Yes      | -             | Pulsar client service URL, e.g., `pulsar://localhost:6650`                                                      |
-| admin.service-url        | String  | Yes      | -             | Pulsar admin HTTP URL, e.g., `http://localhost:8080`                                                            |
-| auth.plugin-class        | String  | No       | -             | Pulsar client authentication plugin class name                                                                   |
-| auth.params              | String  | No       | -             | Pulsar client authentication parameters                                                                          |
-| poll.timeout             | Integer | No       | 100           | Timeout (ms) for polling messages from Pulsar                                                                    |
-| poll.interval            | Long    | No       | 50            | Interval (ms) between two polls                                                                                  |
-| poll.batch.size          | Integer | No       | 500           | Maximum number of messages to poll in a single batch                                                             |
-| cursor.startup.mode      | Enum    | No       | LATEST        | Startup position mode. Options: `EARLIEST`, `LATEST`, `SUBSCRIPTION`, `TIMESTAMP`                                |
-| cursor.startup.timestamp | Long    | No       | -             | Start timestamp (ms) when `cursor.startup.mode=TIMESTAMP`                                                        |
-| cursor.reset.mode        | Enum    | No       | LATEST        | Reset mode when `cursor.startup.mode=SUBSCRIPTION`. Options: `EARLIEST`, `LATEST`                               |
-| cursor.stop.mode         | Enum    | No       | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch)                         |
-| cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
-| schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
-| format                   | String  | No       | json          | Data format. Default is json. **Multi-table mode only supports JSON and CANAL_JSON**                            |
-| common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md) for details           |
+| Name                     | Type    | Required                                          | Default Value | Description                                                                                                                                                                              |
+|--------------------------|---------|---------------------------------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topic                    | String  | No                                                | -             | Topic name(s) to read. Supports a comma-separated list. Only one of `topic`, `topic-pattern`, and `tables_configs` can be configured.                                                  |
+| topic-pattern            | String  | No                                                | -             | Regular expression for topic names. Only one of `topic`, `topic-pattern`, and `tables_configs` can be configured.                                                                       |
+| table_path               | String  | No                                                | -             | Logical table identifier used inside a `tables_configs` entry. Mainly used in multi-table mode.                                                                                         |
+| tables_configs           | Array   | No                                                | -             | Multi-table configuration. Each item can override global defaults. Only one of `topic`, `topic-pattern`, and `tables_configs` can be configured.                                         |
+| topic-discovery.interval | Long    | No                                                | -1            | Interval (ms) for dynamically discovering new topic partitions. Non-positive disables discovery. Only works when `topic-pattern` is used.                                              |
+| subscription.name        | String  | Required for single-table mode or per multi-table item | -         | Consumer subscription name. Can be defined globally or per `tables_configs` item.                                                                                                        |
+| client.service-url       | String  | Yes                                               | -             | Pulsar client service URL, for example `pulsar://localhost:6650`.                                                                                                                        |
+| admin.service-url        | String  | Yes                                               | -             | Pulsar admin HTTP URL, for example `http://localhost:8080`.                                                                                                                              |
+| auth.plugin-class        | String  | No                                                | -             | Pulsar client authentication plugin class name.                                                                                                                                          |
+| auth.params              | String  | No                                                | -             | Pulsar client authentication parameters, for example `key1:val1,key2:val2`.                                                                                                              |
+| poll.timeout             | Integer | No                                                | 100           | Timeout (ms) for polling messages from Pulsar.                                                                                                                                          |
+| poll.interval            | Long    | No                                                | 50            | Interval (ms) between two polls.                                                                                                                                                        |
+| poll.batch.size          | Integer | No                                                | 500           | Maximum number of messages fetched in a single poll.                                                                                                                                    |
+| cursor.startup.mode      | Enum    | No                                                | LATEST        | Startup position mode. Options: `EARLIEST`, `LATEST`, `SUBSCRIPTION`, `TIMESTAMP`.                                                                                                       |
+| cursor.startup.timestamp | Long    | No                                                | -             | Startup timestamp (ms) when `cursor.startup.mode = TIMESTAMP`.                                                                                                                           |
+| cursor.reset.mode        | Enum    | Required when `cursor.startup.mode = SUBSCRIPTION` | -            | Reset mode when `cursor.startup.mode = SUBSCRIPTION`. Options: `EARLIEST`, `LATEST`.                                                                                                     |
+| cursor.stop.mode         | Enum    | No                                                | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch).                                                                                                 |
+| cursor.stop.timestamp    | Long    | No                                                | -             | Stop timestamp (ms) when `cursor.stop.mode = TIMESTAMP`.                                                                                                                                 |
+| schema                   | Config  | No                                                | -             | Data structure, including field names and types. See [Schema Feature](../../introduction/concepts/schema-feature.md) for details.                                                        |
+| format                   | String  | No                                                | json          | Data format. Supported values: `json`, `canal_json`, `avro`. Multi-table mode only supports `JSON`, `CANAL_JSON`, and `AVRO`. The `schema` option is required for `avro` format.        |
+| field_delimiter          | String  | No                                                | ,             | Field delimiter for the `text` format.                                                                                                                                                  |
+| common-options           |         | No                                                | -             | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md) for details.                                                                    |
 
 ### topic [String]
 
-Topic name(s) to read data from when the table is used as source. It also supports topic lists by separating topics with commas like `'topic-1,topic-2'`.
+Topic name(s) to read data from when the table is used as source. Supports a
+comma-separated list of topics, for example `'topic-1,topic-2'`.
 
-**Note, only one of `topic`, `topic-pattern` and `tables_configs` can be specified for sources.**
+**Note:** Only one of `topic`, `topic-pattern`, and `tables_configs` can be
+specified for sources.
 
 ### topic-pattern [String]
 
-The regular expression for a pattern of topic names to read from. All topics with names that match the specified regular expression will be subscribed by the consumer when the job starts running.
+Regular expression for a pattern of topic names to read from. All topics with
+names that match the specified regular expression will be subscribed by the
+consumer when the job starts running.
 
-**Note, only one of `topic`, `topic-pattern` and `tables_configs` can be specified for sources.**
+**Note:** Only one of `topic`, `topic-pattern`, and `tables_configs` can be
+specified for sources.
 
 ### table_path [String]
 
-Logical table identifier for one `tables_configs` item. This option is mainly used in multi-table mode.
+Logical table identifier for one `tables_configs` item. This option is mainly
+used in multi-table mode.
 
 ### tables_configs [Array]
 
-Multi-table source configuration. Each item can override global defaults such as `format`, cursor options and `subscription.name`.
+Multi-table source configuration. Each item can override global defaults such
+as `format`, cursor options, and `subscription.name`.
 
 Each item must configure exactly one of:
 
@@ -72,34 +85,45 @@ Additional rules:
 
 - `table_path` is required when `topic-pattern` is used.
 - `subscription.name` must exist either globally or inside the item.
-- Only `JSON` and `CANAL_JSON` are supported in multi-table mode.
+- Only `JSON`, `CANAL_JSON`, and `AVRO` are supported in multi-table mode.
 - Explicit `topic` entries must not overlap with any `topic-pattern` entry.
-- If multiple `topic-pattern` items can match the same topic, the first matching item in `tables_configs` wins. Put more specific patterns before broader ones.
-- In batch mode, multi-table configurations must be bounded. If more than one table is configured and any table uses `cursor.stop.mode = NEVER`, the source is unbounded and batch jobs are rejected. Single-table mode and single-entry `tables_configs` keep backward-compatible batch behavior.
+- If multiple `topic-pattern` items can match the same topic, the first
+  matching item in `tables_configs` wins. Put more specific patterns before
+  broader ones.
+- In batch mode, multi-table configurations must be bounded. If more than one
+  table is configured and any table uses `cursor.stop.mode = NEVER`, the
+  source is unbounded and batch jobs are rejected. Single-table mode and
+  single-entry `tables_configs` keep backward-compatible batch behavior.
 
 ### topic-discovery.interval [Long]
 
-The interval (in ms) for the Pulsar source to discover the new topic partitions. A non-positive value disables the topic partition discovery.
+The interval (in ms) for the Pulsar source to discover new topic partitions. A
+non-positive value disables topic partition discovery.
 
-**Note, This option only works if the 'topic-pattern' option is used.**
+**Note:** This option only works if `topic-pattern` is used.
 
 ### subscription.name [String]
 
-Specify the subscription name for this consumer. This is required for each effective table configuration, but in multi-table mode it can be defined globally or overridden per `tables_configs` item.
+The subscription name for this consumer.
+
+For a single-table source, `subscription.name` is required. For a multi-table
+source, it can be defined globally or inside each `tables_configs` item. If
+configured in both places, the item-level value takes effect for that item.
 
 ### client.service-url [String]
 
-Service URL provider for Pulsar service.
-To connect to Pulsar using client libraries, you need to specify a Pulsar protocol URL.
-You can assign Pulsar protocol URLs to specific clusters and use the Pulsar scheme.
+Service URL provider for the Pulsar service. To connect to Pulsar using the
+client libraries, specify a Pulsar protocol URL. Multiple URLs can be assigned
+to specific clusters using the Pulsar scheme.
 
-For example, `localhost`: `pulsar://localhost:6650,localhost:6651`.
+For example: `pulsar://localhost:6650,localhost:6651`.
 
 ### admin.service-url [String]
 
-The Pulsar service HTTP URL for the admin endpoint.
+Pulsar service HTTP URL for the admin endpoint.
 
-For example, `http://my-broker.example.com:8080`, or `https://my-broker.example.com:8443` for TLS.
+For example, `http://my-broker.example.com:8080`, or
+`https://my-broker.example.com:8443` for TLS.
 
 ### auth.plugin-class [String]
 
@@ -109,107 +133,165 @@ Name of the authentication plugin.
 
 Parameters for the authentication plugin.
 
-For example, `key1:val1,key2:val2`
+For example: `key1:val1,key2:val2`.
 
 ### poll.timeout [Integer]
 
-The maximum time (in ms) to wait when fetching records. A longer time increases throughput but also latency.
+Maximum time (in ms) to wait when fetching records. A longer time increases
+throughput but also latency.
 
 ### poll.interval [Long]
 
-The interval time(in ms) when fetcing records. A shorter time increases throughput, but also increases CPU load.
+Interval (in ms) between two polls. A shorter time increases throughput, but
+also increases CPU load.
 
 ### poll.batch.size [Integer]
 
-The maximum number of records to fetch to wait when polling. A longer time increases throughput but also latency.
+Maximum number of records fetched in one poll.
 
 ### cursor.startup.mode [Enum]
 
-Startup mode for Pulsar consumer, valid values are `'EARLIEST'`, `'LATEST'`, `'SUBSCRIPTION'`, `'TIMESTAMP'`.
+Startup mode for the Pulsar consumer. Valid values are `EARLIEST`, `LATEST`,
+`SUBSCRIPTION`, and `TIMESTAMP`.
 
 ### cursor.startup.timestamp [Long]
 
 Start from the specified epoch timestamp (in milliseconds).
 
-**Note, This option is required when the "cursor.startup.mode" option used `'TIMESTAMP'`.**
+**Note:** Required when `cursor.startup.mode = TIMESTAMP`.
 
 ### cursor.reset.mode [Enum]
 
-Cursor reset strategy for Pulsar consumer valid values are `'EARLIEST'`, `'LATEST'`.
-
-**Note, This option only works if the "cursor.startup.mode" option used `'SUBSCRIPTION'`.**
+Cursor reset strategy when `cursor.startup.mode = SUBSCRIPTION`. Valid values
+are `EARLIEST` and `LATEST`. It has no default value and must be configured in
+that mode.
 
 ### cursor.stop.mode [String]
 
-Stop mode for Pulsar consumer, valid values are `'NEVER'`, `'LATEST'`and `'TIMESTAMP'`.
+Stop mode for the Pulsar consumer. Valid values are `NEVER`, `LATEST`, and
+`TIMESTAMP`.
 
-**Note, When `'NEVER' `is specified, it is a real-time job, and other mode are off-line jobs.**
+**Note:** When `NEVER` is specified, the job runs in streaming mode; the
+other modes run in batch mode.
 
 ### cursor.stop.timestamp [Long]
 
 Stop from the specified epoch timestamp (in milliseconds).
 
-**Note, This option is required when the "cursor.stop.mode" option used `'TIMESTAMP'`.**
+**Note:** Required when `cursor.stop.mode = TIMESTAMP`.
 
 ### schema [Config]
 
-The structure of the data, including field names and field types.
-reference to [Schema-Feature](../../introduction/concepts/schema-feature.md)
+Data structure, including field names and types. See
+[Schema Feature](../../introduction/concepts/schema-feature.md) for details.
 
-## format [String]
+### format [String]
 
-Data format. The default format is json, reference [formats](../formats).
+Data format. The default format is `json`. Supported formats: `json`,
+`canal_json`, and `avro`. The `schema` option is required for `avro` format.
+See [formats](../formats) for more details.
+
+### field_delimiter [String]
+
+Field delimiter for the `text` format. The default value is `,`.
 
 ### common options
 
-Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+Source plugin common parameters, please refer to
+[Source Common Options](../common-options/source-common-options.md) for
+details.
 
-## Example
+## Task Example
+
+### Single-Topic Batch Read
 
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
   Pulsar {
-    topic = "example"
+    topic = "topic-it"
     subscription.name = "seatunnel"
     client.service-url = "pulsar://localhost:6650"
-    admin.service-url = "http://my-broker.example.com:8080"
-    plugin_output = "test"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = json
+    schema = {
+      fields {
+        c_string = string
+        c_boolean = boolean
+        c_int = int
+        c_bigint = bigint
+        c_double = double
+        c_timestamp = timestamp
+      }
+    }
   }
 }
 ```
 
-## Multi-table Example
+### Read Canal JSON Messages
+
+Use `format = canal_json` when the Pulsar topic stores Canal JSON change
+events.
 
 ```hocon
 source {
   Pulsar {
-    subscription.name = "seatunnel-sub"
+    topic = "test-cdc_mds"
+    subscription.name = "seatunnel-cdc-sub"
     client.service-url = "pulsar://localhost:6650"
     admin.service-url = "http://localhost:8080"
     cursor.startup.mode = "EARLIEST"
-    cursor.stop.mode = "NEVER"
+    cursor.stop.mode = "LATEST"
+    format = canal_json
+    schema = {
+      fields {
+        id = int
+        name = string
+        description = string
+        weight = string
+      }
+    }
+  }
+}
+```
+
+### Multi-Table Read
+
+```hocon
+source {
+  Pulsar {
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
     format = "json"
 
     tables_configs = [
       {
-        table_path = "default.orders"
+        table_path = "db.orders"
         topic = "persistent://public/default/orders"
+        subscription.name = "sub-orders"
         schema = {
           fields {
-            order_id = "bigint"
-            user_id = "int"
+            order_id = int
+            amount = double
           }
         }
       },
       {
-        table_path = "default.users"
+        table_path = "db.users"
         topic-pattern = "persistent://public/default/users-.*"
-        subscription.name = "users-sub"
-        format = "canal_json"
+        subscription.name = "sub-users"
         schema = {
           fields {
-            user_id = "int"
-            name = "string"
+            user_id = int
+            name = string
           }
         }
       }
@@ -218,7 +300,8 @@ source {
 }
 ```
 
-In batch mode, replace `cursor.stop.mode = "NEVER"` with a bounded mode such as `LATEST` or `TIMESTAMP`.
+For batch jobs, use a bounded stop mode such as `LATEST` or `TIMESTAMP`. Use
+`cursor.stop.mode = "NEVER"` for streaming jobs.
 
 ## Changelog
 

--- a/docs/en/connectors/source/TDengine.md
+++ b/docs/en/connectors/source/TDengine.md
@@ -4,95 +4,200 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 > TDengine source connector
 
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Read external data source data through TDengine.
+Read data from TDengine super tables.
 
-## Key features
+The source reads data in batch mode by querying a time range from one super
+table. You can read all sub tables under the super table, limit the read to
+specific sub tables, and select only part of the columns.
+
+Each source split reads one TDengine sub table. The output schema always adds
+`subtable_name` as the first field so that downstream sinks can keep the
+original TDengine sub table name. This is also the field consumed by the
+TDengine sink when writing rows back to TDengine.
+
+:::tip
+
+The connector uses the TDengine REST endpoint (`jdbc:TAOS-RS://...`). Make sure
+the TDengine REST service is enabled on the server. Tested against TDengine
+3.x.
+
+:::
+
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
-
-supports query SQL and can achieve projection effect.
-
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-| name         | type   | required | default value |
-|--------------|--------|----------|---------------|
-| url          | string | yes      | -             |
-| username     | string | yes      | -             |
-| password     | string | yes      | -             |
-| database     | string | yes      |               |
-| stable       | string | yes      | -             |
-| sub_tables   | list   | no       | -             |
-| lower_bound  | long   | yes      | -             |
-| upper_bound  | long   | yes      | -             |
-| read_columns | list   | no       | -             |
+| Name         | Type   | Required | Default Value | Description                                                                                                                                                                                       |
+|--------------|--------|----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url          | String | Yes      | -             | The TDengine REST JDBC URL, for example `jdbc:TAOS-RS://localhost:6041/`.                                                                                                                          |
+| username     | String | Yes      | -             | The username used to connect to TDengine.                                                                                                                                                         |
+| password     | String | Yes      | -             | The password used to connect to TDengine.                                                                                                                                                         |
+| database     | String | Yes      | -             | The TDengine database name.                                                                                                                                                                       |
+| stable       | String | Yes      | -             | The TDengine super table name to read from.                                                                                                                                                      |
+| sub_tables   | List   | No       | -             | A list of sub table names to read. If it is not configured, all sub tables under the configured super table are read. If it is configured, only the listed sub tables are read.                   |
+| lower_bound  | String | Yes      | -             | The inclusive lower bound of the query time range. The connector adds `timestamp_column >= lower_bound` to each sub table query. Use a TDengine-compatible timestamp string, e.g. `2018-10-03 14:38:05.000`. |
+| upper_bound  | String | Yes      | -             | The exclusive upper bound of the query time range. The connector adds `timestamp_column < upper_bound` to each sub table query. Use a TDengine-compatible timestamp string, e.g. `2018-10-03 14:38:16.801`. |
+| read_columns | List   | No       | -             | A list of column names to read. If it is not configured, all columns are read. When reading from a super table, put TAGS columns at the end of the list. Do not include `subtable_name`; the connector adds it automatically as the first output field. |
+| common-options |     | No       | -             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                  |
 
-### url [string]
+:::tip
 
-the url of the TDengine when you select the TDengine
+`lower_bound` and `upper_bound` together define the query window. Each
+parallel reader scans its own sub table within that window, so `parallelism`
+maps to the number of sub tables being read. Make sure the time range covers
+all the rows you want to read.
 
-e.g.
+:::
+
+### url [String]
+
+The TDengine REST JDBC URL.
 
 ```
 jdbc:TAOS-RS://localhost:6041/
 ```
 
-### username [string]
+### username [String]
 
-the username of the TDengine when you select
+The username used to connect to TDengine.
 
-### password [string]
+### password [String]
 
-the password of the TDengine when you select
+The password used to connect to TDengine.
 
-### database [string]
+### database [String]
 
-the database of the TDengine when you select
+The TDengine database name.
 
-### stable [string]
+### stable [String]
 
-the stable of the TDengine when you select
+The TDengine super table name. Each source split reads one sub table under this
+super table.
 
-### sub_tables [list]
-A list of sub_table names. If not specified, all sub-tables will be selected. If specified, only the specified sub-tables will be selected.
+### sub_tables [List]
 
-### lower_bound [long]
+A list of sub table names. If it is not configured, all sub tables under the
+configured super table are read. If it is configured, only the listed sub tables
+are read.
 
-the lower_bound of the migration period
+### lower_bound [String]
 
-### upper_bound [long]
+The inclusive lower bound of the query time range. The connector adds
+`timestamp_column >= lower_bound` to each sub table query. Use a
+TDengine-compatible timestamp string, for example `2018-10-03 14:38:05.000`.
 
-the upper_bound of the migration period
+### upper_bound [String]
 
-### read_columns [list]
-A list of column names to read. If not specified, all columns will be selected. 
-When reading from a super table, please make sure to put the TAGS columns at the end of the list.
+The exclusive upper bound of the query time range. The connector adds
+`timestamp_column < upper_bound` to each sub table query. Use a
+TDengine-compatible timestamp string, for example `2018-10-03 14:38:16.801`.
 
-## Example
+### read_columns [List]
 
-### source
+A list of column names to read. If it is not configured, all columns are read.
+When reading from a super table, put TAGS columns at the end of the list. Do not
+include `subtable_name`; the connector adds it automatically as the first output
+field.
+
+The order of `read_columns` decides the output field order after
+`subtable_name`. If the result is written to a TDengine sink, keep normal columns
+before TAGS columns so the sink can split column values and TAGS values
+correctly.
+
+### common options
+
+Source plugin common parameters, please refer to
+[Source Common Options](../common-options/source-common-options.md) for details.
+
+## Task Example
+
+### Read all sub tables in a time range
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Read selected sub tables and columns
 
 ```hocon
 source {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power"
-          stable : "meters"
-          sub_tables : ["meter_1","meter_2"]
-          lower_bound : "2018-10-03 14:38:05.000"
-          upper_bound : "2018-10-03 14:38:16.800"
-          plugin_output : "tdengine_result"
-          read_columns : ["ts","voltage","current","power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    sub_tables = ["d1001", "d1002"]
+    read_columns = ["ts", "current", "voltage", "phase", "off", "nc", "location", "groupid"]
+  }
+}
+```
+
+### Read from TDengine and write back to TDengine
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://tdengine-src:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://tdengine-sink:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+  }
 }
 ```
 

--- a/docs/en/transforms/llm.md
+++ b/docs/en/transforms/llm.md
@@ -90,8 +90,7 @@ transform {
 ### model
 
 The model to use. Different model providers have different models. For example, the OpenAI model can be `gpt-4o-mini`.
-If you use OpenAI model, please refer https://platform.openai.com/docs/models/model-endpoint-compatibility
-of `/v1/chat/completions` endpoint.
+If you use OpenAI model, please refer https://developers.openai.com/api/docs/models for supported models and endpoints, including `/v1/chat/completions` where available.
 
 ### api_key
 

--- a/docs/zh/connectors/sink/Elasticsearch.md
+++ b/docs/zh/connectors/sink/Elasticsearch.md
@@ -9,7 +9,9 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 ## 主要特性
 
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 
@@ -21,32 +23,34 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 
 ## 选项
 
-|           名称           | 类型      | 是否必须 |             默认值              |
-|------------------------|---------|------|------------------------------|
-| hosts                  | array   | 是    | -                            |
-| index                  | string  | 是    | -                            |
-| schema_save_mode       | string  | 是    | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode         | string  | 是    | APPEND_DATA                  |
-| index_type             | string  | 否    |                              |
-| primary_keys           | list    | 否    |                              |
-| key_delimiter          | string  | 否    | `_`                          |
-| auth_type              | string  | 否    | basic                        |
-| username               | string  | 否    |                              |
-| password               | string  | 否    |                              |
-| auth.api_key_id        | string  | 否    | -                            |
-| auth.api_key           | string  | 否    | -                            |
-| auth.api_key_encoded   | string  | 否    | -                            |
-| max_retry_count        | int     | 否    | 3                            |
-| max_batch_size         | int     | 否    | 10                           |
-| tls_verify_certificate | boolean | 否    | true                         |
-| tls_verify_hostname    | boolean | 否    | true                         |
-| tls_keystore_path      | string  | 否    | -                            |
-| tls_keystore_password  | string  | 否    | -                            |
-| tls_truststore_path    | string  | 否    | -                            |
-| tls_truststore_password | string  | 否    | -                            |
-| common-options         |         | 否    | -                            |
-| vectorization_fields   | array   | 否    | -                            |
-| vector_dimensions      | int     | 否    | -                            |
+|           名称           | 类型      | 是否必须 |             默认值              | 说明                                                                                                                                                |
+|------------------------|---------|------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| hosts                  | 数组    | 是    | -                            | Elasticsearch 集群 HTTP 地址，格式 `host:port`，允许指定多个主机，例如 `["host1:9200", "host2:9200"]`。                                                                  |
+| index                  | String  | 是    | -                            | Elasticsearch 索引名。支持上游字段名占位符，例如 `seatunnel_${age}`（需配合 `schema_save_mode = "IGNORE"`）。占位符字段必须存在于上游 row，否则按字面量处理。                                       |
+| schema_save_mode       | Enum    | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST | 同步开始前对目标索引结构的处理方式，详见 `schema_save_mode` 说明。                                                                                                          |
+| data_save_mode         | Enum    | 否    | APPEND_DATA                  | 写入前对目标已有文档的处理方式，详见 `data_save_mode` 说明。                                                                                                                |
+| index_type             | String  | 否    | -                            | Elasticsearch 索引类型，6 及以上版本建议不要指定。                                                                                                                |
+| primary_keys           | List    | 否    | -                            | 用于生成文档 `_id` 的主键字段。CDC 源必须配置以产出确定的文档 ID。                                                                                                            |
+| key_delimiter          | String  | 否    | `_`                          | 拼接 `primary_keys` 生成复合 `_id` 的分隔符。默认 `_` 生成 `KEY1_KEY2_KEY3`，`$` 生成 `KEY1$KEY2$KEY3`。                                                            |
+| auth_type              | String  | 否    | basic                        | 认证方式：`basic`、`api_key`、`api_key_encoded`，默认 `basic`。                                                                                                  |
+| username               | String  | 否    | -                            | HTTP Basic 认证用户名。                                                                                                                                  |
+| password               | String  | 否    | -                            | HTTP Basic 认证密码。                                                                                                                                   |
+| auth.api_key_id        | String  | 否    | -                            | `auth_type = "api_key"` 时使用的 API key ID。                                                                                                              |
+| auth.api_key           | String  | 否    | -                            | `auth_type = "api_key"` 时使用的 API key 密钥。                                                                                                            |
+| auth.api_key_encoded   | String  | 否    | -                            | `auth_type = "api_key_encoded"` 时使用的 Base64 编码 API key。                                                                                                |
+| max_retry_count        | Int     | 否    | 3                            | 单次 Bulk 请求的最大重试次数。                                                                                                                                |
+| max_batch_size         | Int     | 否    | 10                           | 单次 Bulk 请求包含的最大文档数。                                                                                                                              |
+| tls_verify_certificate | Boolean | 否    | true                         | 是否校验 HTTPS 端点的证书。                                                                                                                                 |
+| tls_verify_hostname    | Boolean | 否    | true                         | 是否校验 HTTPS 端点的主机名。                                                                                                                               |
+| tls_keystore_path      | String  | 否    | -                            | PEM 或 JKS 密钥库路径。                                                                                                                                  |
+| tls_keystore_password  | String  | 否    | -                            | 上述密钥库的密码。                                                                                                                                          |
+| tls_truststore_path    | String  | 否    | -                            | PEM 或 JKS 信任库路径。                                                                                                                                  |
+| tls_truststore_password | String  | 否    | -                            | 上述信任库的密码。                                                                                                                                          |
+| common-options         |         | 否    | -                            | Sink 通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md)。                                                                            |
+| vectorization_fields   | 数组    | 否    | -                            | 需要向量化的字段名。需 Elasticsearch 7.3+。                                                                                                                  |
+| vector_dimensions      | Int     | 否    | 0                            | 向量维度。需 Elasticsearch 7.3+。                                                                                                                          |
+| multi_table_sink_replica | Int   | 否    | 1                            | 多表写入时，每张表对应的 Sink Writer 副本数。通常保持默认值即可。                                                                                                          |
+
 
 ### hosts [array]
 
@@ -67,6 +71,10 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 ### key_delimiter [string]
 
 设定复合键的分隔符（默认为 `_`），例如，如果使用 `$` 作为分隔符，那么文档的 `_id` 将呈现为 `KEY1$KEY2$KEY3` 的格式
+
+### multi_table_sink_replica [int]
+
+多表写入时，每张表对应的 Sink Writer 副本数。通常保持默认值即可；只有单表写入压力较大、需要更多写入并行度时再调大。
 
 ## 认证
 
@@ -208,6 +216,32 @@ Sink插件常用参数，请参考 [Sink常用选项](../common-options/sink-com
 `APPEND_DATA`：保留数据库结构，保留数据<br/>
 `ERROR_WHEN_DATA_EXISTS`：当有数据时抛出错误<br/>
 
+### Zeta 定时刷新
+
+该引擎级能力仅由 Zeta 支持，Spark 和 Flink 不会注入 `FlushSignal`。在 Zeta 中，可以在 `env` 块配置 `sink.flush.interval`，使未达到 `max_batch_size` 的待处理 bulk 请求也能定时写出。
+
+:::tip
+
+Elasticsearch 定时刷新不提供基于 2PC 的精确一次语义。Elasticsearch Sink 当前提供至少一次语义；如果文档 ID 不是确定性的，失败重试可能产生重复写入。
+
+:::
+
+```hocon
+env {
+  job.mode = "STREAMING"
+  checkpoint.interval = 300000
+  sink.flush.interval = 5000
+}
+
+sink {
+  Elasticsearch {
+    hosts = ["localhost:9200"]
+    index = "seatunnel-index"
+    max_batch_size = 10000
+  }
+}
+```
+
 ## 示例
 
 简单示例
@@ -230,6 +264,7 @@ sink {
         hosts = ["localhost:9200"]
         index = "${table_name}"
         schema_save_mode="IGNORE"
+        multi_table_sink_replica = 1
     }
 }
 ```
@@ -261,7 +296,6 @@ sink {
 }
 ```
 
-```
 变更数据捕获 (Change data capture) 事件多表写入
 
 ```conf

--- a/docs/zh/connectors/sink/Hive.md
+++ b/docs/zh/connectors/sink/Hive.md
@@ -33,25 +33,26 @@ import ChangeLog from '../changelog/connector-hive.md';
 
 ## 选项
 
-| 名称                                    | 类型      | 必需 | 默认值            |
-|---------------------------------------|---------|----|----------------|
-| table_name                            | string  | 是  | -              |
-| metastore_uri                         | string  | 是  | -              |
-| compress_codec                        | string  | 否  | none           |
-| hdfs_site_path                        | string  | 否  | -              |
-| hive_site_path                        | string  | 否  | -              |
-| hive.hadoop.conf                      | Map     | 否  | -              |
-| hive.hadoop.conf-path                 | string  | 否  | -              |
-| krb5_path                             | string  | 否  | /etc/krb5.conf |
-| kerberos_principal                    | string  | 否  | -              |
-| kerberos_keytab_path                  | string  | 否  | -              |
-| abort_drop_partition_metadata         | boolean | 否  | false          |
-| parquet_avro_write_timestamp_as_int96 | boolean | 否  | false          |
-| overwrite                             | boolean | 否  | false          |
-| data_save_mode                        | enum    | 否  | APPEND_DATA    |
-| schema_save_mode                      | enum    | 否  | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| save_mode_create_template             | string  | 否  | -              |
-| common-options                        |         | 否  | -              |
+| 名称                                    | 类型      | 必需 | 默认值            | 说明                                                                                                                                                |
+|---------------------------------------|---------|----|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| table_name                            | String  | 是  | -              | 目标 Hive 表名，例如 `db1.table1`。源为多表模式时，可使用 `${database_name}.${table_name}` 占位符。                                                                  |
+| metastore_uri                         | String  | 是  | -              | Hive 元存储 URI。支持逗号分隔配置多个 URI 用于高可用/故障切换。                                                                                                       |
+| compress_codec                        | String  | 否  | none           | 文件压缩编解码器。`text`/`csv`/`json` 支持 `lzo`、`none`；`orc`/`parquet` 自动识别压缩类型。                                                                                  |
+| hdfs_site_path                        | String  | 否  | -              | `hdfs-site.xml` 的路径，用于加载 Namenode 的高可用配置。                                                                                                       |
+| hive_site_path                        | String  | 否  | -              | `hive-site.xml` 的路径。                                                                                                                            |
+| hive.hadoop.conf                      | Map     | 否  | -              | Hadoop 配置中的属性（`core-site.xml`、`hdfs-site.xml`、`hive-site.xml`）。                                                                                      |
+| hive.hadoop.conf-path                 | String  | 否  | -              | 指定加载 `core-site.xml`、`hdfs-site.xml`、`hive-site.xml` 文件的路径。                                                                                            |
+| remote_user                           | String  | 否  | -              | 未使用 Kerberos 凭据连接 HDFS/Hive 存储时使用的 Hadoop 远端用户名。                                                                                                |
+| krb5_path                             | String  | 否  | /etc/krb5.conf | `krb5.conf` 的路径，用于 Kerberos 认证。                                                                                                                 |
+| kerberos_principal                    | String  | 否  | -              | Kerberos 认证的主体。                                                                                                                                |
+| kerberos_keytab_path                  | String  | 否  | -              | Kerberos 认证的 keytab 文件路径。                                                                                                                       |
+| abort_drop_partition_metadata         | Boolean | 否  | false          | 中止操作时是否删除 Hive Metastore 中的分区元数据；只影响元数据，分区数据始终会被删除。                                                                                       |
+| parquet_avro_write_timestamp_as_int96 | Boolean | 否  | false          | 支持从时间戳写入 Parquet INT96，仅对 Parquet 文件有效。                                                                                                          |
+| overwrite                             | Boolean | 否  | false          | 是否以覆盖写入方式写入 Hive。批量模式下删除目标目录再写入；流式模式下每个 checkpoint 最多删除一次目标目录。                                                                              |
+| data_save_mode                        | Enum    | 否  | APPEND_DATA    | 写入前对目标已有数据的处理方式。详见 `data_save_mode` 说明。                                                                                                          |
+| schema_save_mode                      | Enum    | 否  | CREATE_SCHEMA_WHEN_NOT_EXIST | 同步开始前对目标表结构的处理方式。详见 `schema_save_mode` 说明。                                                                |
+| save_mode_create_template             | String  | 否  | -              | 自动建表使用的模板。可用变量：`${database}`、`${table}`、`${rowtype_fields}`、`${rowtype_partition_fields}`、`${table_location}`。                              |
+| common-options                        |         | 否  | -              | Sink 插件的通用参数，请参阅 [Sink Common Options](../common-options/sink-common-options.md) 了解详细信息。                                                              |
 
 ### table_name [string]
 
@@ -77,6 +78,10 @@ Hadoop 配置中的属性（`core-site.xml`、`hdfs-site.xml`、`hive-site.xml`�
 
 指定加载 `core-site.xml`、`hdfs-site.xml`、`hive-site.xml` 文件的路径
 
+### remote_user [string]
+
+未使用 Kerberos 凭据连接 HDFS/Hive 存储时使用的 Hadoop 远端用户名。
+
 ### krb5_path [string]
 
 `krb5.conf` 的路径，用于 Kerberos 认证
@@ -94,6 +99,8 @@ Kerberos 的 keytab 文件路径
 ### abort_drop_partition_metadata [boolean]
 
 在中止操作期间是否从 Hive Metastore 中删除分区元数据的标志。注意：这只影响元存储中的元数据，分区中的数据将始终被删除（同步过程中生成的数据）。
+
+默认值为 `false`。
 
 ### parquet_avro_write_timestamp_as_int96 [boolean]
 
@@ -115,6 +122,8 @@ Kerberos 的 keytab 文件路径
 - CUSTOM_PROCESSING / ERROR_WHEN_DATA_EXISTS：如无特殊需求，不建议在 Hive sink 下使用
 
 注意：overwrite=true 与 data_save_mode=DROP_DATA 行为等价，二者择一配置即可，勿同时设置。
+
+批处理作业中，如果希望本次运行替换目标 Hive 表里的已有数据，可以使用 `overwrite = true` 或 `data_save_mode = "DROP_DATA"`。普通追加写入场景保持默认的 `data_save_mode = "APPEND_DATA"` 即可。
 
 ### schema_save_mode [枚举]
 
@@ -578,51 +587,20 @@ sink {
 ```
 ## 常见问题
 
-### Hive Sink 支持哪些文件格式？
-
-Hive Sink 支持 `ORC`、`PARQUET`、`TEXT`、`JSON` 和 `SEQUENCE` 格式。通过 `file_format_type` 参数指定，需确保 Hive 表的 `STORED AS` 子句与配置的格式一致。
-
-### Hive Sink 是否支持分区表？
-
-支持。对于分区表，通过 `partition_by` 指定分区字段，SeaTunnel 会自动将数据写入正确的分区目录：
-
-```hocon
-sink {
-  Hive {
-    table_name = "mydb.sales"
-    metastore_uri = "thrift://hive-metastore:9083"
-    partition_by = ["dt", "region"]
-  }
-}
-```
-
-### 如何连接已启用 Kerberos 的 Hadoop 集群？
-
-在连接器配置中提供 Kerberos keytab 和 principal：
-
-```hocon
-sink {
-  Hive {
-    table_name = "mydb.events"
-    metastore_uri = "thrift://hive-metastore:9083"
-    kerberos_principal = "hive/host@REALM.COM"
-    kerberos_keytab_path = "/etc/security/keytabs/hive.keytab"
-    krb5_path = "/etc/krb5.conf"
-  }
-}
-```
-
 ### 为什么 Hive 表中产生了大量小文件？
 
 当任务并行度较高或批次较小时会产生大量小文件。减少小文件的方法：
 
 - 降低 `env` 块中的 `parallelism`。
-- 增大 `batch_size`，使每个 task 写入更大的文件。
 - 定期运行 `ALTER TABLE ... CONCATENATE` 或使用 Spark merge 任务合并小文件。
 
 ### Hive Sink 是否支持 Schema 演变？
 
 Hive Sink 从 Hive Metastore 读取当前表 schema。若上游新增了列，需先手动执行 `ALTER TABLE` 更新 Hive 表结构，SeaTunnel 不会自动修改 Hive schema。
+
+### `overwrite` 与 `data_save_mode` 有什么区别？
+
+`overwrite = true` 与 `data_save_mode = "DROP_DATA"` 行为一致：先删除目标目录（非分区表删除表目录，分区表删除相关分区目录），再写入新数据。两者择一配置即可，不要同时设置。默认的 `data_save_mode = "APPEND_DATA"` 会保留已有数据并追加新行。
 
 ## 变更日志
 

--- a/docs/zh/connectors/sink/TDengine.md
+++ b/docs/zh/connectors/sink/TDengine.md
@@ -4,79 +4,197 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 > TDengine 数据接收器
 
+## 支持的引擎
+
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
-用于将数据写入TDengine。
+用于将数据写入 TDengine。
+
+运行 SeaTunnel 任务前，需要先创建目标数据库和超级表。该 Sink 支持单表写入，也支持在 `stable` 中使用 `${table_name}` 这类占位符完成多表写入。
+
+输入数据需要符合 TDengine 超级表写入结构：第一列是目标子表名，中间是普通列，最后几列是 TAGS 值。连接器会读取目标超级表元数据来判断末尾有几列 TAGS。
+
+例如，目标超级表有 2 个 TAGS 字段时，输入数据最后 2 列会作为 TAGS 值，第一列会作为子表名。
+
+:::tip
+
+默认情况下 Sink 使用 2PC 提交来保证 `精确一次`。流式任务需要 Zeta 引擎开启 checkpoint。
+
+:::
 
 ## 主要特性
 
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
-- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-## 选项
+## 配置项
 
-|   名称   | 类型     | 是否必传 | 默认值 |
-|----------|--------|----------|---------------|
-| url      | string | 是      | -             |
-| username | string | 是      | -             |
-| password | string | 是      | -             |
-| database | string | 是      |               |
-| stable   | string | 是      | -             |
-| timezone | string | 否       | UTC           |
-| write_columns | list   | 否       | -             |
+| 名称           | 类型   | 必填 | 默认值 | 说明                                                                                                                                                                                       |
+|----------------|--------|------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url            | String | 是   | -      | TDengine REST JDBC 连接地址，例如 `jdbc:TAOS-RS://localhost:6041/`。                                                                                                                       |
+| username       | String | 是   | -      | 连接 TDengine 使用的用户名。                                                                                                                                                              |
+| password       | String | 是   | -      | 连接 TDengine 使用的密码。                                                                                                                                                                  |
+| database       | String | 是   | -      | TDengine 数据库名称。                                                                                                                                                                       |
+| stable         | String | 是   | -      | 目标 TDengine 超级表名称。多表写入时可以使用占位符，例如 `${table_name}`，占位符会按上游 `CatalogTable` 进行替换。                                                                            |
+| timezone       | String | 否   | UTC    | TDengine 服务端时区，用于时间戳转换。请确保该值与 TDengine 服务器时区保持一致，以避免时间戳列写入时出现偏差。                                                                              |
+| write_columns  | List   | 否   | -      | 要写入的普通列名列表。不配置时，TDengine 会按目标超级表的列顺序写入。请不要包含第一列子表名，也不要包含 TAGS 字段；连接器会自动从输入数据末尾取出 TAGS 值。                                       |
+| common-options |        | 否   | -      | Sink 通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md) 获取更多细节。                                                                                              |
 
-### url [string]
+### url [String]
 
-TDengine的url
-
-例如
+TDengine REST JDBC 连接地址，例如：
 
 ```
 jdbc:TAOS-RS://localhost:6041/
 ```
 
-### username [string]
+### username [String]
 
-TDengine的用户名
+连接 TDengine 使用的用户名。
 
-### password [string]
+### password [String]
 
-TDengine的密码
+连接 TDengine 使用的密码。
 
-### database [string]
+### database [String]
 
-TDengine的数据库
+TDengine 数据库名称。
 
-### stable [string]
+### stable [String]
 
-TDengine的超级表
+目标 TDengine 超级表名称。多表写入时可以使用占位符，例如 `${table_name}`，
+占位符会按上游 `CatalogTable` 进行替换。
 
-### timezone [string]
+### timezone [String]
 
-TDengine服务器的时间，对ts字段很重要
+TDengine 服务端时区，用于时间戳转换，默认值为 `UTC`。请确保该值与 TDengine
+服务器时区保持一致。
 
-### write_columns [list]
-TDengine的写入列，默认为所有列。无需包含 TAGS 字段，插件会自动处理 TAGS 字段的写入。
+### write_columns [List]
 
+要写入的普通列名列表。不配置时，TDengine 会按目标超级表的列顺序写入。
+请不要包含第一列子表名，也不要包含 TAGS 字段；连接器会自动从输入数据末尾取出
+TAGS 值。
 
-## 示例
+### 通用选项
 
-### sink
+Sink 通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)
+获取更多细节。多表写入时，可以配合通用参数中的 `multi_table_sink_replica`
+使用。
+
+## 任务示例
+
+### 写入单个超级表
 
 ```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake"
+    schema = {
+      fields {
+        ts = timestamp
+        voltage = float
+        current = float
+        power = float
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["2023-04-22T14:38:05", 219.0, 0.31, 68.2]
+      }
+    ]
+  }
+}
+
 sink {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power2"
-          stable : "meters2"
-          timezone: UTC
-          write_columns: ["ts", "voltage", "current", "power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+    write_columns = ["ts", "voltage", "current", "power"]
+  }
 }
 ```
 
+### 多表写入匹配的超级表
+
+```hocon
+source {
+  FakeSource {
+    plugin_output = "fake"
+    tables_configs = [
+      {
+        schema = {
+          table = "meters3"
+          fields {
+            device_id = "string"
+            event_time = "timestamp"
+            metric1 = "float"
+            metric2 = "int"
+            metric3 = "float"
+            status_flag = "boolean"
+            notes = "string"
+            location_tag = "string"
+            group_tag = "int"
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["d2001", "2023-04-22T14:38:05", 10.3, 219, 0.31, true, "nc", "California.SanFrancisco", 2]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "meters4"
+          fields {
+            device_id = "string"
+            event_time = "timestamp"
+            metric1 = "float"
+            metric2 = "int"
+            metric3 = "float"
+            status_flag = "boolean"
+            notes = "string"
+            location_tag = "string"
+            group_tag = "int"
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["d1005", "2023-04-22T14:38:05", 110.3, 219, 0.31, true, "nc", "California.SanFrancisco", 2]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "${table_name}"
+    timezone = "UTC"
+  }
+}
+```
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Elasticsearch.md
+++ b/docs/zh/connectors/source/Elasticsearch.md
@@ -8,47 +8,47 @@ import ChangeLog from '../changelog/connector-elasticsearch.md';
 
 支持读取 Elasticsearch2.x 版本和 8.x 版本之间的数据
 
-## Key features
+## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义的分片](../../introduction/concepts/connector-v2-features.md)
 
 ## 配置参数选项
 
-| 参数名称                | 类型    | 是否必须 | 默认值或者描述                             |
-| ----------------------- | ------- | -------- |-------------------------------------|
-| hosts                   | 数组    | yes      | -                                   |
-| auth_type               | string  | no       | basic                               |
-| username                | string  | no       | -                                   |
-| password                | string  | no       | -                                   |
-| auth.api_key_id         | string  | no       | -                                   |
-| auth.api_key            | string  | no       | -                                   |
-| auth.api_key_encoded    | string  | no       | -                                   |
-| index                   | string  | No       | 单索引同步配置，如果index_list没有配置，则必须配置index |
-| index_list              | array   | no       | 用来定义多索引同步任务                         |
-| source                  | array   | no       | -                                   |
-| query                   | json    | no       | {"match_all": {}}                   |
-| search_type             | enum    | no       | 查询类型，SQL 或 DSL，默认 DSL              |
-| search_api_type         | enum    | no       | 分页 API 类型，SCROLL 或 PIT，默认 SCROLL    |
-| sql_query               | json    | no       | SQL 查询语句，当 search_type 为 SQL 时必须    |
-| scroll_time             | string  | no       | 1m                                  |
-| scroll_size             | int     | no       | 100                                 |
-| tls_verify_certificate  | boolean | no       | true                                |
-| tls_verify_hostname     | boolean | no       | true                                |
-| array_column            | map     | no       |                                     |
-| tls_keystore_path       | string  | no       | -                                   |
-| tls_keystore_password   | string  | no       | -                                   |
-| tls_truststore_path     | string  | no       | -                                   |
-| tls_truststore_password | string  | no       | -                                   |
-| pit_keep_alive          | long    | no       | 60000 (1 minute)                    |
-| pit_batch_size          | int     | no       | 100                                 |
-| slice_max               | int     | no       | 1（SCROLL 需 ES >= 5.0，PIT 需 ES >= 7.10） |
-| runtime_fields          | array   | no       | -                                   |
-| common-options          |         | no       | -                                   |
+| 参数名称                | 类型    | 是否必须 | 默认值            | 说明                                                                                                                                                                                                                                  |
+| ----------------------- | ------- | -------- |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| hosts                   | 数组    | 是       | -                 | Elasticsearch 集群的 HTTP 地址，格式为 `host:port`，允许指定多个主机，例如 `["host1:9200", "host2:9200"]`。                                                                                                                              |
+| auth_type               | String  | 否       | basic             | 认证方式：`basic`、`api_key`、`api_key_encoded`，默认 `basic`。                                                                                                                                                                       |
+| username                | String  | 否       | -                 | HTTP Basic 认证的用户名（X-Pack 用户名）。                                                                                                                                                                                              |
+| password                | String  | 否       | -                 | HTTP Basic 认证的密码（X-Pack 密码）。                                                                                                                                                                                                  |
+| auth.api_key_id         | String  | 否       | -                 | `auth_type = "api_key"` 时使用的 API key ID。                                                                                                                                                                                          |
+| auth.api_key            | String  | 否       | -                 | `auth_type = "api_key"` 时使用的 API key 密钥。                                                                                                                                                                                        |
+| auth.api_key_encoded    | String  | 否       | -                 | `auth_type = "api_key_encoded"` 时使用的 Base64 编码 API key。`auth.api_key_id` + `auth.api_key` 与 `auth.api_key_encoded` 二者择一。                                                                                                       |
+| index                   | String  | 否       | -                 | Elasticsearch 索引名。`index_list` 未配置时此项必填。支持 `*` 模糊匹配。                                                                                                                                                                |
+| index_list              | 数组    | 否       | -                 | 多索引同步任务配置列表。当不同索引需要不同的 `query`、`source`、`schema` 或分页选项时使用。                                                                                                                                                  |
+| source                  | 数组    | 否       | -                 | 要读取的字段列表，可显式包含 `_id`。未配置时按索引 mapping 自动推导。                                                                                                                                                                       |
+| query                   | Json    | 否       | `{"match_all": {}}` | Elasticsearch DSL 查询，用于过滤读取的数据范围。                                                                                                                                                                                       |
+| search_type             | Enum    | 否       | DSL               | 查询类型：`DSL` 或 `SQL`。                                                                                                                                                                                                               |
+| search_api_type         | Enum    | 否       | SCROLL            | 分页 API 类型：`SCROLL` 或 `PIT`（Point-in-Time）。                                                                                                                                                                                    |
+| sql_query               | String  | 否       | -                 | SQL 查询语句，当 `search_type = "SQL"` 时必填。                                                                                                                                                                                          |
+| scroll_time             | String  | 否       | 1m                | Scroll 请求的上下文保持时长。                                                                                                                                                                                                            |
+| scroll_size             | Int     | 否       | 100               | 单次 Scroll 请求返回的最大命中数。                                                                                                                                                                                                       |
+| tls_verify_certificate  | Boolean | 否       | true              | 是否校验 HTTPS 端点的证书。                                                                                                                                                                                                              |
+| tls_verify_hostname     | Boolean | 否       | true              | 是否校验 HTTPS 端点的主机名。                                                                                                                                                                                                            |
+| array_column            | Map     | 否       | -                 | 标记为数组类型的字段，Elasticsearch 没有数组类型，需要显式声明，例如 `{c_array = "array<tinyint>"}`。                                                                                                                                       |
+| tls_keystore_path       | String  | 否       | -                 | PEM 或 JKS 密钥库路径。运行 SeaTunnel 的用户必须可读。                                                                                                                                                                                  |
+| tls_keystore_password   | String  | 否       | -                 | 上述密钥库的密码。                                                                                                                                                                                                                       |
+| tls_truststore_path     | String  | 否       | -                 | PEM 或 JKS 信任库路径。运行 SeaTunnel 的用户必须可读。                                                                                                                                                                                  |
+| tls_truststore_password | String  | 否       | -                 | 上述信任库的密码。                                                                                                                                                                                                                       |
+| pit_keep_alive          | Long    | 否       | 60000             | PIT 上下文保持时长（毫秒）。                                                                                                                                                                                                              |
+| pit_batch_size          | Int     | 否       | 100               | 单次 PIT 搜索请求返回的最大命中数。                                                                                                                                                                                                       |
+| slice_max               | Int     | 否       | 1                 | 将单个索引切分为多个分片并行读取。仅对 `SCROLL`/`PIT` 生效。`SCROLL` 切片要求 ES 5.0+；`PIT` 切片要求 ES 7.10+。当 `search_type = "SQL"` 时忽略。                                                                                                  |
+| runtime_fields          | 数组    | 否       | -                 | 在查询时计算的运行时字段（Elasticsearch 7.11+）。详见下文 `runtime_fields`。                                                                                                                                                              |
+| common-options          |         | 否       | -                 | 源插件通用参数，请参考 [Source Common Options](../common-options/source-common-options.md)。                                                                                                                                              |
 
 ### hosts [array]
 
@@ -134,6 +134,8 @@ source {
 ### index [string]
 
 Elasticsearch 索引名称，支持 * 模糊匹配。比如存在索引index1,index2,可以指定index*同时读取两个索引的数据。
+
+`index` 和 `index_list` 至少需要配置一个。单索引或索引通配场景使用 `index`；不同索引需要单独配置 `query`、`source`、`schema` 或分页参数时，使用 `index_list`。
 
 ### source [array]
 
@@ -247,6 +249,8 @@ runtime_fields = [
 - PIT 切片需要 Elasticsearch 7.10 及以上版本（PIT 在 7.10.0 引入）。
 
 **取舍说明：**切片能提升吞吐，但可能降低跨切片的一致性。对一致性要求高时，建议使用 PIT（共享快照）或将 `slice_max = 1`；对追加写或写入较少的场景，开启切片通常可以接受。
+
+当 `search_type = "SQL"` 时，Elasticsearch SQL 查询不支持切片，`slice_max` 会被忽略。
 
 ### common options
 

--- a/docs/zh/connectors/source/Hive.md
+++ b/docs/zh/connectors/source/Hive.md
@@ -8,7 +8,7 @@ import ChangeLog from '../changelog/connector-hive.md';
 
 从 Hive 读取数据。
 
-使用 markdown 格式时，SeaTunnel 可以解析存储在 Hive 表中的 markdown 文件并提取结构化数据，包括标题、段落、列表、代码块和表格等元素。每个元素都转换为具有以下架构的行：
+使用 markdown 格式时，SeaTunnel 可以解析存储在 Hive 表中的 markdown 文件并提取结构化数据，包括标题、段落、列表、代码块和表格等元素。每个提取出的元素都会转换为一条文档元素结构化记录，schema 如下：
 - `element_id`：元素的唯一标识符
 - `element_type`：元素类型（Heading、Paragraph、ListItem 等）
 - `heading_level`：标题级别（1-6，非标题元素为 null）
@@ -48,26 +48,39 @@ import ChangeLog from '../changelog/connector-hive.md';
 
 ## 选项
 
-|         名称          |  类型  | 必需 | 默认值  |
-|-----------------------|--------|------|---------|
-| table_name            | string | 是   | -       |
-| use_regex             | boolean| 否   | false   |
-| metastore_uri         | string | 是   | -       |
-| krb5_path             | string | 否   | /etc/krb5.conf |
-| kerberos_principal    | string | 否   | -       |
-| kerberos_keytab_path  | string | 否   | -       |
-| hdfs_site_path        | string | 否   | -       |
-| hive_site_path        | string | 否   | -       |
-| hive.hadoop.conf      | Map    | 否   | -       |
-| hive.hadoop.conf-path | string | 否   | -       |
-| read_partitions       | list   | 否   | -       |
-| read_columns          | list   | 否   | -       |
-| compress_codec        | string | 否   | none    |
-| common-options        |        | 否   | -       |
+|         名称          |  类型  | 必需 | 默认值  | 说明                                                                                                                                                                                                                                  |
+|-----------------------|--------|------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| table_name            | String | 否   | 单表模式必填 | 目标 Hive 表名，格式为 `db.table`。当 `use_regex = true` 时，使用 `数据库正则.表正则`（Hive 没有 schema）来匹配 Hive 元存储中的多张表。                                                                                                |
+| table_list            | Array  | 否   | -       | Hive 多表读取配置列表。每个元素可以包含 `table_name`、`metastore_uri`、`use_regex`、`read_partitions`、`read_columns`，以及与根配置相同的认证和 Hadoop 配置。                                                                          |
+| tables_configs        | Array  | 否   | -       | 已废弃的多表配置列表。新作业请使用 `table_list`。                                                                                                                                                                                       |
+| use_regex             | Boolean| 否   | false   | 是否将 `table_name` 视为正则表达式进行匹配。开启后，可用于整库/多表同步；也支持在 `table_list` / `tables_configs` 的每个表配置里单独开启。                                                                                            |
+| metastore_uri         | String | 否   | 单表模式必填 | Hive 元存储 URI。支持逗号分隔配置多个 URI 用于高可用/故障切换（自动去除空格）。                                                                                                                                                       |
+| krb5_path             | String | 否   | /etc/krb5.conf | `krb5.conf` 的路径，用于 Kerberos 认证。                                                                                                                                                                                          |
+| kerberos_principal    | String | 否   | -       | Kerberos 认证的主体。                                                                                                                                                                                                                  |
+| kerberos_keytab_path  | String | 否   | -       | Kerberos 认证的 keytab 文件路径。                                                                                                                                                                                                    |
+| hdfs_site_path        | String | 否   | -       | `hdfs-site.xml` 的路径，用于加载 Namenode 的高可用配置。                                                                                                                                                                               |
+| hive_site_path        | String | 否   | -       | `hive-site.xml` 的路径。                                                                                                                                                                                                              |
+| hive.hadoop.conf      | Map    | 否   | -       | Hadoop 配置中的属性（`core-site.xml`、`hdfs-site.xml`、`hive-site.xml`）。                                                                                                                                                            |
+| hive.hadoop.conf-path | String | 否   | -       | 指定加载 `core-site.xml`、`hdfs-site.xml`、`hive-site.xml` 文件的路径。                                                                                                                                                              |
+| remote_user           | String | 否   | -       | 未使用 Kerberos 凭据连接 HDFS/Hive 存储时使用的 Hadoop 远端用户名。                                                                                                                                                                    |
+| read_partitions       | List   | 否   | -       | 用户希望从 Hive 表中读取的目标分区；不配置时读取所有分区。分区列表中的每个分区必须具有相同的目录层级。                                                                                                                                |
+| read_columns          | List   | 否   | -       | 数据源的读取列列表，可用于实现字段投影。                                                                                                                                                                                              |
+| compress_codec        | String | 否   | none    | 文件压缩编解码器。`text`/`json`/`csv` 支持 `lzo`、`none`；`orc`/`parquet` 自动识别压缩类型。                                                                                                                                            |
+| common-options        |        | 否   | -       | 源插件的通用参数，请参阅 [Source Common Options](../common-options/source-common-options.md) 了解详细信息。                                                                                                                              |
 
 ### table_name [string]
 
 目标 Hive 表名，例如：`db1.table1`。当 `use_regex = true` 时，该字段支持 `数据库正则.表正则`（Hive 没有 schema）来匹配 Hive 元存储中的多张表。
+
+单表读取时，在根配置中填写 `table_name` 和 `metastore_uri`。多表读取时，建议使用 `table_list`。`tables_configs` 仍兼容旧配置，但新作业建议使用 `table_list`。
+
+### table_list [array]
+
+Hive 多表读取配置列表。每个元素可以包含 `table_name`、`metastore_uri`、`use_regex`、`read_partitions`、`read_columns`，以及与根配置相同的认证和 Hadoop 配置。
+
+### tables_configs [array]
+
+已废弃的多表配置列表。新作业请使用 `table_list`。
 
 ### use_regex [boolean]
 
@@ -84,6 +97,10 @@ import ChangeLog from '../changelog/connector-hive.md';
 ### metastore_uri [string]
 
 Hive 元存储 URI。支持通过逗号分隔配置多个 URI 用于高可用/故障切换（会自动去除空格）。SeaTunnel 会将该值写入 Hive 的 `hive.metastore.uris`，并在运行时优先使用 Hive 的 `RetryingMetaStoreClient` 实现重试/切换。注意：该能力仅做客户端连接端点切换，元数据一致性需要由 metastore 部署保证。
+
+### remote_user [string]
+
+未使用 Kerberos 凭据连接 HDFS/Hive 存储时使用的 Hadoop 远端用户名。
 
 ### hdfs_site_path [string]
 
@@ -188,7 +205,7 @@ Kerberos 认证的 keytab 文件路径
   }
 ```
 
-### 示例 3：正则匹配多表（整库/整库子集）
+### 示例 4：正则匹配多表（整库/整库子集）
 
 ```bash
   Hive {
@@ -221,7 +238,7 @@ Kerberos 认证的 keytab 文件路径
   }
 ```
 
-### 示例 4：Kerberos
+### 示例 5：Kerberos
 
 ```bash
 source {

--- a/docs/zh/connectors/source/TDengine.md
+++ b/docs/zh/connectors/source/TDengine.md
@@ -4,96 +4,184 @@ import ChangeLog from '../changelog/connector-tdengine.md';
 
 > TDengine 源端连接器
 
+## 支持的引擎
+
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
-通过 TDengine 读取外部数据源的数据。
+从 TDengine 超级表读取数据。
+
+该 Source 以批处理方式按时间范围读取一个超级表的数据。可以读取该超级表下的所有子表，也可以只读取指定子表；同时支持只读取部分列。
+
+每个 source 分片会读取一个 TDengine 子表。输出字段会自动把 `subtable_name` 放在第一列，用来保留原始子表名；如果下游继续写入 TDengine，TDengine sink 也会使用这一列作为目标子表名。
+
+:::tip
+
+连接器使用 TDengine 的 REST 接口（`jdbc:TAOS-RS://...`），请确保服务器已开启 REST 服务。当前已测试 TDengine 3.x。
+
+:::
 
 ## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流式](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
-
-支持查询 SQL，并可实现投影效果。
-
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 配置项
+## 源端配置项
 
-| 名称           | 类型   | 必填 | 默认值         |
-|----------------|--------|------|----------------|
-| url            | string | 是   | -              |
-| username       | string | 是   | -              |
-| password       | string | 是   | -              |
-| database       | string | 是   |                |
-| stable         | string | 是   | -              |
-| sub_tables     | list   | 否   | -              |
-| lower_bound    | long   | 是   | -              |
-| upper_bound    | long   | 是   | -              |
-| read_columns   | list   | 否   | -              |
+| 名称           | 类型   | 必填 | 默认值 | 说明                                                                                                                                                                                       |
+|----------------|--------|------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url            | String | 是   | -      | TDengine REST JDBC 连接地址，例如 `jdbc:TAOS-RS://localhost:6041/`。                                                                                                                       |
+| username       | String | 是   | -      | 连接 TDengine 使用的用户名。                                                                                                                                                              |
+| password       | String | 是   | -      | 连接 TDengine 使用的密码。                                                                                                                                                                  |
+| database       | String | 是   | -      | TDengine 数据库名称。                                                                                                                                                                       |
+| stable         | String | 是   | -      | 要读取的 TDengine 超级表名称。                                                                                                                                                              |
+| sub_tables     | List   | 否   | -      | 要读取的子表名称列表。不配置时读取该超级表下的所有子表；配置后只读取列表中的子表。                                                                                                          |
+| lower_bound    | String | 是   | -      | 查询时间范围的下界（包含）。连接器会为每个子表查询加上 `timestamp_column >= lower_bound`。请使用 TDengine 可识别的时间字符串，例如 `2018-10-03 14:38:05.000`。                              |
+| upper_bound    | String | 是   | -      | 查询时间范围的上界（不包含）。连接器会为每个子表查询加上 `timestamp_column < upper_bound`。请使用 TDengine 可识别的时间字符串，例如 `2018-10-03 14:38:16.801`。                          |
+| read_columns   | List   | 否   | -      | 要读取的列名列表。不配置时读取所有列。读取超级表时，请将 TAGS 字段放在列表末尾；不要包含 `subtable_name`，连接器会自动把它作为第一列输出。                                                |
+| common-options |        | 否   | -      | 源端通用参数，请参考 [源端通用选项](../common-options/source-common-options.md) 获取更多细节。                                                                                                |
 
-### url [string]
+:::tip
 
-选择 TDengine 时的连接 URL
+`lower_bound` 和 `upper_bound` 共同决定查询的时间窗口。每个并行 reader 都会在自己的子表范围内扫描该时间窗口内的数据，因此并行度通常对应被读取的子表数量。请确保时间范围覆盖需要读取的全部数据。
 
-例如：
+:::
+
+### url [String]
+
+TDengine REST JDBC 连接地址，例如：
 
 ```
 jdbc:TAOS-RS://localhost:6041/
 ```
 
-### username [string]
+### username [String]
 
-选择 TDengine 时的用户名
+连接 TDengine 使用的用户名。
 
-### password [string]
+### password [String]
 
-选择 TDengine 时的密码
+连接 TDengine 使用的密码。
 
-### database [string]
+### database [String]
 
-选择 TDengine 时的数据库名
+TDengine 数据库名称。
 
-### stable [string]
+### stable [String]
 
-选择 TDengine 时的超级表名
+要读取的 TDengine 超级表名称。每个 source 分片会读取该超级表下的一个子表。
 
-### sub_tables [list]
+### sub_tables [List]
 
-TDengine 的子表名。如果不指定，则会选择所有子表；如果指定，则只选择指定的子表。
+要读取的子表名称列表。不配置时读取该超级表下的所有子表；配置后只读取列表中的子表。
 
-### lower_bound [long]
+### lower_bound [String]
 
-迁移时间段的下界
+查询时间范围的下界（包含）。连接器会为每个子表查询加上
+`timestamp_column >= lower_bound`。请使用 TDengine 可识别的时间字符串，
+例如 `2018-10-03 14:38:05.000`。
 
-### upper_bound [long]
+### upper_bound [String]
 
-迁移时间段的上界
+查询时间范围的上界（不包含）。连接器会为每个子表查询加上
+`timestamp_column < upper_bound`。请使用 TDengine 可识别的时间字符串，
+例如 `2018-10-03 14:38:16.801`。
 
-### read_columns [list]
+### read_columns [List]
 
-选择 TDengine 时的列名。如果不指定，则选择所有字段；如果指定，则只选择指定的字段。读取超级表时，请包含TAGS 字段，并放在末尾。
+要读取的列名列表。不配置时读取所有列。读取超级表时，请将 TAGS 字段放在列表
+末尾；不要包含 `subtable_name`，连接器会自动把它作为第一列输出。
 
-## 示例
+`read_columns` 的顺序决定 `subtable_name` 之后的输出字段顺序。如果结果继续
+写入 TDengine Sink，请保持普通列在前、TAGS 字段在后，这样 Sink 才能正确区分
+普通列和 TAGS 值。
 
-### source 配置示例
+### 通用选项
+
+源端通用参数，请参考
+[源端通用选项](../common-options/source-common-options.md) 获取更多细节。
+
+## 任务示例
+
+### 按时间范围读取所有子表
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### 读取指定子表和指定列
 
 ```hocon
 source {
-        TDengine {
-          url : "jdbc:TAOS-RS://localhost:6041/"
-          username : "root"
-          password : "taosdata"
-          database : "power"
-          stable : "meters"
-          sub_tables : ["meter_1","meter_2"]
-          lower_bound : "2018-10-03 14:38:05.000"
-          upper_bound : "2018-10-03 14:38:16.800"
-          plugin_output = "tdengine_result"
-          read_columns : ["ts","voltage","current","power"]
-        }
+  TDengine {
+    url = "jdbc:TAOS-RS://localhost:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    sub_tables = ["d1001", "d1002"]
+    read_columns = ["ts", "current", "voltage", "phase", "off", "nc", "location", "groupid"]
+  }
+}
+```
+
+### 从 TDengine 读取并写入 TDengine
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  TDengine {
+    url = "jdbc:TAOS-RS://tdengine-src:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power"
+    stable = "meters"
+    lower_bound = "2018-10-03 14:38:05.000"
+    upper_bound = "2018-10-03 14:38:16.801"
+    plugin_output = "tdengine_result"
+  }
+}
+
+sink {
+  TDengine {
+    url = "jdbc:TAOS-RS://tdengine-sink:6041/"
+    username = "root"
+    password = "taosdata"
+    database = "power2"
+    stable = "meters2"
+    timezone = "UTC"
+  }
 }
 ```
 

--- a/docs/zh/transforms/llm.md
+++ b/docs/zh/transforms/llm.md
@@ -88,7 +88,7 @@ transform {
 ### model
 
 要使用的模型。不同的模型提供者有不同的模型。例如，OpenAI 模型可以是 `gpt-4o-mini`。
-如果使用 OpenAI 模型，请参考 https://platform.openai.com/docs/models/model-endpoint-compatibility 文档的`/v1/chat/completions` 端点。
+如果使用 OpenAI 模型，请参考 https://developers.openai.com/api/docs/models 文档的 `/v1/chat/completions` 端点。
 
 ### api_key
 


### PR DESCRIPTION
### Purpose

This PR improves the documentation of five connector-V2 docs in `docs/en` and `docs/zh`:

- TDengine (`source/TDengine.md`, `sink/TDengine.md`)
- Hive (`source/Hive.md`, `sink/Hive.md`)
- Elasticsearch (`source/Elasticsearch.md`, `sink/Elasticsearch.md`)
- Pulsar (`source/Pulsar.md`, `sink/Pulsar.md`)
- OceanBase (`source/OceanBase.md`, `sink/OceanBase.md`)

The goal is to align the docs with the current connector code, make option tables easier to read, and ensure both languages stay in sync. No source code, no source-version metadata, and no recent PR (within the last 7 days) was touched.

### Changes

- **TDengine (source & sink)**: Add `Support Those Engines`, a REST-endpoint tip, and an explicit description column for every option. Sink doc clarifies the `timezone` semantics and the 2PC exactly-once behavior. Task examples are refreshed with explicit `env` blocks.
- **Hive (source & sink)**: Replace the option tables with a typed `Name / Type / Required / Default / Description` form for both languages and expand each option's explanation. Sink doc fixes the FAQ that previously referenced undocumented `file_format_type` and `partition_by` options and now documents the actual `overwrite` / `data_save_mode` interaction.
- **Elasticsearch (source & sink)**: Rewrite the option tables so every entry has its own description column (the previous tables mixed default values and descriptions). Source doc refreshes the `runtime_fields`, PIT-with-slicing, and SSL examples; sink doc harmonises the feature list and clarifies the CDC/auth/timer-flush options.
- **Pulsar (source & sink)**: Complete the option table descriptions and refresh the multi-table examples. Sink doc now starts with `Support Those Engines` and `Description` before the feature list.
- **OceanBase (source & sink)**: Replace the option tables with the typed description form and restore a clean `Description` section. Sink doc clarifies the XA-based exactly-once semantics and the relationship between `generate_sink_sql`, `database`, `table`, and `primary_keys`.

### Validation

- Spot-checked option names and defaults against the connector source code (`connector-tdengine`, `connector-hive`, `connector-elasticsearch`, `connector-pulsar`, and the JDBC-backed OceanBase connector).
- Bilingual parity: every English doc change is mirrored in the corresponding Chinese doc; the existing Chinese descriptions that were already correct were kept and only the tables and headings were normalized.
- No version metadata in the changelog files is modified.
- Markdown structure follows the same shape used by the recently merged connector doc PRs.

### Notes

- This PR is opened as a draft per the contributor workflow; it will be marked ready for review after CI passes.
- Five connectors were touched per batch, matching the contributor guidance.
- Old PRs from `DanielCarter-stack` have all CI green and no outstanding review comments; they were checked before opening this new PR.