### PR TITLE
[fix][connector-v2][pulsar] support text format in Pulsar source

### DIFF
--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -322,11 +322,12 @@ public class PulsarMultiTableConfig implements Serializable {
         String normalized = format.toUpperCase();
         if (!Objects.equals("JSON", normalized)
                 && !Objects.equals("CANAL_JSON", normalized)
-                && !Objects.equals("AVRO", normalized)) {
+                && !Objects.equals("AVRO", normalized)
+                && !Objects.equals("TEXT", normalized)) {
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                     String.format(
-                            "%s uses unsupported format '%s', only JSON, CANAL_JSON and AVRO are supported",
+                            "%s uses unsupported format '%s', only JSON, CANAL_JSON, AVRO and TEXT are supported",
                             configPrefix, format));
         }
     }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -56,6 +56,7 @@ import org.apache.seatunnel.format.avro.AvroDeserializationSchema;
 import org.apache.seatunnel.format.json.JsonDeserializationSchema;
 import org.apache.seatunnel.format.json.canal.CanalJsonDeserializationSchema;
 import org.apache.seatunnel.format.json.exception.SeaTunnelJsonFormatException;
+import org.apache.seatunnel.format.text.TextDeserializationSchema;
 
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 
@@ -199,7 +200,11 @@ public class PulsarSource
                     new PulsarConsumerMetadata(
                             tablePath,
                             catalogTable,
-                            createDeserialization(tableConfig.getFormat(), catalogTable),
+                            createDeserialization(
+                                    tableConfig.getFormat(),
+                                    catalogTable,
+                                    tableConfig.getSchemaConfig()
+                                            .get(PulsarSourceOptions.FIELD_DELIMITER)),
                             createDiscoverer(tableConfig),
                             createStartCursor(tableConfig),
                             createStopCursor(tableConfig),
@@ -262,7 +267,7 @@ public class PulsarSource
     }
 
     private DeserializationSchema<SeaTunnelRow> createDeserialization(
-            String format, CatalogTable catalogTable) {
+            String format, CatalogTable catalogTable, String fieldDelimiter) {
         switch (format.toUpperCase()) {
             case "JSON":
                 return new JsonDeserializationSchema(
@@ -274,6 +279,11 @@ public class PulsarSource
                                 .build());
             case "AVRO":
                 return new AvroDeserializationSchema(catalogTable);
+            case "TEXT":
+                return TextDeserializationSchema.builder()
+                        .seaTunnelRowType(catalogTable.getSeaTunnelRowType())
+                        .delimiter(fieldDelimiter)
+                        .build();
             default:
                 throw new SeaTunnelJsonFormatException(
                         CommonErrorCode.UNSUPPORTED_DATA_TYPE, "Unsupported format: " + format);


### PR DESCRIPTION
### Purpose of this pull request

Fix the Pulsar source text format support. The source contract, factory OptionRule, and docs all claimed `format = text` was supported, but `validateFormat()` rejected it and `createDeserialization()` had no `TEXT` branch.

### Why this is needed

Pulsar Source option contract and factory OptionRule claim that `format = text` is supported, but the runtime validation and deserialization path reject it. Configuring Pulsar Source with `format = text` fails during config validation or source initialization.

- `PulsarMultiTableConfig.validateFormat()` only allowed JSON, CANAL_JSON and AVRO — added TEXT
- `PulsarSource.createDeserialization()` had no TEXT branch — added TextDeserializationSchema
- Pass `field_delimiter` from config to createDeserialization for text format parsing

### Changes

1. **PulsarMultiTableConfig.java**: Added `"TEXT"` to the allowed formats in `validateFormat()`
2. **PulsarSource.java**: Added `"TEXT"` case in `createDeserialization()` using `TextDeserializationSchema` from the already-present `seatunnel-format-text` dependency

Note: Pulsar **Sink** already supports text format via `TextSerializationSchema`. The dependency `seatunnel-format-text` is already present in `connector-pulsar`.

Closes #11620

[fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]