### PR TITLE
[Improve][Zeta] Add worker node resource view

### DIFF
--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -761,6 +761,40 @@ When we can't get the job info, the response will be:
 
 ------------------------------------------------------------------------------------------
 
+### Returns Per-Worker Resource Overview
+
+<details>
+ <summary><code>GET</code> <code><b>/resource/workers</b></code> <code>(Returns the resource manager's live per-worker slot and load state.)</code></summary>
+
+This is a read-only projection of state the resource manager already tracks for scheduling; it
+adds no new persisted state. `cpuPercentage` and `memPercentage` are best-effort and may be
+`null` for a worker the scheduler has not yet sampled. Join with
+[`/system-monitoring-information`](#returns-system-monitoring-information) by `host`/`port` for a
+full per-node view.
+
+#### Parameters
+
+#### Responses
+
+```json
+[
+  {
+    "host": "192.168.0.1",
+    "port": 5801,
+    "totalSlot": 4,
+    "usedSlot": 2,
+    "dynamicSlot": false,
+    "cpuPercentage": 0.13,
+    "memPercentage": 0.42,
+    "attributes": {}
+  }
+]
+```
+
+</details>
+
+------------------------------------------------------------------------------------------
+
 ### Submit A Job
 
 <details>

--- a/docs/en/engines/zeta/web-ui.md
+++ b/docs/en/engines/zeta/web-ui.md
@@ -43,8 +43,8 @@ The Web UI of Apache SeaTunnel is a visual inspection console for SeaTunnel Engi
 | Overview | View cluster version, slot usage, worker count, and job counts |
 | Jobs | View running and finished jobs, paginate job lists, and open job details |
 | Job Detail | View DAG, job metrics, exception text, job configuration, logs, and realtime observability data |
-| Workers | View worker-node system monitoring information |
-| Master | View master-node system monitoring information |
+| Workers | View worker-node system monitoring information, plus per-worker slot usage |
+| Master | View master-node system monitoring information, plus per-worker slot usage |
 
 ## Jobs
 
@@ -86,7 +86,9 @@ The "Finished Jobs" section displays jobs that have reached a terminal state, su
 
 ### Workers Information
 
-The "Workers" section displays system monitoring information for worker nodes. Use it to inspect worker address, resource status, and runtime health signals exposed by the engine.
+The "Workers" section displays system monitoring information for worker nodes: host, port, role, CPU load, heap usage, physical memory, GC counts, thread count, and per-worker slot usage (used/total, sourced live from the resource manager). Click "View" on a row to open a details drawer with the complete raw monitoring payload for that node.
+
+See [Worker Node Resource View](worker-node-resource-view.md) for the design background.
 
 ![workers.png](../../../images/ui/workers.png)
 
@@ -94,7 +96,7 @@ The "Workers" section displays system monitoring information for worker nodes. U
 
 ### Master Information
 
-The "Master" section displays system monitoring information for master nodes. Use it to inspect the current master-side runtime state and resource signals exposed by the engine.
+The "Master" section displays the same system monitoring and slot-usage columns as Workers, scoped to master nodes. Use it to inspect the current master-side runtime state and resource signals exposed by the engine.
 
 ![master.png](../../../images/ui/master.png)
 
@@ -102,5 +104,6 @@ The "Master" section displays system monitoring information for master nodes. Us
 
 - [REST API and Web UI](./rest-api-and-web-ui.md)
 - [REST API V2](./rest-api-v2.md)
+- [Worker Node Resource View](./worker-node-resource-view.md)
 - [Job Lifecycle API](./rest-api-job-lifecycle.md)
 - [Security](./security.md)

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -738,6 +738,38 @@ seatunnel:
 
 ------------------------------------------------------------------------------------------
 
+### 返回按 Worker 维度的资源概览
+
+<details>
+ <summary><code>GET</code> <code><b>/resource/workers</b></code> <code>(返回资源管理器当前维护的按 worker 统计的 slot 与负载状态。)</code></summary>
+
+这是对资源管理器已有调度状态的只读投影，不引入任何新的持久化状态。`cpuPercentage` 和 `memPercentage`
+是 best-effort 字段，如果调度器还没有采集到对应 worker 的数据，可能为 `null`。可以按 `host`/`port`
+和 [`/system-monitoring-information`](#返回系统监控信息) 的结果做关联，得到更完整的单节点视图。
+
+#### 参数
+
+#### 返回结果
+
+```json
+[
+  {
+    "host": "192.168.0.1",
+    "port": 5801,
+    "totalSlot": 4,
+    "usedSlot": 2,
+    "dynamicSlot": false,
+    "cpuPercentage": 0.13,
+    "memPercentage": 0.42,
+    "attributes": {}
+  }
+]
+```
+
+</details>
+
+------------------------------------------------------------------------------------------
+
 ### 提交作业
 
 <details>

--- a/docs/zh/engines/zeta/web-ui.md
+++ b/docs/zh/engines/zeta/web-ui.md
@@ -43,8 +43,8 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 | Overview | 查看集群版本、slot 使用、worker 数量和作业数量 |
 | Jobs | 查看运行中和已完成作业、分页浏览作业列表、进入作业详情 |
 | Job Detail | 查看 DAG、作业指标、异常文本、作业配置、日志，以及开启后的实时可观测指标 |
-| Workers | 查看 worker 节点系统监控信息 |
-| Master | 查看 master 节点系统监控信息 |
+| Workers | 查看 worker 节点系统监控信息，以及按 worker 统计的 slot 使用情况 |
+| Master | 查看 master 节点系统监控信息，以及按 worker 统计的 slot 使用情况 |
 
 ## 作业
 
@@ -87,7 +87,9 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 
 ### 工作节点信息
 
-“工作节点”模块展示 worker 节点的系统监控信息。可以用它查看 worker 地址、资源状态和引擎暴露的运行时健康信号。
+“工作节点”模块展示 worker 节点的系统监控信息：主机、端口、角色、CPU load、堆内存使用、物理内存、GC 次数、线程数，以及按 worker 统计的 slot 使用情况（已用/总数，数据来自资源管理器的实时状态）。点击某一行的“View”可以打开详情抽屉，查看该节点完整的原始监控数据。
+
+设计背景参见 [Worker 节点资源视图](worker-node-resource-view.md)。
 
 ![workers.png](../../../images/ui/workers.png)
 
@@ -95,7 +97,7 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 
 ### 管理节点信息
 
-“管理节点”模块展示 master 节点的系统监控信息。可以用它查看当前 master 侧运行状态和引擎暴露的资源信号。
+“管理节点”模块展示和工作节点相同的系统监控与 slot 使用情况列，范围限定在 master 节点。可以用它查看当前 master 侧运行状态和引擎暴露的资源信号。
 
 ![master.png](../../../images/ui/master.png)
 
@@ -103,5 +105,6 @@ Apache SeaTunnel 的 Web UI 是 SeaTunnel Engine 的可视化巡检控制台。�
 
 - [REST API 与 Web UI](./rest-api-and-web-ui.md)
 - [REST API V2](./rest-api-v2.md)
+- [Worker 节点资源视图](./worker-node-resource-view.md)
 - [作业生命周期 API](./rest-api-job-lifecycle.md)
 - [安全](./security.md)

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
@@ -52,6 +52,7 @@ import org.apache.seatunnel.engine.server.rest.servlet.SubmitJobsServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.SystemMonitoringServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.ThreadDumpServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.UpdateTagsServlet;
+import org.apache.seatunnel.engine.server.rest.servlet.WorkerOverviewServlet;
 
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import lombok.extern.slf4j.Slf4j;
@@ -92,6 +93,7 @@ import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_SUBM
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_SYSTEM_MONITORING_INFORMATION;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_THREAD_DUMP;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_UPDATE_TAGS;
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_WORKER_OVERVIEW;
 
 /** The Jetty service for SeaTunnel engine server. */
 @Slf4j
@@ -189,6 +191,8 @@ public class JettyService {
         ServletHolder finishedJobsHolder = new ServletHolder(new FinishedJobsServlet(nodeEngine));
         ServletHolder systemMonitoringHolder =
                 new ServletHolder(new SystemMonitoringServlet(nodeEngine));
+        ServletHolder workerOverviewHolder =
+                new ServletHolder(new WorkerOverviewServlet(nodeEngine));
         ServletHolder jobInfoHolder = new ServletHolder(new JobInfoServlet(nodeEngine));
         ServletHolder threadDumpHolder = new ServletHolder(new ThreadDumpServlet(nodeEngine));
 
@@ -227,6 +231,7 @@ public class JettyService {
         context.addServlet(finishedJobsHolder, convertUrlToPath(REST_URL_FINISHED_JOBS));
         context.addServlet(
                 systemMonitoringHolder, convertUrlToPath(REST_URL_SYSTEM_MONITORING_INFORMATION));
+        context.addServlet(workerOverviewHolder, convertUrlToPath(REST_URL_WORKER_OVERVIEW));
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_JOB_INFO));
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_RUNNING_JOB));
         context.addServlet(threadDumpHolder, convertUrlToPath(REST_URL_THREAD_DUMP));

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/GetWorkerOverviewOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/GetWorkerOverviewOperation.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.resourcemanager.opeartion;
+
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SystemLoadInfo;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.WorkerOverviewInfo;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
+import org.apache.seatunnel.engine.server.serializable.ResourceDataSerializerHook;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+/**
+ * Projects the resource manager's existing live {@link WorkerProfile} map into a per-worker DTO for
+ * the Web UI. This operation only reads already-tracked scheduler state ({@code
+ * assignedSlots}/{@code unassignedSlots} counts, {@code systemLoadInfo}); it introduces no new
+ * scheduling state and never mutates slot assignment.
+ */
+public class GetWorkerOverviewOperation extends Operation implements IdentifiedDataSerializable {
+
+    private List<WorkerOverviewInfo> workerOverviewInfos;
+
+    public GetWorkerOverviewOperation() {}
+
+    @Override
+    public void run() throws Exception {
+        SeaTunnelServer server = getService();
+        workerOverviewInfos = getWorkerOverviewInfos(server);
+    }
+
+    @Override
+    public Object getResponse() {
+        return workerOverviewInfos;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ResourceDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ResourceDataSerializerHook.GET_WORKER_OVERVIEW_TYPE;
+    }
+
+    @Override
+    public String getServiceName() {
+        return SeaTunnelServer.SERVICE_NAME;
+    }
+
+    public static List<WorkerOverviewInfo> getWorkerOverviewInfos(SeaTunnelServer server) {
+        ResourceManager resourceManager = server.getCoordinatorService().getResourceManager();
+        ConcurrentMap<Address, WorkerProfile> registerWorker = resourceManager.getRegisterWorker();
+        return registerWorker.values().stream()
+                .map(GetWorkerOverviewOperation::toWorkerOverviewInfo)
+                .collect(Collectors.toList());
+    }
+
+    // package-private for direct unit testing without mocking the SeaTunnelServer chain
+    static WorkerOverviewInfo toWorkerOverviewInfo(WorkerProfile workerProfile) {
+        WorkerOverviewInfo info = new WorkerOverviewInfo();
+        Address address = workerProfile.getAddress();
+        info.setHost(address.getHost());
+        info.setPort(address.getPort());
+
+        int assignedSlots =
+                workerProfile.getAssignedSlots() == null
+                        ? 0
+                        : workerProfile.getAssignedSlots().length;
+        int unassignedSlots =
+                workerProfile.getUnassignedSlots() == null
+                        ? 0
+                        : workerProfile.getUnassignedSlots().length;
+        info.setUsedSlot(assignedSlots);
+        info.setTotalSlot(assignedSlots + unassignedSlots);
+        info.setDynamicSlot(workerProfile.isDynamicSlot());
+
+        SystemLoadInfo systemLoadInfo = workerProfile.getSystemLoadInfo();
+        if (systemLoadInfo != null) {
+            info.setCpuPercentage(systemLoadInfo.getCpuPercentage());
+            info.setMemPercentage(systemLoadInfo.getMemPercentage());
+        }
+        info.setAttributes(workerProfile.getAttributes());
+        return info;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/resource/WorkerOverviewInfo.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/resource/WorkerOverviewInfo.java
@@ -15,12 +15,27 @@
  * limitations under the License.
  */
 
-import { get } from '@/service/service'
-import type { Monitor, WorkerOverview } from './types'
+package org.apache.seatunnel.engine.server.resourcemanager.resource;
 
-export const getMonitors = () => get<Monitor[]>('/system-monitoring-information')
-export const getWorkerOverview = () => get<WorkerOverview[]>('/resource/workers')
-export const managerService = {
-  getMonitors,
-  getWorkerOverview
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Read-only, per-worker projection of the resource manager's live {@link
+ * org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile} state for the Web UI.
+ * Every field is derived from state the resource manager already tracks for scheduling; this class
+ * adds no new persisted or mutable state of its own.
+ */
+@Data
+public class WorkerOverviewInfo implements Serializable {
+    private String host;
+    private int port;
+    private int totalSlot;
+    private int usedSlot;
+    private boolean dynamicSlot;
+    private Double cpuPercentage;
+    private Double memPercentage;
+    private Map<String, String> attributes;
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
@@ -93,6 +93,8 @@ public class RestConstant {
     public static final String REST_URL_RUNNING_THREADS = "/running-threads";
     public static final String REST_URL_SYSTEM_MONITORING_INFORMATION =
             "/system-monitoring-information";
+    // Per-worker slot/load projection of the resource manager's live WorkerProfile state
+    public static final String REST_URL_WORKER_OVERVIEW = "/resource/workers";
     public static final String REST_URL_SUBMIT_JOB = "/submit-job";
 
     public static final String REST_URL_SUBMIT_JOB_BY_UPLOAD_FILE = "/submit-job/upload";

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/WorkerOverviewService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/WorkerOverviewService.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetWorkerOverviewOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.WorkerOverviewInfo;
+import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Serves the per-worker resource projection ({@link GetWorkerOverviewOperation}) for the Web UI
+ * Workers/Master pages. Mirrors {@link OverviewService}'s local-vs-forward-to-master routing: when
+ * this node is not the active master, the request is forwarded there since resource manager state
+ * only lives on the master.
+ */
+public class WorkerOverviewService extends BaseService {
+
+    private final NodeEngineImpl nodeEngine;
+
+    public WorkerOverviewService(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+        this.nodeEngine = nodeEngine;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<WorkerOverviewInfo> getWorkerOverviewInfos() {
+        SeaTunnelServer seaTunnelServer = getSeaTunnelServer(true);
+
+        if (seaTunnelServer == null) {
+            // Master election may not be finished yet (e.g. right after local engine startup).
+            // Avoid sending operation to a null master address which will trigger NPE.
+            if (nodeEngine.getMasterAddress() == null) {
+                return Collections.emptyList();
+            }
+            return (List<WorkerOverviewInfo>)
+                    NodeEngineUtil.sendOperationToMasterNode(
+                                    nodeEngine, new GetWorkerOverviewOperation())
+                            .join();
+        }
+        return GetWorkerOverviewOperation.getWorkerOverviewInfos(seaTunnelServer);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/WorkerOverviewServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/WorkerOverviewServlet.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.servlet;
+
+import org.apache.seatunnel.engine.server.rest.service.WorkerOverviewService;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class WorkerOverviewServlet extends BaseServlet {
+
+    private final WorkerOverviewService workerOverviewService;
+
+    public WorkerOverviewServlet(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+        this.workerOverviewService = new WorkerOverviewService(nodeEngine);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        writeJson(resp, workerOverviewService.getWorkerOverviewInfos());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHook.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHook.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.engine.server.master.cleanup.JobCleanupRecord;
 import org.apache.seatunnel.engine.server.master.cleanup.PipelineCleanupRecord;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetOverviewOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetPendingJobsOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetWorkerOverviewOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReleaseSlotOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.RequestSlotOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ResetResourceOperation;
@@ -61,6 +62,8 @@ public class ResourceDataSerializerHook implements DataSerializerHook {
     public static final int PIPELINE_CLEANUP_RECORD_TYPE = 11;
 
     public static final int JOB_CLEANUP_RECORD_TYPE = 12;
+
+    public static final int GET_WORKER_OVERVIEW_TYPE = 13;
 
     public static final int FACTORY_ID =
             FactoryIdHelper.getFactoryId(
@@ -106,6 +109,8 @@ public class ResourceDataSerializerHook implements DataSerializerHook {
                     return new PipelineCleanupRecord();
                 case JOB_CLEANUP_RECORD_TYPE:
                     return new JobCleanupRecord();
+                case GET_WORKER_OVERVIEW_TYPE:
+                    return new GetWorkerOverviewOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/GetWorkerOverviewOperationTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/GetWorkerOverviewOperationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.resourcemanager.opeartion;
+
+import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SystemLoadInfo;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.WorkerOverviewInfo;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.cluster.Address;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+
+/**
+ * Covers {@link GetWorkerOverviewOperation#toWorkerOverviewInfo(WorkerProfile)}, the pure mapping
+ * from the resource manager's live {@link WorkerProfile} to the Web UI-facing {@link
+ * WorkerOverviewInfo} projection. No new scheduling behavior is under test here - only that the
+ * projection reads existing slot/load state correctly and tolerates the fields being absent.
+ */
+class GetWorkerOverviewOperationTest {
+
+    @Test
+    void mapsSlotCountsAndLoadFromAFullyPopulatedWorkerProfile() throws UnknownHostException {
+        Address address = new Address("localhost", 5801);
+        SlotProfile assignedSlot = new SlotProfile(address, 0, new ResourceProfile(), "sequence-0");
+        WorkerProfile workerProfile =
+                new WorkerProfile(
+                        address,
+                        new ResourceProfile(),
+                        new ResourceProfile(),
+                        true,
+                        new SlotProfile[] {assignedSlot},
+                        new SlotProfile[] {
+                            new SlotProfile(address, 1, new ResourceProfile(), "sequence-1"),
+                            new SlotProfile(address, 2, new ResourceProfile(), "sequence-2")
+                        },
+                        Collections.singletonMap("tag", "value"));
+        workerProfile.setSystemLoadInfo(new SystemLoadInfo(0.42, 0.13));
+
+        WorkerOverviewInfo info = GetWorkerOverviewOperation.toWorkerOverviewInfo(workerProfile);
+
+        Assertions.assertEquals("localhost", info.getHost());
+        Assertions.assertEquals(5801, info.getPort());
+        Assertions.assertEquals(1, info.getUsedSlot());
+        Assertions.assertEquals(3, info.getTotalSlot());
+        Assertions.assertTrue(info.isDynamicSlot());
+        Assertions.assertEquals(0.42, info.getMemPercentage().doubleValue());
+        Assertions.assertEquals(0.13, info.getCpuPercentage().doubleValue());
+        Assertions.assertEquals("value", info.getAttributes().get("tag"));
+    }
+
+    @Test
+    void treatsMissingSlotArraysAndLoadInfoAsZeroInsteadOfThrowing() throws UnknownHostException {
+        // The no-arg WorkerProfile constructor leaves assignedSlots/unassignedSlots/
+        // systemLoadInfo null; a worker that has not fully reported yet must not crash
+        // the projection.
+        WorkerProfile workerProfile = new WorkerProfile();
+        workerProfile.setAddress(new Address("localhost", 5802));
+
+        WorkerOverviewInfo info = GetWorkerOverviewOperation.toWorkerOverviewInfo(workerProfile);
+
+        Assertions.assertEquals(0, info.getUsedSlot());
+        Assertions.assertEquals(0, info.getTotalSlot());
+        Assertions.assertNull(info.getCpuPercentage());
+        Assertions.assertNull(info.getMemPercentage());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-ui/src/service/manager/types.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/service/manager/types.ts
@@ -65,3 +65,16 @@ export interface Monitor {
   'client.connection.count': string
   'connection.count': string
 }
+
+// Read-only per-worker slot/load projection from GET /resource/workers. Every field mirrors
+// the resource manager's own live WorkerProfile state; see WorkerOverviewInfo.java.
+export interface WorkerOverview {
+  host: string
+  port: number
+  totalSlot: number
+  usedSlot: number
+  dynamicSlot: boolean
+  cpuPercentage: number | null
+  memPercentage: number | null
+  attributes: Record<string, string> | null
+}

--- a/seatunnel-engine/seatunnel-engine-ui/src/tests/managers.spec.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/tests/managers.spec.ts
@@ -21,7 +21,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { createApp } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import i18n from '@/locales'
-import type { Monitor } from '@/service/manager/types'
+import type { Monitor, WorkerOverview } from '@/service/manager/types'
 import { managerService } from '@/service/manager'
 import managers from '@/views/managers'
 
@@ -49,8 +49,21 @@ describe('managers', () => {
         'heap.memory.used': '1002.6M'
       }
     ] as Monitor[]
+    const mockWorkerOverview = [
+      {
+        host: 'localhost',
+        port: 5801,
+        totalSlot: 4,
+        usedSlot: 2,
+        dynamicSlot: false,
+        cpuPercentage: 0.1,
+        memPercentage: 0.2,
+        attributes: {}
+      }
+    ] as WorkerOverview[]
 
     vi.spyOn(managerService, 'getMonitors').mockResolvedValue(mockData)
+    vi.spyOn(managerService, 'getWorkerOverview').mockResolvedValue(mockWorkerOverview)
 
     const wrapper = mount(managers, {
       global: {
@@ -62,5 +75,10 @@ describe('managers', () => {
     expect(managerService.getMonitors).toHaveBeenCalledWith()
     await flushPromises()
     expect(wrapper.text()).toContain('localhost')
+    // Row for port 5801 has a matching WorkerOverview entry: used/total slots should render.
+    expect(wrapper.text()).toContain('2/4')
+    // Row for port 5802 has no matching WorkerOverview entry: falls back to a placeholder
+    // instead of throwing or showing "undefined/undefined".
+    expect(wrapper.text()).toContain('-')
   })
 })

--- a/seatunnel-engine/seatunnel-engine-ui/src/views/managers/index.tsx
+++ b/seatunnel-engine/seatunnel-engine-ui/src/views/managers/index.tsx
@@ -14,32 +14,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { defineComponent, getCurrentInstance, h, ref } from 'vue'
-import { useMessage, NDataTable } from 'naive-ui'
+import { defineComponent, h, ref } from 'vue'
+import { NDataTable, NDrawer, NDrawerContent } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import type { DataTableColumns } from 'naive-ui'
 import { NButton } from 'naive-ui'
-import { NSpace, NLayout, NLayoutContent } from 'naive-ui'
+import { NLayout, NLayoutContent } from 'naive-ui'
 import { managerService } from '@/service/manager'
-import type { Monitor } from '@/service/manager/types'
+import type { Monitor, WorkerOverview } from '@/service/manager/types'
 import { useRoute } from 'vue-router'
+import Configuration from '@/components/configuration'
+
+// A Workers/Master table row: the raw system-monitoring-information fields plus, when the
+// resource manager has a matching live WorkerProfile, its slot/attribute projection. The slot
+// fields are optional because a monitored node and a registered resource-manager worker are two
+// independent sources joined client-side by host+port; one can be present without the other
+// (e.g. right after a node joins, or for a non-worker node type in the future).
+type WorkerRow = Monitor & Partial<Pick<WorkerOverview, 'totalSlot' | 'usedSlot' | 'attributes'>>
 
 export default defineComponent({
   setup() {
     const { t } = useI18n()
     const route = useRoute()
-    const monitors = ref([] as Monitor[])
+    const monitors = ref([] as WorkerRow[])
+    const drawerShow = ref(false)
+    const selectedRow = ref({} as WorkerRow)
 
     const fetch = async () => {
-      let res = await managerService.getMonitors()
       const isMaster = route?.path.endsWith('/master') || false
-      res = res.filter((row) => row.isMaster === String(isMaster)) || []
-      monitors.value = res
+      const [monitorRes, workerOverviews] = await Promise.all([
+        managerService.getMonitors(),
+        // The resource manager only knows about workers, and may be briefly unreachable
+        // right after startup; never let that block rendering the monitoring table itself.
+        managerService.getWorkerOverview().catch(() => [] as WorkerOverview[])
+      ])
+      const overviewByAddress = new Map<string, WorkerOverview>()
+      workerOverviews.forEach((worker) => {
+        overviewByAddress.set(`${worker.host}:${worker.port}`, worker)
+      })
+
+      monitors.value = (monitorRes || [])
+        .filter((row) => row.isMaster === String(isMaster))
+        .map((row) => {
+          const worker = overviewByAddress.get(`${row.host}:${row.port}`)
+          return worker
+            ? {
+                ...row,
+                totalSlot: worker.totalSlot,
+                usedSlot: worker.usedSlot,
+                attributes: worker.attributes
+              }
+            : row
+        })
     }
     fetch()
 
-    function createColumns(): DataTableColumns<Monitor> {
-      const view = (row: Monitor) => {}
+    const viewDetail = (row: WorkerRow) => {
+      selectedRow.value = row
+      drawerShow.value = true
+    }
+
+    function createColumns(): DataTableColumns<WorkerRow> {
       return [
         {
           title: 'Host',
@@ -50,28 +85,55 @@ export default defineComponent({
           key: 'port'
         },
         {
-          title: 'Physical MEM',
-          key: 'physical.memory.total'
+          title: 'Role',
+          key: 'isMaster',
+          render: (row) => (row.isMaster === 'true' ? 'Master' : 'Worker')
+        },
+        {
+          title: 'CPU Load',
+          key: 'load.systemAverage'
         },
         {
           title: 'Heap MEM Used',
           key: 'heap.memory.used'
-          // },
-          // {
-          //   title: 'Action',
-          //   key: 'actions',
-          //   render(row) {
-          //     return h(
-          //       NButton,
-          //       {
-          //         strong: true,
-          //         tertiary: true,
-          //         size: 'small',
-          //         onClick: () => view(row)
-          //       },
-          //       { default: () => 'View' }
-          //     )
-          //   }
+        },
+        {
+          title: 'Heap MEM Max',
+          key: 'heap.memory.max'
+        },
+        {
+          title: 'Physical MEM',
+          key: 'physical.memory.total'
+        },
+        {
+          title: 'GC (minor/major)',
+          key: 'gc',
+          render: (row) => `${row['minor.gc.count']}/${row['major.gc.count']}`
+        },
+        {
+          title: 'Threads',
+          key: 'thread.count'
+        },
+        {
+          title: 'Slots (used/total)',
+          key: 'slots',
+          render: (row) => (row.totalSlot === undefined ? '-' : `${row.usedSlot}/${row.totalSlot}`)
+        },
+        {
+          title: 'Action',
+          key: 'actions',
+          render: (row) => {
+            return h(
+              NButton,
+              {
+                strong: true,
+                tertiary: true,
+                size: 'small',
+                onClick: () => viewDetail(row)
+              },
+              { default: () => 'View' }
+            )
+          }
         }
       ]
     }
@@ -89,6 +151,16 @@ export default defineComponent({
               bordered={false}
             />
           </div>
+          <NDrawer
+            show={drawerShow.value}
+            width={'40%'}
+            closeOnEsc
+            onUpdateShow={(show: boolean) => (drawerShow.value = show)}
+          >
+            <NDrawerContent title={`${selectedRow.value.host}:${selectedRow.value.port}`} closable>
+              <Configuration data={selectedRow.value}></Configuration>
+            </NDrawerContent>
+          </NDrawer>
         </NLayoutContent>
       </NLayout>
     )


### PR DESCRIPTION
## Purpose

Implements issue #11665: extend the Zeta Web UI Workers/Master page into a usable node resource view. This is the implementation follow-up to the STIP/design PR #11732 (please merge #11732 first, or at least review it alongside this one - this PR's docs link to the design page it adds).

## What changed

**Backend (read-only projection, no new scheduling behavior):**
- `WorkerOverviewInfo`: a new DTO, one row per worker (`host`, `port`, `totalSlot`, `usedSlot`, `dynamicSlot`, `cpuPercentage`, `memPercentage`, `attributes`).
- `GetWorkerOverviewOperation`: maps `ResourceManager#getRegisterWorker()`'s live `WorkerProfile` map to `WorkerOverviewInfo` - `totalSlot`/`usedSlot` come directly from `assignedSlots.length`/`unassignedSlots.length`, which is the same state the resource manager itself uses to accept or reject allocation requests. No new field is added to `WorkerProfile`, and no allocation/scheduling code path is touched.
- `WorkerOverviewService` / `WorkerOverviewServlet`: new `GET /resource/workers` endpoint, following the exact local-vs-forward-to-master routing already used by `OverviewService`/`OverviewServlet`.
- Wiring: `RestConstant#REST_URL_WORKER_OVERVIEW`, `JettyService` servlet registration, `ResourceDataSerializerHook#GET_WORKER_OVERVIEW_TYPE` (next available id, 13).

**Frontend:**
- `managers/index.tsx`: fetches `/system-monitoring-information` and `/resource/workers` in parallel and joins them client-side by `host:port` (the new call is wrapped in `.catch()` so a resource-manager hiccup never blocks the existing monitoring table). Table now shows Host, Port, Role, CPU Load, Heap Used/Max, Physical MEM, GC, Threads, and Slots (used/total) instead of today's 4 columns. Re-enables the previously commented-out Action column as a "View Details" drawer (reusing the existing `Configuration` key-value component) showing the complete raw payload for a row.
- `service/manager/types.ts` / `index.ts`: `WorkerOverview` type and `getWorkerOverview()` call.

**Docs:** `web-ui.md` (EN/ZH) capability description, `rest-api-v2.md` (EN/ZH) endpoint reference.

**Tests:** `GetWorkerOverviewOperationTest` covers the `WorkerProfile` -> `WorkerOverviewInfo` mapping, including a worker with no slots/load info yet reported (must not throw). `managers.spec.ts` covers the client-side join, including a row with no matching `WorkerOverview` entry.

## Non-goals (see the design doc)

Per-worker "tasks currently running here" (would need `/trace/task-mapping` fan-out across all running jobs), historical retention, capacity planning - explicitly deferred, not silently dropped.

## Validation

- `./mvnw spotless:apply -pl seatunnel-engine/seatunnel-engine-server -am` - clean.
- `npx prettier --write` / `npx eslint --fix` on the changed frontend files - clean.
- Per this SeaTunnel workspace's local-verification policy, no local compile/test/service run was performed; CI is the functional validation source for both the new Java unit test and the Vitest component test.

Refs #11665
