### PR TITLE
[Fix][Connector-V2] Honor connection-test-query from properties config in JDBC sink HikariCP pool

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkWriter.java
@@ -107,12 +107,23 @@ public class JdbcSinkWriter extends AbstractJdbcSinkWriter<ConnectionPoolManager
 
     /**
      * Configures pool-level validation for JDBC drivers that cannot pass Hikari's default
-     * Connection.isValid(timeout) probe.
+     * Connection.isValid(timeout) probe, and honors user-specified connection test queries
+     * from the {@code properties} configuration block.
      */
     static void applyConnectionValidation(
             HikariDataSource dataSource, JdbcConnectionConfig jdbcConnectionConfig) {
         JdbcConnectionValidationUtils.getConnectionValidationQuery(jdbcConnectionConfig)
                 .ifPresent(dataSource::setConnectionTestQuery);
+        // Also honor user-specified connection test query from the properties config.
+        // HikariCP's setConnectionTestQuery() must be used instead of addDataSourceProperty()
+        // because the latter passes the property to the JDBC DataSource, not to HikariCP's pool.
+        String testQuery = jdbcConnectionConfig.getProperties().get("connectionTestQuery");
+        if (testQuery == null) {
+            testQuery = jdbcConnectionConfig.getProperties().get("connection-test-query");
+        }
+        if (testQuery != null) {
+            dataSource.setConnectionTestQuery(testQuery);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Purpose

Fix the JDBC sink HikariCP connection pool ignoring the `connection-test-query` configured by users in the `properties` block.

### Root Cause

When users configure a connection test query via `properties.connection-test-query` (or `properties.connectionTestQuery`), the current code passes it to the JDBC DataSource via `HikariDataSource.addDataSourceProperty()`. HikariCP pool properties are silently ignored when passed as DataSource properties — the `setConnectionTestQuery()` method must be used instead. This means the connection test query never takes effect during long-running streaming jobs, leading to `No operations allowed after statement closed` errors when the MySQL server closes idle connections.

### Changes

- Extended `JdbcSinkWriter.applyConnectionValidation()` to check the user's `properties` config for `connectionTestQuery` and `connection-test-query` keys
- When found, applies them to the HikariCP pool via `setConnectionTestQuery()` directly

### Related issue

Closes #11769