### PR TITLE
[Bug][connector-jdbc] Support Dameng NCHAR type in DmdbTypeConverter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -67,6 +67,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
+    public static final String DM_NCHAR = "NCHAR";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
     public static final String DM_TEXT = "TEXT";
@@ -200,6 +201,11 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
             case DM_VARCHAR:
             case DM_VARCHAR2:
                 builder.sourceType(String.format("%s(%s)", DM_VARCHAR2, typeDefine.getLength()));
+                builder.dataType(BasicType.STRING_TYPE);
+                builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
+                break;
+            case DM_NCHAR:
+                builder.sourceType(String.format("%s(%s)", DM_NCHAR, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;


### PR DESCRIPTION
### Purpose

Add support for Dameng `NCHAR` type in `DmdbTypeConverter`. The NCHAR column type was not handled by the converter, causing an `unsupported convert type 'nchar'` error.

### Changes

- Added `DM_NCHAR` constant
- Added `case DM_NCHAR:` to the `convert()` method's switch statement, treating it as a STRING type like NVARCHAR

### Related Issue

Closes #11688