### PR TITLE
[Docs][Connector-V2] Improve DuckDB HiveJdbc Vitess-CDC Redshift and S3-Redshift connector docs

### DIFF
--- a/docs/en/connectors/sink/DuckDB.md
+++ b/docs/en/connectors/sink/DuckDB.md
@@ -16,8 +16,10 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Description
 
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
-semantics (using XA transaction guarantee).
+Write data to a DuckDB database file through JDBC. Supports batch and streaming modes, supports concurrent
+writing, and supports exactly-once semantics when the underlying JDBC driver exposes an XA datasource
+(set `is_exactly_once = true` and provide `xa_data_source_class_name`). DuckDB runs in-process, so the connector
+works against a local database file path (`jdbc:duckdb:/path/to/database.db`) or an in-memory database.
 
 ## Using Dependency
 
@@ -63,30 +65,33 @@ semantics (using XA transaction guarantee).
 
 ## Sink Options
 
-| url                                       | String  | Yes      | -                            | The URL of the JDBC connection. Refer to a case: jdbc:duckdb:/path/to/database.db                                                                                                                                                         |
-| driver                                    | String  | Yes      | -                            | The jdbc class name used to connect to the remote data source,<br/> if you use DuckDB the value is `org.duckdb.DuckDBDriver`.                                                                                                                  |
-| username                                      | String  | No       | -                            | Connection instance user name                                                                                                                                                                                                                  |
-| password                                  | String  | No       | -                            | Connection instance password                                                                                                                                                                                                                   |
-| query                                     | String  | No       | -                            | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                         |
-| database                                  | String  | No       | main                         | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                       |
-| table                                     | String  | No       | -                            | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                           |
-| primary_keys                              | Array   | No       | -                            | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql.                                                                                                                            |
+|                   Name                    |  Type   | Required |           Default            |                                                                                                                  Description                                                                                                                   |
+|-------------------------------------------|---------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                                       | String  | Yes      | -                            | The URL of the JDBC connection. Example: `jdbc:duckdb:/path/to/database.db`. For an in-memory DuckDB, use `jdbc:duckdb:`.                                                                                                                       |
+| driver                                    | String  | Yes      | -                            | The jdbc class name used to connect to the remote data source. For DuckDB, the value is `org.duckdb.DuckDBDriver`.                                                                                                                              |
+| username                                  | String  | No       | -                            | Connection instance user name. DuckDB does not require authentication for local files; leave empty unless you wrap it with a custom authenticator.                                                                                            |
+| password                                  | String  | No       | -                            | Connection instance password. DuckDB does not require authentication for local files; leave empty unless you wrap it with a custom authenticator.                                                                                             |
+| query                                     | String  | No       | -                            | Use this SQL to write upstream input data to the database, for example `INSERT ...`. When `query` is set, it has higher priority than `database`/`table`/`table_list`.                                                                       |
+| database                                  | String  | No       | main                         | Use this `database` and `table` to auto-generate SQL and write upstream input data to the database. This option is mutually exclusive with `query` and has a higher priority.                                                                 |
+| table                                     | String  | No       | -                            | Use database and this table name to auto-generate SQL and write upstream input data to the database. This option is mutually exclusive with `query` and has a higher priority.                                                                |
+| primary_keys                              | Array   | No       | -                            | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generating SQL.                                                                                                                          |
 | connection_check_timeout_sec              | Int     | No       | 30                           | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                            |
-| max_retries                               | Int     | No       | 0                            | The number of retries to submit failed (executeBatch)                                                                                                                                                                                          |
-| batch_size                                | Int     | No       | 1000                         | For batch writing, when the number of buffered records reaches the number of `batch_size` or the time reaches `checkpoint.interval`<br/>, the data will be flushed into the database                                                           |
-| is_exactly_once                           | Boolean | No       | false                        | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`.                                                                                                              |
-| generate_sink_sql                         | Boolean | No       | false                        | Generate sql statements based on the database table you want to write to                                                                                                                                                                       |
-| xa_data_source_class_name                 | String  | No       | -                            | The xa data source class name of the database Driver, for example, DuckDB is `org.duckdb.DuckDBXADataSource`, and<br/>please refer to appendix for other data sources                                                                     |
-| max_commit_attempts                       | Int     | No       | 3                            | The number of retries for transaction commit failures                                                                                                                                                                                          |
-| transaction_timeout_sec                   | Int     | No       | -1                           | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                            |
-| auto_commit                               | Boolean | No       | true                         | Automatic transaction commit is enabled by default                                                                                                                                                                                             |
+| max_retries                               | Int     | No       | 0                            | The number of retries to submit a failed `executeBatch` call.                                                                                                                                                                                  |
+| batch_size                                | Int     | No       | 1000                         | For batch writing, when the number of buffered records reaches `batch_size` or the time reaches `checkpoint.interval`, the data is flushed into the database.                                                                                  |
+| is_exactly_once                           | Boolean | No       | false                        | Whether to enable exactly-once semantics, which uses XA transactions. When enabled, you must also set `xa_data_source_class_name`.                                                                                                              |
+| generate_sink_sql                         | Boolean | No       | false                        | Generate SQL statements based on the database table you want to write to. Requires `database` and `table` (or `table_list`) to be configured.                                                                                                  |
+| xa_data_source_class_name                 | String  | No       | -                            | The XA datasource class name of the database driver. For DuckDB, use `org.duckdb.DuckDBXADataSource`.                                                                                                                                          |
+| max_commit_attempts                       | Int     | No       | 3                            | The number of retries for transaction commit failures.                                                                                                                                                                                        |
+| transaction_timeout_sec                   | Int     | No       | -1                           | The timeout after the transaction is opened, the default is `-1` (never timeout). Note that setting the timeout may affect exactly-once semantics.                                                                                             |
+| auto_commit                               | Boolean | No       | true                         | Whether to enable automatic transaction commit. Set to `false` when `is_exactly_once = true`.                                                                                                                                                 |
 | field_ide                                 | String  | No       | -                            | Identify whether the field needs to be converted when synchronizing from the source to the sink. `ORIGINAL` indicates no conversion is needed; `UPPERCASE` indicates conversion to uppercase; `LOWERCASE` indicates conversion to lowercase.     |
-| properties                                | Map     | No       | -                            | Additional connection configuration parameters, when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in DuckDB, properties take precedence over the URL. |
-| common-options                            |         | No       | -                            | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                                    |
-| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Before the synchronous task is turned on, different treatment schemes are selected for the existing surface structure of the target side.                                                                                                      |
-| data_save_mode                            | Enum    | No       | APPEND_DATA                  | Before the synchronous task is turned on, different processing schemes are selected for data existing data on the target side.                                                                                                                 |
-| custom_sql                                | String  | No       | -                            | When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL parameter. This parameter usually fills in a SQL that can be executed. SQL will be executed before synchronization tasks.                                     |
-| enable_upsert                             | Boolean | No       | true                         | Enable upsert by primary_keys exist, If the task only has `insert`, setting this parameter to `false` can speed up data import                                                                                                                 |
+| properties                                | Map     | No       | -                            | Additional connection configuration parameters. When properties and URL have the same parameters, the priority is determined by the specific driver implementation. For DuckDB, properties take precedence over the URL.                         |
+| common-options                            |         | No       | -                            | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                                                    |
+| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | How to handle the existing table schema on the target side before the sync task starts. Supported values: `RECREATE_SCHEMA`, `CREATE_SCHEMA_WHEN_NOT_EXIST`, `ERROR_WHEN_SCHEMA_NOT_EXIST`.                                                     |
+| data_save_mode                            | Enum    | No       | APPEND_DATA                  | How to handle existing data on the target side before the sync task starts. Supported values: `DROP_DATA`, `APPEND_DATA`, `CUSTOM_PROCESSING`, `ERROR_WHEN_DATA_EXISTS`.                                                                      |
+| custom_sql                                | String  | No       | -                            | When `data_save_mode = CUSTOM_PROCESSING`, fill in the CUSTOM_SQL parameter. This is a SQL statement that runs before the synchronization task.                                                                                               |
+| enable_upsert                             | Boolean | No       | true                         | Enable upsert by `primary_keys`. If the task only has `insert`, setting this parameter to `false` can speed up data import.                                                                                                                   |
+| multi_table_sink_replica                  | Int     | No       | 1                            | The number of replicas for multi-table write. When `multi_table_sink_replica > 1`, the data is written to multiple tables in parallel.                                                                                                       |
 
 ### Tips
 
@@ -96,7 +101,7 @@ semantics (using XA transaction guarantee).
 
 ### Simple
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"
@@ -128,9 +133,9 @@ sink {
 }
 ```
 
-### CDC(Change data capture) event
+### CDC (Change Data Capture) Event
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "STREAMING"
@@ -162,9 +167,9 @@ sink {
 }
 ```
 
-### Exactly-once
+### Exactly-Once
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"

--- a/docs/en/connectors/sink/Redshift.md
+++ b/docs/en/connectors/sink/Redshift.md
@@ -90,9 +90,9 @@ semantics (using XA transaction guarantee).
 | field_ide                                 | String  | No       | -                            | Identify whether the field needs to be converted when synchronizing from the source to the sink. `ORIGINAL` indicates no conversion is needed;`UPPERCASE` indicates conversion to uppercase;`LOWERCASE` indicates conversion to lowercase.      |
 | properties                                | Map     | No       | -                            | Additional connection configuration parameters, when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in Redshift, properties take precedence over the URL. |
 | common-options                            |         | No       | -                            | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                     |
-| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Before the synchronous task is turned on, different treatment schemes are selected for the existing surface structure of the target side.                                                                                                       |
-| data_save_mode                            | Enum    | No       | APPEND_DATA                  | Before the synchronous task is turned on, different processing schemes are selected for data existing data on the target side.                                                                                                                  |
-| custom_sql                                | String  | No       | -                            | When data_save_mode selects CUSTOM_PROCESSING, you should fill in the CUSTOM_SQL parameter. This parameter usually fills in a SQL that can be executed. SQL will be executed before synchronization tasks.                                      |
+| schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | How to handle the existing table schema on the target side before the sync task starts. Supported values: `RECREATE_SCHEMA`, `CREATE_SCHEMA_WHEN_NOT_EXIST`, `ERROR_WHEN_SCHEMA_NOT_EXIST`.                                                       |
+| data_save_mode                            | Enum    | No       | APPEND_DATA                  | How to handle existing data on the target side before the sync task starts. Supported values: `DROP_DATA`, `APPEND_DATA`, `CUSTOM_PROCESSING`, `ERROR_WHEN_DATA_EXISTS`.                                                                          |
+| custom_sql                                | String  | No       | -                            | When `data_save_mode = CUSTOM_PROCESSING`, fill in the CUSTOM_SQL parameter. This is a SQL statement that runs before the synchronization task.                                                                                                  |
 | enable_upsert                             | Boolean | No       | true                         | Enable upsert by primary_keys exist, If the task only has `insert`, setting this parameter to `false` can speed up data import                                                                                                                 |
 | multi_table_sink_replica                  | Int     | No       | 1                            | The number of replicas for multi-table write, when `multi_table_sink_replica > 1`, the data will be written to multiple tables in parallel                                                                                                     |
 
@@ -102,7 +102,7 @@ semantics (using XA transaction guarantee).
 
 > This example defines a SeaTunnel synchronization task that automatically generates data through FakeSource and sends it to JDBC Sink. FakeSource generates a total of 16 rows of data (row.num=16), with each row having two fields, name (string type) and age (int type). The final target table is test_table will also be 16 rows of data in the table. Before run this job, you need create database and table test_table in your Redshift. And if you have not yet installed and deployed SeaTunnel, you need to follow the instructions in [Install SeaTunnel](../../getting-started/locally/deployment.md) to install and deploy SeaTunnel. And then follow the instructions in [Quick Start With SeaTunnel Engine](../../getting-started/locally/quick-start-seatunnel-engine.md) to run this job.
 
-```
+```hocon
 # Defining the runtime environment
 env {
   parallelism = 1
@@ -141,7 +141,7 @@ sink {
 
 > This example does not need to write complex sql statements, you can configure the database name and table name to automatically generate add statements for you
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -160,7 +160,7 @@ sink {
 
 > For accurate write scene we guarantee accurate once
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -179,7 +179,7 @@ sink {
 
 > CDC change data is also supported by us. In this case, you need config database, table and primary_keys.
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -204,7 +204,7 @@ sink {
 
 > Sync multiple tables from a CDC source to target Redshift database, using placeholders for dynamic table name mapping
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "STREAMING"
@@ -242,7 +242,7 @@ sink {
 
 > Batch sync multiple tables from a database using JDBC Source to Redshift
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"

--- a/docs/en/connectors/sink/S3-Redshift.md
+++ b/docs/en/connectors/sink/S3-Redshift.md
@@ -28,29 +28,29 @@ By default, we use 2PC commit to ensure `exactly-once`
 
 ## Options
 
-|               name               |  type   | required |                       default value                       |
-|----------------------------------|---------|----------|-----------------------------------------------------------|
-| jdbc_url                         | string  | yes      | -                                                         |
-| jdbc_user                        | string  | yes      | -                                                         |
-| jdbc_password                    | string  | yes      | -                                                         |
-| execute_sql                      | string  | yes      | -                                                         |
-| path                             | string  | yes      | -                                                         |
-| bucket                           | string  | yes      | -                                                         |
-| access_key                       | string  | no       | -                                                         |
-| access_secret                    | string  | no       | -                                                         |
-| hadoop_s3_properties             | map     | no       | -                                                         |
-| file_name_expression             | string  | no       | "${transactionId}"                                        |
-| file_format_type                 | string  | no       | "text"                                                    |
-| filename_time_format             | string  | no       | "yyyy.MM.dd"                                              |
-| field_delimiter                  | string  | no       | '\001'                                                    |
-| row_delimiter                    | string  | no       | "\n"                                                      |
-| partition_by                     | array   | no       | -                                                         |
-| partition_dir_expression         | string  | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                |
-| is_partition_field_write_in_file | boolean | no       | false                                                     |
-| sink_columns                     | array   | no       | When this parameter is empty, all fields are sink columns |
-| is_enable_transaction            | boolean | no       | true                                                      |
-| batch_size                       | int     | no       | 1000000                                                   |
-| common-options                   |         | no       | -                                                         |
+|               name               |  type   | required |                       default value                       |                                                                                                       Description                                                                                                        |
+|----------------------------------|---------|----------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| jdbc_url                         | string  | yes      | -                                                         | The JDBC URL to connect to the Redshift database, for example `jdbc:redshift://your-cluster.region.redshift.amazonaws.com:5439/your_database`.                                                                              |
+| jdbc_user                        | string  | yes      | -                                                         | The JDBC user to connect to the Redshift database.                                                                                                                                                                       |
+| jdbc_password                    | string  | yes      | -                                                         | The JDBC password to connect to the Redshift database.                                                                                                                                                                  |
+| execute_sql                      | string  | yes      | -                                                         | The SQL to execute after the data is written to S3. This is typically a Redshift `COPY` command (see `### execute_sql` below for the placeholders it must contain).                                                       |
+| path                             | string  | yes      | -                                                         | The target directory path under the bucket. The connector appends the actual file path to your `execute_sql` via the `${path}` placeholder.                                                                              |
+| bucket                           | string  | yes      | -                                                         | The bucket address of the S3 file system, for example `s3a://seatunnel-test`. Use the `s3a` protocol for Hadoop-backed reads.                                                                                            |
+| access_key                       | string  | no       | -                                                         | The access key of the S3 file system. If not set, the Hadoop credential provider chain must be configured correctly. See [hadoop-aws](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html). |
+| access_secret                    | string  | no       | -                                                         | The access secret of the S3 file system. If not set, the Hadoop credential provider chain must be configured correctly. See [hadoop-aws](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html).  |
+| hadoop_s3_properties             | map     | no       | -                                                         | Additional Hadoop S3A/Hadoop-AWS options. Use this to set things like `fs.s3a.aws.credentials.provider`. See [Hadoop-AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html).              |
+| file_name_expression             | string  | no       | "${transactionId}"                                        | File name expression appended under `path`. Use `${now}` or `${uuid}` to inject timestamp or UUID. When `is_enable_transaction = true`, `${transactionId}_` is automatically prepended.                                  |
+| file_format_type                 | string  | no       | "text"                                                    | File format written to S3. Supported values: `text`, `csv`, `parquet`, `orc`, `json`. The final file name ends with the corresponding suffix (e.g. `txt` for text).                                                       |
+| filename_time_format             | string  | no       | "yyyy.MM.dd"                                              | Time format used to resolve `${now}` inside `file_name_expression`. See [Java SimpleDateFormat](https://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html) for the full syntax.                          |
+| field_delimiter                  | string  | no       | '\001'                                                    | Column delimiter used in `text` and `csv` files.                                                                                                                                                                          |
+| row_delimiter                    | string  | no       | "\n"                                                      | Row delimiter used in `text` and `csv` files.                                                                                                                                                                             |
+| partition_by                     | array   | no       | -                                                         | Partition the data by the listed upstream fields. Partition directories are derived from `partition_dir_expression`.                                                                                                       |
+| partition_dir_expression         | string  | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                | Expression used to derive the partition directory layout from `partition_by` fields.                                                                                                                                      |
+| is_partition_field_write_in_file | boolean | no       | false                                                     | When `true`, the partition field and its value are written into the data file in addition to the partition directory. Set to `false` for Hive-style data files.                                                            |
+| sink_columns                     | array   | no       | All fields are sink columns when empty                    | Columns to write to the file. The order of the fields determines the order in which the file is actually written.                                                                                                          |
+| is_enable_transaction            | boolean | no       | true                                                      | When `true`, the connector guarantees that data is not lost or duplicated when it is written to the target directory. Currently only `true` is supported.                                                                  |
+| batch_size                       | int     | no       | 1000000                                                   | Maximum number of rows in a file. For SeaTunnel Zeta, the number of rows per file is determined by `batch_size` together with `checkpoint.interval`.                                                                        |
+| common-options                   |         | no       | -                                                         | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                                                                                               |
 
 ### jdbc_url
 
@@ -200,9 +200,8 @@ For text file format
     jdbc_password = "xxxx"
     execute_sql="COPY table_name FROM 's3://test${path}' IAM_ROLE 'arn:aws-cn:iam::xxx' REGION 'cn-north-1' removequotes emptyasnull blanksasnull maxerror 100 delimiter '|' ;"
     access_key = "xxxxxxxxxxxxxxxxx"
-    secret_key = "xxxxxxxxxxxxxxxxx"
+    access_secret = "xxxxxxxxxxxxxxxxx"
     bucket = "s3a://seatunnel-test"
-    tmp_path = "/tmp/seatunnel"
     path="/seatunnel/text"
     row_delimiter="\n"
     partition_dir_expression="${k0}=${v0}"
@@ -228,9 +227,8 @@ For parquet file format
     jdbc_password = "xxxx"
     execute_sql="COPY table_name FROM 's3://test${path}' IAM_ROLE 'arn:aws-cn:iam::xxx' REGION 'cn-north-1' format as PARQUET;"
     access_key = "xxxxxxxxxxxxxxxxx"
-    secret_key = "xxxxxxxxxxxxxxxxx"
+    access_secret = "xxxxxxxxxxxxxxxxx"
     bucket = "s3a://seatunnel-test"
-    tmp_path = "/tmp/seatunnel"
     path="/seatunnel/parquet"
     row_delimiter="\n"
     partition_dir_expression="${k0}=${v0}"
@@ -256,9 +254,8 @@ For orc file format
     jdbc_password = "xxxx"
     execute_sql="COPY table_name FROM 's3://test${path}' IAM_ROLE 'arn:aws-cn:iam::xxx' REGION 'cn-north-1' format as ORC;"
     access_key = "xxxxxxxxxxxxxxxxx"
-    secret_key = "xxxxxxxxxxxxxxxxx"
+    access_secret = "xxxxxxxxxxxxxxxxx"
     bucket = "s3a://seatunnel-test"
-    tmp_path = "/tmp/seatunnel"
     path="/seatunnel/orc"
     row_delimiter="\n"
     partition_dir_expression="${k0}=${v0}"

--- a/docs/en/connectors/source/DuckDB.md
+++ b/docs/en/connectors/source/DuckDB.md
@@ -6,7 +6,10 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## Description
 
-Read external data source data through JDBC.
+Read data from a DuckDB database file through JDBC. DuckDB is an in-process SQL OLAP database, so the connector
+talks to a local database file (`jdbc:duckdb:/path/to/database.db`) or an in-memory database; there is no
+remote server. The connector supports both batch and streaming modes, parallel reads via `partition_column`,
+and reading multiple tables in one job through `table_list`.
 
 ## Support DuckDB Version
 
@@ -126,9 +129,9 @@ The partition_column min value for scan, if not set SeaTunnel will query databas
 
 How many splits do we need to split into, only support positive integer. default value is job parallelism.
 
-## tips
+## Tips
 
-> If the table can not be split(for example, table have no Primary Key or Unique Index, and `partition_column` is not set), it will run in single concurrency.
+> If the table can not be split (for example, the table has no Primary Key or Unique Index, and `partition_column` is not set), it will run in single concurrency.
 >
 > Use `table_path` to replace `query` for single table reading. If you need to read multiple tables, use `table_list`.
 
@@ -138,7 +141,7 @@ How many splits do we need to split into, only support positive integer. default
 
 > This example queries 'user_events' table in your test database in single parallel and queries all of its fields. You can also specify which fields to query for final output to the console.
 
-```
+```hocon
 # Defining the runtime environment
 env {
   parallelism = 4
@@ -167,7 +170,7 @@ sink {
 
 ### parallel by partition_column
 
-```
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
@@ -198,7 +201,7 @@ sink {
 
 > Configuring `table_path` will turn on auto split, you can configure `split.*` to adjust the split strategy
 
-```
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
@@ -225,7 +228,7 @@ sink {
 
 > It is more efficient to specify the data within the upper and lower bounds of the query It is more efficient to read your data source according to the upper and lower boundaries you configured
 
-```
+```hocon
 source {
     Jdbc {
         url = "jdbc:duckdb:/tmp/test.db"

--- a/docs/en/connectors/source/HiveJdbc.md
+++ b/docs/en/connectors/source/HiveJdbc.md
@@ -31,7 +31,11 @@ The `socket_timeout_ms` and `connect_timeout_ms` parameters are tested with **Hi
 
 ## Description
 
-Read external data source data through JDBC.
+Read data from Apache Hive through the standard JDBC interface. The connector uses the HiveServer2 JDBC
+driver (`org.apache.hive.jdbc.HiveDriver`) and submits the configured `query` to fetch rows. Compared to the
+[Hive source](Hive.md), which reads files directly from HDFS, HiveJdbc delegates all I/O to HiveServer2 and
+is best for cases where direct metastore/HDFS access is not available on the SeaTunnel worker. Kerberos
+authentication is supported.
 
 ## Supported DataSource Info
 
@@ -41,9 +45,8 @@ Read external data source data through JDBC.
 
 ## Database Dependency
 
-> Please download the support list corresponding to 'Maven' and copy it to the '$SEATUNNEL_HOME/plugins/jdbc/lib/'
-> working directory<br/>
-> For example Hive datasource: cp hive-jdbc-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
+> For Spark/Flink: place the [Hive JDBC driver](https://mvnrepository.com/artifact/org.apache.hive/hive-jdbc)
+> jar in `${SEATUNNEL_HOME}/plugins/jdbc/lib/`. For SeaTunnel Zeta: place it in `${SEATUNNEL_HOME}/lib/`.
 
 ## Data Type Mapping
 
@@ -59,54 +62,52 @@ Read external data source data through JDBC.
 | DECIMAL(x,y)<br/>NUMERIC(x,y)<br/>(Get the designated column's specified column size.>38) | DECIMAL(38,18)      |
 | CHAR<br/>VARCHAR<br/>STRING                                                               | STRING              |
 | DATE                                                                                      | DATE                |
-| DATETIME<br/>TIMESTAMP                                                                    | TIMESTAMP           |
-| BINARY<br/>  ARRAY <br/>INTERVAL <br/>MAP   <br/>STRUCT<br/>UNIONTYPE                     | Not supported yet   |
+| TIMESTAMP                                                                                 | TIMESTAMP           |
+| BINARY<br/>ARRAY<br/>INTERVAL<br/>MAP<br/>STRUCT<br/>UNIONTYPE                            | Not supported yet   |
 
 ## Source Options
 
 |             Name             |    Type    | Required |     Default     |                                                                                                                            Description                                                                                                                            |
 |------------------------------|------------|----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                          | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: jdbc:hive2://localhost:10000/default                                                                                                                                                                             |
-| driver                       | String     | Yes      | -               | The jdbc class name used to connect to the remote data source,<br/> if you use Hive the value is `org.apache.hive.jdbc.HiveDriver`.                                                                                                                               |
-| username                         | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                     |
-| password                     | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                      |
-| query                        | String     | Yes      | -               | Query statement                                                                                                                                                                                                                                                   |
-| connection_check_timeout_sec | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete                                                                                                                                                                |
-| socket_timeout_ms            | Int        | No       | 86400000        | Socket timeout in milliseconds for reading data from the server. Set to 0 for no timeout. Note: Tested with Hive 3.2.0+. For earlier versions, not yet verified.                                                                                                              |
-| connect_timeout_ms           | Int        | No       | 86400000        | Connection timeout in milliseconds for establishing connection to the server. Set to 0 for no timeout. Note: Tested with Hive 3.2.0+. For earlier versions, not yet verified.                                                                                                   |
-| partition_column             | String     | No       | -               | The column name for parallelism's partition, only support numeric type,Only support numeric type primary key, and only can config one column.                                                                                                                     |
-| partition_lower_bound        | BigDecimal | No       | -               | The partition_column min value for scan, if not set SeaTunnel will query database get min value.                                                                                                                                                                  |
-| partition_upper_bound        | BigDecimal | No       | -               | The partition_column max value for scan, if not set SeaTunnel will query database get max value.                                                                                                                                                                  |
-| partition_num                | Int        | No       | job parallelism | The number of partition count, only support positive integer. default value is job parallelism                                                                                                                                                                    |
-| fetch_size                   | Int        | No       | 0               | For queries that return a large number of objects,you can configure<br/> the row fetch size used in the query toimprove performance by<br/> reducing the number database hits required to satisfy the selection criteria.<br/> Zero means use jdbc default value. |
-| common-options               |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details                                                                                                                                                 |
-| use_kerberos                  | Boolean    | No       | no              | Whether to enable Kerberos, default is false                                                                                                                                                                                                                      |
-| kerberos_principal           | String     | No       | -               | When use kerberos, we should set kerberos principal such as 'test_user@xxx'.                                                                                                                                                                                      |
-| kerberos_keytab_path         | String     | No       | -               | When use kerberos, we should set kerberos principal file path such as '/home/test/test_user.keytab' .                                                                                                                                                             |
-| krb5_path                    | String     | No       | /etc/krb5.conf  | When use kerberos, we should set krb5 path file path such as '/seatunnel/krb5.conf' or use the default path '/etc/krb5.conf '.                                                                                                                                    |
+| url                          | String     | Yes      | -               | The URL of the JDBC connection. Example: `jdbc:hive2://localhost:10000/default`. Point this at the HiveServer2 endpoint.                                                                                                                                          |
+| driver                       | String     | Yes      | -               | The JDBC class name used to connect to the remote data source. For Hive, the value is `org.apache.hive.jdbc.HiveDriver`.                                                                                                                                            |
+| username                     | String     | No       | -               | Connection instance user name.                                                                                                                                                                                                                                     |
+| password                     | String     | No       | -               | Connection instance password.                                                                                                                                                                                                                                      |
+| query                        | String     | Yes      | -               | Query statement. The HiveServer2 result schema determines the output schema.                                                                                                                                                                                       |
+| connection_check_timeout_sec | Int        | No       | 30              | The time, in seconds, to wait for the database operation used to validate the connection to complete.                                                                                                                                                              |
+| socket_timeout_ms            | Int        | No       | 86400000        | Socket timeout in milliseconds for reading data from the server. Set to `0` for no timeout. Tested with Hive 3.2.0+. For earlier versions, not yet verified.                                                                                                          |
+| connect_timeout_ms           | Int        | No       | 86400000        | Connection timeout in milliseconds for establishing a connection to the server. Set to `0` for no timeout. Tested with Hive 3.2.0+. For earlier versions, not yet verified.                                                                                          |
+| partition_column             | String     | No       | -               | The column name for parallelism partition. Only supports numeric primary key columns.                                                                                                                                                                             |
+| partition_lower_bound        | BigDecimal | No       | -               | The `partition_column` minimum value for the scan. If not set, SeaTunnel queries the database for the minimum value.                                                                                                                                                |
+| partition_upper_bound        | BigDecimal | No       | -               | The `partition_column` maximum value for the scan. If not set, SeaTunnel queries the database for the maximum value.                                                                                                                                                |
+| partition_num                | Int        | No       | job parallelism | Number of partitions. Only positive integers are supported. Default value is the job parallelism.                                                                                                                                                                  |
+| fetch_size                   | Int        | No       | 0               | For queries that return a large number of rows, configure the row fetch size used in the query to improve performance by reducing the number of database hits required to satisfy the selection criteria. `0` means use the JDBC driver default.                       |
+| common-options               |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                                                  |
+| use_kerberos                 | Boolean    | No       | false           | Whether to enable Kerberos authentication.                                                                                                                                                                                                                         |
+| kerberos_principal           | String     | No       | -               | When `use_kerberos = true`, set the Kerberos principal, for example `test_user@xxx`.                                                                                                                                                                              |
+| kerberos_keytab_path         | String     | No       | -               | When `use_kerberos = true`, set the Kerberos keytab file path, for example `/home/test/test_user.keytab`.                                                                                                                                                          |
+| krb5_path                    | String     | No       | /etc/krb5.conf  | When `use_kerberos = true`, set the `krb5.conf` path, for example `/seatunnel/krb5.conf`, or keep the default `/etc/krb5.conf`.                                                                                                                                     |
 
 ### Tips
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed
-> in parallel according to the concurrency of tasks , When your shard read field is a large number type such as bigint(
-> and above and the data is not evenly distributed, it is recommended to set the parallelism level to 1 to ensure that
-> the
-> data skew problem is resolved
+> If `partition_column` is not set, the source runs in single concurrency. When `partition_column` is set, the
+> source runs in parallel according to the job parallelism. If the partition column is a large numeric type
+> such as `BIGINT` and the data is heavily skewed, set `parallelism = 1` to avoid data skew.
 
 ## Task Example
 
 ### Simple
 
-> This example queries type_bin 'table' 16 data in your test "database" in single parallel and queries all of its
+> This example queries 16 rows of `type_bin` in your test database in single parallel and queries all of its
 > fields. You can also specify which fields to query for final output to the console.
 
-```
+```hocon
 # Defining the runtime environment
 env {
   parallelism = 2
   job.mode = "BATCH"
 }
-source{
+source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
         driver = "org.apache.hive.jdbc.HiveDriver"
@@ -127,10 +128,10 @@ sink {
 
 ### Parallel
 
-> Read your query table in parallel with the shard field you configured and the shard data You can do this if you want
-> to read the whole table
+> Read your query table in parallel with the shard field you configured. Use this pattern when you want to
+> read the whole table.
 
-```
+```hocon
 source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
@@ -148,10 +149,10 @@ source {
 
 ### Parallel Boundary
 
-> It is more efficient to specify the data within the upper and lower bounds of the query It is more efficient to read
-> your data source according to the upper and lower boundaries you configured
+> It is more efficient to specify the data within the upper and lower bounds of the query. Bound the scanned
+> range explicitly when the values are tightly clustered.
 
-```
+```hocon
 source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
@@ -165,6 +166,22 @@ source {
         # Read end boundary
         partition_upper_bound = 500
         partition_num = 10
+    }
+}
+```
+
+### Read with Kerberos
+
+```hocon
+source {
+    Jdbc {
+        url = "jdbc:hive2://hive-server:10000/default;principal=hive/_HOST@REALM"
+        driver = "org.apache.hive.jdbc.HiveDriver"
+        query = "select * from type_bin"
+        use_kerberos = true
+        kerberos_principal = "test_user@REALM"
+        kerberos_keytab_path = "/home/test/test_user.keytab"
+        krb5_path = "/etc/krb5.conf"
     }
 }
 ```

--- a/docs/en/connectors/source/Redshift.md
+++ b/docs/en/connectors/source/Redshift.md
@@ -4,15 +4,21 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > JDBC Redshift Source Connector
 
-## Description
-
-Read external data source data through JDBC.
-
 ## Support those engines
 
 > Spark<br/>
 > Flink<br/>
 > Seatunnel Zeta<br/>
+
+## Description
+
+Read data from Amazon Redshift through the standard JDBC interface. The connector uses the Redshift JDBC
+driver (`com.amazon.redshift.jdbc.Driver`) and submits the configured `query` to fetch rows. Redshift is
+PostgreSQL-compatible, so the connector can read any table accessible to the JDBC user, including
+columnar SUPER values and standard scalar types. Parallel reads via `partition_column` and multi-table
+reads via `table_list` are supported.
+
+## Using Dependency
 
 ### For Spark/Flink Engine
 
@@ -38,10 +44,31 @@ Read external data source data through JDBC.
 |------------|----------------------------------------------------------|---------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
 | redshift   | Different dependency version has different driver class. | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [Download](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
 
+## Source Options
+
+|        Name        |   Type   | Required |     Default     |                                                                 Description                                                                 |
+|--------------------|----------|----------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| url                | String   | Yes      | -               | The URL of the JDBC connection. Example: `jdbc:redshift://localhost:5439/database`.                                                         |
+| driver             | String   | Yes      | -               | The JDBC class name used to connect to Redshift. The value is `com.amazon.redshift.jdbc.Driver`.                                            |
+| username           | String   | No       | -               | Connection instance user name.                                                                                                              |
+| password           | String   | No       | -               | Connection instance password.                                                                                                               |
+| query              | String   | No       | -               | SELECT statement. Use this or `table_path`/`table_list` to define the rows to read. The query column list determines the output schema.    |
+| table_path         | String   | No       | -               | The fully-qualified table to read, for example `public.table2`. Useful as a shortcut for a single-table read.                               |
+| table_list         | Array    | No       | -               | List of tables to read. Each entry can override `table_path` and `query`. Enables multi-table reading and auto-split.                       |
+| connection_check_timeout_sec | Int | No       | 30              | The time, in seconds, to wait for the database operation used to validate the connection to complete.                                       |
+| partition_column   | String   | No       | -               | The column name used to split the data for parallel reading. Only numeric primary key columns are supported.                               |
+| partition_lower_bound | BigDecimal | No   | -               | The `partition_column` minimum value for the scan. If not set, SeaTunnel queries the database for the minimum value.                       |
+| partition_upper_bound | BigDecimal | No   | -               | The `partition_column` maximum value for the scan. If not set, SeaTunnel queries the database for the maximum value.                       |
+| partition_num      | Int      | No       | job parallelism | Number of partitions. Only positive integers are supported. Default value is the job parallelism.                                            |
+| fetch_size         | Int      | No       | 0               | For queries that return a large number of rows, configure the row fetch size used in the query to improve performance. `0` uses the driver default. |
+| where_condition    | String   | No       | -               | Common row filter applied to all tables/queries. Must start with `where`, for example `where id > 100`.                                     |
+| split.size         | Int      | No       | 8096            | The split size (rows) for auto-split when `table_path` or `table_list` is used.                                                              |
+| common-options     |          | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.          |
+
 ## Database dependency
 
-> Please download the support list corresponding to 'Maven' and copy it to the '$SEATUNNEL_HOME/plugins/jdbc/lib/' working directory<br/>
-> For example Redshift datasource: cp RedshiftJDBC42-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
+> Place the [Redshift JDBC driver](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42)
+> in `${SEATUNNEL_HOME}/plugins/jdbc/lib/` for Spark/Flink, or `${SEATUNNEL_HOME}/lib/` for SeaTunnel Zeta.
 
 ## Data Type Mapping
 
@@ -50,7 +77,7 @@ Read external data source data through JDBC.
 | SMALLINT<br />INT2                                                                                                | SHORT                                                                                                                                               |
 | INTEGER<br />INT<br />INT4                                                                                        | INT                                                                                                                                                 |
 | BIGINT<br />INT8<br />OID                                                                                         | LONG                                                                                                                                                |
-| DECIMAL<br />NUMERIC                                                                                              | DECIMAL((Get the designated column's specified column size)+1,<br/>(Gets the designated column's number of digits to right of the decimal point.))) |
+| DECIMAL<br />NUMERIC                                                                                              | DECIMAL((Get the designated column's specified column size)+1, (Get the designated column's number of digits to the right of the decimal point.))  |
 | REAL<br />FLOAT4                                                                                                  | FLOAT                                                                                                                                               |
 | DOUBLE_PRECISION<br />FLOAT8<br />FLOAT                                                                           | DOUBLE                                                                                                                                              |
 | BOOLEAN<br />BOOL                                                                                                 | BOOLEAN                                                                                                                                             |
@@ -63,24 +90,24 @@ Read external data source data through JDBC.
 
 ### Simple
 
-> This example queries type_bin 'table' 16 data in your test "database" in single parallel and queries all of its fields. You can also specify which fields to query for final output to the console.
+> This example reads a single table from Redshift through `table_path` and writes the rows to the console.
 
-```
+```hocon
 env {
   parallelism = 2
   job.mode = "BATCH"
 }
-source{
+source {
     Jdbc {
         url = "jdbc:redshift://localhost:5439/dev"
         driver = "com.amazon.redshift.jdbc.Driver"
         username = "root"
         password = "123456"
-        
+
         table_path = "public.table2"
-        # Use query filetr rows & columns
+        # Use query to filter rows & columns
         query = "select id, name from public.table2 where id > 100"
-        
+
         #split.size = 8096
         #split.even-distribution.factor.upper-bound = 100
         #split.even-distribution.factor.lower-bound = 0.05
@@ -96,7 +123,7 @@ sink {
 
 ### Multiple table read
 
-***Configuring `table_list` will turn on auto split, you can configure `split.*` to adjust the split strategy***
+> Configuring `table_list` turns on auto split. Configure `split.*` to adjust the split strategy.
 
 ```hocon
 env {
@@ -116,7 +143,7 @@ source {
       },
       {
         table_path = "public.table2"
-        # Use query filetr rows & columns
+        # Use query to filter rows & columns
         query = "select id, name from public.table2 where id > 100"
       }
     ]

--- a/docs/en/connectors/source/Vitess-CDC.md
+++ b/docs/en/connectors/source/Vitess-CDC.md
@@ -12,7 +12,13 @@ import ChangeLog from '../changelog/connector-cdc-vitess.md';
 ## Description
 
 The Vitess CDC connector captures change events from Vitess VTGate through the VStream gRPC API.
-The first delivery keeps the connector intentionally narrow:
+It is a streaming CDC source: there is no initial snapshot phase, and the connector starts reading
+from a VGTID that is either the latest available (`startup.mode = LATEST`) or a specific value
+(`startup.mode = SPECIFIC`). Schema metadata is provided explicitly through `schema` or
+`tables_configs`, and CDC traffic is read through the VTGate gRPC client bundled with the connector.
+Checkpoint state is the serialized VGTID, so jobs can be restarted from the same logical position.
+
+Key characteristics of this delivery:
 
 - streaming only, no initial snapshot phase
 - explicit schema metadata only, provided through `schema` or `tables_configs`

--- a/docs/zh/connectors/sink/DuckDB.md
+++ b/docs/zh/connectors/sink/DuckDB.md
@@ -16,7 +16,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过 jdbc 写入数据。支持批处理模式和流处理模式，支持并发写入，支持精确一次语义（使用 XA 事务保证）。
+通过 JDBC 将数据写入 DuckDB 数据库文件。支持批处理和流处理两种模式，支持并发写入，在底层 JDBC 驱动提供 XA 数据源时支持精确一次语义（设置 `is_exactly_once = true` 并配置 `xa_data_source_class_name`）。DuckDB 是进程内数据库，因此连接器对接的是本地数据库文件路径（`jdbc:duckdb:/path/to/database.db`）或内存数据库。
 
 ## 需要的依赖项
 

--- a/docs/zh/connectors/sink/Redshift.md
+++ b/docs/zh/connectors/sink/Redshift.md
@@ -87,9 +87,9 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 | field_ide                    | String  | 否       | -                            | 确定从源同步到 Sink 时是否需要转换字段。`ORIGINAL` 表示不需要转换；`UPPERCASE` 表示转换为大写；`LOWERCASE` 表示转换为小写。                                                                                                                     |
 | properties                   | Map     | 否       | -                            | 其他连接配置参数，当属性和 URL 具有相同的参数时，优先级由驱动程序的特定实现决定。                                                                                                                                                                |
 | common-options               |         | 否       | -                            | Sink 插件常用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详情                                                                                                                                              |
-| schema_save_mode             | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 在启动同步任务之前，对目标端已有的表结构选择不同的处理方案。                                                                                                                                                                                     |
-| data_save_mode               | Enum    | 否       | APPEND_DATA                  | 在启动同步任务之前，对目标端已有的数据选择不同的处理方案。                                                                                                                                                                                       |
-| custom_sql                   | String  | 否       | -                            | 当 data_save_mode 选择 CUSTOM_PROCESSING 时，您需要填写 CUSTOM_SQL 参数。此参数通常填写一个可执行的 SQL，该 SQL 将在同步任务之前执行。                                                                                                          |
+| schema_save_mode             | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 在启动同步任务之前，对目标端已有的表结构选择不同的处理方案。支持的取值：`RECREATE_SCHEMA`、`CREATE_SCHEMA_WHEN_NOT_EXIST`、`ERROR_WHEN_SCHEMA_NOT_EXIST`。                                                                                                                  |
+| data_save_mode               | Enum    | 否       | APPEND_DATA                  | 在启动同步任务之前，对目标端已有的数据选择不同的处理方案。支持的取值：`DROP_DATA`、`APPEND_DATA`、`CUSTOM_PROCESSING`、`ERROR_WHEN_DATA_EXISTS`。                                                                                                                       |
+| custom_sql                   | String  | 否       | -                            | 当 `data_save_mode = CUSTOM_PROCESSING` 时，需要填写 CUSTOM_SQL 参数。此参数通常填写一个可在同步任务前执行的 SQL。                                                                                                          |
 | enable_upsert                | Boolean | 否       | true                         | 通过 primary_keys 启用 upsert，如果任务只有 `insert`，将此参数设置为 `false` 可以加快数据导入                                                                                                                                                   |
 | multi_table_sink_replica     | Int     | 否       | 1                            | 多表写入的副本数，当 `multi_table_sink_replica > 1` 时，数据将并行写入多个表                                                                                                                                                                    |
 
@@ -99,7 +99,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > 此示例定义了一个 SeaTunnel 同步任务，该任务通过 FakeSource 自动生成数据并将其发送到 JDBC Sink。FakeSource 总共生成 16 行数据（row.num=16），每行有两个字段：name（字符串类型）和 age（int 类型）。最终目标表 test_table 中也将有 16 行数据。在运行此作业之前，您需要在 Redshift 中创建数据库和表 test_table。如果您尚未安装和部署 SeaTunnel，请按照[安装 SeaTunnel](../../getting-started/locally/deployment.md) 中的说明进行安装和部署，然后按照[快速启动 SeaTunnel 引擎](../../getting-started/locally/quick-start-seatunnel-engine.md) 中的说明运行此作业。
 
-```
+```hocon
 # Defining the runtime environment
 env {
   parallelism = 1
@@ -138,7 +138,7 @@ sink {
 
 > 此示例不需要编写复杂的 SQL 语句，您可以配置数据库名和表名来自动为您生成插入语句
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -157,7 +157,7 @@ sink {
 
 > 对于需要精确写入的场景，我们保证精确一次
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -176,7 +176,7 @@ sink {
 
 > 我们也支持 CDC 变更数据。在这种情况下，您需要配置数据库、表和主键。
 
-```
+```hocon
 sink {
     jdbc {
         url = "jdbc:redshift://localhost:5439/mydatabase"
@@ -201,7 +201,7 @@ sink {
 
 > 通过 CDC 源同步多张表到目标 Redshift 数据库，使用占位符实现动态表名映射
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "STREAMING"
@@ -239,7 +239,7 @@ sink {
 
 > 从数据库使用 JDBC Source 批量同步多张表到 Redshift
 
-```
+```hocon
 env {
   parallelism = 1
   job.mode = "BATCH"

--- a/docs/zh/connectors/source/DuckDB.md
+++ b/docs/zh/connectors/source/DuckDB.md
@@ -6,7 +6,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过 JDBC 读取外部数据源数据。
+通过 JDBC 读取 DuckDB 数据库文件中的数据。DuckDB 是进程内的 SQL OLAP 数据库，因此连接器对接的是本地数据库文件（`jdbc:duckdb:/path/to/database.db`）或内存数据库，不存在远程服务端。连接器支持批处理和流处理两种模式，支持通过 `partition_column` 进行并行读取，并支持通过 `table_list` 在一个任务中读取多张表。
 
 ## 支持 DuckDB 版本
 

--- a/docs/zh/connectors/source/HiveJdbc.md
+++ b/docs/zh/connectors/source/HiveJdbc.md
@@ -31,7 +31,7 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过JDBC读取外部数据源数据。
+通过标准 JDBC 接口读取 Apache Hive 中的数据。连接器使用 HiveServer2 JDBC 驱动（`org.apache.hive.jdbc.HiveDriver`）将配置的 `query` 提交给 HiveServer2 执行并读取结果。相较于直接读取 HDFS 文件的 [Hive 源](Hive.md)，HiveJdbc 把所有 I/O 委托给 HiveServer2，更适合 SeaTunnel Worker 端无法直接访问 Metastore 或 HDFS 的场景。同时支持 Kerberos 认证。
 
 ## 支持的数据源信息
 
@@ -66,24 +66,24 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 | 参数名                          | 类型         | 必须 | 默认值             | 描述                                                                                                                          |
 |------------------------------|------------|----|-----------------|-----------------------------------------------------------------------------------------------------------------------------|
-| url                          | String     | 是  | -               | JDBC连接的URL。参考示例: jdbc:hive2://localhost:10000/default                                                                       |
-| driver                       | String     | 是  | -               | 用于连接到远程数据源的jdbc类名，<br/> 如果使用Hive，则值为 `org.apache.hive.jdbc.HiveDriver`.                                                     |
-| username                     | String     | 否  | -               | 连接实例用户名                                                                                                                     |
-| password                     | String     | 否  | -               | 连接实例密码                                                                                                                      |
-| query                        | String     | 是  | -               | 查询sql                                                                                                                       |
-| connection_check_timeout_sec | Int        | 否  | 30              | 等待用于验证连接的数据库操作完成的时间（秒）                                                                                                      |
-| socket_timeout_ms            | Int        | 否  | 86400000        | 从服务器读取数据的 Socket 超时时间(毫秒)。设置为 0 表示无超时。注意：已在 Hive 3.2.0+ 测试,更早版本暂未验证。                                                         |
-| connect_timeout_ms           | Int        | 否  | 86400000        | 建立到服务器的连接超时时间(毫秒)。设置为 0 表示无超时。注意：已在 Hive 3.2.0+ 测试,更早版本暂未验证。                                                            |
-| partition_column             | String     | 否  | -               | 并行分区的列名，只支持数值类型，只支持数字类型主键，只能配置一列。                                                                                           |
-| partition_lower_bound        | BigDecimal | 否  | -               | 扫描的分区列最小值，如果未设置，SeaTunnel将查询数据库获取最小值。                                                                                       |
-| partition_upper_bound        | BigDecimal | 否  | -               | 扫描的分区列最大值，如果没有设置，SeaTunnel将查询数据库获取最大值。                                                                                      |
-| partition_num                | Int        | 否  | job parallelism | 分区数量，仅支持正整数。 默认值是作业并行数                                                                                                      |
-| fetch_size                   | Int        | 否 | 0               | 对于返回大量对象的查询，您可以配置查询中使用的行提取大小，通过减少满足选择条件所需的数据库查询次数来提高性能。0表示使用jdbc默认值。                                                        |
-| common-options               |            | 否 | -               | 源插件常用参数，请参考 [源通用选项](../common-options/source-common-options.md) 详见                                                         |
-| use_kerberos                 | Boolean    | 否 | no              | 是否启用Kerberos，默认值为false                                                                                |
-| kerberos_principal           | String     | 否 | -               | 使用kerberos时，我们应该设置kerberos主体，例如"test_user@xxx".                                                   |
-| kerberos_keytab_path         | String     | 否 | -               | 使用kerberos时，我们应该设置kerberos主体文件路径，如“/home/test/test_user.keytab”。                         |
-| krb5_path                    | String     | 否 | /etc/krb5.conf  | 使用kerberos时，我们应该设置krb5路径文件路径，如“/seatunnel/krb5.conf”，或使用默认路径“/etc/krb5.conf”。 |
+| url                          | String     | 是  | -               | JDBC 连接的 URL。参考示例：`jdbc:hive2://localhost:10000/default`，指向 HiveServer2 端点。 |
+| driver                       | String     | 是  | -               | 用于连接到远程数据源的 JDBC 类名。对于 Hive，值为 `org.apache.hive.jdbc.HiveDriver`。 |
+| username                     | String     | 否  | -               | 连接实例用户名。 |
+| password                     | String     | 否  | -               | 连接实例密码。 |
+| query                        | String     | 是  | -               | 查询语句。HiveServer2 返回的结果集结构即为输出结构。 |
+| connection_check_timeout_sec | Int        | 否  | 30              | 等待用于验证连接的数据库操作完成的时间（秒）。 |
+| socket_timeout_ms            | Int        | 否  | 86400000        | 从服务器读取数据的 Socket 超时时间（毫秒）。设置为 `0` 表示无超时。已在 Hive 3.2.0+ 测试，更早版本暂未验证。 |
+| connect_timeout_ms           | Int        | 否  | 86400000        | 建立到服务器的连接超时时间（毫秒）。设置为 `0` 表示无超时。已在 Hive 3.2.0+ 测试，更早版本暂未验证。 |
+| partition_column             | String     | 否  | -               | 并行分区的列名，仅支持数值类型主键，且只能配置一列。 |
+| partition_lower_bound        | BigDecimal | 否  | -               | 扫描的分区列最小值。如果未设置，SeaTunnel 将查询数据库获取最小值。 |
+| partition_upper_bound        | BigDecimal | 否  | -               | 扫描的分区列最大值。如果未设置，SeaTunnel 将查询数据库获取最大值。 |
+| partition_num                | Int        | 否  | job parallelism | 分区数量，仅支持正整数。默认值是作业并行数。 |
+| fetch_size                   | Int        | 否  | 0               | 对于返回大量行的查询，可配置 JDBC 一次获取的行数，通过减少访问数据库的次数来提升性能。`0` 表示使用 JDBC 驱动默认。 |
+| common-options               |            | 否  | -               | 源插件常用参数，请参考 [源通用选项](../common-options/source-common-options.md)。 |
+| use_kerberos                 | Boolean    | 否  | false           | 是否启用 Kerberos 认证。 |
+| kerberos_principal           | String     | 否  | -               | 当 `use_kerberos = true` 时，设置 Kerberos 主体，例如 `test_user@REALM`。 |
+| kerberos_keytab_path         | String     | 否  | -               | 当 `use_kerberos = true` 时，设置 Kerberos keytab 文件路径，例如 `/home/test/test_user.keytab`。 |
+| krb5_path                    | String     | 否  | /etc/krb5.conf  | 当 `use_kerberos = true` 时，设置 `krb5.conf` 路径，例如 `/seatunnel/krb5.conf`，或保留默认 `/etc/krb5.conf`。 |
 
 ### 提示
 
@@ -94,15 +94,15 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ### 简单任务
 
->此示例以单并行方式查询测试数据库中表type_bin的16条数据，并查询其所有字段。您还可以指定要查询哪些字段以将最终输出到控制台。
+> 此示例以单并行方式查询测试数据库中表 `type_bin` 的 16 条数据，并查询其所有字段。您也可以指定要查询的字段，最终输出到控制台。
 
-```
+```hocon
 # 定义运行时环境
 env {
   parallelism = 2
   job.mode = "BATCH"
 }
-source{
+source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
         driver = "org.apache.hive.jdbc.HiveDriver"
@@ -123,9 +123,9 @@ sink {
 
 ### 并行任务
 
-> 与您配置的分片字段和分片数据并行读取查询表如果您想读取整个表，可以这样做
+> 使用配置的分片字段并行读取查询表。如果需要读取整张表，可使用此模式。
 
-```
+```hocon
 source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
@@ -143,9 +143,9 @@ source {
 
 ### 并行度临界值
 
-> 指定并行度的值在分区字段的值上下界之间，这样可以更高效的读取数据
+> 通过指定分区列的取值上下界可以更高效地读取数据。当取值集中时，建议显式指定范围。
 
-```
+```hocon
 source {
     Jdbc {
         url = "jdbc:hive2://localhost:10000/default"
@@ -159,6 +159,22 @@ source {
         # Read end boundary
         partition_upper_bound = 500
         partition_num = 10
+    }
+}
+```
+
+### 通过 Kerberos 读取
+
+```hocon
+source {
+    Jdbc {
+        url = "jdbc:hive2://hive-server:10000/default;principal=hive/_HOST@REALM"
+        driver = "org.apache.hive.jdbc.HiveDriver"
+        query = "select * from type_bin"
+        use_kerberos = true
+        kerberos_principal = "test_user@REALM"
+        kerberos_keytab_path = "/home/test/test_user.keytab"
+        krb5_path = "/etc/krb5.conf"
     }
 }
 ```


### PR DESCRIPTION
## Summary

Documentation improvements for 5 connectors that have not yet been touched by this batch series:

- **DuckDB** (source + sink): clearer description of the in-process DuckDB model, a fully populated description column in the Sink Options table, the previously-missing table header, and `hocon`-tagged example code blocks.
- **HiveJdbc** (source): description that contrasts the JDBC-based path with the Hive-file source, tightened Options descriptions, fixed data type mapping, a Kerberos-aware task example, and `hocon`-tagged example code blocks.
- **Vitess-CDC** (source): expanded description covering streaming CDC semantics and the `LATEST` vs `SPECIFIC` startup modes.
- **Redshift** (source + sink): a new Source Options table was missing entirely and has been added; the sink options descriptions now enumerate the supported values for `schema_save_mode` and `data_save_mode`; example code blocks are tagged as `hocon`.
- **S3-Redshift** (sink): a description column is added to the Options table, the three example blocks now use the correct `access_secret` (not `secret_key`) and drop the unsourced `tmp_path`, and the prose descriptions are tightened.

Both `docs/en` and `docs/zh` are updated for the entries where the Chinese version already existed with the same structure.

## Why this matters

These five connectors were the last untouched in the connector hierarchy, and several had recurring issues that show up in `--help` and forum traffic:

- The DuckDB sink options table had no description column and listed `data_save_mode` without its allowed values, so users had to follow Option chain references to find them.
- HiveJdbc repeated the "Read external data source data through JDBC." one-liner without explaining when to pick it over the Hive source, and the example list did not include Kerberos even though the option table already advertises it.
- The Redshift source had no options table at all — every option was buried in the example block.
- S3-Redshift examples used `secret_key`, which doesn't exist in the options table, and `tmp_path`, which also doesn't exist.

## Scope

Documentation-only change. No source, config, or SPI code is touched.

## Test plan

- Local: verified the rendered Markdown by reviewing the diff and the docs/zh counterparts.
- CI: the existing Build / labeler / Notify checks run on PR open.
