### PR TITLE
[Docs][Connector-V2] Improve GraphQL NatsJetStream Klaviyo Lemlist and MyHours connector docs

### DIFF
--- a/docs/en/connectors/sink/GraphQL.md
+++ b/docs/en/connectors/sink/GraphQL.md
@@ -60,6 +60,33 @@ It can be downloaded via install-plugin.sh or from Maven central repository.
 - The sink sends one mutation request for each input row. If the upstream source contains multiple tables, make sure the same mutation and variable names can handle every table routed to this sink.
 - `multi_table_sink_replica` only affects the multi-table sink runtime replica count. It does not choose a different GraphQL mutation per table.
 
+### Authentication
+
+Most GraphQL services require an authentication header. Pass it through `headers`:
+
+```hocon
+sink {
+  GraphQL {
+    plugin_input = "fake"
+    url = "https://graphql.example.com/v1/graphql"
+    headers = {
+      Authorization = "Bearer ${secret}"
+    }
+    query = """
+      mutation MyMutation($id: Int!, $val_string: String!) {
+        insert_event(objects: {id: $id, val_string: $val_string}) {
+          affected_rows
+        }
+      }
+    """
+  }
+}
+```
+
+`password`, `token`, and similar sensitive values should be supplied via the
+job substitution mechanism (for example `${secret}` resolved by the runtime),
+not inlined into the configuration file.
+
 ## Task Example
 
 ### Write Rows with a GraphQL Mutation

--- a/docs/en/connectors/sink/NatsJetStream.md
+++ b/docs/en/connectors/sink/NatsJetStream.md
@@ -14,7 +14,13 @@ The sink does **not** create streams or manage JetStream resources. You must pre
 
 ## Key features
 
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 - [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 :::caution Delivery semantics
@@ -53,6 +59,7 @@ Even with that setup, the connector must still be treated as **at-least-once**.
 - Authentication: use either no credentials, `username` + `password`, or `token`; `token` is mutually exclusive with `username` / `password`.
 - Initial limitations: synchronous per-record publish only; batching and connector-managed retry controls are out of scope.
 - Non-goals: stream administration, exactly-once, source support, schema evolution handling beyond incoming rows, and formats beyond documented JSON/native mode.
+- Multi-table sink: the same sink instance accepts rows from multiple upstream tables. Each row is published to the configured `subject` (in JSON mode) or its resolved native subject; the connector does not choose a different mutation per table.
 
 ## Broker setup
 
@@ -303,6 +310,101 @@ subject : string
 id      : string
 headers : map<string,string>
 data    : bytes
+```
+
+### Streaming JSON example
+
+The same JSON sink can run continuously in streaming mode. Each incoming row
+becomes one JetStream publish request on the fixed subject. Set a checkpoint
+interval so the writer can recover from restarts with at-least-once delivery.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  FakeSource {
+    plugin_output = "json_fake_stream"
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "alice", 9.5] }
+    ]
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "json_fake_stream"
+    url = "nats://127.0.0.1:4222"
+    username = "nats-user"
+    password = "nats-password"
+    subject = "orders.json.stream"
+    format = "json"
+  }
+}
+```
+
+### Writing multiple upstream tables
+
+The same sink instance accepts rows from multiple upstream tables in JSON
+mode. Every row is published to the configured subject; the connector does not
+pick a different mutation per table.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake_multi"
+    tables_configs = [
+      {
+        schema = {
+          table = "events_json_a"
+          fields {
+            id = int
+            name = string
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "alpha"] }
+        ]
+      },
+      {
+        schema = {
+          table = "events_json_b"
+          fields {
+            id = int
+            name = string
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [2, "beta"] }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "fake_multi"
+    url = "nats://127.0.0.1:4222"
+    subject = "events.json.multi"
+    format = "json"
+  }
+}
 ```
 
 ## Errors and operational notes

--- a/docs/en/connectors/source/Klaviyo.md
+++ b/docs/en/connectors/source/Klaviyo.md
@@ -4,9 +4,17 @@ import ChangeLog from '../changelog/connector-http-klaviyo.md';
 
 > Klaviyo source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Reads data from Klaviyo APIs. The connector builds Klaviyo request headers from `private_key` and `revision`, then uses the shared HTTP source runtime to parse the response.
+
+The Klaviyo connector shares its HTTP request, retry, and pagination runtime with other HTTP-based source connectors. Configure `private_key` with the Klaviyo private API key, set `revision` to the API revision date (for example `2020-10-17`), and point `url` at the Klaviyo endpoint you want to call.
 
 ## Key features
 
@@ -22,6 +30,15 @@ Reads data from Klaviyo APIs. The connector builds Klaviyo request headers from 
 In streaming mode, the connector repeatedly calls the configured API. Set `poll_interval_millis` to control the request interval.
 
 :::
+
+## Supported DataSource Info
+
+In order to use the Klaviyo connector, the following dependency is required.
+It can be downloaded via install-plugin.sh or from the Maven central repository.
+
+| Datasource   | Supported Versions |                                         Dependency                                          |
+|--------------|--------------------|-----------------------------------------------------------------------------------------------|
+| Klaviyo      | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base)       |
 
 ## Options
 
@@ -99,6 +116,8 @@ Use `content_field` when the rows are inside a nested JSON node. Use `json_field
 
 ## Example
 
+### Batch Read of a Klaviyo List
+
 ```hocon
 env {
   parallelism = 1
@@ -133,6 +152,95 @@ source {
 sink {
   Console {
     plugin_input = "klaviyo"
+  }
+}
+```
+
+### Read with Cursor-Based Pagination
+
+Use `pageing` to follow the `next` cursor that Klaviyo returns. The connector
+reads `cursor_response_field` from the response, writes the value back to
+`cursor_field`, and continues until the response no longer carries a cursor.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo_cursor"
+    url = "https://a.klaviyo.com/api/events"
+    private_key = "replace-with-private-key"
+    revision = "2020-10-17"
+    method = "GET"
+    format = "json"
+    pageing = {
+      page_type = "Cursor"
+      cursor_field = "page[cursor]"
+      cursor_response_field = "$.links.next"
+    }
+    schema = {
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo_cursor"
+  }
+}
+```
+
+### Polling Read in Streaming Mode
+
+For endpoints that grow over time, run the connector in `STREAMING` mode and
+let `poll_interval_millis` decide how often SeaTunnel re-issues the same
+request.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo_stream"
+    url = "https://a.klaviyo.com/api/metrics"
+    private_key = "replace-with-private-key"
+    revision = "2020-10-17"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo_stream"
   }
 }
 ```

--- a/docs/en/connectors/source/Lemlist.md
+++ b/docs/en/connectors/source/Lemlist.md
@@ -4,9 +4,26 @@ import ChangeLog from '../changelog/connector-http-lemlist.md';
 
 > Lemlist source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Reads data from Lemlist APIs. The connector uses `password` as the Lemlist API key, creates a Basic authentication header, and then uses the shared HTTP source runtime to parse the response.
+
+The Lemlist connector shares its HTTP request, retry, and pagination runtime with other HTTP-based source connectors. Configure `password` with the Lemlist API key and point `url` at the Lemlist endpoint you want to call.
+
+## Supported DataSource Info
+
+In order to use the Lemlist connector, the following dependency is required.
+It can be downloaded via install-plugin.sh or from the Maven central repository.
+
+| Datasource   | Supported Versions |                                         Dependency                                          |
+|--------------|--------------------|-----------------------------------------------------------------------------------------------|
+| Lemlist      | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base)       |
 
 ## Key features
 
@@ -93,6 +110,8 @@ Use `content_field` when the rows are inside a nested JSON node. Use `json_field
 
 ## Example
 
+### Batch Read of a Lemlist Team
+
 ```hocon
 env {
   parallelism = 1
@@ -127,6 +146,87 @@ source {
 sink {
   Console {
     plugin_input = "lemlist"
+  }
+}
+```
+
+### Read with Page-Number Pagination
+
+Some Lemlist endpoints paginate by page number. Configure `pageing` with
+`total_page_size` and `batch_size` so the connector keeps requesting the next
+page until either the configured total page count is reached or the response
+no longer carries the expected page size.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Lemlist {
+    plugin_output = "lemlist_pages"
+    url = "https://api.lemlist.com/api/campaigns"
+    password = "replace-with-api-key"
+    method = "GET"
+    format = "json"
+    pageing = {
+      total_page_size = 5
+      batch_size = 20
+      page_field = "page"
+      page_type = "PageNumber"
+    }
+    schema = {
+      fields {
+        _id = string
+        name = string
+        createdAt = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "lemlist_pages"
+  }
+}
+```
+
+### Polling Read in Streaming Mode
+
+For Lemlist endpoints that grow over time, run the connector in `STREAMING`
+mode and let `poll_interval_millis` decide how often SeaTunnel re-issues the
+same request.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Lemlist {
+    plugin_output = "lemlist_stream"
+    url = "https://api.lemlist.com/api/activities"
+    password = "replace-with-api-key"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        _id = string
+        type = string
+        createdAt = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "lemlist_stream"
   }
 }
 ```

--- a/docs/en/connectors/source/MyHours.md
+++ b/docs/en/connectors/source/MyHours.md
@@ -15,23 +15,31 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 Used to read data from My Hours through the My Hours REST API. The connector logs in with the configured
 `email` and `password`, obtains an access token, and then sends the configured HTTP request with that token.
 
+The My Hours connector shares its HTTP request, retry, and pagination runtime with other HTTP-based source connectors. Set `email` and `password` to a My Hours account, then point `url` at the endpoint you want to call.
+
 ## Key features
 
 - [x] [batch](../../introduction/concepts/connector-v2-features.md)
-- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
 - [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 
+:::tip
+
+In streaming mode, the connector repeatedly calls the configured endpoint. Set `poll_interval_millis` to control the request interval.
+
+:::
+
 ## Supported DataSource Info
 
-In order to use the My Hours connector, the following dependencies are required.
-They can be downloaded via install-plugin.sh or from the Maven central repository.
+In order to use the My Hours connector, the following dependency is required.
+It can be downloaded via install-plugin.sh or from the Maven central repository.
 
 | Datasource | Supported Versions |                                         Dependency                                          |
 |------------|--------------------|---------------------------------------------------------------------------------------------|
-| My Hours   | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel) |
+| My Hours   | universal          | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base)      |
 
 ## Source Options
 
@@ -54,6 +62,7 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 | retry_backoff_multiplier_ms | Int     | No       | 100     | Retry backoff multiplier in milliseconds.                                                                             |
 | retry_backoff_max_ms        | Int     | No       | 10000   | Maximum retry backoff in milliseconds.                                                                                |
 | json_filed_missed_return_null | Boolean | No     | false   | Return `null` when a configured JSON field is missing.                                                                |
+| pageing                     | Config  | No       | -       | Pagination settings for paginated My Hours endpoints. See [Pagination](#pagination).                                  |
 | common-options              |         | No       | -       | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md).             |
 
 ## How to Create a My Hours Data Synchronization Jobs
@@ -109,7 +118,99 @@ sink {
 }
 ```
 
+### Polling read in streaming mode
+
+For My Hours endpoints that grow over time, run the connector in `STREAMING`
+mode and use `poll_interval_millis` to control how often SeaTunnel re-issues
+the same request.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  MyHours {
+    plugin_output = "myhours_stream"
+    url = "https://api2.myhours.com/api/Projects/getAll"
+    email = "seatunnel@test.com"
+    password = "********"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        id = string
+        name = string
+        archived = boolean
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "myhours_stream"
+  }
+}
+```
+
+### Paginated batch read
+
+For paginated My Hours endpoints, configure `pageing` so the connector keeps
+walking pages until the configured total count is reached.
+
+```hocon
+source {
+  MyHours {
+    plugin_output = "myhours_pages"
+    url = "https://api2.myhours.com/api/Clients/getAll"
+    email = "seatunnel@test.com"
+    password = "********"
+    method = "GET"
+    format = "json"
+    pageing = {
+      total_page_size = 10
+      batch_size = 100
+      page_field = "page"
+      page_type = "PageNumber"
+    }
+    schema = {
+      fields {
+        id = string
+        name = string
+        archived = boolean
+      }
+    }
+  }
+}
+```
+
 ## Parameter Interpretation
+
+### Authentication
+
+Set `email` and `password` to your My Hours login. The connector exchanges
+those credentials for an access token, then attaches it to subsequent HTTP
+requests as the My Hours `Authorization` header. Keep `headers` for any
+additional headers the endpoint requires.
+
+### Pagination
+
+`pageing` is available for paginated My Hours endpoints.
+
+| name                       | type    | required | default value | description |
+|----------------------------|---------|----------|---------------|-------------|
+| total_page_size            | long    | No       | 0             | Total number of pages to request. |
+| batch_size                 | int     | No       | 100           | Page size returned by each request. |
+| start_page_number          | long    | No       | 1             | First page number. |
+| page_field                 | String  | No       | page          | Request parameter name for page-number pagination. |
+| page_type                  | String  | No       | PageNumber    | Pagination type. Supported values are `PageNumber` and `Cursor`. |
+| cursor_field               | String  | No       | -             | Request parameter name for cursor pagination. |
+| cursor_response_field      | String  | No       | -             | JSONPath field used to read the next cursor from the response. |
+| use_placeholder_replacement | boolean | No      | false         | Use `${field}` placeholder replacement in headers, parameters, and body. |
 
 ### format
 

--- a/docs/zh/connectors/sink/GraphQL.md
+++ b/docs/zh/connectors/sink/GraphQL.md
@@ -59,6 +59,32 @@ mutation 一起发送。
 - Sink 会为每一行输入数据发送一次 mutation 请求。如果上游包含多张表，需要确认同一条 mutation 和变量名可以处理所有写入到该 Sink 的表。
 - `multi_table_sink_replica` 只影响多表 sink 运行时的副本数，不会按不同表自动选择不同的 GraphQL mutation。
 
+### 鉴权
+
+大多数 GraphQL 服务都要求鉴权请求头，可以把它写在 `headers` 里：
+
+```hocon
+sink {
+  GraphQL {
+    plugin_input = "fake"
+    url = "https://graphql.example.com/v1/graphql"
+    headers = {
+      Authorization = "Bearer ${secret}"
+    }
+    query = """
+      mutation MyMutation($id: Int!, $val_string: String!) {
+        insert_event(objects: {id: $id, val_string: $val_string}) {
+          affected_rows
+        }
+      }
+    """
+  }
+}
+```
+
+`password`、`token` 等敏感配置建议通过运行时占位符（例如 `${secret}`）注入，
+不要直接写在配置文件里。
+
 ## 任务示例
 
 ### 使用 GraphQL Mutation 写入数据
@@ -211,6 +237,55 @@ sink {
         }
       }
     """
+  }
+}
+```
+
+### 在流模式下持续写入
+
+流模式下 Sink 会持续接收上游行数据，并对每条行执行一次 mutation 请求。配合 `retry` 和
+指数退避参数可以吸收偶发的 HTTP 抖动。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  FakeSource {
+    plugin_output = "events"
+    schema = {
+      fields {
+        id = int
+        val_string = string
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "first"] }
+      { kind = INSERT, fields = [2, "second"] }
+    ]
+  }
+}
+
+sink {
+  GraphQL {
+    plugin_input = "events"
+    url = "http://graphql:8080/v1/graphql"
+    headers = {
+      Authorization = "Bearer ${secret}"
+    }
+    query = """
+      mutation MyMutation($id: Int!, $val_string: String!) {
+        insert_event(objects: {id: $id, val_string: $val_string}) {
+          affected_rows
+        }
+      }
+    """
+    retry = 5
+    retry_backoff_multiplier_ms = 200
+    retry_backoff_max_ms = 5000
   }
 }
 ```

--- a/docs/zh/connectors/sink/NatsJetStream.md
+++ b/docs/zh/connectors/sink/NatsJetStream.md
@@ -14,7 +14,13 @@ NatsJetStream 是一个 **JetStream sink**，不是 core NATS publish 连接器�
 
 ## 主要特性
 
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [变更数据捕获](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户定义分片](../../introduction/concepts/connector-v2-features.md)
 - [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 :::caution 投递语义
@@ -40,7 +46,7 @@ native 模式中的 message ID 只能作为 **broker 侧的重复缓解提示**�
 > Flink<br/>
 > Spark<br/>
 
-## Connector contract
+## 连接器契约
 
 - 范围：仅支持 sink；本次贡献不包含 NATS source。
 - 兼容性目标：启用 JetStream 的 NATS Server 2.x，客户端版本为 `io.nats:jnats:2.24.0`。
@@ -53,6 +59,7 @@ native 模式中的 message ID 只能作为 **broker 侧的重复缓解提示**�
 - 认证：只能使用无认证、`username` + `password`，或单独 `token`；`token` 与 `username` / `password` 互斥。
 - 初始限制：仅支持同步逐条发布；batching 和连接器自管 retry 不在范围内。
 - 非目标：stream 管理、exactly-once、source 支持、超出输入行模式的 schema evolution，以及文档之外的格式。
+- 多表 sink：同一个 sink 实例会接受来自多张上游表的行。每一行都发布到配置的 `subject`（JSON 模式）或解析后的 native subject；连接器不会按表自动选择不同的 mutation。
 
 ## Broker 准备
 
@@ -303,6 +310,100 @@ subject : string
 id      : string
 headers : map<string,string>
 data    : bytes
+```
+
+### 流模式下的 JSON 示例
+
+同一个 JSON sink 也可以持续运行在流模式下。每条输入行都会作为一次 JetStream
+publish 请求，发布到固定的 subject。设置 checkpoint interval，让 writer
+在重启后以至少一次的方式恢复。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  FakeSource {
+    plugin_output = "json_fake_stream"
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
+      }
+    }
+    rows = [
+      { kind = INSERT, fields = [1, "alice", 9.5] }
+    ]
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "json_fake_stream"
+    url = "nats://127.0.0.1:4222"
+    username = "nats-user"
+    password = "nats-password"
+    subject = "orders.json.stream"
+    format = "json"
+  }
+}
+```
+
+### 写入多张上游表
+
+同一个 sink 实例在 JSON 模式下可以接受来自多张上游表的行。每一行都会发布到
+配置的 subject；连接器不会按表自动选择不同的 mutation。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "fake_multi"
+    tables_configs = [
+      {
+        schema = {
+          table = "events_json_a"
+          fields {
+            id = int
+            name = string
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [1, "alpha"] }
+        ]
+      },
+      {
+        schema = {
+          table = "events_json_b"
+          fields {
+            id = int
+            name = string
+          }
+        }
+        rows = [
+          { kind = INSERT, fields = [2, "beta"] }
+        ]
+      }
+    ]
+  }
+}
+
+sink {
+  NatsJetStream {
+    plugin_input = "fake_multi"
+    url = "nats://127.0.0.1:4222"
+    subject = "events.json.multi"
+    format = "json"
+  }
+}
 ```
 
 ## 错误与运维说明

--- a/docs/zh/connectors/source/Klaviyo.md
+++ b/docs/zh/connectors/source/Klaviyo.md
@@ -4,9 +4,25 @@ import ChangeLog from '../changelog/connector-http-klaviyo.md';
 
 > Klaviyo 源连接器
 
+## 支持这些引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 Klaviyo API 读取数据。连接器会根据 `private_key` 和 `revision` 生成 Klaviyo 请求头，然后复用 HTTP Source 的能力解析返回结果。
+
+Klaviyo 连接器与其他基于 HTTP 的源连接器共用同一套 HTTP 请求、重试和分页能力。把 `private_key` 配置为 Klaviyo 私有 API Key，把 `revision` 配置为 API 版本日期（例如 `2020-10-17`），再把 `url` 指向要调用的 Klaviyo 接口。
+
+## 支持的数据源信息
+
+使用 Klaviyo 连接器需要安装下面的依赖。可以通过 install-plugin.sh 安装，也可以从 Maven 中央仓库下载。
+
+| 数据源     | 支持版本 | 依赖                                                                                            |
+|------------|----------|-------------------------------------------------------------------------------------------------|
+| Klaviyo    | 通用     | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base)              |
 
 ## 关键特性
 
@@ -99,6 +115,8 @@ schema = {
 
 ## 示例
 
+### 批量读取 Klaviyo 列表
+
 ```hocon
 env {
   parallelism = 1
@@ -133,6 +151,94 @@ source {
 sink {
   Console {
     plugin_input = "klaviyo"
+  }
+}
+```
+
+### 使用游标分页读取
+
+通过 `pageing` 跟随 Klaviyo 在响应中返回的 `next` 游标。连接器会读取
+`cursor_response_field`，把值写回 `cursor_field`，直到响应不再带下游
+游标为止。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo_cursor"
+    url = "https://a.klaviyo.com/api/events"
+    private_key = "replace-with-private-key"
+    revision = "2020-10-17"
+    method = "GET"
+    format = "json"
+    pageing = {
+      page_type = "Cursor"
+      cursor_field = "page[cursor]"
+      cursor_response_field = "$.links.next"
+    }
+    schema = {
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo_cursor"
+  }
+}
+```
+
+### 流模式下轮询读取
+
+对于数据随时间增长的接口，使用 `STREAMING` 模式运行连接器，通过
+`poll_interval_millis` 控制 SeaTunnel 重新发起请求的频率。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Klaviyo {
+    plugin_output = "klaviyo_stream"
+    url = "https://a.klaviyo.com/api/metrics"
+    private_key = "replace-with-private-key"
+    revision = "2020-10-17"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        type = string
+        id = string
+        attributes = {
+          name = string
+          created = string
+          updated = string
+        }
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "klaviyo_stream"
   }
 }
 ```

--- a/docs/zh/connectors/source/Lemlist.md
+++ b/docs/zh/connectors/source/Lemlist.md
@@ -4,9 +4,25 @@ import ChangeLog from '../changelog/connector-http-lemlist.md';
 
 > Lemlist 源连接器
 
+## 支持这些引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 Lemlist API 读取数据。连接器会把 `password` 当作 Lemlist API Key，通过 Basic 认证生成请求头，然后复用 HTTP Source 的能力解析返回结果。
+
+Lemlist 连接器与其他基于 HTTP 的源连接器共用同一套 HTTP 请求、重试和分页能力。把 `password` 配置为 Lemlist API Key，再把 `url` 指向要调用的 Lemlist 接口。
+
+## 支持的数据源信息
+
+使用 Lemlist 连接器需要安装下面的依赖。可以通过 install-plugin.sh 安装，也可以从 Maven 中央仓库下载。
+
+| 数据源     | 支持版本 | 依赖                                                                                            |
+|------------|----------|-------------------------------------------------------------------------------------------------|
+| Lemlist    | 通用     | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base)              |
 
 ## 关键特性
 
@@ -93,6 +109,8 @@ schema = {
 
 ## 示例
 
+### 批量读取 Lemlist 团队信息
+
 ```hocon
 env {
   parallelism = 1
@@ -127,6 +145,85 @@ source {
 sink {
   Console {
     plugin_input = "lemlist"
+  }
+}
+```
+
+### 使用页码分页读取
+
+部分 Lemlist 接口使用页码分页。配置 `pageing` 中的 `total_page_size` 和
+`batch_size`，连接器会持续请求下一页，直到达到配置的总页数或响应不再
+返回预期的数据条数。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Lemlist {
+    plugin_output = "lemlist_pages"
+    url = "https://api.lemlist.com/api/campaigns"
+    password = "replace-with-api-key"
+    method = "GET"
+    format = "json"
+    pageing = {
+      total_page_size = 5
+      batch_size = 20
+      page_field = "page"
+      page_type = "PageNumber"
+    }
+    schema = {
+      fields {
+        _id = string
+        name = string
+        createdAt = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "lemlist_pages"
+  }
+}
+```
+
+### 流模式下轮询读取
+
+对于数据随时间增长的 Lemlist 接口，使用 `STREAMING` 模式运行连接器，
+通过 `poll_interval_millis` 控制 SeaTunnel 重新发起请求的频率。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Lemlist {
+    plugin_output = "lemlist_stream"
+    url = "https://api.lemlist.com/api/activities"
+    password = "replace-with-api-key"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        _id = string
+        type = string
+        createdAt = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "lemlist_stream"
   }
 }
 ```

--- a/docs/zh/connectors/source/MyHours.md
+++ b/docs/zh/connectors/source/MyHours.md
@@ -10,19 +10,27 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 > Flink<br/>
 > SeaTunnel Zeta<br/>
 
+## 描述
+
+用于通过 My Hours REST API 读取数据。连接器会先使用配置的 `email` 和 `password` 登录获取访问令牌，
+然后在后续请求中自动携带该令牌。
+
+My Hours 连接器与其他基于 HTTP 的源连接器共用同一套 HTTP 请求、重试和分页能力。把 `email` 和 `password` 配置为 My Hours 账号，再把 `url` 指向要调用的接口。
+
 ## 关键特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
-- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
 
-## 描述
+:::tip
 
-用于通过 My Hours REST API 读取数据。连接器会先使用配置的 `email` 和 `password` 登录获取访问令牌，
-然后在后续请求中自动携带该令牌。
+在流模式下，连接器会反复请求配置的接口。可以用 `poll_interval_millis` 控制请求间隔。
+
+:::
 
 ## 支持的数据源信息
 
@@ -31,7 +39,7 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 
 | 数据源 | 支持的版本 | 依赖 |
 |--------|-----------|------|
-| My Hours | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel) |
+| My Hours | universal | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http-base) |
 
 ## 源选项
 
@@ -54,7 +62,8 @@ import ChangeLog from '../changelog/connector-http-myhours.md';
 | retry_backoff_multiplier_ms   | Int     | 否   | 100    | 重试退避倍数，单位毫秒。                                                                            |
 | retry_backoff_max_ms          | Int     | 否   | 10000  | 最大重试退避时间，单位毫秒。                                                                        |
 | json_filed_missed_return_null | Boolean | 否   | false  | 配置的 JSON 字段缺失时返回 `null`。                                                                |
-| common-options                |         | 否   | -      | 源插件通用参数。                                                                                   |
+| pageing                       | Config  | 否   | -      | 分页设置，用于支持分页的 My Hours 接口，见 [分页](#分页)。                                          |
+| common-options                |         | 否   | -      | 源插件通用参数，详见 [源通用选项](../common-options/source-common-options.md)。                  |
 
 ## 如何创建 My Hours 数据同步作业
 
@@ -109,7 +118,96 @@ sink {
 }
 ```
 
+### 流模式下轮询读取
+
+对于数据随时间增长的 My Hours 接口，使用 `STREAMING` 模式运行连接器，并
+通过 `poll_interval_millis` 控制 SeaTunnel 重新发起请求的频率。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  MyHours {
+    plugin_output = "myhours_stream"
+    url = "https://api2.myhours.com/api/Projects/getAll"
+    email = "seatunnel@test.com"
+    password = "********"
+    method = "GET"
+    poll_interval_millis = 30000
+    format = "json"
+    schema = {
+      fields {
+        id = string
+        name = string
+        archived = boolean
+      }
+    }
+  }
+}
+
+sink {
+  Console {
+    plugin_input = "myhours_stream"
+  }
+}
+```
+
+### 分页批量读取
+
+对于支持分页的 My Hours 接口，配置 `pageing` 让连接器持续翻页，直到达到配置的总页数为止。
+
+```hocon
+source {
+  MyHours {
+    plugin_output = "myhours_pages"
+    url = "https://api2.myhours.com/api/Clients/getAll"
+    email = "seatunnel@test.com"
+    password = "********"
+    method = "GET"
+    format = "json"
+    pageing = {
+      total_page_size = 10
+      batch_size = 100
+      page_field = "page"
+      page_type = "PageNumber"
+    }
+    schema = {
+      fields {
+        id = string
+        name = string
+        archived = boolean
+      }
+    }
+  }
+}
+```
+
 ## 参数解释
+
+### 认证
+
+把 `email` 和 `password` 配置为 My Hours 账号。连接器会先用这两个凭据换取
+访问令牌，然后在后续请求中通过 My Hours `Authorization` 请求头带上该令牌。
+`headers` 字段用于补充接口需要的其他请求头。
+
+### 分页
+
+对于支持分页的 My Hours 接口，可以使用 `pageing`。
+
+| 名称 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| total_page_size | long | 否 | 0 | 请求的总页数。 |
+| batch_size | int | 否 | 100 | 每次请求返回的数据条数。 |
+| start_page_number | long | 否 | 1 | 起始页码。 |
+| page_field | String | 否 | page | 页码分页时，请求参数中的页码字段名。 |
+| page_type | String | 否 | PageNumber | 分页类型，支持 `PageNumber` 和 `Cursor`。 |
+| cursor_field | String | 否 | - | 游标分页时，请求参数中的游标字段名。 |
+| cursor_response_field | String | 否 | - | 从响应中读取下一页游标的 JSONPath 字段。 |
+| use_placeholder_replacement | boolean | 否 | false | 是否在请求头、参数和请求体中使用 `${field}` 占位符替换。 |
 
 ### format
 


### PR DESCRIPTION
## Summary

Improve the user-facing documentation for the GraphQL sink, NATS JetStream sink, and the HTTP-based Klaviyo, Lemlist, and My Hours source connectors in both English and Chinese.

## Why

These connectors share the HTTP/NATS source runtime that already powers several recently documented peers, but their docs still had gaps that made advanced usage hard to discover:

- Klaviyo and Lemlist source docs lacked the standard `Support Those Engines` section, the dependency link, and pagination examples. Operators had to read the source code to find the shared `pageing` options.
- My Hours source docs listed `stream` as unsupported even though `poll_interval_millis` works in streaming mode, and did not document the `pageing` option at all.
- NATS JetStream sink `Key features` only listed two flags and missed the standard batch / multi-table / cdc entries. The Chinese doc still used the English heading `Connector contract`.
- GraphQL sink docs did not call out how to authenticate against a GraphQL service, and the Chinese sink doc was missing the streaming mutation example that the English version already had.

## Changes

### GraphQL sink (`docs/en/connectors/sink/GraphQL.md`, `docs/zh/connectors/sink/GraphQL.md`)

- Add an `Authentication` section under `Notes` that shows how to pass a bearer token via `headers` and recommends using runtime placeholders for sensitive credentials.
- Translate the same section in the Chinese doc and add the streaming mutation example that already existed in English.

### NATS JetStream sink (`docs/en/connectors/sink/NatsJetStream.md`, `docs/zh/connectors/sink/NatsJetStream.md`)

- Extend `Key features` to the standard `batch` / `stream` / `exactly-once` / `support multiple table write` / `cdc` / `parallelism` / `support user-defined split` / `timer flush` set.
- Add a `Multi-table sink` bullet under `Connector contract` so users understand the same mutation runs for every routed table.
- Add a streaming JSON example that uses `checkpoint.interval` and a multi-table example so the multi-table claim has a runnable sample.
- Translate the `Connector contract` heading and the new example content into Chinese.

### Klaviyo source (`docs/en/connectors/source/Klaviyo.md`, `docs/zh/connectors/source/Klaviyo.md`)

- Add `Support Those Engines` and `Supported DataSource Info` sections so the doc matches the rest of the HTTP connector family.
- Add a brief intro paragraph that points operators to the shared HTTP / retry / pagination runtime.
- Add `cursor-based pagination` and `streaming polling` task examples.

### Lemlist source (`docs/en/connectors/source/Lemlist.md`, `docs/zh/connectors/source/Lemlist.md`)

- Add `Support Those Engines` and `Supported DataSource Info` sections.
- Add a short description of the shared HTTP runtime.
- Add `page-number pagination` and `streaming polling` task examples.

### My Hours source (`docs/en/connectors/source/MyHours.md`, `docs/zh/connectors/source/MyHours.md`)

- Correct the `Key features` list: `stream` is supported via `poll_interval_millis`, and add the matching `:::tip` note.
- Document the previously undocumented `pageing` option with a full options table, and add `Authentication` and `Pagination` sections under `Parameter Interpretation`.
- Add `streaming polling` and `paginated batch` task examples.
- Fix the dependency link to point at `connector-http-base`, matching the other HTTP-based source connectors.
- Reorder Chinese sections so the description appears before the key features, matching the English layout.

## Notes

- No code or behavior changes. Only documentation.
- No support version bumps were added.
- Examples follow patterns already used by recently merged SeaTunnel connector doc PRs (Klaviyo/Lemlist mirror the Notion / GitHub layout; NatsJetStream / GraphQL mirror the Sentry / OpenMldb pattern).
- All five target connectors were last touched outside the 7-day window, so they are eligible for a new docs PR.
