### PR TITLE
[Docs][Connector-V2] Improve Cassandra Hbase Maxcompute Neo4j and Qdrant connector docs

### DIFF
--- a/docs/en/connectors/sink/Cassandra.md
+++ b/docs/en/connectors/sink/Cassandra.md
@@ -110,6 +110,11 @@ Sink plugin common parameters. For details, see [Sink Common Options](../common-
 - `fields` is useful when the upstream row has extra columns. It is not a schema creation option.
 - `async_write = true` improves throughput, while `batch_size` controls how many rows are grouped
   before a flush.
+- The sink uses the Cassandra Java driver. Authentication and consistency options match the
+  driver's terminology; configure `consistency_level` together with the cluster's replication
+  strategy when stronger guarantees are required.
+- `batch_type = "UNLOGGED"` is the typical default. Use `LOGGED` for atomic batches when
+  correctness outweighs throughput, or `COUNTER` for counter tables.
 
 ## Task Example
 

--- a/docs/en/connectors/sink/Hbase.md
+++ b/docs/en/connectors/sink/Hbase.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 > Hbase sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Writes SeaTunnel rows to Apache HBase. The sink can create or reuse target tables, write one or
@@ -144,16 +150,21 @@ Sink plugin common parameters, please refer to [Sink Common Options](../common-o
 ### Write One Table
 
 ```hocon
-
-Hbase {
-  zookeeper_quorum = "hadoop001:2181,hadoop002:2181,hadoop003:2181"
-  table = "seatunnel_test"
-  rowkey_column = ["name"]
-  family_name {
-    all_columns = seatunnel
-  }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
 }
 
+sink {
+  Hbase {
+    zookeeper_quorum = "hadoop001:2181,hadoop002:2181,hadoop003:2181"
+    table = "seatunnel_test"
+    rowkey_column = ["name"]
+    family_name {
+      all_columns = "seatunnel"
+    }
+  }
+}
 ```
 
 ### Create Table When It Does Not Exist
@@ -215,49 +226,49 @@ env {
 source {
   FakeSource {
     tables_configs = [
-       {
+      {
         schema = {
           table = "hbase_sink_1"
-         fields {
-                    name = STRING
-                    c_string = STRING
-                    c_double = DOUBLE
-                    c_bigint = BIGINT
-                    c_float = FLOAT
-                    c_int = INT
-                    c_smallint = SMALLINT
-                    c_boolean = BOOLEAN
-                    time = BIGINT
-           }
+          fields {
+            name = STRING
+            c_string = STRING
+            c_double = DOUBLE
+            c_bigint = BIGINT
+            c_float = FLOAT
+            c_int = INT
+            c_smallint = SMALLINT
+            c_boolean = BOOLEAN
+            time = BIGINT
+          }
         }
-            rows = [
-              {
-                kind = INSERT
-                fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
-              }
-              ]
-       },
-       {
-       schema = {
-         table = "hbase_sink_2"
-              fields {
-                    name = STRING
-                    c_string = STRING
-                    c_double = DOUBLE
-                    c_bigint = BIGINT
-                    c_float = FLOAT
-                    c_int = INT
-                    c_smallint = SMALLINT
-                    c_boolean = BOOLEAN
-                    time = BIGINT
-              }
-       }
-           rows = [
-             {
-               kind = INSERT
-               fields = ["label_2", "sink_2", 4.3, 200, 2.5, 2, 5, true, 1627529632357]
-             }
-             ]
+        rows = [
+          {
+            kind = INSERT
+            fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "hbase_sink_2"
+          fields {
+            name = STRING
+            c_string = STRING
+            c_double = DOUBLE
+            c_bigint = BIGINT
+            c_float = FLOAT
+            c_int = INT
+            c_smallint = SMALLINT
+            c_boolean = BOOLEAN
+            time = BIGINT
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["label_2", "sink_2", 4.3, 200, 2.5, 2, 5, true, 1627529632357]
+          }
+        ]
       }
     ]
   }
@@ -269,7 +280,7 @@ sink {
     table = "${table_name}"
     rowkey_column = ["name"]
     family_name {
-      all_columns = info
+      all_columns = "info"
     }
   }
 }

--- a/docs/en/connectors/sink/Maxcompute.md
+++ b/docs/en/connectors/sink/Maxcompute.md
@@ -12,9 +12,10 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## Description
 
-Used to write data to Maxcompute. The connector supports password / AccessKey authentication,
-STS-token authentication, and the default Aliyun credentials provider chain. It can append to or
-overwrite a target table or partition, create the target table from a template, and uses an upload
+Used to write data to Maxcompute. The connector supports AccessKey (`accessId`/`accesskey`)
+authentication, STS-token authentication, and the default Aliyun credentials provider chain. It can
+append to or overwrite a target table or partition, create the target table from a template, and
+uses an upload
 or upsert session selected by `insert_strategy`.
 
 ## Key features

--- a/docs/en/connectors/sink/Maxcompute.md
+++ b/docs/en/connectors/sink/Maxcompute.md
@@ -4,9 +4,18 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 > Maxcompute sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Used to write data to Maxcompute.
+Used to write data to Maxcompute. The connector supports password / AccessKey authentication,
+STS-token authentication, and the default Aliyun credentials provider chain. It can append to or
+overwrite a target table or partition, create the target table from a template, and uses an upload
+or upsert session selected by `insert_strategy`.
 
 ## Key features
 
@@ -17,27 +26,27 @@ Used to write data to Maxcompute.
 
 ## Options
 
-| name                      | type    | required | default value |
-|---------------------------|---------|----------|---------------|
-| accessId                  | string  | no       | -             |
-| accesskey                 | string  | no       | -             |
-| sts_token                 | string  | no       | -             |
-| endpoint                  | string  | yes      | -             |
-| project                   | string  | yes      | -             |
-| table_name                | string  | yes      | -             |
-| schema_name               | string  | no       | -             |
-| partition_spec            | string  | no       | -             |
-| overwrite                 | boolean | no       | false         |
-| schema_save_mode          | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode            | enum    | no       | APPEND_DATA   |
-| custom_sql                | string  | no       | -             |
-| save_mode_create_template | string  | no       | see below     |
-| datetime_format           | string  | no       | yyyy-MM-dd HH:mm:ss |
-| tunnel_endpoint           | string  | no       | -             |
-| tunnel_name               | string  | no       | -             |
-| insert_strategy           | string  | no       | upload        |
-| multi_table_sink_replica  | int     | no       | 1             |
-| common-options            | string  | no       |               |
+| name                      | type    | required | default value                | description                                                                                                              |
+|---------------------------|---------|----------|------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| accessId                  | string  | no       | -                            | Aliyun AccessKey ID used to access MaxCompute.                                                                            |
+| accesskey                 | string  | no       | -                            | Aliyun AccessKey secret used to access MaxCompute.                                                                        |
+| sts_token                 | string  | no       | -                            | STS token used for temporary MaxCompute authentication. When `sts_token` is provided, `accessId` and `accesskey` are required. |
+| endpoint                  | string  | yes      | -                            | MaxCompute endpoint, starting with `http`.                                                                                |
+| project                   | string  | yes      | -                            | MaxCompute project created in Alibaba Cloud.                                                                              |
+| table_name                | string  | yes      | -                            | Target MaxCompute table name, for example `fake`.                                                                         |
+| schema_name               | string  | no       | -                            | MaxCompute schema name (namespace between project and table). Required only when the table is in a non-default schema.    |
+| partition_spec            | string  | no       | -                            | Partition spec for a MaxCompute partitioned table, for example `ds='20220101'`.                                           |
+| overwrite                 | boolean | no       | false                        | Whether to overwrite the target table or partition.                                                                       |
+| schema_save_mode          | enum    | no       | CREATE_SCHEMA_WHEN_NOT_EXIST | How to handle the target table before writing, such as `RECREATE_SCHEMA` or `CREATE_SCHEMA_WHEN_NOT_EXIST`.                |
+| data_save_mode            | enum    | no       | APPEND_DATA                  | How to handle existing target data before writing, such as `DROP_DATA`, `APPEND_DATA`, or `ERROR_WHEN_DATA_EXISTS`.      |
+| custom_sql                | string  | no       | -                            | Custom SQL to execute before writing when `data_save_mode = CUSTOM_PROCESSING`.                                          |
+| save_mode_create_template | string  | no       | see below                    | DDL template used when the sink creates the target table.                                                                 |
+| datetime_format           | string  | no       | yyyy-MM-dd HH:mm:ss          | Format string used to convert `LocalDateTime` fields to strings.                                                         |
+| tunnel_endpoint           | string  | no       | -                            | Custom endpoint URL for the MaxCompute Tunnel service. When not set, the endpoint is auto-inferred from the region.       |
+| tunnel_name               | string  | no       | -                            | Tunnel Quota name used for exclusive resource groups. Requires both `endpoint` and `tunnel_endpoint` to be VPC endpoints. |
+| insert_strategy           | string  | no       | upload                       | Insert session strategy: `upload` uses an upload session, `upsert` uses an upsert session and requires a primary key.    |
+| multi_table_sink_replica  | int     | no       | 1                            | Number of sink writer replicas for each table in a multi-table job.                                                      |
+| common-options            |         | no       | -                            | Sink plugin common parameters, such as `plugin_input`.                                                                   |
 
 ### accessId [string]
 

--- a/docs/en/connectors/sink/Neo4j.md
+++ b/docs/en/connectors/sink/Neo4j.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-neo4j.md';
 
 > Neo4j sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 The Neo4j sink connector writes SeaTunnel rows to Neo4j by running a Cypher statement.

--- a/docs/en/connectors/sink/Qdrant.md
+++ b/docs/en/connectors/sink/Qdrant.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 > Qdrant sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 [Qdrant](https://qdrant.tech/) is a high-performance vector search engine and vector database.

--- a/docs/en/connectors/source/Cassandra.md
+++ b/docs/en/connectors/source/Cassandra.md
@@ -142,6 +142,9 @@ Source plugin common parameters. For details, see [Source Common Options](../com
 - The source is a batch source. It reads the current query result and then finishes.
 - A single CQL query is read as one source split. Increasing job parallelism does not split one
   Cassandra table scan automatically.
+- The connector uses the Cassandra Java driver. The connection options exposed in this doc are
+  the only settings the connector reads; other driver options can be supplied through the
+  runtime if needed.
 
 ## Task Example
 

--- a/docs/en/connectors/source/Cassandra.md
+++ b/docs/en/connectors/source/Cassandra.md
@@ -142,9 +142,8 @@ Source plugin common parameters. For details, see [Source Common Options](../com
 - The source is a batch source. It reads the current query result and then finishes.
 - A single CQL query is read as one source split. Increasing job parallelism does not split one
   Cassandra table scan automatically.
-- The connector uses the Cassandra Java driver. The connection options exposed in this doc are
-  the only settings the connector reads; other driver options can be supplied through the
-  runtime if needed.
+- The connector uses the Cassandra Java driver. The connection options documented above are the
+  only settings the connector reads; any other DataStax driver option uses its built-in default.
 
 ## Task Example
 

--- a/docs/en/connectors/source/Hbase.md
+++ b/docs/en/connectors/source/Hbase.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 > Hbase Source Connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Reads data from Apache HBase tables. The source supports normal scans, row key range scans, timestamp

--- a/docs/en/connectors/source/Maxcompute.md
+++ b/docs/en/connectors/source/Maxcompute.md
@@ -12,9 +12,10 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## Description
 
-Used to read data from Maxcompute. The connector supports password / AccessKey authentication,
-STS-token authentication, and the default Aliyun credentials provider chain (environment variables,
-ECS RAM roles, and so on). It can read a single table with `table_name`, a list of tables with
+Used to read data from Maxcompute. The connector supports AccessKey (`accessId`/`accesskey`)
+authentication, STS-token authentication, and the default Aliyun credentials provider chain
+(environment variables, ECS RAM roles, and so on). It can read a single table with `table_name`,
+a list of tables with
 `table_list`, and supports partitioned tables, custom column lists, and a configurable `split_row`
 for parallel reads.
 

--- a/docs/en/connectors/source/Maxcompute.md
+++ b/docs/en/connectors/source/Maxcompute.md
@@ -4,11 +4,19 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 > Maxcompute source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Used to read data from Maxcompute.
-
-## Key features
+Used to read data from Maxcompute. The connector supports password / AccessKey authentication,
+STS-token authentication, and the default Aliyun credentials provider chain (environment variables,
+ECS RAM roles, and so on). It can read a single table with `table_name`, a list of tables with
+`table_list`, and supports partitioned tables, custom column lists, and a configurable `split_row`
+for parallel reads.
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
@@ -18,23 +26,23 @@ Used to read data from Maxcompute.
 
 ## Options
 
-| name           | type   | required | default value |
-|----------------|--------|----------|---------------|
-| accessId       | string | no       | -             |
-| accesskey      | string | no       | -             |
-| sts_token      | string | no       | -             |
-| endpoint       | string | yes      | -             |
-| project        | string | yes      | -             |
-| table_name     | string | yes when `table_list` is not set | -             |
-| schema_name    | string | no       | -             |
-| partition_spec | string | no       | -             |
-| split_row      | int    | no       | 10000         |
-| read_columns   | Array  | no       | -             |
-| table_list     | Array  | No       | -             |
-| tunnel_endpoint | string | no       | -             |
-| tunnel_name     | string | no       | -             |
-| common-options | string | no       |               |
-| schema         | config | no       |               |
+| name            | type   | required                          | default value | description                                                                                                         |
+|-----------------|--------|-----------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------|
+| accessId        | string | no                                | -             | Aliyun AccessKey ID used to access MaxCompute.                                                                      |
+| accesskey       | string | no                                | -             | Aliyun AccessKey secret used to access MaxCompute.                                                                  |
+| sts_token       | string | no                                | -             | STS token used for temporary MaxCompute authentication. When `sts_token` is provided, `accessId` and `accesskey` are required. |
+| endpoint        | string | yes                               | -             | MaxCompute endpoint, starting with `http`.                                                                          |
+| project         | string | yes                               | -             | MaxCompute project created in Alibaba Cloud.                                                                        |
+| table_name      | string | yes when `table_list` is not set  | -             | Target MaxCompute table name, for example `fake`.                                                                   |
+| schema_name     | string | no                                | -             | MaxCompute schema name (namespace between project and table). Required only when the table is in a non-default schema. |
+| partition_spec  | string | no                                | -             | Partition spec for a MaxCompute partitioned table, for example `ds='20220101'`.                                     |
+| split_row       | int    | no                                | 10000         | Number of rows per split.                                                                                            |
+| read_columns    | Array  | no                                | -             | Columns to read. When not set, all columns are read, for example `["col1", "col2"]`.                                |
+| table_list      | Array  | no                                | -             | List of tables to read. Use this instead of `table_name` to read multiple MaxCompute tables in one job.              |
+| tunnel_endpoint | string | no                                | -             | Custom endpoint URL for the MaxCompute Tunnel service. When not set, the endpoint is auto-inferred from the region. |
+| tunnel_name     | string | no                                | -             | Tunnel Quota name used for exclusive resource groups. Requires both `endpoint` and `tunnel_endpoint` to be VPC endpoints. |
+| schema          | config | no                                | -             | Schema of the source table. When `read_columns` is not set, all schema fields are read.                             |
+| common-options  |        | no                                | -             | Source plugin common parameters, such as `plugin_output`.                                                           |
 
 ### accessId [string]
 

--- a/docs/en/connectors/source/Neo4j.md
+++ b/docs/en/connectors/source/Neo4j.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-neo4j.md';
 
 > Neo4j source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 The Neo4j source connector reads data from Neo4j by running a Cypher query and mapping

--- a/docs/en/connectors/source/Qdrant.md
+++ b/docs/en/connectors/source/Qdrant.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 > Qdrant source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 [Qdrant](https://qdrant.tech/) is a high-performance vector search engine and vector database.

--- a/docs/zh/connectors/sink/Cassandra.md
+++ b/docs/zh/connectors/sink/Cassandra.md
@@ -105,6 +105,9 @@ Sink 插件通用参数，详情请参考 [Sink 常用选项](../common-options/
 - 任务启动前，目标 keyspace 和表必须已经存在。
 - `fields` 适合上游数据有额外字段、只想写入其中一部分字段的场景；它不是建表配置。
 - `async_write = true` 可以提升吞吐，`batch_size` 用来控制每次 flush 前聚合的行数。
+- 连接器底层使用 Cassandra Java Driver；认证和一致性相关参数与 Driver 保持一致，需要更强一致性时请结合
+  集群的副本策略设置 `consistency_level`。
+- `batch_type = "UNLOGGED"` 是常见默认值；当正确性优先于吞吐时使用 `LOGGED`，counter 表使用 `COUNTER`。
 
 ## 任务示例
 

--- a/docs/zh/connectors/sink/Hbase.md
+++ b/docs/zh/connectors/sink/Hbase.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 > Hbase 接收器连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 将 SeaTunnel 数据写入 Apache HBase。支持创建或复用目标表、写入单表或多表、把字段映射到一个或多个列簇，并可控制空值、行键、WAL、时间戳和已有数据的处理方式。
@@ -138,16 +144,21 @@ Sink 插件常用参数，详见 Sink 常用选项 [Sink Common Options](../comm
 ### 写入单表
 
 ```hocon
-
-Hbase {
-  zookeeper_quorum = "hadoop001:2181,hadoop002:2181,hadoop003:2181"
-  table = "seatunnel_test"
-  rowkey_column = ["name"]
-  family_name {
-    all_columns = seatunnel
-  }
+env {
+  parallelism = 1
+  job.mode = "BATCH"
 }
 
+sink {
+  Hbase {
+    zookeeper_quorum = "hadoop001:2181,hadoop002:2181,hadoop003:2181"
+    table = "seatunnel_test"
+    rowkey_column = ["name"]
+    family_name {
+      all_columns = "seatunnel"
+    }
+  }
+}
 ```
 
 ### 目标表不存在时自动创建
@@ -209,49 +220,49 @@ env {
 source {
   FakeSource {
     tables_configs = [
-       {
+      {
         schema = {
           table = "hbase_sink_1"
-         fields {
-                    name = STRING
-                    c_string = STRING
-                    c_double = DOUBLE
-                    c_bigint = BIGINT
-                    c_float = FLOAT
-                    c_int = INT
-                    c_smallint = SMALLINT
-                    c_boolean = BOOLEAN
-                    time = BIGINT
-           }
+          fields {
+            name = STRING
+            c_string = STRING
+            c_double = DOUBLE
+            c_bigint = BIGINT
+            c_float = FLOAT
+            c_int = INT
+            c_smallint = SMALLINT
+            c_boolean = BOOLEAN
+            time = BIGINT
+          }
         }
-            rows = [
-              {
-                kind = INSERT
-                fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
-              }
-              ]
-       },
-       {
-       schema = {
-         table = "hbase_sink_2"
-              fields {
-                    name = STRING
-                    c_string = STRING
-                    c_double = DOUBLE
-                    c_bigint = BIGINT
-                    c_float = FLOAT
-                    c_int = INT
-                    c_smallint = SMALLINT
-                    c_boolean = BOOLEAN
-                    time = BIGINT
-              }
-       }
-           rows = [
-             {
-               kind = INSERT
-               fields = ["label_2", "sink_2", 4.3, 200, 2.5, 2, 5, true, 1627529632357]
-             }
-             ]
+        rows = [
+          {
+            kind = INSERT
+            fields = ["label_1", "sink_1", 4.3, 200, 2.5, 2, 5, true, 1627529632356]
+          }
+        ]
+      },
+      {
+        schema = {
+          table = "hbase_sink_2"
+          fields {
+            name = STRING
+            c_string = STRING
+            c_double = DOUBLE
+            c_bigint = BIGINT
+            c_float = FLOAT
+            c_int = INT
+            c_smallint = SMALLINT
+            c_boolean = BOOLEAN
+            time = BIGINT
+          }
+        }
+        rows = [
+          {
+            kind = INSERT
+            fields = ["label_2", "sink_2", 4.3, 200, 2.5, 2, 5, true, 1627529632357]
+          }
+        ]
       }
     ]
   }
@@ -263,7 +274,7 @@ sink {
     table = "${table_name}"
     rowkey_column = ["name"]
     family_name {
-      all_columns = info
+      all_columns = "info"
     }
   }
 }

--- a/docs/zh/connectors/sink/Maxcompute.md
+++ b/docs/zh/connectors/sink/Maxcompute.md
@@ -12,7 +12,7 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## 描述
 
-用于向 Maxcompute 写入数据。连接器支持账号密码认证、STS Token 临时认证以及阿里云默认凭据链免密认证；支持追加写入、覆盖整表或分区、自动创建目标表（基于 DDL 模板）以及通过 `insert_strategy` 选择 upload 或 upsert 会话。
+用于向 Maxcompute 写入数据。连接器支持 AccessKey（`accessId`/`accesskey`）认证、STS Token 临时认证以及阿里云默认凭据链免密认证；支持追加写入、覆盖整表或分区、自动创建目标表（基于 DDL 模板）以及通过 `insert_strategy` 选择 upload 或 upsert 会话。
 
 ## 主要特性
 

--- a/docs/zh/connectors/sink/Maxcompute.md
+++ b/docs/zh/connectors/sink/Maxcompute.md
@@ -4,9 +4,15 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 > Maxcompute 接收器连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
-用于向 Maxcompute 写入数据。
+用于向 Maxcompute 写入数据。连接器支持账号密码认证、STS Token 临时认证以及阿里云默认凭据链免密认证；支持追加写入、覆盖整表或分区、自动创建目标表（基于 DDL 模板）以及通过 `insert_strategy` 选择 upload 或 upsert 会话。
 
 ## 主要特性
 
@@ -17,27 +23,27 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## 选项
 
-| 参数名                    | 类型    | 必须 | 默认值 |
-|---------------------------|---------|------|--------|
-| accessId                  | string  | 否   | -      |
-| accesskey                 | string  | 否   | -      |
-| sts_token                 | string  | 否   | -      |
-| endpoint                  | string  | 是   | -      |
-| project                   | string  | 是   | -      |
-| table_name                | string  | 是   | -      |
-| schema_name               | string  | 否   | -      |
-| partition_spec            | string  | 否   | -      |
-| overwrite                 | boolean | 否   | false  |
-| schema_save_mode          | enum    | 否   | CREATE_SCHEMA_WHEN_NOT_EXIST |
-| data_save_mode            | enum    | 否   | APPEND_DATA |
-| custom_sql                | string  | 否   | -      |
-| save_mode_create_template | string  | 否   | 见下文 |
-| datetime_format           | string  | 否   | yyyy-MM-dd HH:mm:ss |
-| tunnel_endpoint           | string  | 否   | -      |
-| tunnel_name               | string  | 否   | -      |
-| insert_strategy           | string  | 否   | upload |
-| multi_table_sink_replica  | int     | 否   | 1      |
-| common-options            | string  | 否   |        |
+| 参数名                    | 类型    | 必须 | 默认值                       | 说明                                                                                              |
+|---------------------------|---------|------|------------------------------|---------------------------------------------------------------------------------------------------|
+| accessId                  | string  | 否   | -                            | 访问 MaxCompute 的 AccessKey ID。                                                                  |
+| accesskey                 | string  | 否   | -                            | 访问 MaxCompute 的 AccessKey Secret。                                                              |
+| sts_token                 | string  | 否   | -                            | MaxCompute 临时认证 STS Token；配置 `sts_token` 时 `accessId` 与 `accesskey` 必填。                  |
+| endpoint                  | string  | 是   | -                            | MaxCompute 端点，以 `http` 开头。                                                                  |
+| project                   | string  | 是   | -                            | 在阿里云中创建的 MaxCompute 项目。                                                                  |
+| table_name                | string  | 是   | -                            | 目标 MaxCompute 表名，例如 `fake`。                                                                |
+| schema_name               | string  | 否   | -                            | MaxCompute Schema 名称；仅当表位于非默认 Schema 时需要设置。                                       |
+| partition_spec            | string  | 否   | -                            | MaxCompute 分区表的规范，例如 `ds='20220101'`。                                                    |
+| overwrite                 | boolean | 否   | false                        | 是否覆盖整张表或单个分区。                                                                          |
+| schema_save_mode          | enum    | 否   | CREATE_SCHEMA_WHEN_NOT_EXIST | 写入前如何处理目标表结构，例如 `RECREATE_SCHEMA` 或 `CREATE_SCHEMA_WHEN_NOT_EXIST`。                |
+| data_save_mode            | enum    | 否   | APPEND_DATA                  | 写入前如何处理已有数据，例如 `DROP_DATA`、`APPEND_DATA`、`ERROR_WHEN_DATA_EXISTS`。                |
+| custom_sql                | string  | 否   | -                            | 当 `data_save_mode = CUSTOM_PROCESSING` 时执行的 SQL。                                              |
+| save_mode_create_template | string  | 否   | 见下文                       | 在 sink 自动建表时使用的 DDL 模板。                                                                  |
+| datetime_format           | string  | 否   | yyyy-MM-dd HH:mm:ss          | 将 `LocalDateTime` 字段序列化为字符串时使用的格式。                                                  |
+| tunnel_endpoint           | string  | 否   | -                            | MaxCompute Tunnel 服务的自定义端点；未配置时根据区域自动推断。                                       |
+| tunnel_name               | string  | 否   | -                            | Tunnel Quota 名称；需同时将 `endpoint` 与 `tunnel_endpoint` 配置为 VPC 端点。                       |
+| insert_strategy           | string  | 否   | upload                       | 插入会话类型：`upload` 使用 upload 会话，`upsert` 使用 upsert 会话并要求目标表存在主键。            |
+| multi_table_sink_replica  | int     | 否   | 1                            | 多表写入时每张表对应的 Sink Writer 副本数。                                                         |
+| common-options            |         | 否   | -                            | Sink 插件通用参数，例如 `plugin_input`。                                                            |
 
 ### accessId [string]
 

--- a/docs/zh/connectors/sink/Neo4j.md
+++ b/docs/zh/connectors/sink/Neo4j.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-neo4j.md';
 
 > Neo4j Sink 连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Neo4j Sink 连接器通过执行 Cypher 语句把 SeaTunnel 数据写入 Neo4j。它支持逐条写入，

--- a/docs/zh/connectors/sink/Qdrant.md
+++ b/docs/zh/connectors/sink/Qdrant.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 > Qdrant 数据写入连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 [Qdrant](https://qdrant.tech/) 是一个高性能的向量搜索引擎和向量数据库。

--- a/docs/zh/connectors/source/Cassandra.md
+++ b/docs/zh/connectors/source/Cassandra.md
@@ -135,6 +135,8 @@ Source 插件通用参数，详情请参考 [Source 常用选项](../common-opti
   `tables_configs`。
 - 这是批处理 source。它读取当前查询结果后就会结束。
 - 一个 CQL 查询会作为一个 source split 读取。调大任务并行度不会自动把单张 Cassandra 表拆成多个扫描任务。
+- 连接器底层使用 Cassandra Java Driver，本文档列出的连接选项是连接器实际读取的设置；其他 Driver 选项
+  可以在运行时按需传入。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/Cassandra.md
+++ b/docs/zh/connectors/source/Cassandra.md
@@ -135,8 +135,8 @@ Source 插件通用参数，详情请参考 [Source 常用选项](../common-opti
   `tables_configs`。
 - 这是批处理 source。它读取当前查询结果后就会结束。
 - 一个 CQL 查询会作为一个 source split 读取。调大任务并行度不会自动把单张 Cassandra 表拆成多个扫描任务。
-- 连接器底层使用 Cassandra Java Driver，本文档列出的连接选项是连接器实际读取的设置；其他 Driver 选项
-  可以在运行时按需传入。
+- 连接器底层使用 Cassandra Java Driver，本文档列出的连接选项是连接器实际读取的全部设置；其他
+  DataStax Driver 选项沿用其内置默认值。
 
 ## 任务示例
 

--- a/docs/zh/connectors/source/Hbase.md
+++ b/docs/zh/connectors/source/Hbase.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-hbase.md';
 
 > Hbase 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 从 Apache HBase 表读取数据。支持普通扫描、行键范围扫描、时间戳范围扫描、二进制行键、自定义命名空间和并行批读取。

--- a/docs/zh/connectors/source/Maxcompute.md
+++ b/docs/zh/connectors/source/Maxcompute.md
@@ -12,7 +12,7 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## 描述
 
-用于从 Maxcompute 读取数据。连接器支持账号密码认证、STS Token 临时认证，以及阿里云默认凭据链（环境变量、ECS RAM 角色等）免密认证；支持通过 `table_name` 读取单表、通过 `table_list` 读取多表，并支持分区表、自定义列和并行读取所需的 `split_row`。
+用于从 Maxcompute 读取数据。连接器支持 AccessKey（`accessId`/`accesskey`）认证、STS Token 临时认证，以及阿里云默认凭据链（环境变量、ECS RAM 角色等）免密认证；支持通过 `table_name` 读取单表、通过 `table_list` 读取多表，并支持分区表、自定义列和并行读取所需的 `split_row`。
 
 ## 主要特性
 

--- a/docs/zh/connectors/source/Maxcompute.md
+++ b/docs/zh/connectors/source/Maxcompute.md
@@ -4,9 +4,15 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 > Maxcompute 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
-用于从 Maxcompute 读取数据。
+用于从 Maxcompute 读取数据。连接器支持账号密码认证、STS Token 临时认证，以及阿里云默认凭据链（环境变量、ECS RAM 角色等）免密认证；支持通过 `table_name` 读取单表、通过 `table_list` 读取多表，并支持分区表、自定义列和并行读取所需的 `split_row`。
 
 ## 主要特性
 
@@ -18,23 +24,23 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 
 ## 选项
 
-| 名称           |  类型  | 必需 | 默认值 |
-|----------------|--------|----|---------------|
-| accessId       | string | 否  | -             |
-| accesskey      | string | 否  | -             |
-| sts_token      | string | 否  | -             |
-| endpoint       | string | 是  | -             |
-| project        | string | 是  | -             |
-| table_name     | string | 未配置 `table_list` 时必填 | -             |
-| schema_name    | string | 否  | -             |
-| partition_spec | string | 否  | -             |
-| split_row      | int    | 否 | 10000         |
-| read_columns   | Array  | 否 | -             |
-| table_list     | Array  | 否 | -             |
-| tunnel_endpoint | string | 否 | -             |
-| tunnel_name     | string | 否 | -             |
-| common-options | string | 否 |               |
-| schema         | config | 否 |               |
+| 名称            | 类型   | 必需                               | 默认值 | 说明                                                                                                        |
+|-----------------|--------|------------------------------------|--------|-------------------------------------------------------------------------------------------------------------|
+| accessId        | string | 否                                 | -      | 访问 MaxCompute 的 AccessKey ID。                                                                            |
+| accesskey       | string | 否                                 | -      | 访问 MaxCompute 的 AccessKey Secret。                                                                       |
+| sts_token       | string | 否                                 | -      | MaxCompute 临时认证 STS Token。配置 `sts_token` 时，`accessId` 与 `accesskey` 必填。                          |
+| endpoint        | string | 是                                 | -      | MaxCompute 端点，以 `http` 开头。                                                                            |
+| project         | string | 是                                 | -      | 在阿里云中创建的 MaxCompute 项目。                                                                           |
+| table_name      | string | 未配置 `table_list` 时必填          | -      | 目标 MaxCompute 表名，例如 `fake`。                                                                          |
+| schema_name     | string | 否                                 | -      | MaxCompute Schema 名称（Project 与 Table 之间的命名空间）。仅当表位于非默认 Schema 时需要设置。               |
+| partition_spec  | string | 否                                 | -      | MaxCompute 分区表的规范，例如 `ds='20220101'`。                                                              |
+| split_row       | int    | 否                                 | 10000  | 每个 split 包含的行数。                                                                                       |
+| read_columns    | Array  | 否                                 | -      | 要读取的列；不设置时读取全部列，例如 `["col1", "col2"]`。                                                    |
+| table_list      | Array  | 否                                 | -      | 要读取的表列表；可替代 `table_name` 一次读取多张 MaxCompute 表。                                              |
+| tunnel_endpoint | string | 否                                 | -      | MaxCompute Tunnel 服务的自定义端点；未配置时根据区域自动推断。                                                |
+| tunnel_name     | string | 否                                 | -      | Tunnel Quota 名称；需同时将 `endpoint` 与 `tunnel_endpoint` 配置为 VPC 端点。                                |
+| schema          | config | 否                                 | -      | 源表结构；未配置 `read_columns` 时按 schema 中字段读取。                                                       |
+| common-options  |        | 否                                 | -      | Source 插件通用参数，例如 `plugin_output`。                                                                  |
 
 ### accessId [string]
 
@@ -100,16 +106,7 @@ import ChangeLog from '../changelog/connector-maxcompute.md';
 MaxCompute Tunnel 服务的自定义端点。未配置时，连接器会根据区域自动推断默认 Tunnel 端点。
 一般只有自定义网络、调试或本地开发时才需要配置，例如 `http://maxcompute:8080`。
 
-### tunnel_endpoint [String]
-
-指定 MaxCompute Tunnel 服务的自定义端点 URL。
-
-默认情况下，端点是从配置的区域自动推断的。
-
-此选项允许您覆盖默认行为并使用自定义 Tunnel 端点。
-如果未指定，连接器将使用基于区域的默认 Tunnel 端点。
-
-通常，您**不需要**设置 tunnel_endpoint。仅在自定义网络、调试或本地开发时才需要。
+通常，您**不需要**设置 `tunnel_endpoint`。仅在自定义网络、调试或本地开发时才需要。
 
 示例值：
 

--- a/docs/zh/connectors/source/Neo4j.md
+++ b/docs/zh/connectors/source/Neo4j.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-neo4j.md';
 
 > Neo4j 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Neo4j 源连接器通过执行 Cypher 查询从 Neo4j 读取数据，并把查询返回字段映射成 SeaTunnel

--- a/docs/zh/connectors/source/Qdrant.md
+++ b/docs/zh/connectors/source/Qdrant.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-qdrant.md';
 
 > Qdrant 数据源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 [Qdrant](https://qdrant.tech/) 是一个高性能的向量搜索引擎和向量数据库。


### PR DESCRIPTION
### Purpose

This PR improves the documentation of five connector-V2 docs in `docs/en` and `docs/zh`:

- Cassandra (`source/Cassandra.md`, `sink/Cassandra.md`)
- Hbase (`source/Hbase.md`, `sink/Hbase.md`)
- Maxcompute (`source/Maxcompute.md`, `sink/Maxcompute.md`)
- Neo4j (`source/Neo4j.md`, `sink/Neo4j.md`)
- Qdrant (`source/Qdrant.md`, `sink/Qdrant.md`)

The goal is to align the docs with the current connector code, add the missing `Support Those Engines` section that the other connector docs already use, fix known structural bugs in the existing docs, and ensure both languages stay in sync. No source code is modified, no source-version metadata is touched, and no recent PR (within the last 7 days) on the same files is duplicated.

### Changes

- **Cassandra (source & sink)**: Add notes that explicitly mention the Cassandra Java Driver and clarify the `batch_type` / `async_write` semantics on the sink side.
- **Hbase (source & sink)**: Add the missing `Support Those Engines` section. Rewrite the `Write One Table` example so it is wrapped in `env` and `sink {}` blocks (the previous Hocon snippet was malformed and was missing a top-level wrapper). Reformat the multi-table `FakeSource` example to use consistent indentation and quoted string literals.
- **Maxcompute (source & sink)**: Add the missing `Support Those Engines` section. Replace the option tables with the typed `Name / Type / Required / Default / Description` form for both languages so every option has an explicit description. Expand the `Description` section with the new auth, partition, template, and `insert_strategy` semantics. In the Chinese source doc, remove the duplicated `tunnel_endpoint` section that left two `### tunnel_endpoint` headings stacked.
- **Neo4j (source & sink)**: Add the missing `Support Those Engines` section.
- **Qdrant (source & sink)**: Add the missing `Support Those Engines` section.

### Validation

- Spot-checked option names, types, and defaults against the connector source code (`connector-cassandra`, `connector-hbase`, `connector-maxcompute`, `connector-neo4j`, and `connector-qdrant`).
- Bilingual parity: every English doc change is mirrored in the corresponding Chinese doc; only the missing sections, fixed structural bugs, and table forms were edited.
- Markdown structure follows the same shape used by the recently merged connector doc PRs.
- No version metadata in the changelog files is modified.

### Notes

- This PR is opened as a draft per the contributor workflow; it will be marked ready for review after CI passes.
- Five connectors were touched per batch, matching the contributor guidance.
- Old PRs from `DanielCarter-stack` have been reviewed; the only outstanding build issue (#11709) does not block this PR and will be handled on its own branch.
