### PR TITLE
[Improve][Connector-V2][JDBC] Fix Vertica exact numeric type mapping

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaTypeMapper.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaTypeMapper.java
@@ -58,6 +58,7 @@ public class VerticaTypeMapper implements JdbcDialectTypeMapper {
     private static final String VERTICA_BIGINT = "BIGINT";
     private static final String VERTICA_BIGINT_UNSIGNED = "BIGINT UNSIGNED";
     private static final String VERTICA_DECIMAL = "DECIMAL";
+    private static final String VERTICA_NUMERIC = "NUMERIC";
     private static final String VERTICA_DECIMAL_UNSIGNED = "DECIMAL UNSIGNED";
     private static final String VERTICA_FLOAT = "FLOAT";
     private static final String VERTICA_FLOAT_UNSIGNED = "FLOAT UNSIGNED";
@@ -114,6 +115,7 @@ public class VerticaTypeMapper implements JdbcDialectTypeMapper {
                 return BasicType.LONG_TYPE;
             case VERTICA_BIGINT_UNSIGNED:
                 return new DecimalType(20, 0);
+            case VERTICA_NUMERIC:
             case VERTICA_DECIMAL:
                 if (precision > 38) {
                     LOG.warn("{} will probably cause value overflow.", VERTICA_DECIMAL);
@@ -162,7 +164,7 @@ public class VerticaTypeMapper implements JdbcDialectTypeMapper {
             case VERTICA_BINARY:
                 return PrimitiveByteArrayType.INSTANCE;
 
-                // Doesn't support yet
+            // Doesn't support yet
             case VERTICA_GEOMETRY:
             case VERTICA_UNKNOWN:
             default:


### PR DESCRIPTION
The Vertica JDBC driver always returns "NUMERIC" as the column type name via ResultSetMetaData for all exact decimal types (DECIMAL, NUMERIC, NUMBER, MONEY), which are all synonyms of the same underlying type.

The previous dialect implementation only matched the "DECIMAL" literal, which never triggers at runtime and causes all decimal columns to fail with an unsupported data type error.

This commit adds proper NUMERIC type support:
- Add VERTICA_NUMERIC constant and corresponding mapping branch
- Keep consistent precision handling: precision > 38 falls back to DECIMAL(38, 18) to align with SeaTunnel type system limits
- NUMBER and MONEY types are covered implicitly since the JDBC driver normalizes them to NUMERIC in column metadata

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
