### PR TITLE
[Fix][Core] Do not charge the byte rate limiter for a zero-byte row

### DIFF
--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGate.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGate.java
@@ -44,7 +44,18 @@ public class FlowControlGate {
     }
 
     public void audit(SeaTunnelRow row) {
-        bytesRateLimiter.ifPresent(rateLimiter -> rateLimiter.acquire(row.getBytesSize()));
+        bytesRateLimiter.ifPresent(
+                rateLimiter -> {
+                    // A row can legitimately measure zero bytes -- SeaTunnelRow#getBytesSize
+                    // counts null as 0 and a String as its length, so an all-null row or one of
+                    // only empty strings sums to 0. RateLimiter rejects a non-positive permit
+                    // count, so charging it would abort the task instead of throttling it. Such a
+                    // row consumes no byte budget; the count limiter is what bounds its rate.
+                    int bytesSize = row.getBytesSize();
+                    if (bytesSize > 0) {
+                        rateLimiter.acquire(bytesSize);
+                    }
+                });
         countRateLimiter.ifPresent(RateLimiter::acquire);
     }
 

--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGate.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGate.java
@@ -44,19 +44,24 @@ public class FlowControlGate {
     }
 
     public void audit(SeaTunnelRow row) {
-        bytesRateLimiter.ifPresent(
-                rateLimiter -> {
-                    // A row can legitimately measure zero bytes -- SeaTunnelRow#getBytesSize
-                    // counts null as 0 and a String as its length, so an all-null row or one of
-                    // only empty strings sums to 0. RateLimiter rejects a non-positive permit
-                    // count, so charging it would abort the task instead of throttling it. Such a
-                    // row consumes no byte budget; the count limiter is what bounds its rate.
-                    int bytesSize = row.getBytesSize();
-                    if (bytesSize > 0) {
-                        rateLimiter.acquire(bytesSize);
-                    }
-                });
+        bytesRateLimiter.ifPresent(rateLimiter -> acquireBytes(rateLimiter, row));
         countRateLimiter.ifPresent(RateLimiter::acquire);
+    }
+
+    /**
+     * Charge the byte limiter for this row, unless the row measures zero bytes.
+     *
+     * <p>A row can legitimately measure zero bytes: {@link SeaTunnelRow#getBytesSize()} counts a
+     * null field as 0 and a String as its length, so an all-null row, or one of only empty strings,
+     * sums to 0. {@link RateLimiter#acquire(int)} rejects a non-positive permit count, so charging
+     * it would abort the task instead of throttling it. Such a row consumes no byte budget; the
+     * count limiter is what bounds its rate.
+     */
+    private void acquireBytes(RateLimiter rateLimiter, SeaTunnelRow row) {
+        int bytesSize = row.getBytesSize();
+        if (bytesSize > 0) {
+            rateLimiter.acquire(bytesSize);
+        }
     }
 
     public static FlowControlGate create(FlowControlStrategy flowControlStrategy) {

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGateTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/flowcontrol/FlowControlGateTest.java
@@ -34,6 +34,24 @@ public class FlowControlGateTest {
     private static final int rowSize = 181;
 
     @Test
+    public void testRowWhoseFieldsAreAllNull() {
+        FlowControlGate flowControlGate = FlowControlGate.create(FlowControlStrategy.ofBytes(100));
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {null, null});
+
+        Assertions.assertEquals(0, row.getBytesSize());
+        Assertions.assertDoesNotThrow(() -> flowControlGate.audit(row));
+    }
+
+    @Test
+    public void testRowWhoseFieldsAreAllEmptyStrings() {
+        FlowControlGate flowControlGate = FlowControlGate.create(FlowControlStrategy.ofBytes(100));
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {"", ""});
+
+        Assertions.assertEquals(0, row.getBytesSize());
+        Assertions.assertDoesNotThrow(() -> flowControlGate.audit(row));
+    }
+
+    @Test
     public void testWithBytes() {
         Clock clock = Clock.systemDefaultZone();
         FlowControlGate flowControlGate = FlowControlGate.create(FlowControlStrategy.ofBytes(100));


### PR DESCRIPTION
### Purpose of this pull request

Closes #11765.

Enabling `read_limit.bytes_per_second` aborts the task on the first row that measures zero bytes:

```
java.lang.IllegalArgumentException: Requested permits (0) must be positive
```

`FlowControlGate#audit` passes `row.getBytesSize()` straight into Guava's `RateLimiter#acquire`, which requires a positive permit count (`checkPermits` → `checkArgument(permits > 0, ...)`).

A zero-byte row is not a corner case. `SeaTunnelRow#getBytesForValue` returns `0` for `null` and `String#length()` for a string, so a row whose selected columns are all `NULL`, or all empty strings, sums to exactly 0. The failure then surfaces from inside shaded Guava as an argument-validation error, so it reads as an engine fault rather than a throttling decision — and only users who turned byte throttling on ever see it.

A zero-byte row consumes no byte budget, so the byte limiter is skipped for it. The count limiter is what bounds the rate of such rows, and it is unchanged.

### Does this PR introduce _any_ user-facing change?

Yes, in the sense that a job which previously crashed now runs. No configuration or semantics change for rows that actually carry bytes.

### How was this patch tested or is it not required?

Two cases added to `FlowControlGateTest`, one for an all-`NULL` row and one for all-empty-string columns. Each asserts `getBytesSize() == 0` first, so the test fails loudly if that premise ever stops holding, and then asserts `audit` does not throw.

Both **fail on `dev`** with exactly the reported exception:

```
FlowControlGateTest.testRowWhoseFieldsAreAllNull:42
  Unexpected exception thrown: java.lang.IllegalArgumentException: Requested permits (0) must be positive
FlowControlGateTest.testRowWhoseFieldsAreAllEmptyStrings:51
  Unexpected exception thrown: java.lang.IllegalArgumentException: Requested permits (0) must be positive
Tests run: 2, Failures: 2
```

With the fix the full class is green — **5/5, including the three existing timing-based tests** (37s), which is the check that matters here: throttling of ordinary rows is unchanged, only the zero-byte case is skipped.

`spotless:check` exits 0.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md) — none added
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — no user-facing config change
* [ ] If you are contributing the connector code, please check that the following files are updated
* [x] Update the `docs/en/about.md` — not applicable
