### PR TITLE
[Docs][Zeta] Add worker node resource view design

### DIFF
--- a/docs/en/engines/zeta/web-ui.md
+++ b/docs/en/engines/zeta/web-ui.md
@@ -88,6 +88,8 @@ The "Finished Jobs" section displays jobs that have reached a terminal state, su
 
 The "Workers" section displays system monitoring information for worker nodes. Use it to inspect worker address, resource status, and runtime health signals exposed by the engine.
 
+For the proposed design to add per-worker slot accounting and a fuller monitoring detail view, see [Worker Node Resource View](worker-node-resource-view.md).
+
 ![workers.png](../../../images/ui/workers.png)
 
 ## Master
@@ -102,5 +104,6 @@ The "Master" section displays system monitoring information for master nodes. Us
 
 - [REST API and Web UI](./rest-api-and-web-ui.md)
 - [REST API V2](./rest-api-v2.md)
+- [Worker Node Resource View](./worker-node-resource-view.md)
 - [Job Lifecycle API](./rest-api-job-lifecycle.md)
 - [Security](./security.md)

--- a/docs/en/engines/zeta/worker-node-resource-view.md
+++ b/docs/en/engines/zeta/worker-node-resource-view.md
@@ -1,0 +1,121 @@
+# Worker Node Resource View
+
+## Status
+
+This page is the proposed design contract for [issue #11665](https://github.com/apache/seatunnel/issues/11665). The first delivery should turn already-collected per-node data into a usable cluster resource view on the existing Workers/Master pages, without introducing new scheduling state.
+
+The design is intentionally bounded:
+
+- reuse the existing `/system-monitoring-information` payload as the source of per-node JVM/host metrics
+- reuse the resource manager's existing live `WorkerProfile` state as the source of per-worker slot accounting
+- add one new lightweight, read-only REST projection; add no new mutable state and change no scheduling decision logic
+- defer per-worker task-assignment drill-down (correlating with `/trace/task-mapping`) to a follow-up, since that endpoint is scoped per-job and the Workers page has no job context
+
+## Problem
+
+The Workers/Master page today (`seatunnel-engine-ui/src/views/managers/index.tsx`) renders only 4 columns - Host, Port, Physical MEM Total, and Heap MEM Used - out of roughly 35 fields already returned by `/system-monitoring-information` (modeled in `seatunnel-engine-ui/src/service/manager/types.ts`). An Action column exists in the source but is commented out.
+
+Separately, there is no per-worker slot view anywhere. `OverviewInfo` (`GET /overview`) only exposes cluster-wide `totalSlot`/`unassignedSlot` integers. An operator cannot tell, from the UI, which worker has free slots, which is fully allocated, or whether cluster capacity is unevenly distributed.
+
+## Existing Foundation
+
+| Area | Existing contract |
+|---|---|
+| Per-node JVM/host metrics | `GET /system-monitoring-information` returns one `Monitor` row per node (CPU load, heap/physical memory, GC counts and time, thread count, executor queue sizes, and more). |
+| Cluster-wide slot totals | `GET /overview` returns `OverviewInfo.totalSlot` / `unassignedSlot` as cluster-wide sums only. |
+| Per-worker live resource state | `ResourceManager.getRegisterWorker()` returns a live `ConcurrentMap<Address, WorkerProfile>`. Each `WorkerProfile` already carries `assignedSlots` / `unassignedSlots` (`SlotProfile[]`), `dynamicSlot`, `attributes` (worker tags), and a `systemLoadInfo` (`cpuPercentage`, `memPercentage`) used internally by the scheduler. This is the canonical source the resource manager itself uses to accept or reject allocation requests - not a derived approximation. |
+| Per-job task-to-worker mapping | `GET /trace/task-mapping/:jobId` already computes task/host assignment for one job, but has no UI consumer and no cluster-wide (cross-job) shape. |
+| Cross-node read pattern | `GetOverviewOperation` already shows the established pattern for a REST call to reach live master-held state: `OverviewService` checks whether the local node is the active master (`getSeaTunnelServer(true)`) and, if not, forwards via `NodeEngineUtil.sendOperationToMasterNode(...)`. |
+
+## Goals
+
+1. Render a curated, operationally useful set of the already-fetched `/system-monitoring-information` fields as table columns, instead of today's 4.
+2. Give access to the *full* raw payload without turning the table into an unreadable ~35-column grid.
+3. Add a per-worker slot view (total / used) sourced from the resource manager's own live state, with no new bookkeeping.
+4. Keep the view useful when the cluster is idle (no jobs running).
+5. Keep refresh cost bounded and consistent with the existing polling model.
+
+## Non-Goals
+
+- Per-worker "tasks currently running here" drill-down via `/trace/task-mapping`. That endpoint is scoped per-job; building a cluster-wide, cross-job view needs its own fan-out design and is left for a follow-up once this view's contract is settled.
+- Historical or long-term retention of node resource metrics.
+- Cluster capacity planning or autoscaling recommendations.
+- Per-node log tailing (already covered by the existing worker log viewer).
+
+## Resource Model
+
+### Per-Node Monitoring Fields (reuse, no backend change)
+
+No new backend work is needed here: the fields already exist in `Monitor`. The V1 table should surface a curated subset instead of all ~35 fields:
+
+| Column | Existing `Monitor` field(s) |
+|---|---|
+| Host / Port | `host`, `port` |
+| Role | derived from `isMaster` (already used to split Master vs. Worker pages) |
+| CPU Load | `load.systemAverage` |
+| Heap Used / Max | `heap.memory.used`, `heap.memory.max` |
+| Physical MEM Total | `physical.memory.total` |
+| GC (minor/major) | `minor.gc.count`, `major.gc.count` |
+| Thread Count | `thread.count` |
+
+The remaining fields stay available, not discarded: a "View Details" action (the column already present but commented out in `managers/index.tsx`) opens a drawer showing the complete raw `Monitor` row as key/value pairs, plus the new per-worker slot/attribute data below. This avoids a wide, hard-to-scan table while keeping every existing field reachable.
+
+### Per-Worker Slot State (new REST projection, no new state)
+
+A new endpoint projects the resource manager's existing live state, one row per registered worker:
+
+| Field | Source |
+|---|---|
+| `address` | `WorkerProfile.address` |
+| `totalSlot` | `assignedSlots.length + unassignedSlots.length` |
+| `usedSlot` | `assignedSlots.length` |
+| `dynamicSlot` | `WorkerProfile.dynamicSlot` |
+| `cpuPercentage` / `memPercentage` | `WorkerProfile.systemLoadInfo` (nullable - only populated where the scheduler already tracks it) |
+| `attributes` | `WorkerProfile.attributes` (worker tags) |
+
+This is a pure read/projection: it calls `getRegisterWorker()` and maps each `WorkerProfile`, following the exact cross-node pattern already used by `GetOverviewOperation`. It introduces no new field on `WorkerProfile` itself and changes no allocation/scheduling code path.
+
+The Workers/Master page joins this by `address` (host + port) with the existing `Monitor` rows client-side, the same way the page already separates Master vs. Worker rows by `isMaster`.
+
+## Stable Contract and Best-Effort Signals
+
+Stable identifiers:
+
+- `host`, `port`, `isMaster` / role
+- `totalSlot`, `usedSlot` (derived from live slot arrays, always internally consistent with the scheduler's own view because it reads the same state)
+
+Best-effort diagnostic signals:
+
+- CPU load, heap/memory usage, GC counters (already best-effort today via `/system-monitoring-information`)
+- `cpuPercentage` / `memPercentage` from `systemLoadInfo` - populated on the scheduler's own cadence, not a guaranteed real-time value
+
+## Refresh, Retention, and Cost
+
+- Reuse the existing Workers/Master page's request-on-navigation model; no continuous polling is introduced beyond what the page already does for `/system-monitoring-information`.
+- The new endpoint is O(number of registered workers) per call, matching the cost profile of `GET /overview`, which already iterates the same resource manager state.
+- No new data is written to disk or retained beyond the live in-memory `WorkerProfile` map the resource manager already maintains.
+
+## Large Cluster Degradation
+
+For clusters with many workers, the table remains a flat, sortable/filterable list rather than a graph; there is no rendering-cost concern comparable to a DAG, since row count scales linearly with worker count and the existing `NDataTable` component already paginates.
+
+## V1 Delivery Plan
+
+1. Add a `WorkerOverviewInfo` DTO and a `GetWorkerOverviewOperation` mirroring `GetOverviewOperation`'s cross-node pattern, backed by `ResourceManager.getRegisterWorker()`.
+2. Add a dedicated REST endpoint and servlet for the new projection, following the existing `OverviewService` / `OverviewServlet` structure.
+3. Extend `seatunnel-engine-ui`'s manager service/types to fetch and join the new endpoint with the existing `/system-monitoring-information` rows by address.
+4. Extend the Workers/Master table with the curated column set above, and re-enable the existing (currently commented-out) Action column as a "View Details" drawer showing the full raw payload.
+5. Update English and Chinese Web UI and REST API documentation.
+
+## Validation Requirements
+
+- Backend unit tests cover the new operation's mapping from `WorkerProfile` to `WorkerOverviewInfo`, including the case of zero registered workers and workers with zero slots.
+- Frontend tests cover the client-side join by address and the curated column rendering.
+- Docs state clearly that slot and load fields reflect the resource manager's live in-memory state, not a persisted history.
+- No new persistent table, file, or write path is introduced for V1.
+
+## Related Documentation
+
+- [Web UI](./web-ui.md)
+- [RESTful API V2](./rest-api-v2.md)
+- [Realtime Observability](./realtime-observability.md)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -271,6 +271,7 @@ const sidebars = {
                                     ]
                                 },
                                 "engines/zeta/web-ui",
+                                "engines/zeta/worker-node-resource-view",
                                 "engines/zeta/security",
                                 "engines/zeta/python-sdk"
                             ]

--- a/docs/zh/engines/zeta/web-ui.md
+++ b/docs/zh/engines/zeta/web-ui.md
@@ -89,6 +89,8 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 
 “工作节点”模块展示 worker 节点的系统监控信息。可以用它查看 worker 地址、资源状态和引擎暴露的运行时健康信号。
 
+关于新增按 worker 统计 slot 以及更完整监控详情视图的设计草案，参见 [Worker 节点资源视图](worker-node-resource-view.md)。
+
 ![workers.png](../../../images/ui/workers.png)
 
 ## 管理节点
@@ -103,5 +105,6 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 
 - [REST API 与 Web UI](./rest-api-and-web-ui.md)
 - [REST API V2](./rest-api-v2.md)
+- [Worker 节点资源视图](./worker-node-resource-view.md)
 - [作业生命周期 API](./rest-api-job-lifecycle.md)
 - [安全](./security.md)

--- a/docs/zh/engines/zeta/worker-node-resource-view.md
+++ b/docs/zh/engines/zeta/worker-node-resource-view.md
@@ -1,0 +1,121 @@
+# Worker 节点资源视图
+
+## 状态
+
+本文是 [issue #11665](https://github.com/apache/seatunnel/issues/11665) 的设计契约草案。第一阶段交付应当把已经收集到的节点数据变成 Workers/Master 页面上可用的集群资源视图，而不引入新的调度状态。
+
+该设计刻意控制边界：
+
+- 复用现有 `/system-monitoring-information` 返回的数据作为节点级 JVM/主机指标来源
+- 复用资源管理器已有的实时 `WorkerProfile` 状态作为按 worker 统计 slot 的数据来源
+- 只新增一个轻量、只读的 REST 投影；不新增任何可变状态，也不改动任何调度决策逻辑
+- 把"按 worker 展示当前运行任务"（需要关联 `/trace/task-mapping`）留给后续版本，因为该接口是按作业维度设计的，而 Workers 页面本身没有作业上下文
+
+## 问题
+
+Workers/Master 页面（`seatunnel-engine-ui/src/views/managers/index.tsx`）目前只渲染 4 列：Host、Port、Physical MEM Total、Heap MEM Used，而 `/system-monitoring-information`（对应模型见 `seatunnel-engine-ui/src/service/manager/types.ts`）实际已经返回约 35 个字段。源码中还留着一个被注释掉的 Action 列。
+
+另外，目前完全没有按 worker 维度展示的 slot 视图。`OverviewInfo`（`GET /overview`）只暴露集群维度的 `totalSlot`/`unassignedSlot` 总数。使用者无法从 UI 上看出哪个 worker 还有空闲 slot、哪个已经打满，也看不出集群容量分布是否均衡。
+
+## 现有基础
+
+| 范围 | 现有契约 |
+|---|---|
+| 节点级 JVM/主机指标 | `GET /system-monitoring-information` 每个节点返回一条 `Monitor` 记录（CPU load、堆内存/物理内存、GC 次数与耗时、线程数、executor 队列大小等）。 |
+| 集群维度 slot 总数 | `GET /overview` 返回的 `OverviewInfo.totalSlot`/`unassignedSlot` 只是集群维度的汇总值。 |
+| 按 worker 的实时资源状态 | `ResourceManager.getRegisterWorker()` 返回实时的 `ConcurrentMap<Address, WorkerProfile>`。每个 `WorkerProfile` 已经带有 `assignedSlots`/`unassignedSlots`（`SlotProfile[]`）、`dynamicSlot`、`attributes`（worker 标签）以及调度器内部使用的 `systemLoadInfo`（`cpuPercentage`、`memPercentage`）。这是资源管理器自己用来判断是否接受分配请求的权威数据源，不是派生近似值。 |
+| 按作业的任务-worker 映射 | `GET /trace/task-mapping/:jobId` 已经能算出单个作业的任务/主机分配关系，但没有 UI 消费方，也没有跨作业的集群级形态。 |
+| 跨节点读取模式 | `GetOverviewOperation` 已经展示了 REST 请求如何触达 master 持有的实时状态的既有模式：`OverviewService` 先判断本节点是否为 active master（`getSeaTunnelServer(true)`），不是的话通过 `NodeEngineUtil.sendOperationToMasterNode(...)` 转发。 |
+
+## 目标
+
+1. 把已经拉取到的 `/system-monitoring-information` 字段中真正有运维价值的一部分渲染成表格列，而不是目前的 4 列。
+2. 保留访问全量原始字段的入口，同时不把表格变成约 35 列、无法阅读的宽表。
+3. 新增按 worker 维度的 slot 视图（总数/已用），数据来自资源管理器已有的实时状态，不新增任何记账逻辑。
+4. 集群空闲（没有作业运行）时该视图依然有意义。
+5. 刷新成本保持可控，和现有轮询模型一致。
+
+## 非目标
+
+- 通过 `/trace/task-mapping` 实现"按 worker 展示当前运行任务"的下钻。该接口是按作业维度设计的，要做成跨作业的集群级视图需要单独的扇出方案，留给本视图契约稳定后的后续版本。
+- 节点资源指标的历史或长期留存。
+- 集群容量规划或自动扩缩容建议。
+- 按节点查看日志（现有的 worker 日志查看器已经覆盖）。
+
+## 资源模型
+
+### 节点监控字段（复用，不改动后端）
+
+这部分不需要任何新的后端工作：字段在 `Monitor` 里已经存在。V1 表格应该展示精选子集，而不是全部约 35 个字段：
+
+| 列 | 对应的现有 `Monitor` 字段 |
+|---|---|
+| Host / Port | `host`、`port` |
+| 角色 | 由 `isMaster` 派生（Master/Worker 页面已经用它做区分） |
+| CPU Load | `load.systemAverage` |
+| Heap Used / Max | `heap.memory.used`、`heap.memory.max` |
+| Physical MEM Total | `physical.memory.total` |
+| GC（minor/major） | `minor.gc.count`、`major.gc.count` |
+| 线程数 | `thread.count` |
+
+其余字段不会被丢弃：一个"查看详情"操作（对应 `managers/index.tsx` 中已经存在但被注释掉的列）会打开一个抽屉，展示该行完整的原始 `Monitor` 字段，以及新增的按 worker 统计的 slot/标签信息。这样既避免了宽表难以阅读的问题，又保证所有既有字段仍然可以访问到。
+
+### 按 Worker 的 Slot 状态（新增只读投影，不新增状态）
+
+新增一个接口，对资源管理器已有的实时状态做投影，每个已注册 worker 一行：
+
+| 字段 | 数据来源 |
+|---|---|
+| `address` | `WorkerProfile.address` |
+| `totalSlot` | `assignedSlots.length + unassignedSlots.length` |
+| `usedSlot` | `assignedSlots.length` |
+| `dynamicSlot` | `WorkerProfile.dynamicSlot` |
+| `cpuPercentage` / `memPercentage` | `WorkerProfile.systemLoadInfo`（可能为空，只有调度器已经采集到时才有值） |
+| `attributes` | `WorkerProfile.attributes`（worker 标签） |
+
+这是一次纯读取/投影操作：调用 `getRegisterWorker()` 并映射每个 `WorkerProfile`，完全复用 `GetOverviewOperation` 已经建立的跨节点访问模式。它不会给 `WorkerProfile` 本身新增任何字段，也不改动任何分配/调度代码路径。
+
+Workers/Master 页面在客户端按 `address`（host + port）把这份数据和现有的 `Monitor` 行做关联，方式和页面现在用 `isMaster` 区分 Master/Worker 行完全一致。
+
+## 稳定契约与 Best-Effort 信号
+
+稳定标识：
+
+- `host`、`port`、`isMaster`/角色
+- `totalSlot`、`usedSlot`（派生自实时 slot 数组，因为读取的是同一份状态，天然和调度器自身视图保持一致）
+
+Best-effort 诊断信号：
+
+- CPU load、内存使用、GC 计数（今天通过 `/system-monitoring-information` 拿到的本来就是 best-effort 数据）
+- 来自 `systemLoadInfo` 的 `cpuPercentage`/`memPercentage`——按调度器自己的节奏采集填充，不保证严格实时
+
+## 刷新、留存与成本
+
+- 复用 Workers/Master 页面现有的"进入页面即请求"模型，不在 `/system-monitoring-information` 之外新增持续轮询。
+- 新接口的开销是 O(已注册 worker 数)，和已经遍历同一份资源管理器状态的 `GET /overview` 成本量级一致。
+- 不会把任何新数据写入磁盘或做超出资源管理器现有内存态 `WorkerProfile` map 之外的留存。
+
+## 大集群降级
+
+对于 worker 数量较多的集群，表格仍然是扁平、可排序/可筛选的列表，而不是图，因此不存在类似 DAG 那样的渲染成本问题——行数随 worker 数量线性增长，且现有 `NDataTable` 组件已经支持分页。
+
+## V1 交付计划
+
+1. 新增 `WorkerOverviewInfo` DTO 和 `GetWorkerOverviewOperation`，复用 `GetOverviewOperation` 的跨节点模式，数据来自 `ResourceManager.getRegisterWorker()`。
+2. 参照现有 `OverviewService`/`OverviewServlet` 的结构，新增对应的 REST 接口和 servlet。
+3. 扩展 `seatunnel-engine-ui` 的 manager service/types，拉取新接口并按 address 与现有 `/system-monitoring-information` 数据做关联。
+4. 按上文的精选列扩展 Workers/Master 表格，并重新启用现有（当前被注释）的 Action 列，作为展示完整原始数据的"查看详情"抽屉。
+5. 更新中英文 Web UI 与 REST API 文档。
+
+## 验收要求
+
+- 后端单元测试覆盖从 `WorkerProfile` 到 `WorkerOverviewInfo` 的映射逻辑，包括零已注册 worker、worker 的 slot 数为零这两种情况。
+- 前端测试覆盖按 address 做客户端关联的逻辑，以及精选列的渲染。
+- 文档需要明确写出 slot 与 load 字段反映的是资源管理器的实时内存态，而不是持久化历史。
+- V1 不引入任何新的持久化表、文件或写入路径。
+
+## 相关文档
+
+- [Web UI](./web-ui.md)
+- [RESTful API V2](./rest-api-v2.md)
+- [实时可观测性](./realtime-observability.md)


### PR DESCRIPTION
## Purpose

This PR adds the STIP/design contract for issue #11665 before implementation starts. It defines the V1 boundary around the existing `/system-monitoring-information` payload and the resource manager's existing live `WorkerProfile` state, adding one new read-only REST projection and no new scheduling state.

## Changes

- Add English and Chinese worker node resource view design pages.
- Register the new Zeta document in the sidebar.
- Link the design from Web UI documentation.

## Validation

- `git diff --check`
- Verified the new relative documentation links exist.
- Cross-checked documented fields (`WorkerProfile`, `SlotProfile`, `SystemLoadInfo`, `ResourceManager#getRegisterWorker`, `Monitor`, `OverviewInfo`) and REST/operation patterns (`GetOverviewOperation`, `OverviewService`) against current dev source.

This is a docs-only change; no compile, tests, or service runs were executed locally, per this SeaTunnel workspace's local-verification policy. CI remains the functional validation source.

Refs #11665
