### PR TITLE
[Bug][connector-jdbc] Support YashanDB VARCHAR2 and NVARCHAR2 types in YashanDbTypeConverter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
@@ -213,11 +213,13 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 // ====================== Character types ======================
             case CHAR:
             case VARCHAR:
+            case VARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case NCHAR:
             case NVARCHAR:
+            case NVARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(
                         TypeDefineUtils.doubleByteTo4ByteLength(typeDefine.getLength()));


### PR DESCRIPTION
### Purpose

Add support for Oracle-compatible synonyms `VARCHAR2` and `NVARCHAR2` in `YashanDbTypeConverter`. These types are not handled by the converter, causing an `unsupported convert type` error.

### Changes

- Added `case VARCHAR2:` to the existing `CHAR`/`VARCHAR` case block
- Added `case NVARCHAR2:` to the existing `NCHAR`/`NVARCHAR` case block

### Related Issue

Closes #11685