### PR TITLE
[Dameng][TypeConverter] Add NCHAR data type support to DmdbTypeConverter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -67,6 +67,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
     public static final String DM_VARCHAR = "VARCHAR";
     public static final String DM_VARCHAR2 = "VARCHAR2";
     public static final String DM_NVARCHAR = "NVARCHAR";
+    public static final String DM_NCHAR = "NCHAR";
     public static final String DM_LONGVARCHAR = "LONGVARCHAR";
     public static final String DM_CLOB = "CLOB";
     public static final String DM_TEXT = "TEXT";
@@ -203,6 +204,7 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
+            case DM_NCHAR:
             case DM_NVARCHAR:
                 builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);


### PR DESCRIPTION
### Purpose

Add NCHAR data type support to DmdbTypeConverter, which is currently missing.

### Changes

- Add `DM_NCHAR` constant
- Add `case DM_NCHAR:` to the `convert()` method, treated the same as NVARCHAR (STRING type with charTo4ByteLength)

### Related Issues

- Fixes #11688