### PR TITLE
[YashanDB][TypeConverter] Add VARCHAR2/NVARCHAR2 data type support to YashanDbTypeConverter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
@@ -213,11 +213,13 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 // ====================== Character types ======================
             case CHAR:
             case VARCHAR:
+            case VARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case NCHAR:
             case NVARCHAR:
+            case NVARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(
                         TypeDefineUtils.doubleByteTo4ByteLength(typeDefine.getLength()));


### PR DESCRIPTION
### Purpose

Add VARCHAR2 and NVARCHAR2 data type support to YashanDbTypeConverter, which are currently missing.

### Changes

- Add `case VARCHAR2:` to the existing `CHAR`/`VARCHAR` case block in the `convert()` method
- Add `case NVARCHAR2:` to the existing `NCHAR`/`NVARCHAR` case block in the `convert()` method

### Related Issues

- Fixes #11685