### PR TITLE
fix: use bitwise AND instead of Math.abs to avoid Integer.MIN_VALUE overflow in hash routing

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
@@ -545,7 +545,7 @@ public class MultiTableSinkWriter
      *
      * <ul>
      *   <li>If the table's primary key information is present and the primary key field value is
-     *       non-null, the row is routed by {@code Math.abs(primaryKeyValue.hashCode()) %
+     *       non-null, the row is routed by {@code (primaryKeyValue.hashCode() & Integer.MAX_VALUE) %
      *       queueSize}, guaranteeing that rows with the same primary key always go to the same
      *       queue for ordered delivery.
      *   <li>If the table's primary key information is present but the actual field value is {@code
@@ -599,7 +599,7 @@ public class MultiTableSinkWriter
             Object object = element.getField(primaryKey.get());
             int index = 0;
             if (object != null) {
-                index = Math.abs(object.hashCode()) % blockingQueues.size();
+                index = (object.hashCode() & Integer.MAX_VALUE) % blockingQueues.size();
             }
             BlockingQueue<MultiTableWriterRunnable.QueueElement> queue = blockingQueues.get(index);
             offerQueueElement(queue, MultiTableWriterRunnable.rowRequest(element));


### PR DESCRIPTION
### Problem

`MultiTableSinkWriter.write` routes each row to a queue using:

```java
index = Math.abs(object.hashCode()) % blockingQueues.size();
```

`Math.abs(Integer.MIN_VALUE)` returns `Integer.MIN_VALUE` — still negative, because `-Integer.MIN_VALUE` is not representable as an `int`. When the queue count is not a power of two, the modulo result is negative and `blockingQueues.get(index)` throws `IndexOutOfBoundsException`.

### Root Cause

`Math.abs(int)` overflows for `Integer.MIN_VALUE` (`0x80000000`), which is its own negation. This is a well-known Java integer overflow pitfall.

### Fix

Replace `Math.abs(hashCode())` with `(hashCode() & Integer.MAX_VALUE)`, which maps `Integer.MIN_VALUE` to `0` and preserves all other values without overflow. This follows the same pattern already applied in the file source split enumerator (PR #2921) and used in 12 other places across the codebase.

### Affected Versions

Any `multi_table_sink_replica` value that is not a power of two triggers the crash when a primary key hashes to `Integer.MIN_VALUE` (e.g. `INT` value `-2147483648`, `BIGINT` value `-9223372036854775808`, or any string with `hashCode() == Integer.MIN_VALUE`).

Closes #11720