### PR TITLE
fix(http-source): preserve rawParams template for placeholder-based pagination (#11759)

### DIFF
--- a/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/http/source/HttpSourceReader.java
@@ -82,6 +82,14 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
      * state is not unintentionally mutated during pagination.
      */
     private String rawBody = null;
+    /**
+     * Holds the original request params template for placeholder replacement. Without a copy of the
+     * raw params, the first {@code updateRequestParam} call replaces the {@code ${pageField}}
+     * placeholder (e.g. {@code ${pageIndex}}) with an actual value, so on subsequent pagination
+     * iterations the placeholder is gone and the page index never advances, causing an infinite
+     * loop (see #11759).
+     */
+    private Map<String, String> rawParams = null;
 
     public HttpSourceReader(
             HttpParameter httpParameter,
@@ -134,6 +142,8 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
         this.contentJson = contentJson;
         this.pageInfoOptional = Optional.ofNullable(pageInfo);
         this.rawBody = httpParameter.getBody();
+        this.rawParams = httpParameter.getParams() == null
+                ? null : new HashMap<>(httpParameter.getParams());
         this.binaryMode = binaryMode;
         this.binaryChunkSize = binaryChunkSize;
 
@@ -272,17 +282,43 @@ public class HttpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
         }
         // if not set keepPageParamAsHttpParam, but page field is in params, then set page index as
         if (MapUtils.isNotEmpty(this.httpParameter.getParams())) {
-
-            processPageMap(
-                    this.httpParameter.getParams(),
-                    pageField,
-                    pageValue.toString(),
-                    usePlaceholderReplacement);
-            processPageMap(
-                    this.httpParameter.getParams(),
-                    pageInfo.getPageCursorFieldName(),
-                    pageInfo.getCursor(),
-                    usePlaceholderReplacement);
+            if (usePlaceholderReplacement && rawParams != null) {
+                // Rebuild params from the raw template on every pagination iteration. Re-using the
+                // already-mutated params map would drop the ${pageField} placeholder after the first
+                // call, so the page index would never advance (causing an infinite loop, see #11759).
+                Map<String, String> rebuiltParams = new HashMap<>();
+                for (Map.Entry<String, String> entry : rawParams.entrySet()) {
+                    String value = entry.getValue();
+                    String replaced = replacePlaceholder(value, pageField, pageValue);
+                    if (replaced == null) {
+                        replaced = value;
+                    }
+                    if (pageInfo.getPageCursorFieldName() != null
+                            && pageInfo.getCursor() != null) {
+                        String cursorReplaced =
+                                replacePlaceholder(
+                                        replaced,
+                                        pageInfo.getPageCursorFieldName(),
+                                        pageInfo.getCursor());
+                        if (cursorReplaced != null) {
+                            replaced = cursorReplaced;
+                        }
+                    }
+                    rebuiltParams.put(entry.getKey(), replaced);
+                }
+                this.httpParameter.setParams(rebuiltParams);
+            } else {
+                processPageMap(
+                        this.httpParameter.getParams(),
+                        pageField,
+                        pageValue.toString(),
+                        usePlaceholderReplacement);
+                processPageMap(
+                        this.httpParameter.getParams(),
+                        pageInfo.getPageCursorFieldName(),
+                        pageInfo.getCursor(),
+                        usePlaceholderReplacement);
+            }
         }
 
         // 2. param in body


### PR DESCRIPTION
## Description

Fix the pagination infinite-loop bug in the HTTP connector when placeholder replacement is enabled.

### Problem

When `use_placeholder_replacement=true` and `page_field` is a placeholder in `params` (e.g. `"pageIndex": "${pageIndex}"`), the page index never advances — the connector keeps requesting page 1 forever.

**Root cause:** In `HttpSourceReader.updateRequestParam()`, the `params` map is mutated in place. The first call replaces the `${pageIndex}` placeholder with the actual value (`"1"`). On every subsequent pagination iteration, the placeholder is no longer present in the map, so `replacePlaceholder` finds nothing to replace and the page index never increments, causing an infinite loop.

### Fix

Add a `rawParams` copy of the original params template (mirroring the existing `rawBody` handling). When `usePlaceholderReplacement` is enabled, rebuild the params map from `rawParams` on each pagination iteration so the `${pageField}` placeholder is always present to be replaced with the current page index.

Closes #11759
