### PR TITLE
[Improve][E2E] Isolate long-running connector tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1491,6 +1491,56 @@ jobs:
         env:
           MAVEN_OPTS: -Xmx4096m
 
+  elasticsearch-connector-it:
+    needs: [ changes, sanity-check ]
+    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-elasticsearch-e2e')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+        os: [ 'ubuntu-latest' ]
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: free disk space
+        run: tools/github/free_disk_space.sh
+      - name: run elasticsearch connector integration test
+        run: |
+          ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :connector-elasticsearch-e2e -am -Pci
+        env:
+          MAVEN_OPTS: -Xmx4096m
+
+  mysql-cdc-connector-it:
+    needs: [ changes, sanity-check ]
+    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-cdc-mysql-e2e')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+        os: [ 'ubuntu-latest' ]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: free disk space
+        run: tools/github/free_disk_space.sh
+      - name: run mysql cdc connector integration test
+        run: |
+          ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :connector-cdc-mysql-e2e -am -Pci
+        env:
+          MAVEN_OPTS: -Xmx4096m
+
 
   doris-connector-it:
     needs: [ changes, sanity-check ]

--- a/tools/update_modules_check/update_modules_check.py
+++ b/tools/update_modules_check/update_modules_check.py
@@ -155,6 +155,8 @@ def get_sub_it_modules(modules, total_num, current_num):
     modules_arr.remove("connector-file-sftp-e2e")
     modules_arr.remove("connector-redis-e2e")
     modules_arr.remove("connector-sensorsdata-e2e")
+    modules_arr.remove("connector-elasticsearch-e2e")
+    modules_arr.remove("connector-cdc-mysql-e2e")
     if "connector-seatunnel-e2e-base" in modules_arr:
         modules_arr.remove("connector-seatunnel-e2e-base")
     if "connector-console-seatunnel-e2e" in modules_arr:
@@ -202,6 +204,10 @@ def get_sub_update_it_modules(modules, total_num, current_num):
         module_list.remove("connector-file-sftp-e2e")
     if "connector-redis-e2e" in module_list:
         module_list.remove("connector-redis-e2e")
+    if "connector-elasticsearch-e2e" in module_list:
+        module_list.remove("connector-elasticsearch-e2e")
+    if "connector-cdc-mysql-e2e" in module_list:
+        module_list.remove("connector-cdc-mysql-e2e")
     if "connector-seatunnel-e2e-base" in module_list:
         module_list.remove("connector-seatunnel-e2e-base")
     if "connector-console-seatunnel-e2e" in module_list:


### PR DESCRIPTION
### Purpose of this pull request

Reduce the critical path of the connector E2E workflow by moving the two dominant suites out of the shared connector shards:

* `connector-elasticsearch-e2e` took about 2 hours 7 minutes in `all-connectors-it-4`.
* `connector-cdc-mysql-e2e` took about 1 hour 13 minutes on both JDK 8 and JDK 11 in `all-connectors-it-7`.

This PR adds dedicated JDK 8/11 jobs for both modules and excludes them from both the full connector shards and the updated-module shards. The test commands and coverage are unchanged; only their scheduling is changed.

Baseline: https://github.com/nzw921rx/seatunnel/actions/runs/31382608165

Relevant jobs:

* Part 4 (JDK 11): https://github.com/nzw921rx/seatunnel/actions/runs/31382608165/job/93640131661
* Part 7 (JDK 11): https://github.com/nzw921rx/seatunnel/actions/runs/31382608165/job/93640131604

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

* `./mvnw spotless:apply`
* `python3 -m unittest discover -s tools/update_modules_check -p 'test_*.py'`
* Parsed `.github/workflows/backend.yml` with Ruby YAML.
* Compiled `tools/update_modules_check/update_modules_check.py` with Python.
* Verified with a focused Python assertion that Elasticsearch and MySQL CDC are excluded from all shared full/update shards while an ordinary module remains assigned.
* `git diff --check`

Full Maven verification was not run because this patch only changes CI scheduling and does not change production or test code.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not necessary because there is no user-facing behavior change.
* [x] No incompatible change is introduced.
