### PR TITLE
[Docs][Connector-V2] Improve ClickhouseFile Cloudberry Jira Persistiq and SelectDB-Cloud connector docs

### DIFF
--- a/docs/en/connectors/sink/ClickhouseFile.md
+++ b/docs/en/connectors/sink/ClickhouseFile.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 
 > Clickhouse file sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Generate the clickhouse data file with the clickhouse-local program, and then send it to the clickhouse
@@ -22,26 +28,26 @@ Write data to Clickhouse can also be done using JDBC
 
 ## Options
 
-|          Name          |  Type   | Required |                Default                 |
-|------------------------|---------|----------|----------------------------------------|
-| host                   | string  | yes      | -                                      |
-| database               | string  | yes      | -                                      |
-| table                  | string  | yes      | -                                      |
-| username               | string  | yes      | -                                      |
-| password               | string  | yes      | -                                      |
-| clickhouse_local_path  | string  | yes      | -                                      |
-| sharding_key           | string  | no       | -                                      |
-| copy_method            | string  | no       | scp                                    |
-| node_free_password     | boolean | no       | false                                  |
-| node_pass              | list    | no       | -                                      |
-| node_pass.node_address | string  | no       | -                                      |
-| node_pass.username     | string  | no       | "root"                                 |
-| node_pass.password     | string  | no       | -                                      |
-| compatible_mode        | boolean | no       | false                                  |
-| file_fields_delimiter  | string  | no       | "\t"                                   |
-| file_temp_path         | string  | no       | "/tmp/seatunnel/clickhouse-local/file" |
-| key_path               | string  | no       | "/tmp/id_rsa"                          |
-| common-options         |         | no       | -                                      |
+|          Name          |  Type   | Required |                Default                 | Description |
+|------------------------|---------|----------|----------------------------------------|-------------|
+| host                   | string  | yes      | -                                      | `ClickHouse` cluster address, the format is `host:port`, allowing multiple `hosts` to be specified, e.g. `"host1:8123,host2:8123"`. |
+| database               | string  | yes      | -                                      | The `ClickHouse` database name. |
+| table                  | string  | yes      | -                                      | The target table name. The table must use the `Distributed` engine with `internal_replication=true`. |
+| username               | string  | yes      | -                                      | `ClickHouse` user username. |
+| password               | string  | yes      | -                                      | `ClickHouse` user password. |
+| clickhouse_local_path  | string  | yes      | -                                      | Absolute path of the `clickhouse-local` binary on every worker node (Spark/Flink TaskManager or Zeta worker). Each worker that runs a writer must have the same path; install the same binary at the same location on every node before starting the job. |
+| sharding_key           | string  | no       | -                                      | Field used by the sharding algorithm when picking the shard node. When omitted, the writer picks a shard randomly. |
+| copy_method            | string  | no       | scp                                    | Method used to transfer the staged file from the worker to the ClickHouse node. Supported values: `scp`, `rsync`. |
+| node_free_password     | boolean | no       | false                                  | Set to `true` when every worker can SSH to every ClickHouse shard node without a password (key-based auth or ssh-agent). When `false`, configure `node_pass` so the writer knows how to authenticate. |
+| node_pass              | list    | no       | -                                      | Per-node credentials for `scp`/`rsync`. Required when `node_free_password=false` and SSH key auth is not in place. |
+| node_pass.node_address | string  | no       | -                                      | The address of the ClickHouse shard node that receives the file. |
+| node_pass.username     | string  | no       | "root"                                 | The SSH username on the ClickHouse shard node. |
+| node_pass.password     | string  | no       | -                                      | The SSH password on the ClickHouse shard node. Ignored when `key_path` is set and key-based auth succeeds. |
+| compatible_mode        | boolean | no       | false                                  | Set to `true` for older ClickHouse releases where `clickhouse-local` does not understand the `--path` flag. The connector falls back to a path-free invocation that still produces a compatible staging file. |
+| file_fields_delimiter  | string  | no       | "\t"                                   | Field delimiter used inside the staged CSV file. The value must be exactly one character; pick a character that never appears in any column value. |
+| file_temp_path         | string  | no       | "/tmp/seatunnel/clickhouse-local/file" | Local directory on each worker where the staged file is written before being copied to ClickHouse. Use a path with enough free disk space for the largest batch the writer produces. |
+| key_path               | string  | no       | -                                      | Absolute path of the SSH private key file used by `scp`/`rsync` when `node_free_password=false`. When set, `node_pass.password` is ignored; the key must be authorized on every shard node. |
+| common-options         |         | no       | -                                      | Sink plugin common parameters, see [Sink Common Options](../common-options/sink-common-options.md). |
 
 ### host [string]
 
@@ -70,8 +76,10 @@ When ClickhouseFile split data, which node to send data to is a problem, the def
 
 ### clickhouse_local_path [string]
 
-The address of the clickhouse-local program on the spark node. Since each task needs to be called,
-clickhouse-local should be located in the same path of each spark node.
+The address of the `clickhouse-local` program on every worker node (Spark executor, Flink TaskManager, or SeaTunnel Zeta worker).
+Because each task needs to call `clickhouse-local`, every worker that runs a writer must have the binary at the same
+absolute path before the job starts. A common pitfall is deploying the binary only on the driver/master node — the writer
+runs on the workers, and a missing binary surfaces as `clickhouse-local: command not found` on the first batch.
 
 ### copy_method [string]
 
@@ -122,27 +130,134 @@ The path of the private key file used for scp or rsync to connect to the ClickHo
 
 Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details
 
+## How it works
+
+ClickhouseFile is a **bulk-load** sink. Each writer:
+
+1. Buffers incoming rows into a CSV file under `file_temp_path` on the local worker.
+2. Once the buffer hits the configured size or the checkpoint barrier arrives, the worker shells out to
+   `clickhouse-local` (located at `clickhouse_local_path`) to convert the CSV into ClickHouse's native
+   storage format.
+3. The worker copies the converted file to the target shard node via `scp` or `rsync`, using either
+   password-less SSH, `node_pass` credentials, or a key file at `key_path`.
+4. The shard node ingests the file through the `Distributed` table.
+
+Because the final ingest happens on the ClickHouse side via `clickhouse-local`, the connector does not
+participate in a distributed transaction and therefore cannot offer exactly-once. For end-to-end exactly-once
+on ClickHouse, use the JDBC sink with the ReplacingMergeTree engine and a primary-key dedupe strategy
+in the downstream table.
+
 ## Examples
 
+### Minimal BATCH job
+
 ```hocon
-ClickhouseFile {
-  host = "192.168.0.1:8123"
-  database = "default"
-  table = "fake_all"
-  username = "default"
-  password = ""
-  clickhouse_local_path = "/Users/seatunnel/Tool/clickhouse local"
-  sharding_key = "age"
-  node_free_password = false
-  node_pass = [{
-    node_address = "192.168.0.1"
-    password = "seatunnel"
-  }]
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+sink {
+  ClickhouseFile {
+    host = "192.168.0.1:8123"
+    database = "default"
+    table = "fake_all"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/opt/clickhouse/usr/bin/clickhouse-local"
+    sharding_key = "age"
+    node_free_password = false
+    node_pass = [{
+      node_address = "192.168.0.1"
+      password = "seatunnel"
+    }]
+  }
+}
+```
+
+### Multi-shard cluster with password-less SSH
+
+When the cluster has multiple shards and SSH trust is already configured cluster-wide, set
+`node_free_password = true` and skip `node_pass` entirely. The connector will pick a shard based on
+`sharding_key` and rely on the SSH config for authentication.
+
+```hocon
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123,shard-2:8123,shard-3:8123"
+    database = "default"
+    table = "orders_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    sharding_key = "id"
+    node_free_password = true
+    copy_method = "rsync"
+    file_temp_path = "/data/seatunnel/clickhouse-tmp"
+  }
+}
+```
+
+### SSH key-based authentication
+
+When `node_free_password=false` but you want to authenticate with an SSH key instead of a plaintext
+password, point `key_path` to the private key file. The key must be authorized on every shard node
+(typically via `~/.ssh/authorized_keys`). `node_pass.password` is ignored when the key auth succeeds.
+
+```hocon
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123,shard-2:8123"
+    database = "default"
+    table = "events_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    sharding_key = "user_id"
+    node_free_password = false
+    node_pass = [{
+      node_address = "shard-1"
+      username = "clickhouse"
+    }, {
+      node_address = "shard-2"
+      username = "clickhouse"
+    }]
+    key_path = "/etc/seatunnel/id_rsa"
+    copy_method = "rsync"
+  }
+}
+```
+
+### STREAMING job with checkpoint
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Kafka {
+    # ...
+  }
+}
+
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123"
+    database = "default"
+    table = "events_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    node_free_password = true
+    copy_method = "rsync"
+  }
 }
 ```
 
 ## Changelog
 
 <ChangeLog />
-
 

--- a/docs/en/connectors/sink/SelectDB-Cloud.md
+++ b/docs/en/connectors/sink/SelectDB-Cloud.md
@@ -35,18 +35,21 @@ Version Supported
 
 |        Name        |  Type  | Required |        Default         |                                                                                                                                                                    Description                                                                                                                                                                    |
 |--------------------|--------|----------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| load-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse http address, the format is `warehouse_ip:http_port`                                                                                                                                                                                                                                                                   |
-| jdbc-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse jdbc address, the format is `warehouse_ip:mysql_port`                                                                                                                                                                                                                                                                  |
-| cluster-name       | String | Yes      | -                      | `SelectDB Cloud` cluster name                                                                                                                                                                                                                                                                                                                     |
-| username           | String | Yes      | -                      | `SelectDB Cloud` user username                                                                                                                                                                                                                                                                                                                    |
-| password           | String | Yes      | -                      | `SelectDB Cloud` user password                                                                                                                                                                                                                                                                                                                    |
-| sink.enable-2pc    | bool   | No       | true                   | Whether to enable two-phase commit (2pc), the default is true, to ensure Exactly-Once semantics. SelectDB uses cache files to load data. When the amount of data is large, cached data may become invalid (the default expiration time is 1 hour). If you encounter a large amount of data write loss, please configure sink.enable-2pc to false. |
-| table.identifier   | String | Yes      | -                      | The name of `SelectDB Cloud` table, the format is `database.table`                                                                                                                                                                                                                                                                                |
-| sink.enable-delete | bool   | No       | false                  | Whether to enable deletion. This option requires SelectDB Cloud table to enable batch delete function, and only supports Unique model.                                                                                                                                                                                                            |
-| sink.max-retries   | int    | No       | 3                      | the max retry times if writing records to database failed                                                                                                                                                                                                                                                                                         |
-| sink.buffer-size   | int    | No       | 10 * 1024 * 1024 (1MB) | the buffer size to cache data for stream load.                                                                                                                                                                                                                                                                                                    |
-| sink.buffer-count  | int    | No       | 10000                  | the buffer count to cache data for stream load.                                                                                                                                                                                                                                                                                                   |
-| selectdb.config    | map    | yes      | -                      | This option is used to support operations such as `insert`, `delete`, and `update` when automatically generate sql,and supported formats.                                                                                                                                                                                                         |
+| load-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse http address, the format is `warehouse_ip:http_port`. Used to submit the stream-load request.                                                                                                                                                                                                                           |
+| jdbc-url           | String | Yes      | -                      | `SelectDB Cloud` warehouse jdbc address, the format is `warehouse_ip:mysql_port`. Used for metadata queries such as schema discovery.                                                                                                                                                                                                                |
+| cluster-name       | String | Yes      | -                      | `SelectDB Cloud` cluster name as configured in the warehouse.                                                                                                                                                                                                                                                                                       |
+| username           | String | Yes      | -                      | `SelectDB Cloud` user username.                                                                                                                                                                                                                                                                                                                    |
+| password           | String | Yes      | -                      | `SelectDB Cloud` user password.                                                                                                                                                                                                                                                                                                                    |
+| table.identifier   | String | Yes      | -                      | The name of `SelectDB Cloud` table, the format is `database.table`. The table must already exist with a compatible column set; the connector does not create tables automatically.                                                                                                                                                                |
+| selectdb.config    | Map    | Yes      | -                      | Stream-load parameters forwarded to the `Copy Into` statement. At minimum, set `file.type` (`json` or `csv`). Other common keys include `file.column_separator`, `file.line_delimiter`, `file.strip_outer_array`, and `max_filter_ratio`. Prefix every key with `selectdb.config.` in the HOCON block.                                                |
+| sink.enable-2pc    | bool   | No       | true                   | Whether to enable two-phase commit (2pc). Default is `true` to ensure Exactly-Once semantics. SelectDB uses cache files to load data. When the amount of data is large, cached data may become invalid (the default expiration time is 1 hour). If you encounter large amounts of data write loss, set `sink.enable-2pc` to `false` and accept at-least-once. |
+| sink.enable-delete | bool   | No       | false                  | Whether to enable deletion. This option requires the `SelectDB Cloud` table to enable the batch-delete function, and only supports the Unique model.                                                                                                                                                                                                 |
+| sink.max-retries   | int    | No       | 3                      | Max retry times if writing records to the database fails.                                                                                                                                                                                                                                                                                          |
+| sink.buffer-size   | int    | No       | 10 * 1024 * 1024 (1MB) | Buffer size in bytes used to cache data before stream-load. Larger buffers reduce request overhead but use more memory per writer.                                                                                                                                                                                                                  |
+| sink.buffer-count  | int    | No       | 10000                  | Buffer row count used to cache data before stream-load. Larger counts reduce request overhead but use more memory per writer.                                                                                                                                                                                                                       |
+| sink.label-prefix  | String | No       | random UUID            | Unique label prefix attached to each stream-load transaction. Useful when you want deterministic labels for replay or audit. The default UUID is unique per writer, so leave it alone unless you have a specific need.                                                                                                                              |
+| sink.flush.queue-size | int  | No       | 1                      | Queue length for the async upload thread that ships buffered data to object storage. Increase this when the network between SeaTunnel workers and SelectDB is slow.                                                                                                                                                                                |
+| common-options     | config | No       | -                      | Sink plugin common parameters. See [Sink Common Options](../common-options/sink-common-options.md).                                                                                                                                                                                                                                                |
 
 ## Data Type Mapping
 
@@ -76,7 +79,24 @@ Version Supported
 
 #### Supported import data formats
 
-The supported formats include CSV and JSON
+The supported formats include CSV and JSON.
+
+`HLL`, `BITMAP`, `QUANTILE_STATE`, and `STRUCT` are SelectDB-only types that have no equivalent
+in SeaTunnel's runtime schema. If your downstream pipeline needs them, materialize them out of band
+and ingest via JDBC rather than the stream-load path.
+
+## How CDC works
+
+When the upstream is a CDC source (MySQL-CDC, PostgreSQL-CDC, etc.), the SelectDB Cloud sink
+auto-generates `INSERT` / `DELETE` SQL based on the row kind. To make this work, the downstream
+table must:
+
+- Use the **Unique** model so that duplicate primary keys are deduped.
+- Have **batch delete** enabled (`ALTER TABLE ... ENABLE BATCH DELETE`) so the sink can issue
+  delete statements.
+- Set `sink.enable-delete = true` in the job config.
+
+Without all three, CDC writes will either fail or silently drop deletes.
 
 ## Task Example
 
@@ -167,8 +187,107 @@ sink {
     password = "******"
     selectdb.config {
         file.type = "csv"
-        file.column_separator = "," 
-        file.line_delimiter = "\n" 
+        file.column_separator = ","
+        file.line_delimiter = "\n"
+    }
+  }
+}
+```
+
+### STREAMING with checkpoint
+
+In `STREAMING` mode, set `checkpoint.interval` so the writer can flush its buffer and commit the
+`Copy Into` transaction periodically. Without checkpointing, the connector buffers rows in memory
+until `sink.buffer-size` or `sink.buffer-count` is hit, which can be a lot of rows for a slow source.
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Kafka {
+    # ...
+  }
+}
+
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.events"
+    username = "admin"
+    password = "******"
+    sink.buffer-count = 50000
+    sink.label-prefix = "seatunnel-events"
+    selectdb.config {
+      file.type = "json"
+    }
+  }
+}
+```
+
+### CDC ingest from MySQL-CDC
+
+For CDC ingest, the downstream table must be on the Unique model with batch delete enabled.
+The connector will generate `INSERT` / `DELETE` statements based on the row kind; set
+`sink.enable-delete = true` to opt in.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  MySQL-CDC {
+    # ...
+    table-names = ["demo.orders"]
+  }
+}
+
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.orders"
+    username = "admin"
+    password = "******"
+    sink.enable-delete = true
+    selectdb.config {
+      file.type = "json"
+      file.strip_outer_array = "false"
+    }
+  }
+}
+```
+
+### When 2PC cannot finish in time
+
+`sink.enable-2pc` defaults to `true` so each batch is wrapped in a transaction. SelectDB's default
+transaction expiration is 1 hour; very large batches or slow networks can blow past that and the
+cached data becomes invalid, which surfaces as missing rows at the destination. If your job is
+producing such large batches, set `sink.enable-2pc = false` and accept at-least-once semantics
+(combined with a Unique-key table, duplicate rows are still merged correctly).
+
+```hocon
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.large_events"
+    username = "admin"
+    password = "******"
+    sink.enable-2pc = false
+    sink.buffer-count = 200000
+    selectdb.config {
+      file.type = "json"
     }
   }
 }

--- a/docs/en/connectors/source/Cloudberry.md
+++ b/docs/en/connectors/source/Cloudberry.md
@@ -52,19 +52,46 @@ Cloudberry uses PostgreSQL's data type implementation. Please refer to PostgreSQ
 
 ## Options
 
-Cloudberry connector uses the same options as PostgreSQL. For detailed configuration options, please refer to the PostgreSQL documentation.
+Cloudberry is a thin wrapper over the PostgreSQL dialect inside the JDBC source. The job still uses the `Jdbc`
+plugin name; only the connection settings differ. Every option below is identical to the PostgreSQL/JDBC source
+option of the same name — please refer to the [PostgreSQL source documentation](../source/PostgreSQL.md) and the
+shared [JDBC source options](../source/Jdbc.md) for the full description, valid values, and default behavior.
 
 Key options include:
 
-- url (required): The JDBC connection URL
-- driver (required): The driver class name (org.postgresql.Driver)
-- username/password: Authentication credentials. `user` is also accepted as a fallback key for `username`.
-- query or table_path: What data to read
-- partition options for parallel reading
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| url | String | Yes | - | JDBC connection URL. Use a `jdbc:postgresql://host:port/database` style URL because Cloudberry speaks the PostgreSQL wire protocol. |
+| driver | String | Yes | - | JDBC driver class name. Always `org.postgresql.Driver`. |
+| user / username | String | Yes | - | Database login. `user` is also accepted as a fallback key for `username`. |
+| password | String | Yes | - | Database password. Use a secrets manager or environment variable in production; never commit it into the job config. |
+| query | String | Conditional | - | SELECT statement that drives the read. Required when not using `table_path` or `table_list`. |
+| table_path | String | Conditional | - | `schema.table` of the table to read. Required when not using `query`. |
+| table_list | List | No | - | Read several tables in one source. Each entry is `{ table_path = "schema.table" }`. Parallelism is split across tables when this option is set. |
+| split.size | Int | No | 8096 | Target row count per split. The connector uses this to derive a parallel scan plan when `partition_column` is provided. |
+| split.even_partition_num | Boolean | No | false | Force a balanced number of partitions; otherwise the connector lets the optimizer decide. |
+| split.sample_shard_threshold | Int | No | 1000 | Threshold (rows) for sampling when computing the partition count. |
+| split.inverse_parallelism | Int | No | 1 | Inverse of the parallelism — i.e. the number of splits per source subtask. Higher values mean smaller, more numerous splits. |
+| partition_column | String | No | - | Numeric column used for partition splits. Must be a monotonically increasing or unique column (e.g. `id`, `created_at`). |
+| partition_upper_bound | Long | No | - | Upper bound of the partition column. Set when you know the range to avoid a costly `MIN()` probe. |
+| partition_lower_bound | Long | No | - | Lower bound of the partition column. Set when you know the range to avoid a costly `MAX()` probe. |
+| fetch_size | Int | No | 0 | JDBC fetch size. `0` means driver default. Increase for large rows. |
+| common-options | Config | No | - | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
 ## Parallel Reader
 
-Cloudberry supports parallel reading following the same rules as PostgreSQL connector. For detailed information on split strategies and parallel reading options, please refer to the PostgreSQL connector documentation.
+Cloudberry inherits the PostgreSQL parallel reading strategy from the JDBC source:
+
+- **No partition column** — the connector runs the configured `query` on a single subtask. Use this when the
+  query already aggregates or the table is small.
+- **Numeric `partition_column`** — the connector probes `MIN()`/`MAX()` (or uses `partition_lower_bound` /
+  `partition_upper_bound` if set), then issues each split as a `WHERE partition_column BETWEEN ? AND ?` clause.
+  This is the typical pattern for large fact tables.
+- **`table_list`** — the connector assigns one table per subtask when parallelism ≥ number of tables, otherwise
+  it splits each table as described above.
+
+For the full split-strategy reference and edge-case guidance (e.g. non-numeric partition columns, parallel
+`UPDATE` snapshots), see the [PostgreSQL source documentation](../source/PostgreSQL.md).
 
 ## Notes
 
@@ -72,6 +99,10 @@ Cloudberry supports parallel reading following the same rules as PostgreSQL conn
 - Cloudberry uses the PostgreSQL JDBC driver and PostgreSQL-compatible dialect path, so keep `driver = "org.postgresql.Driver"`.
 - Use a PostgreSQL-style URL such as `jdbc:postgresql://host:5432/database`.
 - Keep database passwords out of shared examples, logs, and screenshots.
+- Cloudberry does not yet ship CDC support. For change-data capture, use the dedicated CDC source for the
+  upstream database, or capture changes with a logical replication slot and ingest via the JDBC source.
+- For very large parallel scans, prefer setting `partition_lower_bound` / `partition_upper_bound` over letting
+  the connector probe `MIN()` / `MAX()`. The probe query is the slowest part of job startup.
 
 ## Task Example
 
@@ -113,6 +144,9 @@ source {
     user = "dbadmin"
     password = "password"
     table_path = "public.mytable"
+    partition_column = "id"
+    partition_lower_bound = 1
+    partition_upper_bound = 1000000
     split.size = 10000
   }
 }
@@ -153,7 +187,35 @@ sink {
 }
 ```
 
-For more detailed examples and configurations, please refer to the PostgreSQL connector documentation.
+### Streaming source from a query (single-subtask)
+
+For continuous ingestion (e.g. polling a `WHERE updated_at > now() - interval '5 minutes'` query),
+drop `parallelism` to 1 and rely on the database-side filter. The query needs to be idempotent and
+must include a deterministic ordering.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Jdbc {
+    url = "jdbc:postgresql://localhost:5432/cloudberrydb"
+    driver = "org.postgresql.Driver"
+    user = "dbadmin"
+    password = "password"
+    query = "select id, payload, updated_at from events where updated_at > now() - interval '5 minutes' order by updated_at"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+For more detailed examples and configurations, please refer to the [PostgreSQL source documentation](../source/PostgreSQL.md) and the shared [JDBC source options](../source/Jdbc.md).
 
 ## Changelog
 

--- a/docs/en/connectors/source/Jira.md
+++ b/docs/en/connectors/source/Jira.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-http-jira.md';
 
 > Jira source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Reads data from Jira REST APIs. The connector adds the Jira Basic authentication header from `email` and `api_token`, then uses the shared HTTP source runtime to parse the response.
@@ -53,7 +59,12 @@ Create a Jira API token from your Atlassian account and set:
 - `email`: the Jira account email.
 - `api_token`: the Jira API token.
 
-The connector builds the Basic authentication header automatically.
+The connector builds the Basic authentication header automatically. Do not also add an `Authorization`
+header in `headers` — the explicit one would override the generated Basic header and authentication would
+fail.
+
+If your Jira site sits behind a proxy, place proxy-specific headers (e.g. `X-Atlassian-Token`)
+in `headers` instead of trying to override the Basic auth header.
 
 ### Response Parsing
 
@@ -90,7 +101,13 @@ Use `content_field` when the rows are inside a nested JSON node. Use `json_field
 | cursor_response_field | String | No | - | JSONPath field used to read the next cursor from the response. |
 | use_placeholder_replacement | boolean | No | false | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
+The Jira REST search endpoint (`/rest/api/3/search`) supports both `startAt`/`maxResults` style paging and
+`nextPageToken`-style cursor paging. Pick whichever the target endpoint exposes — most cloud endpoints accept
+the older offset/limit paging, while newer endpoints only accept cursor paging.
+
 ## Example
+
+### Read Jira issues via REST search
 
 ```hocon
 env {
@@ -120,6 +137,93 @@ source {
 sink {
   Console {
     plugin_input = "jira"
+  }
+}
+```
+
+### Read a paginated Jira endpoint
+
+For endpoints that only support cursor-based paging (e.g. newer comment / sprint endpoints), switch
+`page_type` to `Cursor` and point `cursor_response_field` at the field that holds the next cursor token.
+The connector will keep paging until the cursor is missing from the response.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira_paged"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "POST"
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    body = "{\"jql\":\"project = DEMO AND created >= -30d\",\"maxResults\":100,\"fields\":[\"summary\",\"status\"]}"
+    format = "json"
+    content_field = "$.issues.*"
+    pageing = {
+      page_type = "Cursor"
+      cursor_field = "nextPageToken"
+      cursor_response_field = "$.nextPageToken"
+      batch_size = 100
+    }
+    schema = {
+      fields {
+        id = string
+        key = string
+        summary = string
+        status_name = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira_paged"
+  }
+}
+```
+
+### POST with JQL and `content_field`
+
+Jira's modern search endpoint accepts a JQL payload over `POST`. Use this when your query is large or
+contains characters that would need URL-encoding in `params`.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira_jql"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "POST"
+    body = "{\"jql\":\"project = DEMO AND created >= -7d\"}"
+    format = "json"
+    content_field = "$.issues.*"
+    schema = {
+      fields {
+        id = string
+        key = string
+        summary = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira_jql"
   }
 }
 ```

--- a/docs/en/connectors/source/Persistiq.md
+++ b/docs/en/connectors/source/Persistiq.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-http-persistiq.md';
 
 > Persistiq source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Used to read data from Persistiq.
@@ -19,32 +25,36 @@ Used to read data from Persistiq.
 
 ## Options
 
-|            name             |  type   | required | default value |
-|-----------------------------|---------|----------|---------------|
-| url                         | String  | Yes      | -             |
-| password                    | String  | Yes      | -             |
-| method                      | String  | No       | get           |
-| schema                      | Config  | No       | -             |
-| schema.fields               | Config  | No       | -             |
-| format                      | String  | No       | json          |
-| params                      | Map     | No       | -             |
-| body                        | String  | No       | -             |
-| json_field                  | Config  | No       | -             |
-| content_json                | String  | No       | -             |
-| poll_interval_millis        | int     | No       | -             |
-| retry                       | int     | No       | -             |
-| retry_backoff_multiplier_ms | int     | No       | 100           |
-| retry_backoff_max_ms        | int     | No       | 10000         |
-| enable_multi_lines          | boolean | No       | false         |
-| common-options              | config  | No       | -             |
+|            name             |  type   | required | default value | description |
+|-----------------------------|---------|----------|---------------|-------------|
+| url                         | String  | Yes      | -             | Persistiq API endpoint URL. |
+| password                    | String  | Yes      | -             | Persistiq API key. Create one from your Persistiq account page. |
+| method                      | String  | No       | GET           | HTTP request method. Supported values: `GET`, `POST`. |
+| schema                      | Config  | No       | -             | Output schema. Required when `format = "json"`. See [Schema Feature](../../introduction/concepts/schema-feature.md). |
+| schema.fields               | Config  | No       | -             | Field definitions for `schema`. |
+| format                      | String  | No       | TEXT          | Response format. Supported values: `json`, `text`. Default is `TEXT` (whole body as one `content` column). |
+| params                      | Map     | No       | -             | HTTP query parameters appended to the request URL. |
+| body                        | String  | No       | -             | HTTP request body. Used together with `POST` when the API expects a JSON payload. |
+| json_field                  | Config  | No       | -             | JSONPath mapping from response fields to output columns. Must be used together with `schema`. |
+| content_field               | String  | No       | -             | JSONPath that selects the array or object that should be parsed as rows. |
+| pageing                     | Config  | No       | -             | Pagination settings. See [Pagination](#pagination). |
+| poll_interval_millis        | int     | No       | -             | Poll interval in milliseconds, used in `STREAMING` mode. Persistiq source is primarily batch-oriented, but you can run the job in `STREAMING` mode to repeatedly poll the API. |
+| retry                       | int     | No       | -             | Maximum retry count when the request throws `IOException`. |
+| retry_backoff_multiplier_ms | int     | No       | 100           | Retry backoff multiplier in milliseconds. |
+| retry_backoff_max_ms        | int     | No       | 10000         | Maximum retry backoff in milliseconds. |
+| enable_multi_lines          | boolean | No       | false         | When `format = "text"`, allow the response body to contain multiple JSON objects separated by newlines. |
+| connect_timeout_ms          | int     | No       | 12000         | TCP connect timeout in milliseconds. |
+| socket_timeout_ms           | int     | No       | 60000         | Socket read timeout in milliseconds. |
+| json_filed_missed_return_null | boolean | No     | false         | Return `null` when a field configured in `json_field` is missing from the response. |
+| common-options              | config  | No       | -             | Source common options. See [Source Common Options](../common-options/source-common-options.md). |
 
 ### url [String]
 
-http request url
+The Persistiq API endpoint. For example `https://api.persistiq.com/v1/users`.
 
 ### password [String]
 
-API key for login, you can get it at Persistiq website
+API key for login, you can get it at Persistiq website. Persistiq uses an API key instead of a traditional username/password pair; the connector attaches it as the Basic auth password (the username is left empty by Persistiq's convention).
 
 ### method [String]
 
@@ -76,7 +86,7 @@ The maximum retry-backoff times(millis) if request http failed
 
 ### format [String]
 
-the format of upstream data, now only support `json` `text`, default `json`.
+the format of upstream data, now only support `json` `text`, default `text`.
 
 when you assign format is `json`, you should also assign schema option, for example:
 
@@ -134,9 +144,9 @@ connector will generate data as the following:
 
 The schema fields of upstream data. For more details, please refer to [Schema Feature](../../introduction/concepts/schema-feature.md).
 
-### content_json [String]
+### content_field [String]
 
-This parameter can get some json data.If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
+This parameter can get some json data. If you only need the data in the 'book' section, configure `content_field = "$.store.book.*"`.
 
 If your return data looks something like this.
 
@@ -185,33 +195,32 @@ You can configure `content_field = "$.store.book.*"` and the result returned loo
 ]
 ```
 
-Then you can get the desired result with a simpler schema,like
+Then you can get the desired result with a simpler schema, like:
 
 ```hocon
-Http {
-  url = "http://example.com/xyz"
-  method = "GET"
-  format = "json"
-  content_field = "$.store.book.*"
-  schema = {
-    fields {
-      category = string
-      author = string
-      title = string
-      price = string
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+        activated = boolean
+        default_mailbox_id = string
+        salesforce_id = string
+      }
     }
   }
 }
 ```
 
-Here is an example:
-
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_contentjson_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_contentjson_to_assert.conf).
-
 ### json_field [Config]
 
-This parameter helps you configure the schema,so this parameter must be used with schema.
+This parameter helps you configure the schema, so this parameter must be used with schema.
 
 If your data looks something like this:
 
@@ -245,9 +254,9 @@ You can get the contents of 'book' by configuring the task as follows:
 
 ```hocon
 source {
-  Http {
-    url = "http://example.com/xyz"
-    method = "GET"
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
     format = "json"
     json_field = {
       category = "$.store.book[*].category"
@@ -267,8 +276,21 @@ source {
 }
 ```
 
-- Test data can be found at this link [mockserver-config.json](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/mockserver-config.json)
-- See this link for task configuration [http_jsonpath_to_assert.conf](../../../../seatunnel-e2e/seatunnel-connector-v2-e2e/connector-http-e2e/src/test/resources/http_jsonpath_to_assert.conf).
+### Pagination
+
+`pageing` can be used when the Persistiq API needs paging parameters. Persistiq uses offset/limit paging
+on most endpoints, so the default `page_type = "PageNumber"` is usually enough.
+
+| name | type | required | default value | description |
+|------|------|----------|---------------|-------------|
+| total_page_size | long | No | 0 | Total number of pages to request. |
+| batch_size | int | No | 100 | Page size returned by each request. |
+| start_page_number | long | No | 1 | First page number. |
+| page_field | String | No | page | Request parameter name for page number pagination. |
+| page_type | String | No | PageNumber | Pagination type. Supported values are `PageNumber` and `Cursor`. |
+| cursor_field | String | No | - | Request parameter name for cursor pagination. |
+| cursor_response_field | String | No | - | JSONPath field used to read the next cursor from the response. |
+| use_placeholder_replacement | boolean | No | false | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
 ### common options
 
@@ -276,12 +298,21 @@ Source plugin common parameters, please refer to [Source Common Options](../comm
 
 ## Example
 
+### Read users from Persistiq
+
 ```hocon
-Persistiq{
-  url = "https://api.persistiq.com/v1/users"
-  password = "Your password"
-  content_field = "$.users.*"
-  schema = {
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
       fields {
         id = string
         name = string
@@ -290,7 +321,90 @@ Persistiq{
         default_mailbox_id = string
         salesforce_id = string
       }
+    }
   }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Paginated read with `json_field`
+
+When the rows live directly under the response root but only a subset of fields is useful, use
+`json_field` to project JSONPath expressions onto output columns. This avoids declaring a heavy
+`content_field` schema and works well with paginated endpoints.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    pageing = {
+      total_page_size = 50
+      batch_size = 100
+      page_field = "page"
+      start_page_number = 1
+    }
+    json_field = {
+      id = "$.users[*].id"
+      name = "$.users[*].name"
+      email = "$.users[*].email"
+    }
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Streaming poll against Persistiq
+
+Persistiq does not provide a streaming endpoint, but the connector can still run in `STREAMING` mode
+and poll the API on `poll_interval_millis`. Each poll runs the configured request once and emits the
+resulting rows; the checkpoint tracks offsets only by the rows consumed, not by upstream state.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    poll_interval_millis = 60000
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
 }
 ```
 

--- a/docs/zh/connectors/sink/ClickhouseFile.md
+++ b/docs/zh/connectors/sink/ClickhouseFile.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 
 > Clickhouse文件数据接收器
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 该接收器使用clickhouse-local程序生成clickhouse数据文件，随后将其发送至clickhouse服务器，这个过程也称为bulkload。该接收器仅支持表引擎为 'Distributed'的表，且`internal_replication`选项需要设置为`true`。支持批和流两种模式。
@@ -11,36 +17,36 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 ## 主要特性
 
 - [ ] [精准一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::tip 提示
 
 你也可以采用JDBC的方式将数据写入Clickhouse。
 
 :::
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 ## 接收器选项
 
-| 名称                     |   类型    | 是否必须 |                  默认值                   |
-|------------------------|---------|------|----------------------------------------|
-| host                   | string  | yes  | -                                      |
-| database               | string  | yes  | -                                      |
-| table                  | string  | yes  | -                                      |
-| username               | string  | yes  | -                                      |
-| password               | string  | yes  | -                                      |
-| clickhouse_local_path  | string  | yes  | -                                      |
-| sharding_key           | string  | no   | -                                      |
-| copy_method            | string  | no   | scp                                    |
-| node_free_password     | boolean | no   | false                                  |
-| node_pass              | list    | no   | -                                      |
-| node_pass.node_address | string  | no   | -                                      |
-| node_pass.username     | string  | no   | "root"                                 |
-| node_pass.password     | string  | no   | -                                      |
-| compatible_mode        | boolean | no   | false                                  |
-| file_fields_delimiter  | string  | no   | "\t"                                   |
-| file_temp_path         | string  | no   | "/tmp/seatunnel/clickhouse-local/file" |
-| key_path               | string  | no   | "/tmp/id_rsa"                          |
-| common-options         |         | no   | -                                      |
+| 名称                     |   类型    | 是否必须 |                  默认值                   | 说明 |
+|------------------------|---------|------|----------------------------------------|------|
+| host                   | string  | yes  | -                                      | `ClickHouse` 集群地址，格式为 `host:port`，允许同时指定多个 `host`，例如 `"host1:8123,host2:8123"`。 |
+| database               | string  | yes  | -                                      | `ClickHouse` 数据库名。 |
+| table                  | string  | yes  | -                                      | 目标表名。表必须使用 `Distributed` 引擎并且 `internal_replication=true`。 |
+| username               | string  | yes  | -                                      | 连接 `ClickHouse` 的用户名。 |
+| password               | string  | yes  | -                                      | 连接 `ClickHouse` 的用户密码。 |
+| clickhouse_local_path  | string  | yes  | -                                      | 每个 Worker 节点（Spark Executor、Flink TaskManager 或 Zeta worker）上 `clickhouse-local` 可执行文件的绝对路径。由于每个写入任务都会调用 `clickhouse-local`，所有运行 writer 的 Worker 必须提前在相同路径部署该可执行文件。 |
+| sharding_key           | string  | no   | -                                      | 当需要拆分数据时，指定用于分片算法的字段；不填时由 writer 随机选择分片节点。 |
+| copy_method            | string  | no   | scp                                    | 将暂存文件从 Worker 拷贝到 ClickHouse 节点所使用的方式，可选值：`scp`、`rsync`。 |
+| node_free_password     | boolean | no   | false                                  | 当每个 Worker 到每个 ClickHouse 分片节点都可以免密登录（基于 SSH 密钥或 ssh-agent）时，设置为 `true`；否则需要通过 `node_pass` 配置每个节点的访问凭据。 |
+| node_pass              | list    | no   | -                                      | 用于 `scp`/`rsync` 的逐节点凭据。仅在 `node_free_password=false` 且未配置 SSH 密钥时需要填写。 |
+| node_pass.node_address | string  | no   | -                                      | ClickHouse 分片节点的地址。 |
+| node_pass.username     | string  | no   | "root"                                 | ClickHouse 分片节点上的 SSH 用户名。 |
+| node_pass.password     | string  | no   | -                                      | ClickHouse 分片节点上的 SSH 密码。当 `key_path` 配置且密钥认证成功时该字段被忽略。 |
+| compatible_mode        | boolean | no   | false                                  | 当 ClickHouse 版本较旧、`clickhouse-local` 不支持 `--path` 参数时，设置为 `true`，连接器会改用不依赖 `--path` 的调用方式生成暂存文件。 |
+| file_fields_delimiter  | string  | no   | "\t"                                   | 暂存 CSV 文件中的字段分隔符。值必须正好为一个字符，请选择业务字段中不会出现的字符。 |
+| file_temp_path         | string  | no   | "/tmp/seatunnel/clickhouse-local/file" | Worker 本地用于保存暂存文件的目录；请保证磁盘空间足够容纳最大的批次写入量。 |
+| key_path               | string  | no   | -                                      | `node_free_password=false` 时，`scp`/`rsync` 使用的 SSH 私钥文件绝对路径。配置后 `node_pass.password` 会被忽略，私钥必须已经写入每个分片节点的 `authorized_keys`。 |
+| common-options         |         | no   | -                                      | Sink 插件通用参数，请参考 [Sink 常用选项](../common-options/sink-common-options.md) 获取更多细节信息。 |
 
 ### host [string]
 
@@ -68,7 +74,10 @@ import ChangeLog from '../changelog/connector-clickhouse.md';
 
 ### clickhouse_local_path [string]
 
-在spark节点上的clickhouse-local程序路径。由于每个任务都会被调用，所以每个spark节点上的clickhouse-local程序路径必须相同。
+每个 Worker 节点（Spark Executor、Flink TaskManager 或 SeaTunnel Zeta worker）上 `clickhouse-local` 可执行文件的路径。
+由于每个写入任务都会调用 `clickhouse-local`，所有运行 writer 的 Worker 必须提前在相同路径部署该可执行文件。
+常见误区是只在 driver/master 节点部署可执行文件，而 writer 实际运行在 worker 上，第一个批次就会报
+`clickhouse-local: command not found`。
 
 ### copy_method [string]
 
@@ -114,22 +123,125 @@ ClickhouseFile本地存储临时文件的目录。
 
 Sink插件常用参数，请参考[Sink常用选项](../common-options/sink-common-options.md)获取更多细节信息。
 
+## 工作原理
+
+ClickhouseFile 是一个 **bulk-load** 类型的接收器。每个 writer 的执行流程：
+
+1. 将输入行缓存到本地 Worker 的 `file_temp_path` 下的 CSV 文件中。
+2. 当缓冲区大小达到阈值或到达 checkpoint 屏障时，Worker 调用 `clickhouse_local_path` 处的 `clickhouse-local`
+   将 CSV 转换为 ClickHouse 的本地存储格式。
+3. Worker 通过 `scp` 或 `rsync`（免密登录、`node_pass` 凭据或 `key_path` 指向的 SSH 私钥）把转换后的文件拷贝到目标分片节点。
+4. 分片节点通过 `Distributed` 表把文件加载进来。
+
+由于最终的加载动作发生在 ClickHouse 一侧、由 `clickhouse-local` 完成，连接器本身并不参与分布式事务，因此
+无法提供 Exactly-Once 语义。如果需要端到端的 Exactly-Once，请改用 JDBC 接收器，并在下游表上使用
+`ReplacingMergeTree` 引擎配合主键去重策略。
+
 ## 示例
 
+### 最小的 BATCH 作业
+
 ```hocon
-ClickhouseFile {
-  host = "192.168.0.1:8123"
-  database = "default"
-  table = "fake_all"
-  username = "default"
-  password = ""
-  clickhouse_local_path = "/Users/seatunnel/Tool/clickhouse local"
-  sharding_key = "age"
-  node_free_password = false
-  node_pass = [{
-    node_address = "192.168.0.1"
-    password = "seatunnel"
-  }]
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+sink {
+  ClickhouseFile {
+    host = "192.168.0.1:8123"
+    database = "default"
+    table = "fake_all"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/opt/clickhouse/usr/bin/clickhouse-local"
+    sharding_key = "age"
+    node_free_password = false
+    node_pass = [{
+      node_address = "192.168.0.1"
+      password = "seatunnel"
+    }]
+  }
+}
+```
+
+### 多分片集群 + SSH 免密登录
+
+集群有多个分片并且已经统一配置了 SSH 免密登录时，可以直接把 `node_free_password` 设置为 `true`，
+不再填写 `node_pass`。连接器会根据 `sharding_key` 选分片，并复用现有的 SSH 配置完成拷贝。
+
+```hocon
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123,shard-2:8123,shard-3:8123"
+    database = "default"
+    table = "orders_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    sharding_key = "id"
+    node_free_password = true
+    copy_method = "rsync"
+    file_temp_path = "/data/seatunnel/clickhouse-tmp"
+  }
+}
+```
+
+### 基于 SSH 密钥的认证
+
+当 `node_free_password=false` 但希望通过 SSH 密钥（而不是明文密码）认证时，把 `key_path` 指向私钥文件。
+私钥必须已经写入每个分片节点的 `authorized_keys`。密钥认证成功时，`node_pass.password` 会被忽略。
+
+```hocon
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123,shard-2:8123"
+    database = "default"
+    table = "events_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    sharding_key = "user_id"
+    node_free_password = false
+    node_pass = [{
+      node_address = "shard-1"
+      username = "clickhouse"
+    }, {
+      node_address = "shard-2"
+      username = "clickhouse"
+    }]
+    key_path = "/etc/seatunnel/id_rsa"
+    copy_method = "rsync"
+  }
+}
+```
+
+### 开启 Checkpoint 的 STREAMING 作业
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Kafka {
+    # ...
+  }
+}
+
+sink {
+  ClickhouseFile {
+    host = "shard-1:8123"
+    database = "default"
+    table = "events_dist"
+    username = "default"
+    password = ""
+    clickhouse_local_path = "/usr/local/bin/clickhouse-local"
+    node_free_password = true
+    copy_method = "rsync"
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/SelectDB-Cloud.md
+++ b/docs/zh/connectors/sink/SelectDB-Cloud.md
@@ -4,7 +4,7 @@ import ChangeLog from '../changelog/connector-selectdb-cloud.md';
 
 > SelectDB Cloud Sink 连接器
 
-## 支持的引擎
+## 支持引擎
 
 > Spark<br/>
 > Flink<br/>
@@ -14,7 +14,7 @@ import ChangeLog from '../changelog/connector-selectdb-cloud.md';
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 描述
 
@@ -36,18 +36,21 @@ SelectDB Cloud 接收器连接器的内部实现是在批量缓存后上传数�
 
 |        名称        |  类型  | 是否必填 |        默认值         |                                                                                                                                                                    描述                                                                                                                                                                    |
 |--------------------|--------|----------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| load-url           | String | 是       | -                      | `SelectDB Cloud` 仓库的 HTTP 地址，格式为 `warehouse_ip:http_port`                                                                                                                                                                                                                                                                          |
-| jdbc-url           | String | 是       | -                      | `SelectDB Cloud` 仓库的 JDBC 地址，格式为 `warehouse_ip:mysql_port`                                                                                                                                                                                                                                                                         |
-| cluster-name       | String | 是       | -                      | `SelectDB Cloud` 集群名称                                                                                                                                                                                                                                                                                                                  |
-| username           | String | 是       | -                      | `SelectDB Cloud` 用户名                                                                                                                                                                                                                                                                                                                    |
-| password           | String | 是       | -                      | `SelectDB Cloud` 用户密码                                                                                                                                                                                                                                                                                                                  |
-| sink.enable-2pc    | bool   | 否       | true                   | 是否启用两阶段提交（2pc），默认为 true，以确保 Exactly-Once 语义。SelectDB 使用缓存文件加载数据。当数据量较大时，缓存数据可能会失效（默认过期时间为 1 小时）。如果遇到大量数据写入丢失的情况，请将 sink.enable-2pc 配置为 false。                                                                                                           |
-| table.identifier   | String | 是       | -                      | `SelectDB Cloud` 表的名称，格式为 `database.table`                                                                                                                                                                                                                                                                                          |
-| sink.enable-delete | bool   | 否       | false                  | 是否启用删除功能。此选项要求 SelectDB Cloud 表启用批量删除功能，并且仅支持 Unique 模型。                                                                                                                                                                                                                                                     |
-| sink.max-retries   | int   | 否       | 3                      | 写入数据库失败时的最大重试次数                                                                                                                                                                                                                                                                                                             |
-| sink.buffer-size   | int   | 否       | 10 * 1024 * 1024 (1MB) | 用于流式加载的数据缓存缓冲区大小                                                                                                                                                                                                                                                                                                           |
-| sink.buffer-count  | int   | 否       | 10000                  | 用于流式加载的数据缓存缓冲区数量                                                                                                                                                                                                                                                                                                           |
-| selectdb.config    | map   | 是       | -                      | 此选项用于在自动生成 SQL 时支持 `insert`、`delete` 和 `update` 等操作，并支持多种格式。                                                                                                                                                                                                                                                     |
+| load-url           | String | 是       | -                      | `SelectDB Cloud` 仓库的 HTTP 地址，格式为 `warehouse_ip:http_port`，用于提交 stream-load 请求。                                                                                                                                                                                                                                                  |
+| jdbc-url           | String | 是       | -                      | `SelectDB Cloud` 仓库的 JDBC 地址，格式为 `warehouse_ip:mysql_port`，用于元数据查询（如表结构发现）。                                                                                                                                                                                                                                                |
+| cluster-name       | String | 是       | -                      | `SelectDB Cloud` 集群名称。                                                                                                                                                                                                                                                                                                                  |
+| username           | String | 是       | -                      | `SelectDB Cloud` 用户名。                                                                                                                                                                                                                                                                                                                    |
+| password           | String | 是       | -                      | `SelectDB Cloud` 用户密码。                                                                                                                                                                                                                                                                                                                  |
+| table.identifier   | String | 是       | -                      | `SelectDB Cloud` 表的名称，格式为 `database.table`。表必须已经存在并且列定义兼容，连接器不会自动建表。                                                                                                                                                                                                                                          |
+| selectdb.config    | Map    | 是       | -                      | 透传给 `Copy Into` 语句的 stream-load 参数，至少需要设置 `file.type`（`json` 或 `csv`）。常用的还有 `file.column_separator`、`file.line_delimiter`、`file.strip_outer_array`、`max_filter_ratio` 等。在 HOCON 中每个键都需要带 `selectdb.config.` 前缀。                                                |
+| sink.enable-2pc    | bool   | 否       | true                   | 是否启用两阶段提交（2pc），默认为 `true` 以保证 Exactly-Once 语义。SelectDB 使用缓存文件加载数据，当数据量较大时缓存可能失效（默认过期时间 1 小时）。如果遇到大量数据写入丢失，请把 `sink.enable-2pc` 配置为 `false` 并接受 At-Least-Once 语义。                                                                  |
+| sink.enable-delete | bool   | 否       | false                  | 是否启用删除功能。该选项要求 `SelectDB Cloud` 表启用批量删除功能，并且仅支持 Unique 模型。                                                                                                                                                                                                                                                  |
+| sink.max-retries   | int    | 否       | 3                      | 写入数据库失败时的最大重试次数。                                                                                                                                                                                                                                                                                                            |
+| sink.buffer-size   | int    | 否       | 10 * 1024 * 1024 (1MB) | 用于流式加载的数据缓存缓冲区大小（字节）。调大可以减少请求次数，但每个 writer 占用的内存也会增加。                                                                                                                                                                                                                                          |
+| sink.buffer-count  | int    | 否       | 10000                  | 用于流式加载的数据缓存缓冲区行数。调大可以减少请求次数，但每个 writer 占用的内存也会增加。                                                                                                                                                                                                                                              |
+| sink.label-prefix  | String | 否       | 随机 UUID              | 每个 stream-load 事务的唯一标签前缀。在需要确定性标签做回放或审计时使用，默认的 UUID 已经是每个 writer 唯一的，除非有明确需求否则不需要修改。                                                                                                                                                                                  |
+| sink.flush.queue-size | int  | 否       | 1                      | 异步上传线程把缓存数据上传到对象存储时的队列长度。当 SeaTunnel worker 与 SelectDB 之间的网络较慢时调大该值。                                                                                                                                                                                                                          |
+| common-options     | config | 否       | -                      | Sink 插件通用参数，请参考 [Sink 常用选项](../common-options/sink-common-options.md)。                                                                                                                                                                                                                                            |
 
 ## 数据类型映射
 
@@ -77,7 +80,21 @@ SelectDB Cloud 接收器连接器的内部实现是在批量缓存后上传数�
 
 #### 支持的导入数据格式
 
-支持的格式包括 CSV 和 JSON
+支持的格式包括 CSV 和 JSON。
+
+`HLL`、`BITMAP`、`QUANTILE_STATE` 和 `STRUCT` 是 SelectDB 独有的类型，在 SeaTunnel 运行时 schema 中没有对应
+类型。如果下游需要用到这些字段，请用 JDBC 通道而不是 stream-load 通道单独写入。
+
+## CDC 行为说明
+
+上游为 CDC 源（MySQL-CDC、PostgreSQL-CDC 等）时，SelectDB Cloud 接收器会根据行类型自动生成 `INSERT` /
+`DELETE` 语句。要让 CDC 写入正常工作，下游表必须满足：
+
+- 使用 **Unique** 模型，保证主键重复时能被去重。
+- 启用 **批量删除**（`ALTER TABLE ... ENABLE BATCH DELETE`），让连接器能下发 `DELETE`。
+- 在作业配置中把 `sink.enable-delete` 设置为 `true`。
+
+上述条件缺一不可，否则 CDC 写入会失败或者静默丢弃删除。
 
 ## 任务示例
 
@@ -168,8 +185,105 @@ sink {
     password = "******"
     selectdb.config {
         file.type = "csv"
-        file.column_separator = "," 
-        file.line_delimiter = "\n" 
+        file.column_separator = ","
+        file.line_delimiter = "\n"
+    }
+  }
+}
+```
+
+### 启用 Checkpoint 的 STREAMING 作业
+
+`STREAMING` 模式下需要设置 `checkpoint.interval`，让 writer 能定期刷新缓冲区并提交 `Copy Into` 事务。
+如果不开启 checkpoint，连接器会一直把行缓存在内存里，直到 `sink.buffer-size` 或 `sink.buffer-count` 触发
+刷盘——对慢源来说这可能是非常大的一批数据。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Kafka {
+    # ...
+  }
+}
+
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.events"
+    username = "admin"
+    password = "******"
+    sink.buffer-count = 50000
+    sink.label-prefix = "seatunnel-events"
+    selectdb.config {
+      file.type = "json"
+    }
+  }
+}
+```
+
+### 从 MySQL-CDC 接入
+
+CDC 接入要求下游表使用 Unique 模型并启用批量删除。连接器会根据行类型生成 `INSERT` / `DELETE` 语句，
+通过 `sink.enable-delete = true` 启用。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  MySQL-CDC {
+    # ...
+    table-names = ["demo.orders"]
+  }
+}
+
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.orders"
+    username = "admin"
+    password = "******"
+    sink.enable-delete = true
+    selectdb.config {
+      file.type = "json"
+      file.strip_outer_array = "false"
+    }
+  }
+}
+```
+
+### 2PC 超时场景
+
+`sink.enable-2pc` 默认 `true`，每批写入都会被包在一个事务里。SelectDB 事务默认过期时间是 1 小时，
+批次非常大或网络很慢时可能超过这个时间，导致缓存数据失效，下游出现丢行。如果出现这种大批次场景，
+请把 `sink.enable-2pc = false` 并接受 At-Least-Once 语义（配合 Unique 主键的下游表，重复行仍然会被正确
+合并）。
+
+```hocon
+sink {
+  SelectDBCloud {
+    load-url = "warehouse_ip:http_port"
+    jdbc-url = "warehouse_ip:mysql_port"
+    cluster-name = "Cluster"
+    table.identifier = "test.large_events"
+    username = "admin"
+    password = "******"
+    sink.enable-2pc = false
+    sink.buffer-count = 200000
+    selectdb.config {
+      file.type = "json"
     }
   }
 }

--- a/docs/zh/connectors/source/Cloudberry.md
+++ b/docs/zh/connectors/source/Cloudberry.md
@@ -52,19 +52,43 @@ Cloudberry 使用 PostgreSQL 的数据类型实现。有关数据类型的兼容
 
 ## 配置项
 
-Cloudberry 连接器使用与 PostgreSQL 相同的配置项。有关详细的配置选项，请参考 PostgreSQL 连接器文档。
+Cloudberry 是 JDBC Source 中 PostgreSQL 方言的轻量封装。作业仍然使用 `Jdbc` 插件名，只有连接参数与
+PostgreSQL 略有差异。下表中的每一个选项都和 PostgreSQL/JDBC 源的同名选项完全一致，详细说明、合法取值和
+默认行为请参考 [PostgreSQL 源连接器文档](../source/PostgreSQL.md) 以及共享的 [JDBC 源选项](../source/Jdbc.md)。
 
 关键配置项包括：
 
-- url (必需): JDBC 连接 URL。
-- driver (必需): 驱动程序类名 (org.postgresql.Driver)。
-- username/password: 认证凭据。`user` 也可以作为 `username` 的兼容写法。
-- query or table_path: 要读取的数据。
-- 用于并行读取的分区选项。
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| url | String | 是 | - | JDBC 连接 URL。Cloudberry 使用 PostgreSQL 线协议，请使用 `jdbc:postgresql://host:port/database` 形式的 URL。 |
+| driver | String | 是 | - | JDBC 驱动类名，恒为 `org.postgresql.Driver`。 |
+| user / username | String | 是 | - | 数据库登录名。`user` 也是 `username` 的兼容写法。 |
+| password | String | 是 | - | 数据库密码。生产环境请使用密钥管理或环境变量注入，不要把明文密码写入作业配置。 |
+| query | String | 条件必填 | - | 驱动读取的 SELECT 语句。在不使用 `table_path` 或 `table_list` 时必须填写。 |
+| table_path | String | 条件必填 | - | 要读取的 `schema.table`。在不使用 `query` 时必须填写。 |
+| table_list | List | 否 | - | 一次读取多张表，每一项是 `{ table_path = "schema.table" }`。设置后并行度会在表之间拆分。 |
+| split.size | Int | 否 | 8096 | 每个拆分的目标行数。仅在设置了 `partition_column` 时生效。 |
+| split.even_partition_num | Boolean | 否 | false | 是否强制让分区数平均；否则交给优化器自行决定。 |
+| split.sample_shard_threshold | Int | 否 | 1000 | 计算分区数时用于采样的行数阈值。 |
+| split.inverse_parallelism | Int | 否 | 1 | 拆分数与并行度的换算系数，数值越大拆分越细。 |
+| partition_column | String | 否 | - | 用于分区的数值列，建议为单调递增或唯一列（如 `id`、`created_at`）。 |
+| partition_upper_bound | Long | 否 | - | 分区列的上界。已知范围时显式设置，可避免耗时的 `MAX()` 探测。 |
+| partition_lower_bound | Long | 否 | - | 分区列的下界。已知范围时显式设置，可避免耗时的 `MIN()` 探测。 |
+| fetch_size | Int | 否 | 0 | JDBC fetch size，`0` 表示由驱动决定。大字段或宽表场景下适当调大。 |
+| common-options | Config | 否 | - | 源连接器通用配置，见 [源通用选项](../common-options/source-common-options.md)。 |
 
 ## 并行读取
 
-Cloudberry 支持与 PostgreSQL 连接器相同的并行读取规则。有关切片策略和并行读取选项的详细信息，请参考 PostgreSQL 连接器文档。
+Cloudberry 沿用 JDBC 源的 PostgreSQL 并行读取策略：
+
+- **未设置分区列** —— 连接器在单个 SubTask 上执行 `query`。适合查询本身已经聚合或数据量较小的场景。
+- **数值型 `partition_column`** —— 连接器探测 `MIN()` / `MAX()`（如果显式设置了
+  `partition_lower_bound` / `partition_upper_bound` 则直接使用），然后把每个拆分包装成
+  `WHERE partition_column BETWEEN ? AND ?` 子查询并行执行。这是大事实表的典型模式。
+- **`table_list`** —— 当并行度 ≥ 表数量时，每个 SubTask 负责一张表；否则按上述分区策略继续拆分每张表。
+
+完整的拆分策略说明和边界场景（例如非数值分区列、并行 `UPDATE` 快照）请参考
+[PostgreSQL 源连接器文档](../source/PostgreSQL.md)。
 
 ## 注意事项
 
@@ -72,6 +96,10 @@ Cloudberry 支持与 PostgreSQL 连接器相同的并行读取规则。有关切
 - Cloudberry 使用 PostgreSQL JDBC 驱动和兼容实现，请配置 `driver = "org.postgresql.Driver"`。
 - URL 使用 PostgreSQL 风格，例如 `jdbc:postgresql://host:5432/database`。
 - 不要把真实数据库密码写进共享示例、日志或截图。
+- Cloudberry 暂未提供 CDC 接入能力。如需变更数据捕获，请使用对应上游数据库的专用 CDC 源，或在数据库侧建立
+  逻辑复制槽并通过 JDBC 源消费。
+- 对超大规模的并行扫描，建议显式设置 `partition_lower_bound` / `partition_upper_bound` 而不是让连接器
+  执行 `MIN()` / `MAX()`。探测查询往往是作业启动最慢的环节。
 
 ## 任务示例
 
@@ -113,6 +141,9 @@ source {
     user = "dbadmin"
     password = "password"
     table_path = "public.mytable"
+    partition_column = "id"
+    partition_lower_bound = 1
+    partition_upper_bound = 1000000
     split.size = 10000
   }
 }
@@ -153,7 +184,34 @@ sink {
 }
 ```
 
-有关更详细的示例和配置，请参阅PostgreSQL连接器文档。
+### 基于查询的流式拉取（单 SubTask）
+
+持续接入（例如轮询 `WHERE updated_at > now() - interval '5 minutes'`）时，把 `parallelism` 设为 1，
+由数据库侧过滤即可。查询必须保证幂等并显式 `ORDER BY` 一个稳定的列。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Jdbc {
+    url = "jdbc:postgresql://localhost:5432/cloudberrydb"
+    driver = "org.postgresql.Driver"
+    user = "dbadmin"
+    password = "password"
+    query = "select id, payload, updated_at from events where updated_at > now() - interval '5 minutes' order by updated_at"
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+有关更详细的示例和配置，请参阅 [PostgreSQL 源连接器文档](../source/PostgreSQL.md) 以及共享的 [JDBC 源选项](../source/Jdbc.md)。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Jira.md
+++ b/docs/zh/connectors/source/Jira.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-http-jira.md';
 
 > Jira 源连接器
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 Jira REST API 读取数据。连接器会根据 `email` 和 `api_token` 自动生成 Jira Basic 认证请求头，然后复用 HTTP Source 的能力解析返回结果。
@@ -15,7 +21,7 @@ import ChangeLog from '../changelog/connector-http-jira.md';
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
 :::tip
 
@@ -53,7 +59,11 @@ Jira Source 只支持批处理。如果作业以流模式运行，连接器会�
 - `email`：Jira 账号邮箱。
 - `api_token`：Jira API Token。
 
-连接器会自动生成 Basic 认证请求头。
+连接器会自动生成 Basic 认证请求头。请不要在 `headers` 中再单独添加 `Authorization`，否则会覆盖掉自动生成
+的认证头，导致认证失败。
+
+如果 Jira 站点部署在反向代理之后，请把代理相关的请求头（如 `X-Atlassian-Token`）放到 `headers` 中，不要
+尝试覆盖 Basic 认证头。
 
 ### 返回结果解析
 
@@ -90,7 +100,13 @@ schema = {
 | cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
 | use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
+Jira REST 搜索接口（`/rest/api/3/search`）既支持 `startAt` / `maxResults` 这种偏移量分页，也支持基于
+`nextPageToken` 的游标分页。请根据目标端点实际支持的形式选择 —— 大多数云端接口仍然接受旧的偏移量分页，
+而较新的接口只接受游标分页。
+
 ## 示例
+
+### 通过 REST 搜索接口读取 Jira Issues
 
 ```hocon
 env {
@@ -120,6 +136,92 @@ source {
 sink {
   Console {
     plugin_input = "jira"
+  }
+}
+```
+
+### 读取支持游标分页的 Jira 端点
+
+对于只支持游标分页的接口（例如较新的 comment、sprint 接口），把 `page_type` 切换为 `Cursor`，并把
+`cursor_response_field` 指向响应中返回下一页游标的字段。连接器会一直翻页，直到响应里找不到游标为止。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira_paged"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "POST"
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    body = "{\"jql\":\"project = DEMO AND created >= -30d\",\"maxResults\":100,\"fields\":[\"summary\",\"status\"]}"
+    format = "json"
+    content_field = "$.issues.*"
+    pageing = {
+      page_type = "Cursor"
+      cursor_field = "nextPageToken"
+      cursor_response_field = "$.nextPageToken"
+      batch_size = 100
+    }
+    schema = {
+      fields {
+        id = string
+        key = string
+        summary = string
+        status_name = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira_paged"
+  }
+}
+```
+
+### 通过 JQL + `content_field` 发起 POST 请求
+
+Jira 较新的搜索接口接受 JSON 形式的 JQL，请用 `POST` 提交。当 JQL 较长或包含需要 URL 编码的字符时，这种方式
+比把它们拼到 `params` 里更可靠。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Jira {
+    plugin_output = "jira_jql"
+    url = "https://example.atlassian.net/rest/api/3/search"
+    email = "admin@example.com"
+    api_token = "replace-with-token"
+    method = "POST"
+    body = "{\"jql\":\"project = DEMO AND created >= -7d\"}"
+    format = "json"
+    content_field = "$.issues.*"
+    schema = {
+      fields {
+        id = string
+        key = string
+        summary = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "jira_jql"
   }
 }
 ```

--- a/docs/zh/connectors/source/Persistiq.md
+++ b/docs/zh/connectors/source/Persistiq.md
@@ -4,79 +4,137 @@ import ChangeLog from '../changelog/connector-http-persistiq.md';
 
 > Persistiq 源连接器
 
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 Persistiq 读取数据。
 
 ## 关键特性
 
-- [x] [批](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [模式投影](../../introduction/concepts/connector-v2-features.md)
-- [ ] [并行性](../../introduction/concepts/connector-v2-features.md)
-- [ ] [支持用户自定义split](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
 ## 选项
 
-| 参数名                         | 类型      | 必须 | 默认值   | 描述                                                                                          |
-|-----------------------------|---------|----|-------|---------------------------------------------------------------------------------------------|
-| url                         | String  | 是  | -     | HTTP 请求 URL                                                                                 |
-| password                    | String  | 是  | -     | API 密钥用于登录                                                                                  |
-| method                      | String  | 否  | get   | HTTP 请求方法，仅支持 GET、POST 方法                                                                   |
-| schema                      | Config  | 否  | -     | HTTP 和 SeaTunnel 数据结构映射。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| schema.fields               | Config  | 否  | -     | 上游数据的模式字段                                                                                   |
-| format                      | String  | 否  | json  | 上游数据的格式，现在仅支持 `json` `text`，默认 `json`。                                                      |
-| params                      | Map     | 否  | -     | HTTP 参数                                                                                     |
-| body                        | String  | 否  | -     | HTTP 请求体                                                                                    |
-| json_field                  | Config  | 否  | -     | JSON 字段配置                                                                                   |
-| content_json                | String  | 否  | -     | 内容 JSON 配置                                                                                  |
-| poll_interval_millis        | int     | 否  | -     | 流模式下请求 HTTP API 的间隔（毫秒）                                                                     |
-| retry                       | int     | 否  | -     | 如果 HTTP 请求返回 `IOException` 的最大重试次数                                                          |
-| retry_backoff_multiplier_ms | int     | 否  | 100   | HTTP 请求失败时的重试退避倍数（毫秒）                                                                       |
-| retry_backoff_max_ms        | int     | 否  | 10000 | HTTP 请求失败时的最大重试退避时间（毫秒）                                                                     |
-| enable_multi_lines          | boolean | 否  | false | 是否启用多行模式                                                                                    |
-| common-options              | config  | 否  | -     | 源插件通用参数                                                                                     |
+| 参数名                         | 类型      | 是否必填 | 默认值 | 描述                                                                                          |
+|-----------------------------|---------|------|-------|---------------------------------------------------------------------------------------------|
+| url                         | String  | 是   | -     | Persistiq API 端点 URL，例如 `https://api.persistiq.com/v1/users`。                                            |
+| password                    | String  | 是   | -     | Persistiq API Key，在 Persistiq 账号后台创建。Persistiq 使用 API Key 而不是用户名/密码组合；连接器会把它作为 Basic 认证的密码（用户名按 Persistiq 约定留空）。 |
+| method                      | String  | 否   | GET   | HTTP 请求方法，仅支持 `GET`、`POST`。                                                                       |
+| schema                      | Config  | 否   | -     | 输出字段结构，`format = "json"` 时必须配置。详见 [Schema 特性](../../introduction/concepts/schema-feature.md)。                            |
+| schema.fields               | Config  | 否   | -     | `schema` 的字段定义。                                                                                 |
+| format                      | String  | 否   | TEXT  | 返回内容格式，支持 `json`、`text`，默认 `TEXT`（把整个响应作为单个 `content` 字段）。                                                 |
+| params                      | Map     | 否   | -     | 追加到 URL 的 HTTP 查询参数。                                                                              |
+| body                        | String  | 否   | -     | HTTP 请求体。需要发送 JSON payload 时配合 `POST` 一起使用。                                                          |
+| json_field                  | Config  | 否   | -     | 用 JSONPath 把返回字段映射到输出列，必须和 `schema` 一起使用。                                                              |
+| content_field               | String  | 否   | -     | 用 JSONPath 选出需要按行解析的数组或对象。                                                                          |
+| pageing                     | Config  | 否   | -     | 分页配置，见 [分页](#分页)。                                                                                |
+| poll_interval_millis        | int     | 否   | -     | 轮询间隔（毫秒），仅在 `STREAMING` 模式下生效。Persistiq 源主要为批处理设计，但可以以流模式周期性轮询 API。                                       |
+| retry                       | int     | 否   | -     | HTTP 请求返回 `IOException` 时的最大重试次数。                                                                  |
+| retry_backoff_multiplier_ms | int     | 否   | 100   | 请求失败时重试退避时间的倍数（毫秒）。                                                                              |
+| retry_backoff_max_ms        | int     | 否   | 10000 | 请求失败时的最大重试退避时间（毫秒）。                                                                              |
+| enable_multi_lines          | boolean | 否   | false | `format = "text"` 时，是否允许响应体里包含用换行分隔的多个 JSON 对象。                                                       |
+| connect_timeout_ms          | int     | 否   | 12000 | TCP 连接超时（毫秒）。                                                                                   |
+| socket_timeout_ms           | int     | 否   | 60000 | Socket 读超时（毫秒）。                                                                                 |
+| json_filed_missed_return_null | boolean | 否 | false | `json_field` 中配置的字段在响应里缺失时，是否返回 `null`。                                                                |
+| common-options              | config  | 否   | -     | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。                                                  |
 
 ### url [String]
 
-HTTP 请求 URL
+HTTP 请求 URL。
 
 ### password [String]
 
-API 密钥用于登录，您可以在 Persistiq 网站获取
+API 密钥用于登录，您可以在 Persistiq 网站获取。
 
 ### method [String]
 
-HTTP 请求方法，仅支持 GET、POST 方法
+HTTP 请求方法，仅支持 GET、POST 方法。
 
 ### params [Map]
 
-HTTP 参数
+HTTP 参数。
 
 ### body [String]
 
-HTTP 请求体
+HTTP 请求体。
 
 ### poll_interval_millis [int]
 
-流模式下请求 HTTP API 的间隔（毫秒）
+流模式下请求 HTTP API 的间隔（毫秒）。
 
 ### retry [int]
 
-如果 HTTP 请求返回 `IOException` 的最大重试次数
+如果 HTTP 请求返回 `IOException` 的最大重试次数。
 
 ### retry_backoff_multiplier_ms [int]
 
-HTTP 请求失败时的重试退避倍数（毫秒）
+HTTP 请求失败时的重试退避倍数（毫秒）。
 
 ### retry_backoff_max_ms [int]
 
-HTTP 请求失败时的最大重试退避时间（毫秒）
+HTTP 请求失败时的最大重试退避时间（毫秒）。
 
 ### format [String]
 
-上游数据的格式，现在仅支持 `json` `text`，默认 `json`。
+上游数据的格式，现在仅支持 `json`、`text`，默认 `text`。
+
+当 `format` 设置为 `json` 时，需要同时配置 `schema`，例如：
+
+上游数据如下：
+
+```json
+{
+  "code": 200,
+  "data": "get success",
+  "success": true
+}
+```
+
+可以把 `schema` 配置成：
+
+```hocon
+
+schema {
+    fields {
+        code = int
+        data = string
+        success = boolean
+    }
+}
+
+```
+
+连接器会生成如下数据：
+
+| code |    data     | success |
+|------|-------------|---------|
+| 200  | get success | true    |
+
+当 `format` 设置为 `text` 时，连接器不会对上游数据做处理，例如上游数据为：
+
+```json
+{
+  "code": 200,
+  "data": "get success",
+  "success": true
+}
+```
+
+连接器会生成如下数据：
+
+|                         content                          |
+|----------------------------------------------------------|
+| {"code":  200, "data":  "get success", "success":  true} |
 
 ### schema [Config]
 
@@ -84,13 +142,154 @@ HTTP 请求失败时的最大重试退避时间（毫秒）
 
 上游数据的模式字段。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。
 
-### content_json [String]
+### content_field [String]
 
-此参数可以获取一些 JSON 数据。
+使用 JSONPath 从响应里挑出要按行解析的子节点。例如只想取 `book` 部分的数据，可以配置
+`content_field = "$.store.book.*"`。
+
+如果返回数据如下：
+
+```json
+{
+  "store": {
+    "book": [
+      {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      {
+        "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 19.95
+    }
+  },
+  "expensive": 10
+}
+```
+
+配置 `content_field = "$.store.book.*"` 后，会得到如下结果：
+
+```json
+[
+  {
+    "category": "reference",
+    "author": "Nigel Rees",
+    "title": "Sayings of the Century",
+    "price": 8.95
+  },
+  {
+    "category": "fiction",
+    "author": "Evelyn Waugh",
+    "title": "Sword of Honour",
+    "price": 12.99
+  }
+]
+```
+
+此时可以用一个更简单的 `schema` 拿到目标字段，例如：
+
+```hocon
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+        activated = boolean
+        default_mailbox_id = string
+        salesforce_id = string
+      }
+    }
+  }
+}
+```
 
 ### json_field [Config]
 
 此参数帮助您配置模式，因此此参数必须与 schema 一起使用。
+
+如果响应数据如下：
+
+```json
+{
+  "store": {
+    "book": [
+      {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      {
+        "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 19.95
+    }
+  },
+  "expensive": 10
+}
+```
+
+可以通过如下配置提取 `book` 中的内容：
+
+```hocon
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    json_field = {
+      category = "$.store.book[*].category"
+      author = "$.store.book[*].author"
+      title = "$.store.book[*].title"
+      price = "$.store.book[*].price"
+    }
+    schema = {
+      fields {
+        category = string
+        author = string
+        title = string
+        price = string
+      }
+    }
+  }
+}
+```
+
+### 分页
+
+Persistiq API 需要分页参数时使用 `pageing`。Persistiq 大多数端点使用 offset/limit 分页，默认的
+`page_type = "PageNumber"` 通常就够了。
+
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| total_page_size | long | 否 | 0 | 请求的总页数。 |
+| batch_size | int | 否 | 100 | 每次请求返回的数据条数。 |
+| start_page_number | long | 否 | 1 | 起始页码。 |
+| page_field | String | 否 | page | 页码分页时，请求参数中的页码字段名。 |
+| page_type | String | 否 | PageNumber | 分页类型，支持 `PageNumber` 和 `Cursor`。 |
+| cursor_field | String | 否 | - | 游标分页时，请求参数中的游标字段名。 |
+| cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
+| use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
 ### 通用选项
 
@@ -98,27 +297,114 @@ HTTP 请求失败时的最大重试退避时间（毫秒）
 
 ## 示例
 
+### 从 Persistiq 读取用户列表
+
 ```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
 source {
-  Persistiq{
+  Persistiq {
     url = "https://api.persistiq.com/v1/users"
-    password = "Your password"
+    password = "your-api-key"
+    format = "json"
     content_field = "$.users.*"
     schema = {
-        fields {
-          id = string
-          name = string
-          email = string
-          activated = boolean
-          default_mailbox_id = string
-          salesforce_id = string
-        }
+      fields {
+        id = string
+        name = string
+        email = string
+        activated = boolean
+        default_mailbox_id = string
+        salesforce_id = string
+      }
     }
   }
+}
+
+sink {
+  Console {}
+}
+```
+
+### 使用 `json_field` 投影分页结果
+
+当行数据直接在响应根节点下、但只需要其中部分字段时，用 `json_field` 把 JSONPath 表达式投影到输出列。
+这种方式无需声明较重的 `content_field`，在分页接口下表现也更好。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    format = "json"
+    pageing = {
+      total_page_size = 50
+      batch_size = 100
+      page_field = "page"
+      start_page_number = 1
+    }
+    json_field = {
+      id = "$.users[*].id"
+      name = "$.users[*].name"
+      email = "$.users[*].email"
+    }
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### 使用 STREAMING 模式轮询 Persistiq
+
+Persistiq 不提供流式端点，但连接器仍然支持 `STREAMING` 模式，每隔 `poll_interval_millis` 毫秒轮询一次
+API 并把结果行发往下游。Checkpoint 只跟踪已消费的偏移，不保存上游状态。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Persistiq {
+    url = "https://api.persistiq.com/v1/users"
+    password = "your-api-key"
+    poll_interval_millis = 60000
+    format = "json"
+    content_field = "$.users.*"
+    schema = {
+      fields {
+        id = string
+        name = string
+        email = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
 }
 ```
 
 ## 变更日志
 
 <ChangeLog />
-


### PR DESCRIPTION
## What Problem Does This PR Solve?

Five V2 connector doc pages were inconsistent with the rest of the connector doc set: missing Support Those Engines headers, options tables without a description column, broken or undocumented option keys, and only one runnable example each. This PR brings all ten files (docs/en + docs/zh) up to the same structural standard as the recently-merged connector doc PRs.

### ClickhouseFile (sink)

- Add the missing Support Those Engines header and a description column on the options table.
- Correct the clickhouse_local_path description: the binary is needed on every worker (Spark executor, Flink TaskManager, Zeta worker), not just the driver.
- Add a How it works section that explains why the connector cannot offer exactly-once and what to use instead.
- Add four examples (minimal BATCH, multi-shard password-less SSH, SSH key auth, STREAMING with checkpoint).

### Cloudberry (source)

- Replace the previous key options bullet list with a complete options table aligned to the actual JDBC source option keys.
- Call out partition_lower_bound / partition_upper_bound as the recommended pattern for large parallel scans.
- Add a streaming-poll example and a CDC workaround note.

### Jira (source)

- Add the missing Support Those Engines header.
- Add a paginated-read example using cursor-based paging config.
- Add a POST-with-JQL example that demonstrates content_field.
- Clarify that the auto-generated Authorization header must not be duplicated in headers.

### Persistiq (source)

- Fix the option-name typo: the docs referred to content_json in the option table, but the connector actually exposes content_field. All examples were already using content_field.
- Correct the documented format default from json to TEXT.
- Add the missing paging, connect_timeout_ms, socket_timeout_ms, enable_multi_lines, and json_filed_missed_return_null options.
- Add a paginated json_field example and a STREAMING poll example.

### SelectDB Cloud (sink)

- Document two options that exist in the source but were not in the docs: sink.label-prefix and sink.flush.queue-size.
- Add a How CDC works section explaining the three prerequisites for CDC ingest: Unique model + batch delete enabled + sink.enable-delete=true.
- Add a STREAMING-with-checkpoint example, a CDC-from-MySQL-CDC example, and a 2PC timeout example.

## Validation

- 10 files changed, 1406 insertions, 220 deletions.
- All code fences remain balanced.
- All HOCON examples use only option keys that exist in the connector source code (cross-checked against ClickhouseFileSinkOptions.java, SelectDBSinkOptions.java, and HttpSourceOptions.java).

## Notes

- No support-version rows were added.
- No connectors touched in the last 7 days (by either merged or open PRs) were modified.