### PR TITLE
[Feature][Connector-V2] Add Hudi timer flush

### DIFF
--- a/docs/en/connectors/sink/Hudi.md
+++ b/docs/en/connectors/sink/Hudi.md
@@ -108,7 +108,8 @@ Note: When this configuration corresponds to a single table, you can flatten the
 
 ### batch_interval_ms [Int]
 
-`batch_interval_ms` The maximum interval, in milliseconds, between two flushes to Hudi.
+`batch_interval_ms` is retained for compatibility. To schedule time-based flushes on Zeta, configure
+`sink.flush.interval` in the job `env` block.
 
 ### batch_size [Int]
 
@@ -156,6 +157,23 @@ Choose how to handle existing data before the synchronization task starts.
 ### common options
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Timer Flush
+
+Timer flush is an engine-level feature supported only by Zeta. Configure `sink.flush.interval` in the job `env` block
+to write pending Hudi records even when `batch_size` has not been reached. Spark and Flink do not inject `FlushSignal`
+records and therefore do not trigger this scheduled flush.
+
+```hocon
+env {
+  sink.flush.interval = 5000
+}
+```
+
+Hudi timer flush reuses the connector's synchronized batch flush and the Hudi client's auto-commit behavior. The Hudi
+sink does not provide a 2PC exactly-once writer, so timer flush provides at-least-once delivery. Retries can create
+additional commits. With `INSERT`, generated record keys can also produce duplicate rows after recovery; `UPSERT` with
+stable `record_key_fields` limits duplicate logical records.
 
 ## Examples
 

--- a/docs/zh/connectors/sink/Hudi.md
+++ b/docs/zh/connectors/sink/Hudi.md
@@ -108,7 +108,8 @@ SeaTunnel Hudi sink 会写入 Hudi 数据文件和 `.hoodie` 元数据，但不�
 
 ### batch_interval_ms [Int]
 
-`batch_interval_ms` 两次刷新到 Hudi 的最大时间间隔，单位为毫秒。
+`batch_interval_ms` 为兼容性保留。在 Zeta 上需要定时刷新时，请在作业 `env` 中配置
+`sink.flush.interval`。
 
 ### batch_size [Int]
 
@@ -153,6 +154,22 @@ SeaTunnel Hudi sink 会写入 Hudi 数据文件和 `.hoodie` 元数据，但不�
 ### 通用选项
 
 Sink插件通用参数，请参考 [Sink Common Options](../common-options/sink-common-options.md) 了解详细信息。
+
+## 定时刷新
+
+定时刷新是仅由 Zeta 支持的引擎级能力。在作业的 `env` 中配置 `sink.flush.interval` 后，即使尚未达到
+`batch_size`，Hudi Sink 也会写出待处理的记录。Spark 和 Flink 不会注入 `FlushSignal`，因此不会触发这种
+定时刷新。
+
+```hocon
+env {
+  sink.flush.interval = 5000
+}
+```
+
+Hudi 定时刷新复用连接器现有的同步批量刷新和 Hudi 客户端 auto-commit 行为。Hudi Sink 没有 2PC 精确一次
+写入器，因此定时刷新提供的是至少一次语义，重试可能产生额外的 commit。使用 `INSERT` 时，自动生成的
+record key 还可能在恢复后产生重复行；使用具有稳定 `record_key_fields` 的 `UPSERT` 可以减少逻辑记录重复。
 
 ## 示例
 

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
@@ -114,9 +114,8 @@ public class HudiSinkWriter
     }
 
     /**
-     * Flushes buffered records when the sink receives a timer-generated FlushSignal. Once accepted
-     * by the pipeline, the signal is processed in order with data records and checkpoint barriers
-     * on the sink task thread.
+     * Flushes buffered records when the sink receives a timer-generated FlushSignal. The signal is
+     * processed on the sink task thread in order with data records and checkpoint barriers.
      */
     private void timerFlush() {
         hudiRecordWriter.flush();

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
@@ -114,8 +114,9 @@ public class HudiSinkWriter
     }
 
     /**
-     * Flushes buffered records when Zeta delivers a timer-generated FlushSignal. The signal is
-     * delivered through the same ordered pipeline path as data and checkpoint barriers.
+     * Flushes buffered records when the sink receives a timer-generated FlushSignal. Once accepted
+     * by the pipeline, the signal is processed in order with data records and checkpoint barriers
+     * on the sink task thread.
      */
     private void timerFlush() {
         hudiRecordWriter.flush();

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
@@ -67,6 +67,7 @@ public class HudiSinkWriter
                         sinkConfig, tableConfig.getTableName(), seaTunnelRowType);
         this.hudiRecordWriter =
                 new HudiRecordWriter(tableConfig, writeClientProvider, seaTunnelRowType);
+        context.registerFlushAction(this::timerFlush);
     }
 
     @Override
@@ -110,6 +111,10 @@ public class HudiSinkWriter
                         tableConfig.getTableName());
         this.hudiRecordWriter =
                 new HudiRecordWriter(tableConfig, writeClientProvider, seaTunnelRowType);
+    }
+
+    private void timerFlush() {
+        hudiRecordWriter.flush();
     }
 
     private void tryOpen() {

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
@@ -113,6 +113,10 @@ public class HudiSinkWriter
                 new HudiRecordWriter(tableConfig, writeClientProvider, seaTunnelRowType);
     }
 
+    /**
+     * Flushes buffered records when Zeta delivers a timer-generated FlushSignal. The signal is
+     * handled on the sink task thread, serializing timer flushes with writes and checkpoints.
+     */
     private void timerFlush() {
         hudiRecordWriter.flush();
     }

--- a/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/main/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriter.java
@@ -115,7 +115,7 @@ public class HudiSinkWriter
 
     /**
      * Flushes buffered records when Zeta delivers a timer-generated FlushSignal. The signal is
-     * handled on the sink task thread, serializing timer flushes with writes and checkpoints.
+     * delivered through the same ordered pipeline path as data and checkpoint barriers.
      */
     private void timerFlush() {
         hudiRecordWriter.flush();

--- a/seatunnel-connectors-v2/connector-hudi/src/test/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-hudi/src/test/java/org/apache/seatunnel/connectors/seatunnel/hudi/sink/writer/HudiSinkWriterTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hudi.sink.writer;
+
+import org.apache.seatunnel.api.sink.MultiTableResourceManager;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.utils.function.RunnableWithException;
+import org.apache.seatunnel.connectors.seatunnel.hudi.config.HudiSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.hudi.config.HudiTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.hudi.exception.HudiConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.hudi.exception.HudiErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.hudi.sink.HudiClientManager;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HudiSinkWriterTest {
+
+    @Test
+    void shouldRegisterAndExecuteTimerFlush() throws Exception {
+        SinkWriter.Context context = mock(SinkWriter.Context.class);
+        ArgumentCaptor<RunnableWithException> actionCaptor =
+                ArgumentCaptor.forClass(RunnableWithException.class);
+
+        try (MockedConstruction<HudiRecordWriter> recordWriters = createWriter(context)) {
+            verify(context, times(1)).registerFlushAction(actionCaptor.capture());
+
+            actionCaptor.getValue().run();
+
+            verify(recordWriters.constructed().get(0), times(1)).flush();
+        }
+    }
+
+    @Test
+    void shouldPropagateTimerFlushFailure() throws Exception {
+        SinkWriter.Context context = mock(SinkWriter.Context.class);
+        ArgumentCaptor<RunnableWithException> actionCaptor =
+                ArgumentCaptor.forClass(RunnableWithException.class);
+
+        try (MockedConstruction<HudiRecordWriter> recordWriters = createWriter(context)) {
+            HudiConnectorException expected =
+                    new HudiConnectorException(
+                            HudiErrorCode.FLUSH_DATA_FAILED, "timer flush failed");
+            doThrow(expected).when(recordWriters.constructed().get(0)).flush();
+            verify(context).registerFlushAction(actionCaptor.capture());
+
+            HudiConnectorException actual =
+                    Assertions.assertThrows(
+                            HudiConnectorException.class, actionCaptor.getValue()::run);
+
+            Assertions.assertSame(expected, actual);
+        }
+    }
+
+    @Test
+    void shouldFlushCurrentRecordWriterAfterResourceManagerReplacement() throws Exception {
+        SinkWriter.Context context = mock(SinkWriter.Context.class);
+        ArgumentCaptor<RunnableWithException> actionCaptor =
+                ArgumentCaptor.forClass(RunnableWithException.class);
+        MultiTableResourceManager<HudiClientManager> resourceManager =
+                mock(MultiTableResourceManager.class);
+        when(resourceManager.getSharedResource())
+                .thenReturn(Optional.of(mock(HudiClientManager.class)));
+
+        try (MockedConstruction<HudiRecordWriter> recordWriters =
+                Mockito.mockConstruction(HudiRecordWriter.class)) {
+            HudiSinkWriter writer =
+                    new HudiSinkWriter(
+                            context,
+                            mock(SeaTunnelRowType.class),
+                            mock(HudiSinkConfig.class),
+                            mock(HudiTableConfig.class));
+            verify(context).registerFlushAction(actionCaptor.capture());
+
+            writer.setMultiTableResourceManager(resourceManager, 0);
+            actionCaptor.getValue().run();
+
+            Assertions.assertEquals(2, recordWriters.constructed().size());
+            verify(recordWriters.constructed().get(0), never()).flush();
+            verify(recordWriters.constructed().get(1)).flush();
+        }
+    }
+
+    private MockedConstruction<HudiRecordWriter> createWriter(SinkWriter.Context context) {
+        MockedConstruction<HudiRecordWriter> recordWriters =
+                Mockito.mockConstruction(HudiRecordWriter.class);
+        new HudiSinkWriter(
+                context,
+                mock(SeaTunnelRowType.class),
+                mock(HudiSinkConfig.class),
+                mock(HudiTableConfig.class));
+        return recordWriters;
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hudi/HudiSinkCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hudi/HudiSinkCDCIT.java
@@ -46,17 +46,13 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.MountableFile;
 
-import com.mysql.cj.jdbc.Driver;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -87,7 +83,8 @@ public class HudiSinkCDCIT extends TestSuiteBase implements TestResource {
     private static final MySqlContainer MYSQL_CONTAINER = createMySqlContainer(MySqlVersion.V8_0);
     private static final String SOURCE_TABLE = "mysql_cdc_e2e_source_table";
 
-    private static final String MYSQL_CDC_PLUGIN_LIB = "/tmp/seatunnel/plugins/MySQL-CDC/lib";
+    private static final String MYSQL_DRIVER =
+            "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
 
     private static final String DATABASE = "st";
     private static final String TABLE_NAME = "st_test";
@@ -121,28 +118,14 @@ public class HudiSinkCDCIT extends TestSuiteBase implements TestResource {
             container -> {
                 container.execInContainer("sh", "-c", "mkdir -p " + TABLE_PATH);
                 container.execInContainer("sh", "-c", "chmod -R 777  " + TABLE_PATH);
-                java.nio.file.Path driverJarPath = driverJarPath();
-                Assertions.assertTrue(
-                        Files.isRegularFile(driverJarPath),
-                        "MySQL JDBC driver should be resolved from the test classpath before E2E runs: "
-                                + driverJarPath);
                 Container.ExecResult extraCommands =
-                        container.execInContainer("sh", "-c", "mkdir -p " + MYSQL_CDC_PLUGIN_LIB);
+                        container.execInContainer(
+                                "sh",
+                                "-c",
+                                "mkdir -p /tmp/seatunnel/plugins/MySQL-CDC/lib && cd /tmp/seatunnel/plugins/MySQL-CDC/lib && wget "
+                                        + MYSQL_DRIVER);
                 Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-                container.copyFileToContainer(
-                        MountableFile.forHostPath(driverJarPath),
-                        MYSQL_CDC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
             };
-
-    private java.nio.file.Path driverJarPath() {
-        try {
-            return Paths.get(
-                    Driver.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
-        }
-    }
 
     @BeforeAll
     @Override

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hudi/HudiSinkCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hudi/HudiSinkCDCIT.java
@@ -28,6 +28,7 @@ import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
@@ -45,13 +46,17 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerLoggerFactory;
+import org.testcontainers.utility.MountableFile;
 
+import com.mysql.cj.jdbc.Driver;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -82,11 +87,12 @@ public class HudiSinkCDCIT extends TestSuiteBase implements TestResource {
     private static final MySqlContainer MYSQL_CONTAINER = createMySqlContainer(MySqlVersion.V8_0);
     private static final String SOURCE_TABLE = "mysql_cdc_e2e_source_table";
 
-    private static final String MYSQL_DRIVER =
-            "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
+    private static final String MYSQL_CDC_PLUGIN_LIB = "/tmp/seatunnel/plugins/MySQL-CDC/lib";
 
     private static final String DATABASE = "st";
     private static final String TABLE_NAME = "st_test";
+    private static final String TIMER_FLUSH_DATABASE = "timer_flush_db";
+    private static final String TIMER_FLUSH_TABLE = "timer_flush_table";
     private static final String TABLE_PATH = HOST_VOLUME_MOUNT_PATH + "/hudi/";
     private static final String NAMESPACE = "hudi";
     private static final String NAMESPACE_TAR = "hudi.tar.gz";
@@ -115,14 +121,28 @@ public class HudiSinkCDCIT extends TestSuiteBase implements TestResource {
             container -> {
                 container.execInContainer("sh", "-c", "mkdir -p " + TABLE_PATH);
                 container.execInContainer("sh", "-c", "chmod -R 777  " + TABLE_PATH);
+                java.nio.file.Path driverJarPath = driverJarPath();
+                Assertions.assertTrue(
+                        Files.isRegularFile(driverJarPath),
+                        "MySQL JDBC driver should be resolved from the test classpath before E2E runs: "
+                                + driverJarPath);
                 Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "sh",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/MySQL-CDC/lib && cd /tmp/seatunnel/plugins/MySQL-CDC/lib && wget "
-                                        + MYSQL_DRIVER);
+                        container.execInContainer("sh", "-c", "mkdir -p " + MYSQL_CDC_PLUGIN_LIB);
                 Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+                container.copyFileToContainer(
+                        MountableFile.forHostPath(driverJarPath),
+                        MYSQL_CDC_PLUGIN_LIB + "/" + driverJarPath.getFileName());
             };
+
+    private java.nio.file.Path driverJarPath() {
+        try {
+            return Paths.get(
+                    Driver.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to resolve MySQL JDBC driver jar from the test classpath", e);
+        }
+    }
 
     @BeforeAll
     @Override
@@ -171,6 +191,117 @@ public class HudiSinkCDCIT extends TestSuiteBase implements TestResource {
         insertAndCheckData(container);
         // upsert/delete data and check
         upsertAndCheckData(container);
+    }
+
+    @TestTemplate
+    public void testHudiTimerFlush(TestContainer container) throws Exception {
+        clearTable(MYSQL_DATABASE, SOURCE_TABLE);
+        FileUtil.fullyDelete(
+                new File(
+                        TABLE_PATH
+                                + File.separator
+                                + TIMER_FLUSH_DATABASE
+                                + File.separator
+                                + TIMER_FLUSH_TABLE));
+        String jobId = String.valueOf(JobIdGenerator.newJobId());
+        CompletableFuture<Container.ExecResult> jobFuture =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return container.executeJob(
+                                        "/hudi/mysql_cdc_to_hudi_timer_flush.conf", jobId);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        try {
+            given().ignoreExceptions()
+                    .await()
+                    .atMost(2, TimeUnit.MINUTES)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                assertJobStillRunning(
+                                        jobFuture,
+                                        "The streaming job terminated before reaching RUNNING");
+                                Assertions.assertEquals("RUNNING", container.getJobStatus(jobId));
+                            });
+
+            executeSql(
+                    "INSERT INTO "
+                            + MYSQL_DATABASE
+                            + "."
+                            + SOURCE_TABLE
+                            + " (id, f_bigint, f_json) VALUES (1001, 1, JSON_OBJECT('phase', 1))");
+            awaitTimerFlush(jobFuture, 1);
+
+            executeSql(
+                    "INSERT INTO "
+                            + MYSQL_DATABASE
+                            + "."
+                            + SOURCE_TABLE
+                            + " (id, f_bigint, f_json) VALUES (1002, 2, JSON_OBJECT('phase', 2))");
+            awaitTimerFlush(jobFuture, 2);
+        } finally {
+            if (!jobFuture.isDone()) {
+                Container.ExecResult cancelResult = container.cancelJob(jobId);
+                Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());
+            }
+        }
+
+        Container.ExecResult jobResult = jobFuture.get(120, TimeUnit.SECONDS);
+        Assertions.assertEquals(0, jobResult.getExitCode(), jobResult.getStderr());
+    }
+
+    private void awaitTimerFlush(
+            CompletableFuture<Container.ExecResult> jobFuture, long expectedRows) {
+        given().ignoreExceptions()
+                .await()
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            assertJobStillRunning(
+                                    jobFuture,
+                                    "The streaming job terminated before timer flush published "
+                                            + expectedRows
+                                            + " rows");
+                            Assertions.assertEquals(
+                                    expectedRows,
+                                    countNewestCommitRows(),
+                                    "Timer flush should publish buffered rows while the job is running");
+                        });
+    }
+
+    private long countNewestCommitRows() throws IOException {
+        File tablePath =
+                new File(
+                        TABLE_PATH
+                                + File.separator
+                                + TIMER_FLUSH_DATABASE
+                                + File.separator
+                                + TIMER_FLUSH_TABLE);
+        Configuration configuration = new Configuration();
+        configuration.set("fs.defaultFS", LocalFileSystem.DEFAULT_FS);
+        long rowCount = 0;
+        try (ParquetReader<Group> reader =
+                ParquetReader.builder(new GroupReadSupport(), getNewestCommitFilePath(tablePath))
+                        .withConf(configuration)
+                        .build()) {
+            while (reader.read() != null) {
+                rowCount++;
+            }
+        }
+        return rowCount;
+    }
+
+    private void assertJobStillRunning(
+            CompletableFuture<Container.ExecResult> jobFuture, String message) throws Exception {
+        if (jobFuture.isDone()) {
+            Container.ExecResult jobResult = jobFuture.get();
+            Assertions.fail(message + ":\n" + jobResult.getStderr());
+        }
     }
 
     private void insertAndCheckData(TestContainer container) throws InterruptedException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/resources/hudi/mysql_cdc_to_hudi_timer_flush.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e/src/test/resources/hudi/mysql_cdc_to_hudi_timer_flush.conf
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 300000
+  sink.flush.interval = 500
+}
+
+source {
+  MySQL-CDC {
+    catalog {
+      factory = Mysql
+    }
+    database-names = ["mysql_cdc"]
+    table-names = ["mysql_cdc.mysql_cdc_e2e_source_table"]
+    format = DEFAULT
+    username = "st_user"
+    password = "seatunnel"
+    url = "jdbc:mysql://mysql_cdc_e2e:3306/mysql_cdc"
+  }
+}
+
+sink {
+  Hudi {
+    op_type = "UPSERT"
+    table_dfs_path = "/tmp/seatunnel_mnt/hudi"
+    database = "timer_flush_db"
+    table_name = "timer_flush_table"
+    table_type = "COPY_ON_WRITE"
+    record_key_fields = "id"
+    cdc_enabled = true
+    batch_size = 100
+    batch_interval_ms = 300000
+  }
+}


### PR DESCRIPTION
## Purpose

- Register Hudi's existing synchronized flush path for Zeta timer flush signals.
- Keep the registered action bound to the current record writer after multi-table resource initialization replaces the original writer.
- Document the Zeta-only, at-least-once behavior in English and Chinese.

## Tests

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-connectors-v2/connector-hudi -DskipIT -Dtest=HudiSinkWriterTest -DargLine=-Djdk.attach.allowAttachSelf=true test`
- `TEST_IN_PR=true RUN_ALL_CONTAINER=false RUN_ZETA_CONTAINER=true ./mvnw -pl seatunnel-connectors-v2/connector-hudi,seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hudi-e2e -DskipUT -DskipIT=false -Dit.test=HudiSinkCDCIT#testHudiTimerFlush -DfailIfNoTests=false integration-test`

The E2E test verifies that two MySQL CDC records become visible in Hudi through separate timer flushes while the streaming job is still running.
