### PR TITLE
fix: remove unreachable LocalTimestampMillisConversion from ParquetWriteStrategy data model [#11743]

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ParquetWriteStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ParquetWriteStrategy.java
@@ -174,7 +174,13 @@ public class ParquetWriteStrategy extends AbstractWriteStrategy<ParquetWriter<Ge
         GenericData dataModel = new GenericData();
         dataModel.addLogicalTypeConversion(new Conversions.DecimalConversion());
         dataModel.addLogicalTypeConversion(new TimeConversions.DateConversion());
-        dataModel.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+        // LocalTimestampMillisConversion is not needed here because
+        // seaTunnelDataType2ParquetDataType maps TIMESTAMP to
+        // INT64.as(OriginalType.TIMESTAMP_MILLIS), which AvroSchemaConverter
+        // converts to Avro's timestamp-millis (not local-timestamp-millis).
+        // resolveObject also handles TIMESTAMP values manually (converting to
+        // epoch millis), bypassing the data model entirely.
+        // See https://github.com/apache/seatunnel/issues/11743
         if (writer == null) {
             Path path = new Path(filePath);
             // initialize the kerberos login


### PR DESCRIPTION
## Description

`ParquetWriteStrategy#getOrCreateOutputStream` registers three Avro logical-type conversions on the data model. The third one (`LocalTimestampMillisConversion`) is unreachable.

### Analysis

1. `seaTunnelDataType2ParquetDataType` maps TIMESTAMP to `INT64.as(OriginalType.TIMESTAMP_MILLIS)`, which parquet-avro's `AvroSchemaConverter` converts to Avro's `timestamp-millis` logical type — NOT `local-timestamp-millis`.

2. `resolveObject` handles TIMESTAMP values manually (converting to epoch millis via `LocalDateTime.toEpochMilli()`), bypassing the data model's conversion entirely.

Therefore, `TimeConversions.LocalTimestampMillisConversion` is never invoked on any code path through this class.

### What changed

- Removed the `LocalTimestampMillisConversion` registration
- Added a comment explaining why it's not needed

### Related issue

Closes #11743