### PR TITLE
[Docs][Connector-V2] Improve RocketMQ Kudu Kingbase Vertica and AmazonDynamoDB connector docs

### DIFF
--- a/docs/en/connectors/sink/AmazonDynamoDB.md
+++ b/docs/en/connectors/sink/AmazonDynamoDB.md
@@ -1,16 +1,12 @@
 import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
-# AmazonDynamoDB
+# AmazonDynamoDB Sink Connector
 
-> Amazon DynamoDB sink connector
+`Sink: AmazonDynamoDB`
 
-## Description
+Write SeaTunnel rows to a DynamoDB table. The target table must already exist; the connector does not create tables or key schemas. Each row is written as a DynamoDB item through a batch write request, so the connector supports single-table writes (by configuring `table`) and multi-table writes (when the upstream row carries a table id, the writer routes each row to that target).
 
-The Amazon DynamoDB sink connector writes SeaTunnel rows to a DynamoDB table.
-
-The target table must already exist. The connector writes each row as a DynamoDB item and uses batch write requests. It supports single-table writes and multi-table writes when the upstream row carries a table id.
-
-## Supported Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -18,25 +14,27 @@ The target table must already exist. The connector writes each row as a DynamoDB
 
 ## Key Features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Sink Options
 
-| name                | type   | required | default value | description                                      |
+| Name                | Type   | Required | Default Value | Description                                      |
 |---------------------|--------|----------|---------------|--------------------------------------------------|
-| url                 | string | yes      | -             | DynamoDB endpoint URL.                           |
-| region              | string | yes      | -             | AWS region of the DynamoDB service.              |
-| access_key_id       | string | yes      | -             | AWS access key ID.                               |
-| secret_access_key   | string | yes      | -             | AWS secret access key.                           |
-| table               | string | yes      | -             | DynamoDB table name to write to.                 |
-| batch_size          | int    | no       | 25            | Records buffered for one batch write request.    |
-| multi_table_sink_replica | int | no       | -             | Sink writer replicas for each table.             |
-| max_retries         | int    | no       | 10            | Retries for unprocessed items.                   |
-| retry_base_delay_ms | long   | no       | 100           | Initial retry backoff delay in milliseconds.     |
-| retry_max_delay_ms  | long   | no       | 5000          | Maximum retry backoff delay in milliseconds.     |
-| common-options      | object | no       | -             | Sink plugin common parameters.                   |
+| url                 | String | Yes      | -             | DynamoDB endpoint URL. For local testing, use `http://127.0.0.1:8000`. |
+| region              | String | Yes      | -             | AWS region of the DynamoDB service, for example `us-east-1`. |
+| access_key_id       | String | Yes      | -             | AWS access key ID.                               |
+| secret_access_key   | String | Yes      | -             | AWS secret access key.                           |
+| table               | String | Yes      | -             | DynamoDB table name to write to. Used as the per-row target only when the upstream row does not carry a table id; otherwise the row's table id is preferred. |
+| batch_size          | Int    | No       | 25            | Records buffered for one DynamoDB batch write request. DynamoDB accepts at most 25 write requests in one batch write call, so do not set this above `25`. |
+| multi_table_sink_replica | Int | No       | -             | Optional common sink option used by multi-table sink jobs. For details, see [Sink Common Options](../common-options/sink-common-options.md). |
+| max_retries         | Int    | No       | 10            | Retries for unprocessed items returned by DynamoDB. |
+| retry_base_delay_ms | Long   | No       | 100           | Initial retry backoff delay in milliseconds.     |
+| retry_max_delay_ms  | Long   | No       | 5000          | Maximum retry backoff delay in milliseconds (exponential).    |
+| common-options      | object | No       | -             | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md). |
 
 ### url [string]
 

--- a/docs/en/connectors/sink/Kingbase.md
+++ b/docs/en/connectors/sink/Kingbase.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Kingbase
+# Kingbase Sink Connector
 
-> JDBC Kingbase Sink Connector
+`Sink: Kingbase` (via the JDBC plugin)
+
+Write data to a KingbaseES database through the JDBC connector. Kingbase is configured by setting the JDBC plugin's `driver` to `com.kingbase8.Driver` and `url` to a `jdbc:kingbase8://` URL. Writes support batch flushing and the optional XA-based exactly-once mode that the generic JDBC sink provides — but only if the Kingbase JDBC driver exposes an XA `DataSource`; if not, keep `is_exactly_once=false`.
 
 ## Support Connector Version
 
@@ -16,14 +18,12 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Key Features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-## Description
-
-> Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
-> support `Xa transactions`. You can set `is_exactly_once=true` to enable it.Kingbase currently does not support
+If you set `is_exactly_once = true`, the connector uses JDBC XA transactions; the driver must therefore expose an XA `DataSource`.
 
 ## Supported DataSource Info
 

--- a/docs/en/connectors/sink/Kudu.md
+++ b/docs/en/connectors/sink/Kudu.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-kudu.md';
 
-# Kudu
+# Kudu Sink Connector
 
-> Kudu sink connector
+`Sink: Kudu`
+
+Writes SeaTunnel rows to Apache Kudu tables. Each row kind is mapped to a Kudu write operation — `INSERT` rows append, `UPDATE_AFTER` rows upsert, and `DELETE` rows delete by primary key. Rows can be routed to a single target table or to multiple tables using placeholders in `table_name`.
 
 ## Support Kudu Version
 
@@ -16,6 +18,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 
 ## Key Features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
@@ -39,21 +42,21 @@ import ChangeLog from '../changelog/connector-kudu.md';
 
 |                   Name                    |  Type  | Required |                    Default                     |                                                                 Description                                                                 |
 |-------------------------------------------|--------|----------|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| kudu_masters                              | String | Yes      | -                                              | Kudu master address. Separated by ',',such as '192.168.88.110:7051'.                                                                        |
-| table_name                                | String | No       | Upstream table name                            | The name of the Kudu table. If this option is omitted, SeaTunnel uses the upstream table name. In multi-table jobs, placeholders such as `${database_name}`, `${schema_name}`, and `${table_name}` can be used. |
-| client_worker_count                       | Int    | No       | 2 * Runtime.getRuntime().availableProcessors() | Kudu worker count. Default value is twice the current number of cpu cores.                                                                  |
-| client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Kudu normal operation time out.                                                                                                             |
-| client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Kudu admin operation time out.                                                                                                              |
-| enable_kerberos                           | Bool   | No       | false                                          | Kerberos principal enable.                                                                                                                  |
-| kerberos_principal                        | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                  |
-| kerberos_keytab                           | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                  |
-| kerberos_krb5conf                         | String | No       | -                                              | Kerberos krb5 conf. Note that all zeta nodes require have this file.                                                                        |
-| save_mode                                 | String | No       | APPEND                                         | Storage mode. Supported values are `append` and `overwrite`. In `overwrite` mode, insert rows are written as Kudu upserts.                                                                                             |
-| session_flush_mode                        | String | No       | AUTO_FLUSH_SYNC                                | Kudu flush mode. Supported values are `AUTO_FLUSH_SYNC`, `AUTO_FLUSH_BACKGROUND`, and `MANUAL_FLUSH`.                                                                                                   |
-| batch_size                                | Int    | No       | 1024                                           | Required only when `session_flush_mode` is `AUTO_FLUSH_BACKGROUND` or `MANUAL_FLUSH`. The writer flushes after this many append, upsert, or delete records. |
-| buffer_flush_interval                     | Int    | No       | 10000                                          | Required only when `session_flush_mode = AUTO_FLUSH_BACKGROUND`. The asynchronous writer flush interval, in milliseconds.                                                             |
-| ignore_not_found                          | Bool   | No       | false                                          | If true, ignore all not found rows.                                                                                                         |
-| ignore_not_duplicate                      | Bool   | No       | false                                          | If true, ignore all duplicate rows.                                                                                                          |
+| kudu_masters                              | String | Yes      | -                                              | Comma-separated list of Kudu master addresses, for example `192.168.88.110:7051`.                                                                        |
+| table_name                                | String | No       | Upstream table name                            | Name of the Kudu table to write to. When omitted, SeaTunnel uses the table id carried by the upstream row. In multi-table jobs, placeholders such as `${database_name}`, `${schema_name}`, and `${table_name}` are substituted with the row's table id. |
+| client_worker_count                       | Int    | No       | 2 * Runtime.getRuntime().availableProcessors() | Number of Kudu client workers. Default value is twice the number of CPU cores available to the JVM.                                                                  |
+| client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Default Kudu operation timeout in milliseconds.                                                                                                             |
+| client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Default Kudu admin operation timeout in milliseconds.                                                                                                              |
+| enable_kerberos                           | Bool   | No       | false                                          | Whether to enable Kerberos authentication for the Kudu client.                                                                                                                  |
+| kerberos_principal                        | String | Conditional (when `enable_kerberos = true`) | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                  |
+| kerberos_keytab                           | String | Conditional (when `enable_kerberos = true`) | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                  |
+| kerberos_krb5conf                         | String | No       | -                                              | Kerberos `krb5.conf` path. Required on every Zeta node that runs the connector.                                                                        |
+| save_mode                                 | String | No       | append                                         | Write mode. Supported values are `append` and `overwrite`. In `overwrite` mode, insert rows are written as Kudu upserts and existing rows are replaced.                                                                                             |
+| session_flush_mode                        | String | No       | AUTO_FLUSH_SYNC                                | Kudu session flush mode. Supported values are `AUTO_FLUSH_SYNC`, `AUTO_FLUSH_BACKGROUND`, and `MANUAL_FLUSH`.                                                                                                   |
+| batch_size                                | Int    | No (required for async flush modes) | 1024                                           | Required only when `session_flush_mode` is `AUTO_FLUSH_BACKGROUND` or `MANUAL_FLUSH`. The writer flushes after this many append, upsert, or delete records. |
+| buffer_flush_interval                     | Int    | No (required for AUTO_FLUSH_BACKGROUND) | 10000                                          | Required only when `session_flush_mode = AUTO_FLUSH_BACKGROUND`. The asynchronous writer flush interval, in milliseconds.                                                             |
+| ignore_not_found                          | Bool   | No       | false                                          | When `true`, ignore "row not found" errors during updates and deletes — useful when rows may have been deleted out of band.                                                                                                         |
+| ignore_not_duplicate                      | Bool   | No       | false                                          | When `true`, ignore "row already present" errors during inserts — useful when rows are idempotent and may already exist.                                                                                                          |
 | multi_table_sink_replica                  | Int    | No       | 1                                              | Number of sink writer replicas for each table in a multi-table job.                                                                          |
 | common-options                            |        | No       | -                                              | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                            |
 
@@ -61,7 +64,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 
 - `table_name` is optional. If it is not set, the sink writes to the table name carried by the upstream row.
 - For multi-table jobs, use placeholders in `table_name` to route rows to different Kudu tables.
-- CDC rows are supported: insert records are appended, update records are written as upserts, and delete records are deleted by key.
+- CDC rows are supported: `INSERT` records are appended, `UPDATE_AFTER` records are written as upserts, and `DELETE` records are deleted by key.
 - `batch_size` is required only for `AUTO_FLUSH_BACKGROUND` or `MANUAL_FLUSH`. `buffer_flush_interval`
   is required only for `AUTO_FLUSH_BACKGROUND`.
 - When `enable_kerberos = true`, both `kerberos_principal` and `kerberos_keytab` are required.

--- a/docs/en/connectors/sink/RocketMQ.md
+++ b/docs/en/connectors/sink/RocketMQ.md
@@ -19,12 +19,12 @@ Writes SeaTunnel rows to an Apache RocketMQ topic. The sink supports JSON and te
 ## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-The sink respects the row kind of upstream rows. `INSERT` and `UPDATE_AFTER` rows are sent as new messages, and `DELETE` rows are sent with empty bodies so RocketMQ-side consumers can recognize tombstones.
+Each upstream row is serialized into a single RocketMQ message. The sink does not branch on row kind, so `INSERT`, `UPDATE_AFTER`, and `DELETE` rows are all sent with the configured format and field delimiter; no tombstone/empty-body handling is performed today.
 
 ## Sink Options
 

--- a/docs/en/connectors/sink/RocketMQ.md
+++ b/docs/en/connectors/sink/RocketMQ.md
@@ -1,14 +1,16 @@
 import ChangeLog from '../changelog/connector-rocketmq.md';
 
-# RocketMQ
+# RocketMQ Sink Connector
 
-> RocketMQ sink connector
+`Sink: RocketMQ`
+
+Writes SeaTunnel rows to an Apache RocketMQ topic. The sink supports JSON and text message bodies, optional message tags, synchronous sending, partition key fields, and transactional messages when `exactly.once = true`.
 
 ## Support Apache RocketMQ Version
 
 - 4.9.0 or newer
 
-## Support These Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -16,33 +18,33 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 ## Key Features
 
-- [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-## Description
-
-Writes SeaTunnel rows to an Apache RocketMQ topic. The sink supports JSON and text message bodies, optional message tags, synchronous sending, partition key fields, and transactional messages when `exactly.once = true`.
+The sink respects the row kind of upstream rows. `INSERT` and `UPDATE_AFTER` rows are sent as new messages, and `DELETE` rows are sent with empty bodies so RocketMQ-side consumers can recognize tombstones.
 
 ## Sink Options
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| topic | String | yes | - | RocketMQ topic name. |
-| name.srv.addr | String | yes | - | RocketMQ name server address, for example `localhost:9876`. |
-| acl.enabled | Boolean | no | false | Whether to enable RocketMQ ACL authentication. |
-| access.key | String | no | - | Access key. Required when `acl.enabled` is `true`. |
-| secret.key | String | no | - | Secret key. Required when `acl.enabled` is `true`. |
-| producer.group | String | no | SeaTunnel-Producer-Group | RocketMQ producer group ID. |
-| tag | String | no | - | RocketMQ message tag written with each message. |
-| partition.key.fields | List | no | - | Field names serialized as the RocketMQ message key. Every listed field must exist in the upstream schema. |
-| format | String | no | json | Message format. Supported values are `json` and `text`. |
-| field.delimiter | String | no | `,` | Field delimiter used when `format = text`. |
-| producer.send.sync | Boolean | no | false | Whether to send messages synchronously. When `false`, messages are sent asynchronously. |
-| exactly.once | Boolean | no | false | Whether to send transactional messages for exactly-once delivery. |
-| max.message.size | int | no | 4194304 | Maximum message body size in bytes. |
-| send.message.timeout | int | no | 3000 | Send timeout in milliseconds. |
-| common-options | config | no | - | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md). |
+| topic | String | Yes | - | RocketMQ topic name. |
+| name.srv.addr | String | Yes | - | RocketMQ NameServer address, for example `localhost:9876`. |
+| acl.enabled | Boolean | No | false | Whether to enable RocketMQ ACL authentication. |
+| access.key | String | No | - | Access key. Required when `acl.enabled` is `true`. |
+| secret.key | String | No | - | Secret key. Required when `acl.enabled` is `true`. |
+| producer.group | String | No | SeaTunnel-Producer-Group | RocketMQ producer group ID. |
+| tag | String | No | - | RocketMQ message tag written with each message. |
+| partition.key.fields | List | No | - | Field names serialized as the RocketMQ message key. Every listed field must exist in the upstream schema. |
+| format | String | No | json | Message format. Supported values are `json` and `text`. |
+| field.delimiter | String | No | `,` | Field delimiter used when `format = text`. |
+| producer.send.sync | Boolean | No | false | Whether to send messages synchronously. When `false`, messages are sent asynchronously. |
+| exactly.once | Boolean | No | false | Whether to send transactional messages for exactly-once delivery. |
+| max.message.size | Int | No | 4194304 | Maximum message body size in bytes. |
+| send.message.timeout | Int | No | 3000 | Send timeout in milliseconds. |
+| common-options | config | No | - | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md). |
 
 ## Option Notes
 

--- a/docs/en/connectors/sink/Vertica.md
+++ b/docs/en/connectors/sink/Vertica.md
@@ -1,19 +1,16 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Vertica
+# Vertica Sink Connector
 
-> JDBC Vertica Sink Connector
+`Sink: Vertica` (via the JDBC plugin)
+
+Write data to a Vertica database through the JDBC connector. Vertica is configured by setting the JDBC plugin's `driver` to `com.vertica.jdbc.Driver` and `url` to a `jdbc:vertica://` URL. Both batch and streaming jobs are supported, and the sink can run with concurrent writers. Exactly-once is **not** enabled by default: Vertica is not listed with a JDBC XA data source in the shared JDBC appendix, so keep `is_exactly_once = false` unless your Vertica driver exposes a compatible XA `DataSource`.
 
 ## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
 > SeaTunnel Zeta<br/>
-
-## Description
-
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
-semantics (using XA transaction guarantee).
 
 ## Using Dependency
 
@@ -27,10 +24,9 @@ semantics (using XA transaction guarantee).
 
 ## Key Features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
-
-> Vertica is listed without a JDBC XA data source in the shared JDBC appendix, so this connector should be used with the default `is_exactly_once=false`.
 - [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## Supported DataSource Info

--- a/docs/en/connectors/source/AmazonDynamoDB.md
+++ b/docs/en/connectors/source/AmazonDynamoDB.md
@@ -1,18 +1,12 @@
 import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
-# AmazonDynamoDB
+# AmazonDynamoDB Source Connector
 
-> Amazon DynamoDB source connector
+`Source: AmazonDynamoDB`
 
-## Description
+Read existing items from an Amazon DynamoDB table by issuing DynamoDB scan requests. The connector is a batch source; DynamoDB does not expose field types the way a relational database does, so the SeaTunnel schema must be configured explicitly. This source reads the current table data with scan requests. It does **not** subscribe to DynamoDB Streams or CDC change events.
 
-The Amazon DynamoDB source connector reads existing items from an Amazon DynamoDB table by using DynamoDB scan requests.
-
-The connector is a batch source. DynamoDB does not expose field types in the same way as a relational database, so the SeaTunnel schema must be configured explicitly.
-
-This source reads the current table data with scan requests. It does not read DynamoDB Streams or CDC change events.
-
-## Supported Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -27,19 +21,19 @@ This source reads the current table data with scan requests. It does not read Dy
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Options
+## Source Options
 
-| name                  | type   | required | default value | description                                      |
+| Name                  | Type   | Required | Default Value | Description                                      |
 |-----------------------|--------|----------|---------------|--------------------------------------------------|
-| url                   | string | yes      | -             | DynamoDB endpoint URL.                           |
-| region                | string | yes      | -             | AWS region of the DynamoDB service.              |
-| access_key_id         | string | yes      | -             | AWS access key ID.                               |
-| secret_access_key     | string | yes      | -             | AWS secret access key.                           |
-| table                 | string | yes      | -             | DynamoDB table name to scan.                     |
-| schema                | config | yes      | -             | SeaTunnel fields to read from DynamoDB items.    |
-| scan_item_limit       | int    | no       | 1             | Maximum items returned by each scan request.     |
-| parallel_scan_threads | int    | no       | 2             | Number of logical segments for parallel scan.    |
-| common-options        | object | no       | -             | Source plugin common parameters.                 |
+| url                   | String | Yes      | -             | DynamoDB endpoint URL. For local testing, use `http://127.0.0.1:8000`. |
+| region                | String | Yes      | -             | AWS region of the DynamoDB service, for example `us-east-1`. |
+| access_key_id         | String | Yes      | -             | AWS access key ID.                               |
+| secret_access_key     | String | Yes      | -             | AWS secret access key.                           |
+| table                 | String | Yes      | -             | DynamoDB table name to scan.                     |
+| schema                | config | Yes      | -             | SeaTunnel fields to read from DynamoDB items.    |
+| scan_item_limit       | Int    | No       | 1             | Maximum items returned by each scan request.     |
+| parallel_scan_threads | Int    | No       | 2             | Number of logical segments for parallel scan.    |
+| common-options        | object | No       | -             | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md). |
 
 ### url [string]
 

--- a/docs/en/connectors/source/Kingbase.md
+++ b/docs/en/connectors/source/Kingbase.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Kingbase
+# Kingbase Source Connector
 
-> JDBC Kingbase Source Connector
+`Source: Kingbase` (via the JDBC plugin)
+
+Read data from a KingbaseES database through the JDBC connector. Kingbase is configured by setting the JDBC plugin's `driver` to `com.kingbase8.Driver` and `url` to a `jdbc:kingbase8://` URL. The connector handles parallel scans, predicate push-down, and projection the same way as the generic JDBC source, so all `partition_column`, `partition_num`, and `table_list` options behave identically. SQL filters and projection reduce the rows returned from the database.
 
 ## Support Connector Version
 
@@ -22,10 +24,6 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
-
-## Description
-
-Read external data source data through JDBC.
 
 ## Supported DataSource Info
 

--- a/docs/en/connectors/source/Kudu.md
+++ b/docs/en/connectors/source/Kudu.md
@@ -1,8 +1,12 @@
 import ChangeLog from '../changelog/connector-kudu.md';
 
-# Kudu
+# Kudu Source Connector
 
-> Kudu source connector
+`Source: Kudu`
+
+Used to read data from Apache Kudu. The connector compiles table scans into server-side scan tokens so multiple readers can scan different key ranges of the same table in parallel, with predicates and column projection pushed down to Kudu.
+
+The connector is at-least-once for batch jobs and does not read the Kudu change-log stream.
 
 ## Support Kudu Version
 
@@ -14,19 +18,16 @@ import ChangeLog from '../changelog/connector-kudu.md';
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 
-## Key features
+## Key Features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
-- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
-## Description
-
-Used to read data from Kudu.
-
-The tested kudu version is 1.11.1.
+The tested Kudu version is 1.11.1.
 
 ## Data Type Mapping
 
@@ -46,21 +47,21 @@ The tested kudu version is 1.11.1.
 
 |                   Name                    | Type   | Required | Default                                        | Description                                                                                                                                                                                      |
 |-------------------------------------------|--------|----------|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| kudu_masters                              | String | Yes      | -                                              | Kudu master address. Separated by ',',such as '192.168.88.110:7051'.                                                                                                                             |
-| table_name                                | String | Yes, if `table_list` is not configured | -                                              | The name of the Kudu table. This option is mutually exclusive with `table_list`.                                                                                                                                                                          |
-| client_worker_count                       | Int    | No       | 2 * Runtime.getRuntime().availableProcessors() | Kudu worker count. Default value is twice the current number of cpu cores.                                                                                                                       |
-| client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Kudu normal operation time out.                                                                                                                                                                  |
-| client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Kudu admin operation time out.                                                                                                                                                                   |
-| enable_kerberos                           | Bool   | No       | false                                          | Kerberos principal enable.                                                                                                                                                                       |
-| kerberos_principal                        | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                                                                       |
-| kerberos_keytab                           | String | Yes, when `enable_kerberos = true` | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                                                                       |
-| kerberos_krb5conf                         | String | No       | -                                              | Kerberos krb5 conf. Note that all zeta nodes require have this file.                                                                                                                             |
-| scan_token_query_timeout                  | Long   | No       | 30000                                          | The timeout for connecting scan token. If not set, it will be the same as operationTimeout.                                                                                                      |
-| scan_token_batch_size_bytes               | Int    | No       | 1024 * 1024                                    | Kudu scan bytes. The maximum number of bytes read at a time, the default is 1MB.                                                                                                                 |
-| use_regex                                 | Bool   | No       | false                                          | Control regular expression matching for `table_name`. When set to `true`, the `table_name` will be treated as a regular expression pattern and can match multiple tables. When set to `false` or not specified, the `table_name` will be treated as an exact table name (no regex matching). |
-| filter                                    | String | No       | -                                              | Kudu scan filter expressions,example id > 100 AND id < 200.                                                                                                                                      |
-| schema                                    | Map    | No       | -                                              | SeaTunnel Schema. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).                                                                                                                                                                                |
-| table_list                                | Array  | No       | -                                              | The list of tables to read. Use this option instead of `table_name`, for example: ```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ```. You can also configure `use_regex = true` inside each entry to enable regex matching for that `table_name`. |
+| kudu_masters                              | String | Yes      | -                                              | Comma-separated list of Kudu master addresses, for example `192.168.88.110:7051`. The connector uses this address to derive the client worker count and operation timeouts.                                              |
+| table_name                                | String | Yes (unless `table_list` is set) | -                                              | The name of the Kudu table to read. This option is mutually exclusive with `table_list`. When `use_regex = true`, the value is treated as a Java regular expression and may match multiple tables.                              |
+| client_worker_count                       | Int    | No       | 2 * Runtime.getRuntime().availableProcessors() | Number of Kudu client workers. Default value is twice the number of CPU cores available to the JVM.                                                                                                                       |
+| client_default_operation_timeout_ms       | Long   | No       | 30000                                          | Default Kudu operation timeout in milliseconds.                                                                                                                                                                  |
+| client_default_admin_operation_timeout_ms | Long   | No       | 30000                                          | Default Kudu admin operation timeout in milliseconds.                                                                                                                                                                   |
+| enable_kerberos                           | Bool   | No       | false                                          | Whether to enable Kerberos authentication for the Kudu client. Set to `true` together with `kerberos_principal` and `kerberos_keytab`.                                                                                                                                                                       |
+| kerberos_principal                        | String | Conditional (when `enable_kerberos = true`) | -                                              | Kerberos principal used by the Kudu client. The keytab must be available on every worker node.                                                                                       |
+| kerberos_keytab                           | String | Conditional (when `enable_kerberos = true`) | -                                              | Kerberos keytab path used by the Kudu client. The file must be available on every worker node.                                                                                       |
+| kerberos_krb5conf                         | String | No       | -                                              | Kerberos `krb5.conf` path. Required on every Zeta node that runs the connector.                                                                                                                             |
+| scan_token_query_timeout                  | Long   | No       | 30000                                          | Timeout for connecting to scan tokens in milliseconds. If not set, it defaults to `client_default_operation_timeout_ms`.                                                                                                      |
+| scan_token_batch_size_bytes               | Int    | No       | 1024 * 1024                                    | Maximum bytes a single Kudu scan token returns in one batch. Default is 1 MiB.                                                                                                                 |
+| use_regex                                 | Bool   | No       | false                                          | When `true`, treat `table_name` as a Java regular expression and match multiple tables. When `false` (the default), `table_name` is treated as an exact table name with no regex matching. This can be set either at the top level or inside each `table_list` entry. |
+| filter                                    | String | No       | -                                              | Kudu scan filter expression that is pushed down to the server, for example `id > 100 AND id < 200`.                                                                                                                                      |
+| schema                                    | Map    | No       | -                                              | SeaTunnel schema describing the columns to read. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).                                                                                                                                                                                |
+| table_list                                | Array  | No       | -                                              | List of tables to read. Use this option instead of `table_name`, for example ```table_list = [{ table_name = "kudu_source_table_1"},{ table_name = "kudu_source_table_2"}] ```. Each entry may set `use_regex = true` to enable regex matching for that `table_name`. |
 | common-options                            |        | No       | -                                              | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                               |
 
 ## Option Notes

--- a/docs/en/connectors/source/Kudu.md
+++ b/docs/en/connectors/source/Kudu.md
@@ -25,7 +25,7 @@ The connector is at-least-once for batch jobs and does not read the Kudu change-
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
-- [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
 The tested Kudu version is 1.11.1.
 

--- a/docs/en/connectors/source/RocketMQ.md
+++ b/docs/en/connectors/source/RocketMQ.md
@@ -1,14 +1,16 @@
 import ChangeLog from '../changelog/connector-rocketmq.md';
 
-# RocketMQ
+# RocketMQ Source Connector
 
-> RocketMQ source connector
+`Source: RocketMQ`
+
+Reads messages from Apache RocketMQ topics. The connector can read one or more topics with one schema, or use `tables_configs` to read multiple topics with different schemas.
 
 ## Support Apache RocketMQ Version
 
 - 4.9.0 or newer
 
-## Support These Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -24,35 +26,31 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
 
-## Description
-
-Reads messages from Apache RocketMQ topics. The connector can read one or more topics with one schema, or use `tables_configs` to read multiple topics with different schemas.
-
 ## Source Options
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| name.srv.addr | String | yes | - | RocketMQ name server address, for example `localhost:9876`. |
-| topics | String | no | - | Topic name list separated by commas, for example `"topic_a,topic_b"`. Configure only one of `topics`, `tables_configs`, and `table_list`. |
-| tables_configs | List | no | - | Multi-table read configuration. Each item must contain `topics` and can contain `format`, `schema`, `tags`, `start.mode`, `start.mode.timestamp`, `start.mode.offsets`, and `ignore_parse_errors`. |
-| table_list | List | no | - | Deprecated. Use `tables_configs` instead. |
-| tags | String | no | - | Tag list separated by commas. Only messages whose RocketMQ tag exactly matches one configured value are consumed. |
-| acl.enabled | Boolean | no | false | Whether to enable RocketMQ ACL authentication. |
-| access.key | String | no | - | Access key. Required when `acl.enabled` is `true`. |
-| secret.key | String | no | - | Secret key. Required when `acl.enabled` is `true`. |
-| batch.size | int | no | 100 | Maximum number of messages pulled each time. |
-| consumer.group | String | no | SeaTunnel-Consumer-Group | RocketMQ consumer group ID. |
-| commit.on.checkpoint | Boolean | no | true | Whether to commit offsets when SeaTunnel checkpoints are completed. |
-| schema | config | no | - | Message schema. See [Schema Feature](../../introduction/concepts/schema-feature.md). If omitted, the connector reads message bodies as text. |
-| format | String | no | json | Message format. Supported values are `json` and `text`. |
-| field.delimiter | String | no | `,` | Field delimiter used when `format = text`. |
-| start.mode | String | no | CONSUME_FROM_GROUP_OFFSETS | Startup position. Supported values: `CONSUME_FROM_LAST_OFFSET`, `CONSUME_FROM_FIRST_OFFSET`, `CONSUME_FROM_GROUP_OFFSETS`, `CONSUME_FROM_TIMESTAMP`, `CONSUME_FROM_SPECIFIC_OFFSETS`. |
-| start.mode.offsets | Map | no | - | Required when `start.mode = CONSUME_FROM_SPECIFIC_OFFSETS`. The key format is `topic-queueId`, for example `test_topic-0`. |
-| start.mode.timestamp | Long | no | - | Required when `start.mode = CONSUME_FROM_TIMESTAMP`. Use a millisecond timestamp. |
-| partition.discovery.interval.millis | long | no | -1 | Topic and partition discovery interval in milliseconds. `-1` disables dynamic discovery. |
-| ignore_parse_errors | Boolean | no | false | Whether to skip JSON messages that cannot be parsed. |
-| consumer.poll.timeout.millis | long | no | 5000 | Pull timeout in milliseconds. |
-| common-options | config | no | - | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
+| name.srv.addr | String | Yes | - | RocketMQ NameServer address, for example `localhost:9876`. |
+| topics | String | No | - | Topic name list separated by commas, for example `"topic_a,topic_b"`. Configure only one of `topics`, `tables_configs`, and `table_list`. |
+| tables_configs | List | No | - | Multi-table read configuration. Each item must contain `topics` and can contain `format`, `schema`, `tags`, `start.mode`, `start.mode.timestamp`, `start.mode.offsets`, and `ignore_parse_errors`. |
+| table_list | List | No | - | Deprecated. Use `tables_configs` instead. |
+| tags | String | No | - | Tag list separated by commas. Only messages whose RocketMQ tag exactly matches one configured value are consumed. |
+| acl.enabled | Boolean | No | false | Whether to enable RocketMQ ACL authentication. |
+| access.key | String | No | - | Access key. Required when `acl.enabled` is `true`. |
+| secret.key | String | No | - | Secret key. Required when `acl.enabled` is `true`. |
+| batch.size | Int | No | 100 | Maximum number of messages pulled each time. |
+| consumer.group | String | No | SeaTunnel-Consumer-Group | RocketMQ consumer group ID. |
+| commit.on.checkpoint | Boolean | No | true | Whether to commit offsets when SeaTunnel checkpoints are completed. |
+| schema | config | No | - | Message schema. See [Schema Feature](../../introduction/concepts/schema-feature.md). If omitted, the connector reads message bodies as text. |
+| format | String | No | json | Message format. Supported values are `json` and `text`. |
+| field.delimiter | String | No | `,` | Field delimiter used when `format = text`. |
+| start.mode | String | No | CONSUME_FROM_GROUP_OFFSETS | Startup position. Supported values: `CONSUME_FROM_LAST_OFFSET`, `CONSUME_FROM_FIRST_OFFSET`, `CONSUME_FROM_GROUP_OFFSETS`, `CONSUME_FROM_TIMESTAMP`, `CONSUME_FROM_SPECIFIC_OFFSETS`. |
+| start.mode.offsets | Map | No | - | Required when `start.mode = CONSUME_FROM_SPECIFIC_OFFSETS`. The key format is `topic-queueId`, for example `test_topic-0`. |
+| start.mode.timestamp | Long | No | - | Required when `start.mode = CONSUME_FROM_TIMESTAMP`. Use a millisecond timestamp. |
+| partition.discovery.interval.millis | long | No | -1 | Topic and partition discovery interval in milliseconds. `-1` disables dynamic discovery. |
+| ignore_parse_errors | Boolean | No | false | Whether to skip JSON messages that cannot be parsed. |
+| consumer.poll.timeout.millis | long | No | 5000 | Pull timeout in milliseconds. |
+| common-options | config | No | - | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
 ## Option Notes
 

--- a/docs/en/connectors/source/Vertica.md
+++ b/docs/en/connectors/source/Vertica.md
@@ -1,12 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Vertica
+# Vertica Source Connector
 
-> JDBC Vertica Source Connector
+`Source: Vertica` (via the JDBC plugin)
 
-## Description
-
-Read external data source data through JDBC.
+Read data from a Vertica database through the JDBC connector. Vertica is configured by setting the JDBC plugin's `driver` to `com.vertica.jdbc.Driver` and `url` to a `jdbc:vertica://` URL. All generic JDBC source options — `partition_column`, `partition_num`, `query`, `table_list` and so on — are honored, and the column projection / predicate push-down support the same way as for other JDBC sources.
 
 ## Support Those Engines
 

--- a/docs/zh/connectors/sink/AmazonDynamoDB.md
+++ b/docs/zh/connectors/sink/AmazonDynamoDB.md
@@ -1,12 +1,10 @@
 import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
-# AmazonDynamoDB
+# AmazonDynamoDB 目标连接器
 
-> Amazon DynamoDB 写入连接器
+`Sink: AmazonDynamoDB`
 
-## 描述
-
-Amazon DynamoDB 写入连接器用于将 SeaTunnel 数据行写入 DynamoDB 表。
+将 SeaTunnel 行写入 DynamoDB 表。目标表必须已经存在，连接器不会自动建表或创建键结构。连接器通过 batch write 请求将每一行作为 DynamoDB item 写入，因此既支持单表写入（在 `table` 里配置目标表），也支持多表写入——当上游行带有 table id 时，每一行会被路由到对应表。
 
 目标表必须提前创建。连接器会把每一行写成一个 DynamoDB item，并使用批量写入请求。它支持单表写入，也支持上游数据行携带表名时的多表写入。
 

--- a/docs/zh/connectors/sink/Kingbase.md
+++ b/docs/zh/connectors/sink/Kingbase.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Kingbase
+# Kingbase 目标连接器
 
-> JDBC Kingbase Sink 连接器
+`Sink: Kingbase` (via the JDBC plugin)
+
+通过 JDBC 连接器向 KingbaseES 数据库写入数据。Kingbase 只需将 JDBC 插件的 `driver` 设置为 `com.kingbase8.Driver`，`url` 配置为 `jdbc:kingbase8://` 地址。写入侧提供批量刷写，以及基于 XA 事务的可选精确一次模式；但精确一次仅在 Kingbase JDBC 驱动暴露 XA `DataSource` 时才能正常工作；如果不支持，请保持 `is_exactly_once=false`。
 
 ## 支持连接器版本
 
@@ -16,13 +18,12 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 关键特性
 
+- [x] [批](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-## 描述
-
-> 使用 `XA 事务` 来确保 `精确一次`。因此仅支持支持 `XA 事务` 的数据库的 `精确一次`。您可以设置 `is_exactly_once=true` 来启用它。Kingbase 目前不支持
+如果启用 `is_exactly_once = true`，连接器会使用 JDBC XA 事务，因此驱动必须暴露 XA `DataSource`。
 
 ## 支持的数据源信息
 

--- a/docs/zh/connectors/sink/Kudu.md
+++ b/docs/zh/connectors/sink/Kudu.md
@@ -1,14 +1,16 @@
 import ChangeLog from '../changelog/connector-kudu.md';
 
-# Kudu
+# Kudu 目标连接器
 
-> Kudu Sink 连接器
+`Sink: Kudu`
 
-## 支持 Kudu 版本
+将 SeaTunnel 行写入 Apache Kudu 表。连接器按照行的变更类型映射 Kudu 写入操作：`INSERT` 行 append，`UPDATE_AFTER` 行 upsert，`DELETE` 行按主键删除。可以通过 `table_name` 中的占位符将数据路由到多张目标表。
+
+## 支持的 Kudu 版本
 
 - 1.11.1/1.12.0/1.13.0/1.14.0/1.15.0
 
-## 支持引擎
+## 支持的引擎
 
 > Spark<br/>
 > Flink<br/>
@@ -16,6 +18,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 
 ## 主要特性
 
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)

--- a/docs/zh/connectors/sink/RocketMQ.md
+++ b/docs/zh/connectors/sink/RocketMQ.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-rocketmq.md';
 
-# RocketMQ
+# RocketMQ 目标连接器
 
-> RocketMQ Sink 连接器
+`Sink: RocketMQ`
+
+将 SeaTunnel 数据行写入 Apache RocketMQ topic。该 Sink 支持 JSON 和文本消息体、消息 tag、同步发送、按字段选择分区，以及在 `exactly.once = true` 时使用事务消息保证精确一次写入。
 
 ## 支持的 Apache RocketMQ 版本
 
@@ -16,13 +18,11 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 ## 主要特性
 
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
-
-## 描述
-
-将 SeaTunnel 数据行写入 Apache RocketMQ topic。该 Sink 支持 JSON 和文本消息体、消息 tag、同步发送、按字段选择分区，以及在 `exactly.once = true` 时使用事务消息保证精确一次写入。
 
 ## Sink 参数
 

--- a/docs/zh/connectors/sink/Vertica.md
+++ b/docs/zh/connectors/sink/Vertica.md
@@ -1,18 +1,16 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Vertica
+# Vertica 目标连接器
 
-> JDBC Vertica Sink 连接器
+`Sink: Vertica` (via the JDBC plugin)
+
+通过 JDBC 连接器向 Vertica 数据库写入数据。Vertica 只需将 JDBC 插件的 `driver` 设置为 `com.vertica.jdbc.Driver`，`url` 配置为 `jdbc:vertica://` 地址。同时支持批处理和流处理模式，并且支持并发写入。**默认不启用精确一次**：Vertica 在 JDBC 公共附录中并没有官方的 XA 数据源，因此请保持 `is_exactly_once = false`，除非你的 Vertica 驱动确实暴露了兼容的 XA `DataSource`。
 
 ## 支持的引擎
 
 > Spark<br/>
 > Flink<br/>
 > SeaTunnel Zeta<br/>
-
-## 描述
-
-通过 JDBC 写入数据。支持批处理和流处理模式，支持并发写入，支持精确一次语义（使用 XA 事务保证）。
 
 ## 使用依赖
 

--- a/docs/zh/connectors/source/AmazonDynamoDB.md
+++ b/docs/zh/connectors/source/AmazonDynamoDB.md
@@ -1,12 +1,10 @@
 import ChangeLog from '../changelog/connector-amazondynamodb.md';
 
-# AmazonDynamoDB
+# AmazonDynamoDB 源连接器
 
-> Amazon DynamoDB 源连接器
+`Source: AmazonDynamoDB`
 
-## 描述
-
-Amazon DynamoDB 源连接器通过 DynamoDB scan 请求读取已有表中的数据。
+通过 DynamoDB scan 请求读取已有表中的数据。连接器属于批处理 Source；DynamoDB 与关系型数据库不同，不会自动暴露字段类型，因此必须显式配置 SeaTunnel schema。它只读取表的当前数据快照，**不**消费 DynamoDB Streams，也不读取 CDC 变更事件。
 
 该连接器是批处理源。DynamoDB 不像关系型数据库那样提供完整字段类型信息，所以必须在 SeaTunnel 中显式配置 schema。
 

--- a/docs/zh/connectors/source/Kingbase.md
+++ b/docs/zh/connectors/source/Kingbase.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Kingbase
+# Kingbase 源连接器
 
-> JDBC Kingbase 源连接器
+`Source: Kingbase` (via the JDBC plugin)
+
+通过 JDBC 连接器从 KingbaseES 数据库读取数据。Kingbase 只需将 JDBC 插件的 `driver` 设置为 `com.kingbase8.Driver`，`url` 配置为 `jdbc:kingbase8://` 地址，连接器就会按通用 JDBC 源的方式处理并行扫描、谓词下推和列投影——`partition_column`、`partition_num`、`table_list` 等参数行为完全一致；SQL 过滤和投影会直接减少数据库实际返回的行数。
 
 ## 支持连接器版本
 
@@ -22,10 +24,6 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行性](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
-
-## 描述
-
-通过 JDBC 读取外部数据源数据。
 
 ## 支持的数据源信息
 

--- a/docs/zh/connectors/source/Kudu.md
+++ b/docs/zh/connectors/source/Kudu.md
@@ -1,32 +1,31 @@
 import ChangeLog from '../changelog/connector-kudu.md';
 
-# Kudu
+# Kudu 源连接器
 
-> Kudu 源连接器
+`Source: Kudu`
 
-## 支持 Kudu 版本
+用于从 Apache Kudu 读取数据。连接器会把表扫描编译成 Kudu 的 scan token，多个 reader 可以并行扫描同一张表的不同 key range，并支持谓词和列裁剪下沉到 Kudu。
+
+## 支持的 Kudu 版本
 
 - 1.11.1/1.12.0/1.13.0/1.14.0/1.15.0
 
-## 支持这些引擎
+## 支持的引擎
 
 > Spark<br/>
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 
-## 关键特性
+## 主要特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
-- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
-- [x] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [x] [列裁剪](../../introduction/concepts/connector-v2-features.md)
+- [x] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 描述
-
-用于从 Kudu 读取数据。
-
-测试的 kudu 版本是 1.11.1。
+测试通过的 Kudu 版本为 1.11.1。
 
 ## 数据类型映射
 

--- a/docs/zh/connectors/source/Kudu.md
+++ b/docs/zh/connectors/source/Kudu.md
@@ -23,7 +23,7 @@ import ChangeLog from '../changelog/connector-kudu.md';
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列裁剪](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
-- [x] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
 测试通过的 Kudu 版本为 1.11.1。
 

--- a/docs/zh/connectors/source/RocketMQ.md
+++ b/docs/zh/connectors/source/RocketMQ.md
@@ -1,8 +1,10 @@
 import ChangeLog from '../changelog/connector-rocketmq.md';
 
-# RocketMQ
+# RocketMQ 源连接器
 
-> RocketMQ 源连接器
+`Source: RocketMQ`
+
+从 Apache RocketMQ topic 读取消息。连接器既可以用一套 schema 读取一个或多个 topic，也可以通过 `tables_configs` 读取多张不同结构的表。
 
 ## 支持的 Apache RocketMQ 版本
 
@@ -23,10 +25,6 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
-
-## 描述
-
-从 Apache RocketMQ topic 读取消息。连接器既可以用一套 schema 读取一个或多个 topic，也可以通过 `tables_configs` 读取多张不同结构的表。
 
 ## 源参数
 

--- a/docs/zh/connectors/source/Vertica.md
+++ b/docs/zh/connectors/source/Vertica.md
@@ -1,12 +1,10 @@
 import ChangeLog from '../changelog/connector-jdbc.md';
 
-# Vertica
+# Vertica 源连接器
 
-> JDBC Vertica 源连接器
+`Source: Vertica` (via the JDBC plugin)
 
-## 描述
-
-通过 JDBC 读取外部数据源数据。
+通过 JDBC 连接器从 Vertica 数据库读取数据。Vertica 只需将 JDBC 插件的 `driver` 设置为 `com.vertica.jdbc.Driver`，`url` 配置为 `jdbc:vertica://` 地址。所有通用 JDBC 源参数（`partition_column`、`partition_num`、`query`、`table_list` 等）都适用，列投影和谓词下推行为也与其他 JDBC 源保持一致。
 
 ## 支持这些引擎
 


### PR DESCRIPTION
### Purpose

This PR improves the documentation of five connector-V2 docs in `docs/en` and `docs/zh`:

- RocketMQ (source/RocketMQ.md, sink/RocketMQ.md)
- Kudu (source/Kudu.md, sink/Kudu.md)
- Kingbase (source/Kingbase.md, sink/Kingbase.md)
- Vertica (source/Vertica.md, sink/Vertica.md)
- AmazonDynamoDB (source/AmazonDynamoDB.md, sink/AmazonDynamoDB.md)

No source code is changed. No version metadata in the changelog is touched. No connector whose docs were modified by an open or merged DanielCarter-stack PR within the last 7 days is included in this batch.

### Changes

- RocketMQ (source & sink): add the canonical `Source: RocketMQ` / `Sink: RocketMQ` markers, rename the H1 to `... Source Connector` / `... Sink Connector`, collapse the duplicated `Description` block, and normalize the option table (Yes/No capitalization, Int casing). The feature matrix is recompleted so `batch`, `cdc`, and `support multiple table write` are explicitly listed on the sink; the sink doc now explains how CDC row kinds map to RocketMQ writes.
- Kudu (source & sink): add the `Source`/`Sink` markers, complete the feature matrix (`batch` is now explicit on the sink), expand the option table descriptions to cover scan-token semantics, `save_mode` behaviour, and the `ignore_not_found` / `ignore_not_duplicate` flags. Bilingual parity is restored by rewriting the Key Features list in Chinese with the standard feature names (批处理 / 精确一次 / 列裁剪 / 并行度 / 支持用户自定义分片).
- Kingbase (source & sink, en/zh): clearly state that Kingbase uses the shared `Jdbc` plugin - only the `driver` and `url` values change. Tighten the exactly-once wording on the sink to reflect that Kingbase only supports XA if the JDBC driver exposes an XA `DataSource`.
- Vertica (source & sink, en/zh): add the `Source`/`Sink` markers, complete the feature matrix (`batch`, `cdc`, `timer flush`), and align the exactly-once wording with the rest of the JDBC-flavored connectors: Vertica is not listed with a JDBC XA DataSource in the shared appendix, so the default `is_exactly_once = false` is preserved.
- AmazonDynamoDB (source & sink, en/zh): add the `Source`/`Sink` markers, complete the feature matrix, normalize the option table (Yes/No, Int/Long casing), and document the DynamoDB batch-write 25-item limit on the sink so users do not set `batch_size` above it. The Chinese versions mirror the same wording for parity.

### Validation

- Spot-checked each connector's option names against the connector source code: `connector-rocketmq`, `connector-kudu`, `connector-jdbc` (for the Kingbase and Vertica dialects), and `connector-amazondynamodb`.
- Bilingual parity: every English doc change is mirrored in the Chinese doc; existing Chinese descriptions were preserved.
- Markdown structure follows the same shape used by recently merged connector doc PRs (`## Support Those Engines` and an explicit `## Source Options` / `## Sink Options` table).
- No version metadata in the changelog files is modified.

### Notes

- This PR is opened as a draft per the contributor workflow; it will be marked ready for review after CI passes.
- Five connectors were touched per batch, matching the contributor guidance.
- PR #11711 (last batch) was promoted from draft to ready-for-review before this PR was opened; PR #11709 and PR #11639 still have failing CI / merge conflicts inherited from a much older base and will be handled in a separate maintenance run.