### PR TITLE
[Docs][Connector-V2] Improve SqlServer Cloudberry Http SftpFile and MySQL connector docs

### DIFF
--- a/docs/en/connectors/sink/Cloudberry.md
+++ b/docs/en/connectors/sink/Cloudberry.md
@@ -2,7 +2,7 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 
 # Cloudberry
 
-> JDBC Cloudberry  Sink Connector
+> JDBC Cloudberry Sink Connector
 
 ## Support Those Engines
 
@@ -12,64 +12,84 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 
 ## Description
 
-Write data through JDBC. Cloudberry currently does not have its own native driver. It uses PostgreSQL's driver for connectivity and follows PostgreSQL's implementation.
+Write data to Cloudberry through JDBC. Cloudberry does not yet ship its own JDBC driver, so this
+connector uses the official PostgreSQL driver (`org.postgresql.Driver`) and follows the
+[PostgreSQL sink connector](./PostgreSql.md) configuration model.
 
-Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
-semantics (using XA transaction guarantee).
+It supports Batch mode and Streaming mode, concurrent writing, and exactly-once semantics
+through XA transactions. CDC events from upstream are also supported when configured with
+`primary_keys` and `generate_sink_sql`.
 
 ## Using Dependency
 
 ### For Spark/Flink Engine
 
-> 1. You need to ensure that the [jdbc driver jar package](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in directory `${SEATUNNEL_HOME}/plugins/`.
+> 1. Place the [PostgreSQL JDBC driver jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) in `${SEATUNNEL_HOME}/plugins/`.
 
 ### For SeaTunnel Zeta Engine
 
-> 1. You need to ensure that the [jdbc driver jar package](https://mvnrepository.com/artifact/org.postgresql/postgresql) has been placed in directory `${SEATUNNEL_HOME}/lib/`.
+> 1. Place the [PostgreSQL JDBC driver jar](https://mvnrepository.com/artifact/org.postgresql/postgresql) in `${SEATUNNEL_HOME}/lib/`.
 
 ## Key Features
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 - [x] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
 > Use `Xa transactions` to ensure `exactly-once`. So only support `exactly-once` for the database which is
-> support `Xa transactions`. You can set `is_exactly_once=true` to enable it.
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+> support `Xa transactions`. You can set `is_exactly_once=true` and `max_retries=0` to enable it.
 
 ## Supported DataSource Info
 
-| Datasource |            Supported Versions            |        Driver         |                  Url                  |                                  Maven                                   |
-|------------|------------------------------------------|------------------------|---------------------------------------|--------------------------------------------------------------------------|
-| Cloudberry | Uses PostgreSQL driver implementation | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| Datasource | Supported Versions                  | Driver                | Url                                  | Maven                                                                       |
+|------------|-------------------------------------|-----------------------|--------------------------------------|-----------------------------------------------------------------------------|
+| Cloudberry | Uses PostgreSQL driver protocol     | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql)    |
 
 ## Database Dependency
 
-> Please download the PostgreSQL driver jar and copy it to the '$SEATUNNEL_HOME/plugins/jdbc/lib/' working directory<br/>
-> For example: cp postgresql-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
+> Place the PostgreSQL driver jar under `$SEATUNNEL_HOME/plugins/jdbc/lib/`.
+> For example: `cp postgresql-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/`
 
 ## Data Type Mapping
 
-Cloudberry uses PostgreSQL's data type implementation. Please refer to PostgreSQL documentation for data type compatibility and mappings.
+Cloudberry follows PostgreSQL's data type implementation. For data type compatibility and
+mapping, please refer to the [PostgreSQL connector documentation](./PostgreSql.md#data-type-mapping).
 
 ## Options
 
-Cloudberry connector uses the same options as PostgreSQL. For detailed configuration options, please refer to the PostgreSQL documentation.
+The Cloudberry sink inherits the full option set of the [PostgreSQL sink connector](./PostgreSql.md),
+because both use the same underlying driver. The connection-related options that differ from
+the generic JDBC sink are listed below; for everything else, follow the PostgreSQL page.
 
-Key options include:
-
-- url (required): The JDBC connection URL
-- driver (required): The driver class name (org.postgresql.Driver)
-- username/password: Authentication credentials. `user` is also accepted as a fallback key for `username`.
-- query or database/table combination: What data to write and how
-- is_exactly_once: Enable exactly-once semantics with XA transactions
-- batch_size: Control batch writing behavior
+|             Name              |  Type   | Required | Default | Description                                                                                                  |
+|-------------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
+| url                           | String  | Yes      | -       | JDBC connection URL. Use the PostgreSQL protocol, for example `jdbc:postgresql://localhost:5432/cloudberrydb` |
+| driver                        | String  | Yes      | -       | Always `org.postgresql.Driver`                                                                               |
+| username                      | String  | Yes      | -       | Connection instance user name. `user` is also accepted as a fallback key for `username`                       |
+| password                      | String  | Yes      | -       | Connection instance password                                                                                 |
+| query                         | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`, `query` have the higher priority     |
+| database                      | String  | No       | -       | Use this `database` and `table` auto-generate sql and receive upstream input datas write to database        |
+| table                         | String  | No       | -       | Use database and this table auto-generate sql and receive upstream input datas write to database            |
+| primary_keys                  | Array   | No       | -       | Required when automatically generating SQL that supports `insert`, `delete`, and `update` operations         |
+| is_exactly_once               | Boolean | No       | false   | Enable exactly-once semantics via XA transactions                                                            |
+| xa_data_source_class_name     | String  | No       | -       | Use `org.postgresql.xa.PGXADataSource` when `is_exactly_once=true`                                            |
+| generate_sink_sql             | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                     |
+| batch_size                    | Int     | No       | 1000    | Maximum number of rows buffered before one flush                                                             |
+| batch_interval_ms             | Long    | No       | 0       | Write-triggered flush interval in milliseconds                                                               |
+| schema_save_mode              | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Before the synchronization task starts, controls how the target table schema is handled                       |
+| data_save_mode                | Enum    | No       | APPEND_DATA | Before the synchronization task starts, controls how existing target table data is handled                   |
+| custom_sql                    | String  | No       | -       | When `data_save_mode` is `CUSTOM_PROCESSING`, SQL executed before the synchronization task starts            |
+| enable_upsert                 | Boolean | No       | true    | Enable upsert by primary_keys exist                                                                          |
+| multi_table_sink_replica      | Int     | No       | 1       | The number of sink writer replicas used when writing multiple tables                                         |
+| common-options                |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details |
 
 ## Notes
 
-- Use the `Jdbc` plugin name for Cloudberry jobs.
-- Cloudberry uses PostgreSQL JDBC behavior; configure `driver = "org.postgresql.Driver"` and a `jdbc:postgresql://...` URL.
-- Use `query` for a hand-written INSERT statement, or use `generate_sink_sql` with `database` and `table` when SeaTunnel should generate SQL.
-- `is_exactly_once=true` also needs a valid XA data source class, for example `org.postgresql.xa.PGXADataSource`.
+- Configure `driver = "org.postgresql.Driver"` and use a `jdbc:postgresql://...` URL.
+- Use the `Jdbc` plugin name in your job; the Cloudberry connector does not have its own factory name.
+- For a hand-written INSERT, set `query`. To let SeaTunnel generate the SQL, set `generate_sink_sql=true` together with `database` and `table`.
+- `is_exactly_once=true` requires a valid XA data source. Use `org.postgresql.xa.PGXADataSource`.
 
 ## Task Example
 
@@ -99,9 +119,9 @@ sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    query = "insert into test_table(name,age) values(?,?)"
+    query = "insert into test_table(name, age) values(?, ?)"
   }
 }
 ```
@@ -113,9 +133,9 @@ sink {
   Jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    
+
     generate_sink_sql = true
     database = "mydb"
     table = "public.test_table"
@@ -130,45 +150,45 @@ sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    query = "insert into test_table(name,age) values(?,?)"
-    
-    is_exactly_once = "true"
+    query = "insert into test_table(name, age) values(?, ?)"
+
+    is_exactly_once = true
     xa_data_source_class_name = "org.postgresql.xa.PGXADataSource"
   }
 }
 ```
 
-### CDC(Change Data Capture) Event
+### CDC (Change Data Capture) Event
 
 ```hocon
 sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    
+
     generate_sink_sql = true
     database = "mydb"
     table = "sink_table"
-    primary_keys = ["id","name"]
+    primary_keys = ["id", "name"]
     field_ide = UPPERCASE
   }
 }
 ```
 
-### Save mode function
+### Save Mode Function
 
 ```hocon
 sink {
   Jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    
+
     generate_sink_sql = true
     database = "mydb"
     table = "public.test_table"
@@ -178,7 +198,26 @@ sink {
 }
 ```
 
-For more detailed examples and options, please refer to the PostgreSQL connector documentation.
+### Multiple Table Sink
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:postgresql://localhost:5432/cloudberrydb"
+    driver = "org.postgresql.Driver"
+    username = "dbadmin"
+    password = "password"
+
+    generate_sink_sql = true
+    database = "${database_name}"
+    table = "${table_name}"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
+}
+```
+
+For more detailed examples and options, please refer to the [PostgreSQL connector documentation](./PostgreSql.md).
 
 ## Changelog
 

--- a/docs/en/connectors/sink/Http.md
+++ b/docs/en/connectors/sink/Http.md
@@ -19,16 +19,17 @@ import ChangeLog from '../changelog/connector-http.md';
 
 ## Description
 
-Used to launch web hooks using data.
+Used to launch web hooks using upstream data. The Http sink always sends `POST` requests; each
+upstream row is serialized to JSON and used as the request body.
 
 > For example, if the data from upstream is [`age: 12, name: tyrantlucifer`], the body content is the following: `{"age": 12, "name": "tyrantlucifer"}`
 
-**Tips: Http sink only support `post json` webhook and the data from source will be treated as body content in web hook.**
+**Tips: Http sink only supports `POST json` webhooks and the data from the source will be treated as body content in the webhook.**
 
 ## Supported DataSource Info
 
-In order to use the Http connector, the following dependencies are required.
-They can be downloaded via install-plugin.sh or from the Maven central repository.
+In order to use the Http connector, the following dependencies are required. They can be
+downloaded via `install-plugin.sh` or from the Maven central repository.
 
 | Datasource | Supported Versions | Dependency                                                                         |
 |------------|--------------------|------------------------------------------------------------------------------------|
@@ -36,53 +37,121 @@ They can be downloaded via install-plugin.sh or from the Maven central repositor
 
 ## Sink Options
 
-|            Name             |  Type  | Required | Default |                                                 Description                                                 |
-|-----------------------------|--------|----------|---------|-------------------------------------------------------------------------------------------------------------|
-| url                         | String | Yes      | -       | Http request url                                                                                            |
-| headers                     | Map    | No       | -       | Http headers                                                                                                |
-| params                      | Map    | No       | -       | Accepted by the option rule. For the current sink writer, put query parameters directly in `url`; rows are posted to the final URL as the request body. |
-| retry                       | Int    | No       | -       | The max retry times if request http return to `IOException`                                                 |
-| retry_backoff_multiplier_ms | Int    | No       | 100     | The retry-backoff times(millis) multiplier if request http failed                                           |
-| retry_backoff_max_ms        | Int    | No       | 10000   | The maximum retry-backoff times(millis) if request http failed                                              |
-| array_mode                  | Boolean| No       | false   | Send data as a JSON array when true, or as a single JSON object when false (default)                        |
-| batch_size                  | Int    | No       | 1       | The batch size of records to send in one HTTP request. Only works when array_mode is true.                  |
-| request_interval_ms         | Int    | No       | 0       | The interval milliseconds between two HTTP requests, to avoid sending requests too frequently.              |
-| multi_table_sink_replica    | Int    | No       | -       | Number of sink replicas used for multi-table write. See [Sink Common Options](../common-options/sink-common-options.md). |
-| common-options              |        | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details |
+|            Name             |  Type   | Required | Default | Description                                                                                                                                                |
+|-----------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                         | String  | Yes      | -       | Http request URL. Static query parameters can be embedded directly in the URL.                                                                            |
+| headers                     | Map     | No       | -       | HTTP headers added to every request. Each entry is one `name = "value"` pair.                                                                              |
+| params                      | Map     | No       | -       | HTTP request parameters. For `POST`/`PUT`/`DELETE` requests without a JSON body they are sent as form fields; for `GET` requests they are appended as URL query parameters. |
+| retry                       | Int     | No       | -       | The maximum retry count if the HTTP request returns an `IOException`.                                                                                      |
+| retry_backoff_multiplier_ms | Int     | No       | 100     | The retry-backoff time (millis) multiplier applied between retries.                                                                                         |
+| retry_backoff_max_ms        | Int     | No       | 10000   | The maximum retry-backoff time (millis) between retries.                                                                                                   |
+| array_mode                  | Boolean | No       | false   | When `true`, rows are accumulated into a JSON array before being sent. When `false`, each row is sent as a single JSON object.                            |
+| batch_size                  | Int     | No       | 1       | The maximum number of rows sent in one HTTP request. Only takes effect when `array_mode = true`.                                                          |
+| request_interval_ms         | Int     | No       | 0       | The interval in milliseconds between two HTTP requests, used to avoid sending requests too frequently.                                                    |
+| multi_table_sink_replica    | Int     | No       | -       | Number of sink writer replicas used when writing multiple tables. See [Sink Common Options](../common-options/sink-common-options.md).                      |
+| common-options              |         | No       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.                              |
+
+### url
+
+The HTTP endpoint that receives the webhook. Static query parameters can be embedded in the URL
+directly, for example `http://localhost/test/webhook?source=seatunnel`.
+
+### params
+
+`params` is the most flexible way to attach HTTP request parameters:
+
+- For `POST`/`PUT`/`DELETE` requests without a JSON body, the entries are sent as `application/x-www-form-urlencoded` form fields.
+- For `GET` requests, the entries are appended to the URL as query string parameters.
+
+If the upstream row itself is a JSON object and the request method is `POST`, the JSON body is sent
+as the request payload and `params` is sent alongside it as additional form fields.
+
+### retry behavior
+
+Retries are triggered only for `IOException` responses. The first retry happens after
+`retry_backoff_multiplier_ms` (default 100 ms), then each subsequent retry waits
+`min(previous_wait * retry_backoff_multiplier_ms, retry_backoff_max_ms)` until either the
+retry succeeds or `retry` attempts are exhausted.
+
+### array_mode and batch_size
+
+When `array_mode = false` (the default), the Http sink sends one HTTP request per row. Set
+`array_mode = true` to send rows in batches; `batch_size` then controls how many rows go into one
+JSON-array request, and `request_interval_ms` adds a delay between consecutive batches.
 
 ## Example
 
-The Http sink always sends `POST` requests. Each upstream row is converted to JSON and used as the request body. When `array_mode = true`, rows are accumulated into a JSON array before sending; `batch_size` controls the maximum number of rows in one request.
-
-simple:
+### Simple
 
 ```hocon
-Http {
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 1
+    schema = {
+      fields {
+        age = "int"
+        name = "string"
+      }
+    }
+  }
+}
+
+sink {
+  Http {
     url = "http://localhost/test/webhook"
     headers {
-        token = "9e32e859ef044462a257e1fc76730066"
+      token = "9e32e859ef044462a257e1fc76730066"
     }
+  }
 }
 ```
 
 ### With Batch Processing
 
 ```hocon
-Http {
+sink {
+  Http {
     url = "http://localhost/test/webhook"
     headers {
-        token = "9e32e859ef044462a257e1fc76730066"
-        Content-Type = "application/json"
+      token = "9e32e859ef044462a257e1fc76730066"
+      Content-Type = "application/json"
     }
     array_mode = true
     batch_size = 50
     request_interval_ms = 500
+  }
 }
 ```
 
-### Multiple table
+### With Retry And Form Params
 
-#### example1
+```hocon
+sink {
+  Http {
+    url = "http://localhost/test/webhook"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
+    params {
+      source = "seatunnel"
+      channel = "cdc"
+    }
+    retry = 3
+    retry_backoff_multiplier_ms = 200
+    retry_backoff_max_ms = 5000
+  }
+}
+```
+
+### Multiple Tables
+
+Use `${database_name}` and `${table_name}` placeholders in the URL to route rows from different
+upstream tables to different endpoints.
 
 ```hocon
 env {
@@ -92,12 +161,12 @@ env {
 }
 
 source {
-  Mysql-CDC {
+  MySQL-CDC {
     url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
     username = "root"
     password = "******"
-    
-    table-names = ["seatunnel.role","seatunnel.user","galileo.Bucket"]
+
+    table-names = ["seatunnel.role", "seatunnel.user", "galileo.Bucket"]
   }
 }
 
@@ -106,26 +175,24 @@ transform {
 
 sink {
   Http {
-    ...
     url = "http://localhost/test/${database_name}_test/${table_name}_test"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
   }
 }
 ```
 
-#### example2
+When the upstream source uses a schema-qualified table list (for example Oracle), use
+`${schema_name}` instead of `${database_name}`:
 
 ```hocon
-env {
-  parallelism = 1
-  job.mode = "BATCH"
-}
-
 source {
   Jdbc {
     driver = oracle.jdbc.driver.OracleDriver
     url = "jdbc:oracle:thin:@localhost:1521/XE"
-    user = testUser
-    password = testPassword
+    username = "testUser"
+    password = "testPassword"
 
     table_list = [
       {
@@ -143,8 +210,10 @@ transform {
 
 sink {
   Http {
-    ...
     url = "http://localhost/test/${schema_name}_test/${table_name}_test"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
   }
 }
 ```

--- a/docs/en/connectors/sink/SftpFile.md
+++ b/docs/en/connectors/sink/SftpFile.md
@@ -4,15 +4,29 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 
 > Sftp file sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
-Output data to Sftp .
+Write data to a remote directory over SFTP. The connector supports multiple file formats
+(`text`, `csv`, `parquet`, `orc`, `json`, `excel`, `binary`, `xml`, `canal_json`, `debezium_json`,
+`maxwell_json`), partition-based output, custom file names, and runtime schema evolution for CDC
+pipelines.
 
 :::tip
 
-If you use spark/flink, In order to use this connector, You must ensure your spark/flink cluster already integrated hadoop. The tested hadoop version is 2.x.
+If you use Spark/Flink, make sure your Spark/Flink cluster already integrates Hadoop. The tested
+Hadoop version is 2.x.
 
-If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you download and install SeaTunnel Engine. You can check the jar package under ${SEATUNNEL_HOME}/lib to confirm this.
+If you use SeaTunnel Engine, the Hadoop JARs are bundled with the engine. You can confirm by
+checking `${SEATUNNEL_HOME}/lib`.
+
+The connector supports both password authentication and public-key authentication via the
+`keyfile` option.
 
 :::
 
@@ -24,11 +38,11 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 
 - [x] [exactly-once](../../introduction/concepts/connector-v2-features.md)
 
-  By default, we use 2PC commit to ensure `exactly-once`
+  By default, we use 2PC commit to ensure `exactly-once`.
 
-- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+  Use `${database_name}` and `${table_name}` placeholders in the `path` to route rows from different upstream tables to separate output directories.
 
 - [x] file format type
   - [x] text
@@ -47,256 +61,139 @@ If you use SeaTunnel Engine, It automatically integrated the hadoop jar when you
 
 | name                                  | type    | required | default value                              | remarks                                                                                                                                                                         |
 |---------------------------------------|---------|----------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| host                                  | string  | yes      | -                                          |                                                                                                                                                                                 |
-| port                                  | int     | yes      | -                                          |                                                                                                                                                                                 |
-| user                                  | string  | yes      | -                                          |                                                                                                                                                                                 |
-| password                              | string  | no       | -                                          | Required when `keyfile` is not set.                                                                                                                                             |
+| host                                  | string  | yes      | -                                          | The target SFTP host.                                                                                                                                                           |
+| port                                  | int     | yes      | -                                          | The target SFTP port, typically `22`.                                                                                                                                            |
+| user                                  | string  | yes      | -                                          | SFTP login user name.                                                                                                                                                           |
+| password                              | string  | no       | -                                          | SFTP login password. Required when `keyfile` is not set.                                                                                                                         |
 | keyfile                               | string  | no       | -                                          | Private key file path used for SFTP public key authentication.                                                                                                                   |
-| path                                  | string  | yes      | -                                          |                                                                                                                                                                                 |
-| tmp_path                              | string  | yes      | /tmp/seatunnel                             | The result file will write to a tmp path first and then use `mv` to submit tmp dir to target dir. Need a FTP dir.                                                               |
-| custom_filename                       | boolean | no       | false                                      | Whether you need custom the filename                                                                                                                                            |
-| file_name_expression                  | string  | no       | "${transactionId}"                         | Only used when custom_filename is true                                                                                                                                          |
-| filename_time_format                  | string  | no       | "yyyy.MM.dd"                               | Only used when custom_filename is true                                                                                                                                          |
-| file_format_type                      | string  | no       | "csv"                                      |                                                                                                                                                                                 |
-| filename_extension                    | string  | no       | -                                          | Override the default file name extensions with custom file name extensions. E.g. `.xml`, `.json`, `dat`, `.customtype`                                                          |
-| field_delimiter                       | string  | no       | '\001' for text and ',' for csv            | Only used when file_format_type is text and csv                                                                                                                                 |
-| row_delimiter                         | string  | no       | "\n"                                       | Only used when file_format_type is `text`, `csv` and `json`                                                                                                                     |
-| have_partition                        | boolean | no       | false                                      | Whether you need processing partitions.                                                                                                                                         |
-| partition_by                          | array   | no       | -                                          | Only used then have_partition is true                                                                                                                                           |
-| partition_dir_expression              | string  | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/" | Only used then have_partition is true                                                                                                                                           |
-| is_partition_field_write_in_file      | boolean | no       | false                                      | Only used then have_partition is true                                                                                                                                           |
-| sink_columns                          | array   | no       |                                            | When this parameter is empty, all fields are sink columns                                                                                                                       |
-| is_enable_transaction                 | boolean | no       | true                                       |                                                                                                                                                                                 |
-| batch_size                            | int     | no       | 1000000                                    |                                                                                                                                                                                 |
-| compress_codec                        | string  | no       | none                                       |                                                                                                                                                                                 |
-| common-options                        | object  | no       | -                                          |                                                                                                                                                                                 |
-| max_rows_in_memory                    | int     | no       | -                                          | Only used when file_format_type is excel.                                                                                                                                       |
-| sheet_max_rows                        | int     | no       | 1048576                                    | Only used when file_format_type is excel.                                                                                                                                       |
-| sheet_name                            | string  | no       | Sheet${Random number}                      | Only used when file_format_type is excel.                                                                                                                                       |
-| csv_string_quote_mode                 | enum    | no       | MINIMAL                                    | Only used when file_format is csv.                                                                                                                                              |
-| xml_root_tag                          | string  | no       | RECORDS                                    | Only used when file_format is xml.                                                                                                                                              |
-| xml_row_tag                           | string  | no       | RECORD                                     | Only used when file_format is xml.                                                                                                                                              |
-| xml_use_attr_format                   | boolean | no       | -                                          | Only used when file_format is xml.                                                                                                                                              |
-| single_file_mode                      | boolean | no       | false                                      | Each parallelism will only output one file. When this parameter is turned on, batch_size will not take effect. The output file name does not have a file block suffix.          |
-| create_empty_file_when_no_data        | boolean | no       | false                                      | When there is no data synchronization upstream, the corresponding data files are still generated.                                                                               |
-| parquet_avro_write_timestamp_as_int96 | boolean | no       | false                                      | Only used when file_format is parquet.                                                                                                                                          |
-| enable_header_write                   | boolean | no       | false                                      | Only used when file_format_type is text,csv.<br/> false:don't write header,true:write header.                                                                                   |
-| parquet_avro_write_fixed_as_int96     | array   | no       | -                                          | Only used when file_format is parquet.                                                                                                                                          |
-| encoding                              | string  | no       | "UTF-8"                                    | Only used when file_format_type is json,text,csv,xml.                                                                                                                           |
-| schema_evolution_enabled              | boolean | no       | false                                      | Enable schema evolution support for CDC pipelines. When true, ADD/DROP/RENAME/MODIFY column events from the source are applied to the sink without a job restart. Not supported for binary format. |
-| schema_save_mode                      | string  | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | Existing dir processing method                                                                                                                                                  |
-| data_save_mode                        | string  | no       | APPEND_DATA                                | Existing data processing method                                                                                                                                                 |
-| merge_update_event                    | boolean | no       | false                                      | Only used when file_format_type is canal_json,debezium_json or maxwell_json. When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data |
-
-### host [string]
-
-The target sftp host is required
-
-### port [int]
-
-The target sftp port is required
-
-### user [string]
-
-The target sftp user is required
-
-### password [string]
-
-The target sftp password. Required when `keyfile` is not set.
-
-### keyfile [string]
-
-The private key file path used for SFTP public key authentication.
-
-### path [string]
-
-The target dir path is required.
-
-### custom_filename [boolean]
-
-Whether custom the filename
+| path                                  | string  | yes      | -                                          | Target directory on the remote SFTP server.                                                                                                                                     |
+| tmp_path                              | string  | yes      | /tmp/seatunnel                             | Staging directory on the SFTP server; the connector writes output files here first and then `mv`s them into `path` once a checkpoint completes.                                   |
+| custom_filename                       | boolean | no       | false                                      | Whether you need to customize the file name.                                                                                                                                     |
+| file_name_expression                  | string  | no       | "${transactionId}"                         | Only used when `custom_filename = true`.                                                                                                                                        |
+| filename_time_format                  | string  | no       | "yyyy.MM.dd"                               | Only used when `custom_filename = true`.                                                                                                                                        |
+| file_format_type                      | string  | no       | "csv"                                      | One of `text`, `csv`, `parquet`, `orc`, `json`, `excel`, `xml`, `binary`, `canal_json`, `debezium_json`, `maxwell_json`.                                                         |
+| filename_extension                    | string  | no       | -                                          | Override the default file name extensions with a custom file name extension, e.g. `.xml`, `.json`, `dat`, `.customtype`.                                                          |
+| field_delimiter                       | string  | no       | '\001' for text and ',' for csv            | Only used when `file_format_type` is `text` or `csv`.                                                                                                                            |
+| row_delimiter                         | string  | no       | "\n"                                       | Only used when `file_format_type` is `text`, `csv`, or `json`.                                                                                                                   |
+| have_partition                        | boolean | no       | false                                      | Whether to partition the output by upstream field values.                                                                                                                        |
+| partition_by                          | array   | no       | -                                          | Only used when `have_partition = true`.                                                                                                                                         |
+| partition_dir_expression              | string  | no       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/" | Only used when `have_partition = true`.                                                                                                                                         |
+| is_partition_field_write_in_file      | boolean | no       | false                                      | Only used when `have_partition = true`.                                                                                                                                         |
+| sink_columns                          | array   | no       |                                            | Columns to write to the file. When empty, all upstream columns are written.                                                                                                       |
+| is_enable_transaction                 | boolean | no       | true                                       | Reserved. Only `true` is supported and it is the default behavior.                                                                                                               |
+| batch_size                            | int     | no       | 1000000                                    | Maximum number of rows per file before rotation.                                                                                                                                 |
+| compress_codec                        | string  | no       | none                                       | Compression codec, see details below.                                                                                                                                           |
+| common-options                        | object  | no       | -                                          | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md).                                                                  |
+| max_rows_in_memory                    | int     | no       | -                                          | Only used when `file_format_type` is `excel`.                                                                                                                                    |
+| sheet_max_rows                        | int     | no       | 1048576                                    | Only used when `file_format_type` is `excel`.                                                                                                                                    |
+| sheet_name                            | string  | no       | Sheet${Random number}                      | Only used when `file_format_type` is `excel`.                                                                                                                                    |
+| csv_string_quote_mode                 | enum    | no       | MINIMAL                                    | Only used when `file_format_type` is `csv`.                                                                                                                                     |
+| xml_root_tag                          | string  | no       | RECORDS                                    | Only used when `file_format_type` is `xml`.                                                                                                                                     |
+| xml_row_tag                           | string  | no       | RECORD                                     | Only used when `file_format_type` is `xml`.                                                                                                                                     |
+| xml_use_attr_format                   | boolean | no       | -                                          | Only used when `file_format_type` is `xml`.                                                                                                                                     |
+| single_file_mode                      | boolean | no       | false                                      | Each parallelism writes a single file; with this on, `batch_size` does not take effect and the file name has no block suffix.                                                    |
+| create_empty_file_when_no_data        | boolean | no       | false                                      | When there is no upstream data, an empty file is still created.                                                                                                                 |
+| parquet_avro_write_timestamp_as_int96 | boolean | no       | false                                      | Only used when `file_format_type` is `parquet`.                                                                                                                                 |
+| parquet_avro_write_fixed_as_int96     | array   | no       | -                                          | Only used when `file_format_type` is `parquet`.                                                                                                                                 |
+| enable_header_write                   | boolean | no       | false                                      | Only used when `file_format_type` is `text` or `csv`. When `true`, a header row is written.                                                                                      |
+| encoding                              | string  | no       | "UTF-8"                                    | Only used when `file_format_type` is `json`, `text`, `csv`, or `xml`.                                                                                                            |
+| schema_evolution_enabled              | boolean | no       | false                                      | Enable CDC schema evolution (ADD/DROP/RENAME/MODIFY) at runtime without job restart. Not supported for `binary`. See details below.                                              |
+| schema_save_mode                      | string  | no       | CREATE_SCHEMA_WHEN_NOT_EXIST               | How the target directory is handled when the job starts.                                                                                                                        |
+| data_save_mode                        | string  | no       | APPEND_DATA                                | How existing data files in the target directory are handled when the job starts.                                                                                                |
+| merge_update_event                    | boolean | no       | false                                      | Only used when `file_format_type` is `canal_json`, `debezium_json`, or `maxwell_json`. When `true`, UPDATE_AFTER and UPDATE_BEFORE are merged into a single UPDATE event.          |
 
 ### file_name_expression [string]
 
-Only used when `custom_filename` is `true`
+Only used when `custom_filename` is `true`.
 
-`file_name_expression` describes the file expression which will be created into the `path`. We can add the variable `${now}` or `${uuid}` in the `file_name_expression`, like `test_${uuid}_${now}`,
-`${now}` represents the current time, and its format can be defined by specifying the option `filename_time_format`.
+`file_name_expression` describes the file expression that will be used to build the file name
+inside `path`. You can add the variables `${now}` or `${uuid}` in the expression, for example
+`test_${uuid}_${now}`. `${now}` represents the current time, and its format can be defined by
+specifying the option `filename_time_format`.
 
-Please note that, If `is_enable_transaction` is `true`, we will auto add `${transactionId}_` in the head of the file.
-
-### filename_time_format [string]
-
-Only used when `custom_filename` is `true`
-
-When the format in the `file_name_expression` parameter is `xxxx-${now}` , `filename_time_format` can specify the time format of the path, and the default value is `yyyy.MM.dd` . The commonly used time formats are listed as follows:
-
-| Symbol |    Description     |
-|--------|--------------------|
-| y      | Year               |
-| M      | Month              |
-| d      | Day of month       |
-| H      | Hour in day (0-23) |
-| m      | Minute in hour     |
-| s      | Second in minute   |
-
-### file_format_type [string]
-
-We supported as the following file types:
-
-`text` `csv` `parquet` `orc` `json` `excel` `xml` `binary` `canal_json` `debezium_json` `maxwell_json`
-
-Please note that, The final file name will end with the file_format_type's suffix, the suffix of the text file is `txt`.
-
-### field_delimiter [string]
-
-The separator between columns in a row of data. Only needed by `text` and `csv` file format.
-
-### row_delimiter [string]
-
-The separator between rows in a file. Only needed by `text`, `csv` and `json` file format.
-
-### have_partition [boolean]
-
-Whether you need processing partitions.
-
-### partition_by [array]
-
-Only used when `have_partition` is `true`.
-
-Partition data based on selected fields.
-
-### partition_dir_expression [string]
-
-Only used when `have_partition` is `true`.
-
-If the `partition_by` is specified, we will generate the corresponding partition directory based on the partition information, and the final file will be placed in the partition directory.
-
-Default `partition_dir_expression` is `${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/`. `k0` is the first partition field and `v0` is the value of the first partition field.
-
-### is_partition_field_write_in_file [boolean]
-
-Only used when `have_partition` is `true`.
-
-If `is_partition_field_write_in_file` is `true`, the partition field and the value of it will be write into data file.
-
-For example, if you want to write a Hive Data File, Its value should be `false`.
-
-### sink_columns [array]
-
-Which columns need be wrote to file, default value is all the columns get from `Transform` or `Source`.
-The order of the fields determines the order in which the file is actually written.
-
-### is_enable_transaction [boolean]
-
-If `is_enable_transaction` is true, we will ensure that data will not be lost or duplicated when it is written to the target directory.
-
-Please note that, If `is_enable_transaction` is `true`, we will auto add `${transactionId}_` in the head of the file.
-
-Only support `true` now.
-
-### batch_size [int]
-
-The maximum number of rows in a file. For SeaTunnel Engine, the number of lines in the file is determined by `batch_size` and `checkpoint.interval` jointly decide. If the value of `checkpoint.interval` is large enough, sink writer will write rows in a file until the rows in the file larger than `batch_size`. If `checkpoint.interval` is small, the sink writer will create a new file when a new checkpoint trigger.
+Please note that, when `is_enable_transaction` is `true`, `${transactionId}_` is automatically
+prepended to the file name.
 
 ### compress_codec [string]
 
-The compress codec of files and the details that supported as the following shown:
+The compression codec to apply to output files. The supported combinations are:
 
-- txt: `lzo` `none`
-- json: `lzo` `none`
-- csv: `lzo` `none`
-- orc: `lzo` `snappy` `lz4` `zlib` `none`
-- parquet: `lzo` `snappy` `lz4` `gzip` `brotli` `zstd` `none`
+- `text` / `json` / `csv`: `lzo`, `none`
+- `orc`: `lzo`, `snappy`, `lz4`, `zlib`, `none`
+- `parquet`: `lzo`, `snappy`, `lz4`, `gzip`, `brotli`, `zstd`, `none`
 
-Tips: excel type does not support any compression format
-
-### common options
-
-Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
-
-### max_rows_in_memory
-
-When File Format is Excel,The maximum number of data items that can be cached in the memory.
-
-### sheet_max_rows
-
-When file format is Excel, the maximum number of rows per sheet.
-
-### sheet_name
-
-Writer the sheet of the workbook
-
-### csv_string_quote_mode [string]
-
-When File Format is CSV,The string quote mode of CSV.
-
-- ALL: All String fields will be quoted.
-- MINIMAL: Quotes fields which contain special characters such as a the field delimiter, quote character or any of the characters in the line separator string.
-- NONE: Never quotes fields. When the delimiter occurs in data, the printer prefixes it with the escape character. If the escape character is not set, format validation throws an exception.
-
-### xml_root_tag [string]
-
-Specifies the tag name of the root element within the XML file.
-
-### xml_row_tag [string]
-
-Specifies the tag name of the data rows within the XML file.
-
-### xml_use_attr_format [boolean]
-
-Specifies Whether to process data using the tag attribute format.
-
-### parquet_avro_write_timestamp_as_int96 [boolean]
-
-Support writing Parquet INT96 from a timestamp, only valid for parquet files.
-
-### parquet_avro_write_fixed_as_int96 [array]
-
-Support writing Parquet INT96 from a 12-byte field, only valid for parquet files.
-
-### enable_header_write [boolean]
-
-Only used when file_format_type is text,csv.false:don't write header,true:write header.
-
-### encoding [string]
-
-Only used when file_format_type is json,text,csv,xml.
-The encoding of the file to write. This param will be parsed by `Charset.forName(encoding)`.
+The `excel` format does not support any compression codec.
 
 ### schema_save_mode [string]
 
-Existing dir processing method.
+How the target directory is handled when the job starts:
 
-- RECREATE_SCHEMA: will create when the dir does not exist, delete and recreate when the dir is exist
-- CREATE_SCHEMA_WHEN_NOT_EXIST: will create when the dir does not exist, skipped when the dir is exist
-- ERROR_WHEN_SCHEMA_NOT_EXIST: error will be reported when the dir does not exist
-- IGNORE ：Ignore the treatment of the table
+- `CREATE_SCHEMA_WHEN_NOT_EXIST` (default): create the directory when it does not exist; skip otherwise.
+- `RECREATE_SCHEMA`: delete and recreate the directory when it exists.
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`: fail fast when the directory does not exist.
+- `IGNORE`: do not touch the directory.
 
 ### data_save_mode [string]
 
-Existing data processing method.
+How existing files in the target directory are handled when the job starts:
 
-- DROP_DATA: preserve dir and delete data files
-- APPEND_DATA: preserve dir, preserve data files
-- ERROR_WHEN_DATA_EXISTS: when there is data files, an error is reported
+- `APPEND_DATA` (default): keep the directory and existing files; append new data.
+- `DROP_DATA`: keep the directory; delete existing data files.
+- `ERROR_WHEN_DATA_EXISTS`: fail fast when there are existing files.
 
-### merge_update_event [boolean]
+### schema_evolution_enabled [boolean]
 
-Only used when file_format_type is canal_json,debezium_json or maxwell_json. 
-When value is true, the UPDATE_AFTER and UPDATE_BEFORE event will be merged into UPDATE event data
+When set to `true`, the SFTP file sink handles CDC schema change events (ADD COLUMN, DROP COLUMN,
+RENAME COLUMN, MODIFY COLUMN type) at runtime without requiring a job restart. On each schema
+change the current output file is closed and a new file is opened with the updated schema.
+
+**Supported formats:** all file formats except `binary`. Setting this option together with
+`file_format_type = binary` fails at job startup with a config validation error.
+
+**Partition constraint:** when `have_partition = true`, dropping a column listed in `partition_by`
+is rejected and fails fast. Partition columns must remain stable across schema changes.
+
+**When `schema_evolution_enabled = false` (default):** if the upstream CDC source has
+`schema-changes.enabled = true` and an `AlterTableEvent` arrives at the sink, the job fails
+immediately with an actionable error:
+
+> `Received AlterTableEvent but schema_evolution_enabled=false at this sink. Either set schema_evolution_enabled=true to handle schema changes, or set schema-changes.enabled=false at the CDC source to suppress them.`
+
+Users on the default CDC source config (`schema-changes.enabled = false`) are completely
+unaffected.
+
+**Known limitation:** schema changes are not atomic with checkpointing. If the job crashes in the
+narrow window between file rotation and the schema metadata update, rows written after restore may
+use the pre-change schema. This is a known architectural gap shared with other SeaTunnel sinks.
 
 ## Example
 
-For text file format with `have_partition` and `custom_filename` and `sink_columns`
+### Text With Partitions And Custom Filename
 
-```bash
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+source {
+  FakeSource {
+    row.num = 100
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "password"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/seatunnel/job1"
     tmp_path = "/data/sftp/seatunnel/tmp"
     file_format_type = "text"
@@ -309,21 +206,24 @@ SftpFile {
     custom_filename = true
     file_name_expression = "${transactionId}_${now}"
     filename_time_format = "yyyy.MM.dd"
-    sink_columns = ["name","age"]
+    sink_columns = ["name", "age"]
     is_enable_transaction = true
+  }
 }
-
 ```
 
-When our source end is multiple tables, and wants different expressions to different directory, we can configure this
-way
+### Multiple Tables
+
+When the source end covers multiple tables and each should land in its own directory, use
+`${table_name}` in the path.
 
 ```hocon
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "password"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/seatunnel/job1/${table_name}"
     tmp_path = "/data/sftp/seatunnel/tmp"
     file_format_type = "text"
@@ -336,41 +236,47 @@ SftpFile {
     custom_filename = true
     file_name_expression = "${transactionId}_${now}"
     filename_time_format = "yyyy.MM.dd"
-    sink_columns = ["name","age"]
+    sink_columns = ["name", "age"]
     is_enable_transaction = true
-    schema_save_mode=RECREATE_SCHEMA
-    data_save_mode=DROP_DATA
+    schema_save_mode = "RECREATE_SCHEMA"
+    data_save_mode = "DROP_DATA"
+  }
 }
-
-
 ```
 
-### schema_evolution_enabled [boolean]
-
-When set to `true`, the file sink handles CDC schema change events (ADD COLUMN, DROP COLUMN, RENAME COLUMN, MODIFY COLUMN type) at runtime without requiring a job restart. On each schema change the current output file is closed and a new file is opened with the updated schema.
-
-**Supported formats:** All file formats except `binary`. Enabling this option with `file_format_type = binary` will fail at job startup with a config validation error.
-
-**Partition constraint:** When `have_partition = true`, dropping a column listed in `partition_by` is not allowed and will fail fast. Partition columns must remain stable across schema changes.
-
-**When `schema_evolution_enabled = false` (default):** If the upstream CDC source has `schema-changes.enabled = true` and an `AlterTableEvent` arrives at the sink, the job will throw immediately with an actionable error:
-> `Received AlterTableEvent but schema_evolution_enabled=false at this sink. Either set schema_evolution_enabled=true to handle schema changes, or set schema-changes.enabled=false at the CDC source to suppress them.`
-
-Users on the default CDC source config (`schema-changes.enabled = false`) are completely unaffected.
-
-**Known limitation:** Schema changes are not atomic with checkpointing. If the job crashes in the narrow window between file rotation and schema metadata update, rows written after restore may use the pre-change schema. This is a known architectural gap shared across other SeaTunnel sinks. For full restart-with-DDL correctness, a follow-up CDC source fix is required (tracked separately).
-
-Example usage in a CDC pipeline:
+### CDC With Schema Evolution
 
 ```hocon
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "xxxxxxxxxxxxxxxxx"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/cdc/${table_name}"
+    tmp_path = "/data/sftp/cdc/tmp"
     file_format_type = "parquet"
     schema_evolution_enabled = true
+    have_partition = true
+    partition_by = ["updated_at_month"]
+  }
+}
+```
+
+### Parquet With Public Key Authentication
+
+```hocon
+sink {
+  SftpFile {
+    host = "sftp.example.com"
+    port = 22
+    user = "seatunnel"
+    keyfile = "/home/seatunnel/.ssh/id_rsa"
+    path = "/data/sftp/seatunnel/parquet"
+    tmp_path = "/data/sftp/seatunnel/tmp"
+    file_format_type = "parquet"
+    sink_columns = ["name", "age"]
+  }
 }
 ```
 

--- a/docs/en/connectors/sink/SqlServer.md
+++ b/docs/en/connectors/sink/SqlServer.md
@@ -12,12 +12,16 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > Spark<br/>
 > Flink<br/>
-> Seatunnel Zeta<br/>
+> SeaTunnel Zeta<br/>
 
 ## Description
 
-Write data through jdbc. Support Batch mode and Streaming mode, support concurrent writing, support exactly-once
-semantics (using XA transaction guarantee).
+Write data to SQL Server through JDBC. This connector inherits all options from the
+[Jdbc sink connector](./Jdbc.md) and uses the Microsoft JDBC driver for SQL Server.
+
+It supports Batch mode and Streaming mode, concurrent writing, and exactly-once semantics
+(using XA transactions). CDC events from upstream are also supported when configured with
+`primary_keys` and `generate_sink_sql`.
 
 ## Using Dependency
 
@@ -69,12 +73,16 @@ semantics (using XA transaction guarantee).
 
 ## Sink Options
 
+This connector uses the same set of options as the [Jdbc sink connector](./Jdbc.md). The options
+listed below cover everything specific to SQL Server; for options that are identical to the generic
+JDBC sink, see the linked page for the canonical description.
+
 |                   Name                    |  Type   | Required | Default |                                                                                                                 Description                                                                                                                  |
 |-------------------------------------------|---------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: jdbc:sqlserver://localhost:1433;databaseName=mydatabase                                                                                                                                     |
-| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source,<br/> if you use sqlServer the value is `com.microsoft.sqlserver.jdbc.SQLServerDriver`.                                                                                        |
-| username                                      | String  | No       | -       | Connection instance user name                                                                                                                                                                                                                |
-| password                                  | String  | No       | -       | Connection instance password                                                                                                                                                                                                                 |
+| url                                       | String  | Yes      | -       | The URL of the JDBC connection. Refer to a case: `jdbc:sqlserver://localhost:1433;databaseName=mydatabase`. The `databaseName` parameter selects the default database for the connection.                                                    |
+| driver                                    | String  | Yes      | -       | The jdbc class name used to connect to the remote data source. For SQL Server use `com.microsoft.sqlserver.jdbc.SQLServerDriver`.                                                                                                            |
+| username                                  | String  | Yes      | -       | Connection instance user name. `user` is also accepted as a fallback alias.                                                                                                                                                                  |
+| password                                  | String  | Yes      | -       | Connection instance password.                                                                                                                                                                                                                 |
 | query                                     | String  | No       | -       | Use this sql write upstream input datas to database. e.g `INSERT ...`,`query` have the higher priority                                                                                                                                       |
 | database                                  | String  | No       | -       | Use this `database` and `table-name` auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                     |
 | table                                     | String  | No       | -       | Use database and this table-name auto-generate sql and receive upstream input datas write to database.<br/>This option is mutually exclusive with `query` and has a higher priority.                                                         |
@@ -83,111 +91,154 @@ semantics (using XA transaction guarantee).
 | max_retries                               | Int     | No       | 0       | The number of retries to submit failed (executeBatch)                                                                                                                                                                                        |
 | batch_size                                | Int     | No       | 1000    | For batch writing, when the number of buffered records reaches `batch_size`, the data will be flushed into the database. If `batch_interval_ms` is greater than 0, elapsed time can also trigger a flush.                                    |
 | batch_interval_ms                         | Long    | No       | 0       | Write-triggered flush interval in milliseconds. `0` disables time-based flushing. When greater than 0, the writer checks elapsed time on each record and flushes synchronously when the interval is reached.                                  |
-| is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to<br/>set `xa_data_source_class_name`.                                                                                                            |
+| is_exactly_once                           | Boolean | No       | false   | Whether to enable exactly-once semantics, which will use Xa transactions. If on, you need to set `xa_data_source_class_name`.                                                                                                                 |
 | generate_sink_sql                         | Boolean | No       | false   | Generate sql statements based on the database table you want to write to                                                                                                                                                                     |
-| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver, for example, SqlServer is `com.microsoft.sqlserver.jdbc.SQLServerXADataSource`, and<br/>please refer to appendix for other data sources                                                |
+| xa_data_source_class_name                 | String  | No       | -       | The xa data source class name of the database Driver, for example, SqlServer is `com.microsoft.sqlserver.jdbc.SQLServerXADataSource`, and please refer to [Jdbc options appendix](./Jdbc.md#sink-options) for other data sources.            |
 | max_commit_attempts                       | Int     | No       | 3       | The number of retries for transaction commit failures                                                                                                                                                                                        |
-| transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect<br/>exactly-once semantics                                                                                          |
+| transaction_timeout_sec                   | Int     | No       | -1      | The timeout after the transaction is opened, the default is -1 (never timeout). Note that setting the timeout may affect exactly-once semantics                                                                                              |
 | auto_commit                               | Boolean | No       | true    | Automatic transaction commit is enabled by default                                                                                                                                                                                           |
 | properties                                | Map     | No       | -       | Additional JDBC connection parameters. When the same parameter exists in both `properties` and the URL, priority depends on the SQL Server JDBC driver.                                                                                        |
-| common-options                            |         | no       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                                  |
+| common-options                            |         | no       | -       | Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details                                                                                                                     |
 | schema_save_mode                          | Enum    | No       | CREATE_SCHEMA_WHEN_NOT_EXIST | Before the synchronization task starts, controls how the target table schema is handled.                                                                                                                                                       |
 | data_save_mode                            | Enum    | No       | APPEND_DATA | Before the synchronization task starts, controls how existing target table data is handled.                                                                                                                                                    |
 | custom_sql                                | String  | No       | -       | When `data_save_mode` is `CUSTOM_PROCESSING`, fill this option with SQL that can be executed before synchronization starts.                                                                                                                   |
 | enable_upsert                             | Boolean | No       | true    | Enable upsert by primary_keys exist, If the task has no key duplicate data, setting this parameter to `false` can speed up data import                                                                                                       |
-| multi_table_sink_replica                  | Int     | No       | 1       | The number of sink writer replicas used when writing multiple tables.                                                                                                                           |
+| multi_table_sink_replica                  | Int     | No       | 1       | The number of sink writer replicas used when writing multiple tables.                                                                                                                                                                         |
 
-## tips
+### Schema Save Mode
 
-> If partition_column is not set, it will run in single concurrency, and if partition_column is set, it will be executed  in parallel according to the concurrency of tasks.
+`schema_save_mode` controls what happens to the target schema before the job starts:
+
+- `CREATE_SCHEMA_WHEN_NOT_EXIST` (default): create the target table when it does not exist; skip if it already exists.
+- `RECREATE_SCHEMA`: drop the target table if it exists and recreate it from the upstream schema.
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`: fail fast when the target table does not exist.
+- `IGNORE`: do nothing and let downstream handle the schema.
+
+### Data Save Mode
+
+`data_save_mode` controls how existing data in the target table is handled when the job starts:
+
+- `APPEND_DATA` (default): append new rows to the existing table.
+- `DROP_DATA`: keep the table and delete the existing data.
+- `CUSTOM_PROCESSING`: run the user-supplied `custom_sql` once before the job starts.
+- `ERROR_WHEN_DATA_EXISTS`: fail fast when the target table already has rows.
 
 ## Task Example
 
-### simple
+### Simple
 
-> This is one that reads Sqlserver data and inserts it directly into another table
+> Read data from SQL Server and write it directly to another SQL Server table.
 
-```
+```hocon
 env {
   # You can set engine configuration here
-  parallelism = 10
+  parallelism = 1
+  job.mode = "BATCH"
 }
 
 source {
-  # This is a example source plugin **only for test and demonstrate the feature source plugin**
   Jdbc {
     driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
     url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-    username = SA
+    username = "SA"
     password = "Y.sa123456"
-    query = "select * from column_type_test.dbo.full_types_jdbc"
-    # Parallel sharding reads fields
-    partition_column = "id"
-    # Number of fragments
-    partition_num = 10
-
+    query = "select id, name, age from column_type_test.dbo.full_types_jdbc"
   }
-  # If you would like to get more information about how to configure seatunnel and see full list of source plugins,
-  # please go to https://seatunnel.apache.org/docs/connectors/source/Jdbc
 }
 
 transform {
-
-  # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-  # please go to https://seatunnel.apache.org/docs/transforms/sql
 }
 
 sink {
   Jdbc {
     driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
     url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-    username = SA
+    username = "SA"
     password = "Y.sa123456"
-    query = "insert into full_types_jdbc_sink( id, val_char, val_varchar, val_text, val_nchar, val_nvarchar, val_ntext, val_decimal, val_numeric, val_float, val_real, val_smallmoney, val_money, val_bit, val_tinyint, val_smallint, val_int, val_bigint, val_date, val_time, val_datetime2, val_datetime, val_smalldatetime ) values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
-
-  }  # If you would like to get more information about how to configure seatunnel and see full list of sink plugins,
-  # please go to https://seatunnel.apache.org/docs/connectors/sink/Jdbc
+    query = "insert into full_types_jdbc_sink(id, name, age) values(?, ?, ?)"
+  }
 }
 ```
 
-### CDC(Change data capture) event
+### CDC (Change Data Capture) Event
 
-> CDC change data is also supported by us In this case, you need config database, table and primary_keys.
+> CDC change data is also supported. In this case you need to configure `database`, `table` and `primary_keys`.
 
-```
-Jdbc {
-  plugin_input = "customers"
-  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
-  url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-  username = SA
-  password = "Y.sa123456"
-  generate_sink_sql = true
-  database = "column_type_test"
-  table = "dbo.full_types_sink"
-  batch_size = 100
-  primary_keys = ["id"]
+```hocon
+sink {
+  Jdbc {
+    plugin_input = "customers_cdc"
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "column_type_test"
+    table = "dbo.full_types_sink"
+    batch_size = 100
+    primary_keys = ["id"]
+  }
 }
 ```
 
 ### Exactly Once Sink
 
-> Transactional writes may be slower but more accurate to the data
+> Transactional writes may be slower but more accurate to the data.
 
-```
+```hocon
+sink {
   Jdbc {
     driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
     url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-    username = SA
+    username = "SA"
     password = "Y.sa123456"
     max_retries = 0
-    query = "insert into full_types_jdbc_sink( id, val_char, val_varchar, val_text, val_nchar, val_nvarchar, val_ntext, val_decimal, val_numeric, val_float, val_real, val_smallmoney, val_money, val_bit, val_tinyint, val_smallint, val_int, val_bigint, val_date, val_time, val_datetime2, val_datetime, val_smalldatetime ) values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
-    is_exactly_once = "true"
-
+    query = "insert into full_types_jdbc_sink(id, name, age) values(?, ?, ?)"
+    is_exactly_once = true
     xa_data_source_class_name = "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"
+  }
+}
+```
 
-  }  # If you would like to get more information about how to configure seatunnel and see full list of sink plugins,
-  # please go to https://seatunnel.apache.org/docs/connectors/sink/Jdbc
+### Save Mode Example
 
+> Recreate the target table on each run, drop the existing rows, then load fresh data.
+
+```hocon
+sink {
+  Jdbc {
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "column_type_test"
+    table = "dbo.full_types_sink"
+    schema_save_mode = "RECREATE_SCHEMA"
+    data_save_mode = "DROP_DATA"
+  }
+}
+```
+
+### Multiple Table Sink
+
+> Use `${database_name}` and `${table_name}` placeholders in the connection URL or write path so rows
+> from different upstream tables are routed to different target tables in a single pipeline.
+
+```hocon
+sink {
+  Jdbc {
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=${database_name}"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "${database_name}"
+    table = "${table_name}"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
+}
 ```
 
 ## Changelog

--- a/docs/en/connectors/source/Mysql.md
+++ b/docs/en/connectors/source/Mysql.md
@@ -2,15 +2,20 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 # MySQL
 
-> JDBC Mysql Source Connector
+> JDBC MySQL Source Connector
 
 ## Description
 
-Read external data source data through JDBC.
+Read data from MySQL through JDBC. The connector inherits the option set of the generic
+[Jdbc source connector](./Jdbc.md) and uses the official MySQL driver (`com.mysql.cj.jdbc.Driver`).
 
-## Support Mysql Version
+It supports Batch mode (parallel reads with split keys) and CDC reads via the
+[MySQL-CDC source connector](./MySQL-CDC.md). For incremental snapshot or change data capture
+semantics, prefer the MySQL-CDC connector.
 
-- 5.5/5.6/5.7/8.0/8.1/8.2/8.3/8.4
+## Support MySQL Version
+
+- 5.5 / 5.6 / 5.7 / 8.0 / 8.1 / 8.2 / 8.3 / 8.4
 
 ## Support Those Engines
 
@@ -38,17 +43,18 @@ Read external data source data through JDBC.
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
 - [x] [support multiple table reading](../../introduction/concepts/connector-v2-features.md)
 
-> supports query SQL and can achieve projection effect.
+> Supports query SQL and can achieve projection effect. For change data capture, use the
+> [MySQL-CDC connector](./MySQL-CDC.md).
 
 ## Supported DataSource Info
 
-| Datasource |                    Supported versions                    |          Driver          |                  Url                  |                                   Maven                                   |
-|------------|----------------------------------------------------------|--------------------------|---------------------------------------|---------------------------------------------------------------------------|
-| Mysql      | Different dependency version has different driver class. | com.mysql.cj.jdbc.Driver | jdbc:mysql://localhost:3306/test | [Download](https://mvnrepository.com/artifact/mysql/mysql-connector-java) |
+| Datasource | Supported versions                    | Driver                | Url                              | Maven                                                                       |
+|------------|---------------------------------------|-----------------------|----------------------------------|-----------------------------------------------------------------------------|
+| MySQL      | Different dependency version has different driver class. | com.mysql.cj.jdbc.Driver | jdbc:mysql://localhost:3306/test | [Download](https://mvnrepository.com/artifact/mysql/mysql-connector-java)    |
 
 ## Data Type Mapping
 
-|                                        Mysql Data Type                                        |                                                                 SeaTunnel Data Type                                                                |
+|                                        MySQL Data Type                                        |                                                                 SeaTunnel Data Type                                                                |
 |-----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | BIT(1)<br/>TINYINT(1)                                                                         | BOOLEAN                                                                                                                                            |
 | TINYINT                                                                                       | BYTE                                                                                                                                               |
@@ -69,174 +75,108 @@ Read external data source data through JDBC.
 
 ## Source Options
 
+The MySQL source connector uses the same options as the [Jdbc source connector](./Jdbc.md#source-options).
+The options below describe every option exposed by this connector; anything not listed follows the
+generic JDBC source behaviour.
+
 | Name                                       | Type       | Required | Default         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 |--------------------------------------------|------------|----------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                        | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: jdbc:mysql://localhost:3306/test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| driver                                     | String     | Yes      | -               | The jdbc class name used to connect to the remote data source,<br/> if you use MySQL the value is `com.mysql.cj.jdbc.Driver`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| username                                       | String     | No       | -               | Connection instance user name                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| password                                   | String     | No       | -               | Connection instance password                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| url                                        | String     | Yes      | -               | The URL of the JDBC connection. Refer to a case: `jdbc:mysql://localhost:3306/test`. Add `serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true` for non-trivial loads.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| driver                                     | String     | Yes      | -               | The jdbc class name used to connect to the remote data source. For MySQL use `com.mysql.cj.jdbc.Driver`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| username                                   | String     | Yes      | -               | Connection instance user name. `user` is also accepted as a fallback alias.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| password                                   | String     | Yes      | -               | Connection instance password.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | query                                      | String     | No       | -               | Query statement. Required when neither `table_path` nor `table_list` is configured.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| connection_check_timeout_sec               | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| partition_column                           | String     | No       | -               | The column name for parallelism's partition, only support numeric type,Only support numeric type primary key, and only can config one column.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| partition_lower_bound                      | BigDecimal | No       | -               | The partition_column min value for scan, if not set SeaTunnel will query database get min value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| partition_upper_bound                      | BigDecimal | No       | -               | The partition_column max value for scan, if not set SeaTunnel will query database get max value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| partition_num                              | Int        | No       | job parallelism | The number of partition count, only support positive integer. default value is job parallelism                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| fetch_size                                 | Int        | No       | 0               | For queries that return a large number of objects,you can configure<br/> the row fetch size used in the query toimprove performance by<br/> reducing the number database hits required to satisfy the selection criteria.<br/> Zero means use jdbc default value.                                                                                                                                                                                                                                                                                                                                                    |
-| properties                                 | Map        | No       | -               | Additional connection configuration parameters,when properties and URL have the same parameters, the priority is determined by the <br/>specific implementation of the driver. For example, in MySQL, properties take precedence over the URL.                                                                                                                                                                                                                                                                                                                                                                       |
-| use_regex                                  | Boolean    | No       | false           | Control regular expression matching for table_path. When set to `true`, the table_path will be treated as a regular expression pattern. When set to `false` or not specified, the table_path will be treated as an exact path (no regex matching).                                                                                                                                                                                                                                                                                                                                                                   |
-| table_path                                 | String     | No       | -               | The path to the full path of table, you can use this configuration instead of `query`. <br/>example: <br/>"testdb.table1"                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| table_list                                 | Array      | No       | -               | The list of tables to be read, you can use this configuration instead of `table_path` example: ```[{ table_path = "testdb.table1"}, {table_path = "testdb.table2", query = "select id, name from testdb.table2"}]```                                                                                                                                                                                                                                                                                                                                                                                                 |
-| where_condition                            | String     | No       | -               | Common row filter conditions for all tables/queries, must start with `where`. for example `where id > 100`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| split.size                                 | Int        | No       | 8096            | The split size (number of rows) of table, captured tables are split into multiple splits when read of table.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| split.even-distribution.factor.lower-bound | Double     | No       | 0.05            | The lower bound of the chunk key distribution factor. This factor is used to determine whether the table data is evenly distributed. If the distribution factor is calculated to be greater than or equal to this lower bound (i.e., (MAX(id) - MIN(id) + 1) / row count), the table chunks would be optimized for even distribution. Otherwise, if the distribution factor is less, the table will be considered as unevenly distributed and the sampling-based sharding strategy will be used if the estimated shard count exceeds the value specified by `sample-sharding.threshold`. The default value is 0.05.  |
-| split.even-distribution.factor.upper-bound | Double     | No       | 100             | The upper bound of the chunk key distribution factor. This factor is used to determine whether the table data is evenly distributed. If the distribution factor is calculated to be less than or equal to this upper bound (i.e., (MAX(id) - MIN(id) + 1) / row count), the table chunks would be optimized for even distribution. Otherwise, if the distribution factor is greater, the table will be considered as unevenly distributed and the sampling-based sharding strategy will be used if the estimated shard count exceeds the value specified by `sample-sharding.threshold`. The default value is 100.0. |
-| split.sample-sharding.threshold            | Int        | No       | 1000            | This configuration specifies the threshold of estimated shard count to trigger the sample sharding strategy. When the distribution factor is outside the bounds specified by `chunk-key.even-distribution.factor.upper-bound` and `chunk-key.even-distribution.factor.lower-bound`, and the estimated shard count (calculated as approximate row count / chunk size) exceeds this threshold, the sample sharding strategy will be used. This can help to handle large datasets more efficiently. The default value is 1000 shards.                                                                                   |
-| split.allow-sampling                       | Boolean    | No       | true            | Whether to allow sampling-based sharding for uneven split keys. When set to `false`, SeaTunnel falls back to iterative uneven chunk splitting.                                                                                                                                                                                                                                                                                                                                                                                                          |
-| use_select_count                           | Boolean    | No       | false           | Whether to use `select count(*)` to estimate table row count before splitting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| skip_analyze                               | Boolean    | No       | false           | Whether to skip table row-count analysis before splitting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| split.inverse-sampling.rate                | Int        | No       | 1000            | The inverse of the sampling rate used in the sample sharding strategy. For example, if this value is set to 1000, it means a 1/1000 sampling rate is applied during the sampling process. This option provides flexibility in controlling the granularity of the sampling, thus affecting the final number of shards. It's especially useful when dealing with very large datasets where a lower sampling rate is preferred. The default value is 1000.                                                                                                                                                              |
-| int_type_narrowing                         | Boolean    | No       | true            | Int type narrowing, if true, the tinyint(1) type will be narrowed to the boolean type if without loss of precision. Support for MySQL at now. Please refer to `int_type_narrowing` below                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| common-options                             |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| connection_check_timeout_sec               | Int        | No       | 30              | The time in seconds to wait for the database operation used to validate the connection to complete.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| partition_column                           | String     | No       | -               | The column name for parallelism's partition. Only numeric primary key columns are supported, and only one column can be configured.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| partition_lower_bound                      | BigDecimal | No       | -               | The `partition_column` minimum value for the scan. If not set, SeaTunnel queries the database for the minimum.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| partition_upper_bound                      | BigDecimal | No       | -               | The `partition_column` maximum value for the scan. If not set, SeaTunnel queries the database for the maximum.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| partition_num                              | Int        | No       | job parallelism | The number of partitions, only positive integers are supported. The default value matches the job parallelism.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| fetch_size                                 | Int        | No       | 0               | For queries that return a large number of objects, configure the row fetch size used in the query to improve performance by reducing the number of database hits required to satisfy the selection criteria. Zero means use the JDBC driver default value.                                                                                                                                                                                                                                                                                                                                                                |
+| properties                                 | Map        | No       | -               | Additional connection configuration parameters. When `properties` and the URL contain the same parameter, the priority is determined by the specific implementation of the driver; in MySQL, `properties` take precedence over the URL.                                                                                                                                                                                                                                                                                                                                                                                |
+| use_regex                                  | Boolean    | No       | false           | Control regular expression matching for `table_path`. When `true`, `table_path` is treated as a regular expression pattern. When `false` or not specified, `table_path` is treated as an exact path (no regex matching).                                                                                                                                                                                                                                                                                                                                                                                            |
+| table_path                                 | String     | No       | -               | The full path of a table; can be used instead of `query`. Example: `"testdb.table1"`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| table_list                                 | Array      | No       | -               | The list of tables to be read; can be used instead of `table_path`. Example: `[{table_path = "testdb.table1"}, {table_path = "testdb.table2", query = "select id, name from testdb.table2"}]`.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| where_condition                            | String     | No       | -               | Common row filter conditions for all tables/queries, must start with `where`, for example `where id > 100`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| split.size                                 | Int        | No       | 8096            | The split size (number of rows) of a table. Captured tables are split into multiple splits when read.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| split.even-distribution.factor.lower-bound | Double     | No       | 0.05            | The lower bound of the chunk key distribution factor. This factor is used to determine whether the table data is evenly distributed. If the distribution factor is calculated to be greater than or equal to this lower bound (i.e., `(MAX(id) - MIN(id) + 1) / row count`), the table chunks are optimized for even distribution. Otherwise, the table is treated as unevenly distributed and the sampling-based sharding strategy is used when the estimated shard count exceeds `sample-sharding.threshold`.                                                                                |
+| split.even-distribution.factor.upper-bound | Double     | No       | 100.0           | The upper bound of the chunk key distribution factor. If the distribution factor is calculated to be less than or equal to this upper bound, the table chunks are optimized for even distribution. Otherwise, the table is treated as unevenly distributed and the sampling-based sharding strategy is used when the estimated shard count exceeds `sample-sharding.threshold`.                                                                                                                                                                                          |
+| split.sample-sharding.threshold            | Int        | No       | 1000            | The estimated shard count threshold that triggers the sample sharding strategy. When the distribution factor is outside `split.even-distribution.factor.upper-bound` and `split.even-distribution.factor.lower-bound`, and the estimated shard count (approximate row count / split size) exceeds this threshold, the sample sharding strategy is used.                                                                                                                                                                                                              |
+| split.allow-sampling                       | Boolean    | No       | true            | Whether to allow sampling-based sharding for uneven split keys. When `false`, SeaTunnel falls back to iterative uneven chunk splitting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| use_select_count                           | Boolean    | No       | false           | Whether to use `select count(*)` to estimate table row count before splitting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| skip_analyze                               | Boolean    | No       | false           | Whether to skip table row-count analysis before splitting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| split.inverse-sampling.rate                | Int        | No       | 1000            | The inverse of the sampling rate used in the sample sharding strategy. For example, a value of 1000 means a 1/1000 sampling rate is applied during sampling. Useful when dealing with very large datasets where a lower sampling rate is preferred.                                                                                                                                                                                                                                                                                                                                                                      |
+| int_type_narrowing                         | Boolean    | No       | true            | Int type narrowing. When `true`, `tinyint(1)` is narrowed to `boolean` if there is no loss of precision. Only supported by MySQL.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| common-options                             |            | No       | -               | Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ### int_type_narrowing
 
-Int type narrowing, if true, the tinyint(1) type will be narrowed to the boolean type if without loss of precision. Support for MySQL at now.
+`int_type_narrowing` controls how MySQL's `tinyint(1)` is mapped to a SeaTunnel type:
 
-eg:
-
-int_type_narrowing = true
-
-| MySQL      | SeaTunnel |
-|------------|-----------|
-| TINYINT(1) | Boolean   |
-
-int_type_narrowing = false
-
-| MySQL      | SeaTunnel |
-|------------|-----------|
-| TINYINT(1) | TINYINT   |
+- `int_type_narrowing = true` (default): `tinyint(1)` → `boolean`.
+- `int_type_narrowing = false`: `tinyint(1)` → `tinyint`.
 
 ## Parallel Reader
 
-The JDBC Source connector supports parallel reading of data from tables. SeaTunnel will use certain rules to split the data in the table, which will be handed over to readers for reading. The number of readers is determined by the `parallelism` option.
+The JDBC source connector supports parallel reading of data from tables. SeaTunnel splits the data in
+the table according to certain rules and hands each split to a reader. The number of readers is
+determined by the `parallelism` option.
 
 **Split Key Rules:**
 
-1. If `partition_column` is not null, It will be used to calculate split. The column must in **Supported split data type**.
-2. If `partition_column` is null, seatunnel will read the schema from table and get the Primary Key and Unique Index. If there are more than one column in Primary Key and Unique Index, The first column which in the **supported split data type** will be used to split data. For example, the table have Primary Key(nn guid, name varchar), because `guid` id not in **supported split data type**, so the column `name` will be used to split data.
+1. If `partition_column` is not null, it is used to calculate the split. The column must be in the
+   **Supported split data type** list.
+2. If `partition_column` is null, SeaTunnel reads the schema from the table and picks the Primary Key
+   or Unique Index. When there are multiple columns in the Primary Key and Unique Index, the first
+   column that is in the **supported split data type** list is used. For example, if a table has
+   `Primary Key(guid, name varchar)`, `guid` is not in the supported split data type list, so the
+   column `name` is used to split the data.
 
 **Supported split data type:**
-* String
-* Number(int, bigint, decimal, ...)
-* Date
 
-### Options Related To Split
+- String
+- Number (`int`, `bigint`, `decimal`, ...)
+- Date
 
-#### split.size
+## Tips
 
-How many rows in one split, captured tables are split into multiple splits when read of table.
-
-#### split.even-distribution.factor.lower-bound
-
-> Not recommended for use
-
-The lower bound of the chunk key distribution factor. This factor is used to determine whether the table data is evenly distributed. If the distribution factor is calculated to be greater than or equal to this lower bound (i.e., (MAX(id) - MIN(id) + 1) / row count), the table chunks would be optimized for even distribution. Otherwise, if the distribution factor is less, the table will be considered as unevenly distributed and the sampling-based sharding strategy will be used if the estimated shard count exceeds the value specified by `sample-sharding.threshold`. The default value is 0.05.
-
-#### split.even-distribution.factor.upper-bound
-
-> Not recommended for use
-
-The upper bound of the chunk key distribution factor. This factor is used to determine whether the table data is evenly distributed. If the distribution factor is calculated to be less than or equal to this upper bound (i.e., (MAX(id) - MIN(id) + 1) / row count), the table chunks would be optimized for even distribution. Otherwise, if the distribution factor is greater, the table will be considered as unevenly distributed and the sampling-based sharding strategy will be used if the estimated shard count exceeds the value specified by `sample-sharding.threshold`. The default value is 100.0.
-
-#### split.sample-sharding.threshold
-
-This configuration specifies the threshold of estimated shard count to trigger the sample sharding strategy. When the distribution factor is outside the bounds specified by `chunk-key.even-distribution.factor.upper-bound` and `chunk-key.even-distribution.factor.lower-bound`, and the estimated shard count (calculated as approximate row count / chunk size) exceeds this threshold, the sample sharding strategy will be used. This can help to handle large datasets more efficiently. The default value is 1000 shards.
-
-#### split.inverse-sampling.rate
-
-The inverse of the sampling rate used in the sample sharding strategy. For example, if this value is set to 1000, it means a 1/1000 sampling rate is applied during the sampling process. This option provides flexibility in controlling the granularity of the sampling, thus affecting the final number of shards. It's especially useful when dealing with very large datasets where a lower sampling rate is preferred. The default value is 1000.
-
-#### partition_column [string]
-
-The column name for split data.
-
-#### partition_upper_bound [BigDecimal]
-
-The partition_column max value for scan, if not set SeaTunnel will query database get max value.
-
-#### partition_lower_bound [BigDecimal]
-
-The partition_column min value for scan, if not set SeaTunnel will query database get min value.
-
-#### partition_num [int]
-
-> Not recommended for use, The correct approach is to control the number of split through `split.size`
-
-How many splits do we need to split into, only support positive integer. default value is job parallelism.
-
-## tips
-
-> If the table can not be split(for example, table have no Primary Key or Unique Index, and `partition_column` is not set), it will run in single concurrency.
+> If the table cannot be split (for example, the table has no Primary Key or Unique Index and
+> `partition_column` is not set), it runs in single concurrency.
 >
-> Use `table_path` to replace `query` for single table reading. If you need to read multiple tables, use `table_list`.
+> Use `table_path` to replace `query` for single-table reading. To read multiple tables, use
+> `table_list`.
 >
-> When inferring a primary key based on a `query`, the key is inherited from the underlying table where the first column in the result set is located, and its strictness for the overall join result set is not guaranteed (for example, when the query contains joins or reads from multiple tables).
+> When inferring a primary key based on a `query`, the key is inherited from the underlying table
+> where the first column in the result set is located, and its strictness for the overall join
+> result set is not guaranteed (for example, when the query contains joins or reads from multiple
+> tables).
+>
+> For incremental snapshot or change data capture semantics, use the [MySQL-CDC source connector](./MySQL-CDC.md).
 
 ## Task Example
 
 ### Simple
 
-> This example queries type_bin 'table' 16 data in your test "database" in single parallel and queries all of its fields. You can also specify which fields to query for final output to the console.
+> This example queries 16 rows from the `type_bin` table in your test database in single parallel and
+> selects all fields. You can also restrict which fields are projected to the sink.
 
-```
-# Defining the runtime environment
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
 }
-source{
-    Jdbc {
-        url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        query = "select * from type_bin limit 16"
-    }
+
+source {
+  Jdbc {
+    url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin limit 16"
+  }
 }
 
 transform {
-    # If you would like to get more information about how to configure seatunnel and see full list of transform plugins,
-    # please go to https://seatunnel.apache.org/docs/transforms/sql
-}
-
-sink {
-    Console {}
-}
-```
-
-### parallel by partition_column
-
-```
-env {
-  parallelism = 4
-  job.mode = "BATCH"
-}
-source {
-    Jdbc {
-        url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        query = "select * from type_bin"
-        partition_column = "id"
-        split.size = 10000
-        # Read start boundary
-        #partition_lower_bound = ...
-        # Read end boundary
-        #partition_upper_bound = ...
-    }
 }
 
 sink {
@@ -244,26 +184,57 @@ sink {
 }
 ```
 
-### parallel by Primary Key or Unique Index
+### Parallel by `partition_column`
 
-> Configuring `table_path` will turn on auto split, you can configure `split.*` to adjust the split strategy
-
-```
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
 }
+
 source {
-    Jdbc {
-        url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        table_path = "testdb.table1"
-        query = "select * from testdb.table1"
-        split.size = 10000
-    }
+  Jdbc {
+    url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin"
+    partition_column = "id"
+    split.size = 10000
+    # Read start boundary; if omitted SeaTunnel queries the database for the minimum
+    # partition_lower_bound = ...
+    # Read end boundary; if omitted SeaTunnel queries the database for the maximum
+    # partition_upper_bound = ...
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Parallel by Primary Key or Unique Index
+
+> Configuring `table_path` turns on automatic split. Adjust the strategy with the `split.*` options.
+
+```hocon
+env {
+  parallelism = 4
+  job.mode = "BATCH"
+}
+
+source {
+  Jdbc {
+    url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    table_path = "testdb.table1"
+    query = "select * from testdb.table1"
+    split.size = 10000
+  }
 }
 
 sink {
@@ -273,40 +244,48 @@ sink {
 
 ### Parallel Boundary
 
-> It is more efficient to specify the data within the upper and lower bounds of the query It is more efficient to read your data source according to the upper and lower boundaries you configured
+> Specifying both the upper and lower bounds of the query range is the most efficient way to drive
+> a parallel read.
 
-```
+```hocon
+env {
+  parallelism = 4
+  job.mode = "BATCH"
+}
+
 source {
-    Jdbc {
-        url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        # Define query logic as required
-        query = "select * from type_bin"
-        partition_column = "id"
-        # Read start boundary
-        partition_lower_bound = 1
-        # Read end boundary
-        partition_upper_bound = 500
-        partition_num = 10
-        properties {
-         useSSL=false
-        }
+  Jdbc {
+    url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin"
+    partition_column = "id"
+    partition_lower_bound = 1
+    partition_upper_bound = 500
+    partition_num = 10
+    properties {
+      useSSL = "false"
     }
+  }
+}
+
+sink {
+  Console {}
 }
 ```
 
-### Multiple table read
+### Multiple Table Read
 
-***Configuring `table_list` will turn on auto split, you can configure `split.*` to adjust the split strategy***
+> Configuring `table_list` turns on automatic split. Adjust the strategy with the `split.*` options.
 
 ```hocon
 env {
   job.mode = "BATCH"
   parallelism = 4
 }
+
 source {
   Jdbc {
     url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
@@ -321,16 +300,16 @@ source {
       },
       {
         table_path = "testdb.table2"
-        # Use query filetr rows & columns
+        # Use query to filter rows and columns
         query = "select id, name from testdb.table2 where id > 100"
       }
     ]
-    #where_condition= "where id > 100"
-    #split.size = 8096
-    #split.even-distribution.factor.upper-bound = 100
-    #split.even-distribution.factor.lower-bound = 0.05
-    #split.sample-sharding.threshold = 1000
-    #split.inverse-sampling.rate = 1000
+    # where_condition = "where id > 100"
+    # split.size = 8096
+    # split.even-distribution.factor.upper-bound = 100
+    # split.even-distribution.factor.lower-bound = 0.05
+    # split.sample-sharding.threshold = 1000
+    # split.inverse-sampling.rate = 1000
   }
 }
 

--- a/docs/zh/connectors/sink/Cloudberry.md
+++ b/docs/zh/connectors/sink/Cloudberry.md
@@ -12,59 +12,79 @@ import ChangeLog from '../changelog/connector-cloudberry.md';
 
 ## 描述
 
-通过 JDBC 写入数据。Cloudberry 目前没有自己的原生驱动程序。它使用 PostgreSQL 的驱动程序进行连接，并遵循 PostgreSQL 的实现。
+通过 JDBC 将数据写入 Cloudberry。Cloudberry 暂未提供自己的 JDBC 驱动，因此本连接器
+使用官方 PostgreSQL 驱动（`org.postgresql.Driver`），配置模型与
+[PostgreSQL Sink 连接器](./PostgreSql.md) 一致。
 
-支持批处理模式和流模式，支持并发写入，支持精确一次语义（使用 XA 事务保证）。
+支持批处理和流模式、并发写入以及精确一次语义（通过 XA 事务保证）。在配置了
+`primary_keys` 和 `generate_sink_sql` 时，也支持接收上游的 CDC 变更事件。
 
 ## 需要的依赖项
 
 ### 对于 Spark/Flink 引擎
 
-> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
+> 1. 将 [PostgreSQL JDBC 驱动 jar 包](https://mvnrepository.com/artifact/org.postgresql/postgresql) 放到 `${SEATUNNEL_HOME}/plugins/` 目录。
 
 ### 对于 SeaTunnel Zeta 引擎
 
-> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/org.postgresql/postgresql) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
+> 1. 将 [PostgreSQL JDBC 驱动 jar 包](https://mvnrepository.com/artifact/org.postgresql/postgresql) 放到 `${SEATUNNEL_HOME}/lib/` 目录。
 
 ## 主要特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-> 使用 `XA 事务` 来确保 `精确一次`。因此，只有支持 `XA 事务` 的数据库才支持 `精确一次`。您可以设置 `is_exactly_once=true` 来启用它。
-- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+> 使用 `XA 事务` 来确保 `精确一次`。因此，只有支持 `XA 事务` 的数据库才支持 `精确一次`。您可以设置 `is_exactly_once=true` 和 `max_retries=0` 来启用它。
 
 ## 支持的数据源信息
 
-| 数据源 | 支持的版本 | 驱动程序 | URL | Maven |
-|--------|-----------|---------|-----|-------|
-| Cloudberry | 使用 PostgreSQL 驱动程序实现 | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [下载](https://mvnrepository.com/artifact/org.postgresql/postgresql) |
+| 数据源     | 支持的版本                  | 驱动程序             | URL                                | Maven                                                                       |
+|------------|------------------------------|----------------------|------------------------------------|-----------------------------------------------------------------------------|
+| Cloudberry | 使用 PostgreSQL 驱动协议     | org.postgresql.Driver | jdbc:postgresql://localhost:5432/test | [下载](https://mvnrepository.com/artifact/org.postgresql/postgresql)        |
 
 ## 数据库依赖
 
-> 请下载 PostgreSQL 驱动程序 jar 并将其复制到 '$SEATUNNEL_HOME/plugins/jdbc/lib/' 工作目录<br/>
-> 例如：cp postgresql-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
+> 将 PostgreSQL 驱动 jar 包放到 `$SEATUNNEL_HOME/plugins/jdbc/lib/` 目录下。
+> 例如：`cp postgresql-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/`
 
 ## 数据类型映射
 
-Cloudberry 使用 PostgreSQL 的数据类型实现。请参考 PostgreSQL 文档了解数据类型兼容性和映射。
+Cloudberry 沿用 PostgreSQL 的数据类型实现。数据类型兼容性与映射关系请参考
+[PostgreSQL 连接器文档](./PostgreSql.md#数据类型映射)。
 
 ## 选项
 
-Cloudberry 连接器使用与 PostgreSQL 相同的选项。有关详细的配置选项，请参考 PostgreSQL 文档。
+由于底层驱动一致，Cloudberry Sink 继承了 [PostgreSQL Sink 连接器](./PostgreSql.md) 的全部选项。
+下表仅列出与通用 JDBC 选项存在差异的连接相关选项；其余选项请参考 PostgreSQL 页面。
 
-关键选项包括：
-- url（必需）：JDBC 连接 URL
-- driver（必需）：驱动程序类名（org.postgresql.Driver）
-- username/password：身份验证凭证。`user` 也可以作为 `username` 的兼容写法
-- query 或 database/table 组合：要写入的数据和方式
-- is_exactly_once：使用 XA 事务启用精确一次语义
-- batch_size：控制批量写入行为
+| 名称                         | 类型    | 是否必填 | 默认值                          | 描述                                                                                                                                                                  |
+|------------------------------|---------|----------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                          | String  | 是       | -                               | JDBC 连接 URL。使用 PostgreSQL 协议，例如 `jdbc:postgresql://localhost:5432/cloudberrydb`                                                                              |
+| driver                       | String  | 是       | -                               | 固定为 `org.postgresql.Driver`                                                                                                                                        |
+| username                     | String  | 是       | -                               | 连接实例的用户名。同时接受 `user` 作为 `username` 的别名                                                                                                                |
+| password                     | String  | 是       | -                               | 连接实例的密码                                                                                                                                                        |
+| query                        | String  | 否       | -                               | 使用此 SQL 将上游输入数据写入数据库，例如 `INSERT ...`；`query` 优先级更高                                                                                              |
+| database                     | String  | 否       | -                               | 使用此 `database` 和 `table` 自动生成 SQL 并接收上游输入数据写入数据库                                                                                                |
+| table                        | String  | 否       | -                               | 使用 `database` 和此 `table` 自动生成 SQL 并接收上游输入数据写入数据库                                                                                                 |
+| primary_keys                 | Array   | 否       | -                               | 在自动生成支持 `insert`、`delete` 和 `update` 的 SQL 时必填                                                                                                            |
+| is_exactly_once              | Boolean | 否       | false                           | 是否启用精确一次语义，通过 XA 事务保证                                                                                                                                  |
+| xa_data_source_class_name    | String  | 否       | -                               | 当 `is_exactly_once=true` 时使用 `org.postgresql.xa.PGXADataSource`                                                                                                    |
+| generate_sink_sql            | Boolean | 否       | false                           | 根据要写入的数据库表生成 SQL 语句                                                                                                                                      |
+| batch_size                   | Int     | 否       | 1000                            | 单次刷新前缓冲的最大记录数                                                                                                                                            |
+| batch_interval_ms            | Long    | 否       | 0                               | 写入触发的定时刷新间隔，单位毫秒                                                                                                                                      |
+| schema_save_mode             | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST     | 同步任务启动前，控制目标表结构的处理方式                                                                                                                                |
+| data_save_mode               | Enum    | 否       | APPEND_DATA                     | 同步任务启动前，控制目标表已有数据的处理方式                                                                                                                            |
+| custom_sql                   | String  | 否       | -                               | 当 `data_save_mode` 为 `CUSTOM_PROCESSING` 时，同步任务启动前需要执行的 SQL                                                                                            |
+| enable_upsert                | Boolean | 否       | true                            | 通过主键存在启用 upsert                                                                                                                                                |
+| multi_table_sink_replica     | Int     | 否       | 1                               | 多表写入时使用的 Sink Writer 副本数量                                                                                                                                  |
+| common-options               |         | 否       | -                               | 接收器插件通用参数，详情请参考 [Sink Common Options](../common-options/sink-common-options.md)                                                                          |
 
 ## 注意事项
 
-- Cloudberry 作业使用 `Jdbc` 插件名。
-- Cloudberry 使用 PostgreSQL JDBC 行为，请配置 `driver = "org.postgresql.Driver"` 和 `jdbc:postgresql://...` URL。
+- 请配置 `driver = "org.postgresql.Driver"`，并使用 `jdbc:postgresql://...` 形式的 URL。
+- 作业中请使用 `Jdbc` 作为插件名；Cloudberry 连接器没有自己的工厂名。
 - 需要手写 INSERT 语句时使用 `query`；希望 SeaTunnel 自动生成 SQL 时，使用 `generate_sink_sql`、`database` 和 `table`。
 - `is_exactly_once=true` 还需要配置可用的 XA 数据源类，例如 `org.postgresql.xa.PGXADataSource`。
 
@@ -96,9 +116,9 @@ sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    query = "insert into test_table(name,age) values(?,?)"
+    query = "insert into test_table(name, age) values(?, ?)"
   }
 }
 ```
@@ -110,7 +130,7 @@ sink {
   Jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
 
     generate_sink_sql = true
@@ -127,11 +147,11 @@ sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
-    query = "insert into test_table(name,age) values(?,?)"
+    query = "insert into test_table(name, age) values(?, ?)"
 
-    is_exactly_once = "true"
+    is_exactly_once = true
     xa_data_source_class_name = "org.postgresql.xa.PGXADataSource"
   }
 }
@@ -144,13 +164,13 @@ sink {
   jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
 
     generate_sink_sql = true
     database = "mydb"
     table = "sink_table"
-    primary_keys = ["id","name"]
+    primary_keys = ["id", "name"]
     field_ide = UPPERCASE
   }
 }
@@ -163,7 +183,7 @@ sink {
   Jdbc {
     url = "jdbc:postgresql://localhost:5432/cloudberrydb"
     driver = "org.postgresql.Driver"
-    user = "dbadmin"
+    username = "dbadmin"
     password = "password"
 
     generate_sink_sql = true
@@ -175,7 +195,26 @@ sink {
 }
 ```
 
-有关更多详细的示例和选项，请参考 PostgreSQL 连接器文档。
+### 多表写入
+
+```hocon
+sink {
+  Jdbc {
+    url = "jdbc:postgresql://localhost:5432/cloudberrydb"
+    driver = "org.postgresql.Driver"
+    username = "dbadmin"
+    password = "password"
+
+    generate_sink_sql = true
+    database = "${database_name}"
+    table = "${table_name}"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
+}
+```
+
+有关更多详细的示例和选项，请参考 [PostgreSQL 连接器文档](./PostgreSql.md)。
 
 ## 变更日志
 

--- a/docs/zh/connectors/sink/Http.md
+++ b/docs/zh/connectors/sink/Http.md
@@ -19,63 +19,198 @@ import ChangeLog from '../changelog/connector-http.md';
 
 ## 描述
 
-接收Source端传入的数据，利用数据触发 web hooks。
+接收 Source 端传入的数据，并使用该数据触发 Webhook。Http Sink 始终发送 `POST` 请求；每条上游
+数据会被序列化为 JSON，作为请求体发送。
 
-> 例如，来自上游的数据为[`age: 12, name: tyrantlucifer`]，则body内容如下：`{"age": 12, "name": "tyrantlucifer"}`
+> 例如，来自上游的数据为 [`age: 12, name: tyrantlucifer`]，则 body 内容如下：`{"age": 12, "name": "tyrantlucifer"}`
 
-**Tips: Http 接收器仅支持 `post json` 类型的 web hook，source 数据将被视为 webhook 中的 body 内容。**
+**提示：Http Sink 仅支持 `POST json` 类型的 Webhook，source 数据将被视为 Webhook 中的 body 内容。**
 
 ## 支持的数据源信息
 
-想使用 Http 连接器，需要安装以下必要的依赖。可以通过运行 install-plugin.sh 脚本或者从 Maven 中央仓库下载这些依赖
+想使用 Http 连接器，需要安装以下必要的依赖。可以通过运行 `install-plugin.sh` 脚本或者从 Maven
+中央仓库下载这些依赖。
 
-| 数据源  | 支持版本 | 依赖                                                                           |
-|------|------|------------------------------------------------------------------------------|
-| Http | 通用   | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http) |
+| 数据源  | 支持版本 | 依赖                                                                            |
+|--------|----------|---------------------------------------------------------------------------------|
+| Http   | 通用     | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-http)   |
 
 ## 接收器选项
 
-|             名称              |   类型   | 是否必须 |  默认值  |                             描述                             |
-|-----------------------------|--------|------|-------|------------------------------------------------------------|
-| url                         | String | 是    | -     | Http 请求链接                                                  |
-| headers                     | Map    | 否    | -     | Http 请求头                                                    |
-| params                      | Map    | 否    | -     | 该参数会通过参数校验。当前 Sink 写入器会把数据作为请求体 POST 到最终 URL，如需查询参数，建议直接写在 `url` 中。 |
-| retry                       | Int    | 否    | -     | 如果请求http返回`IOException`的最大重试次数                             |
-| retry_backoff_multiplier_ms | Int    | 否    | 100   | http请求失败，重试回退次数（毫秒）乘数                                      |
-| retry_backoff_max_ms        | Int    | 否    | 10000 | http请求失败，最大重试回退时间(毫秒)                                      |
-| array_mode                  | Boolean| 否    | false | 为true时将数据作为JSON数组发送，为false时作为单个JSON对象发送（默认）                |
-| batch_size                  | Int    | 否    | 1     | 在一个HTTP请求中发送的记录批量大小。仅在array_mode为true时有效                   |
-| request_interval_ms         | Int    | 否    | 0     | 两次HTTP请求之间的间隔毫秒数，以避免请求过于频繁                                 |
-| multi_table_sink_replica    | Int    | 否    | -     | 多表写入时使用的 Sink 副本数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。 |
-| common-options              |        | 否    | -     | Sink插件常用参数，请参考 [Sink常用选项 ](../common-options/sink-common-options.md) 了解详情 |
+|             名称              |  类型   | 是否必须 | 默认值 | 描述                                                                                                                                              |
+|-------------------------------|--------|----------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                           | String | 是       | -      | Http 请求 URL。静态查询参数可以直接拼接在 URL 中。                                                                                                  |
+| headers                       | Map    | 否       | -      | 每个请求都会携带的 HTTP 头，每个条目是一个 `name = "value"` 键值对。                                                                                  |
+| params                        | Map    | 否       | -      | HTTP 请求参数。对 `POST`/`PUT`/`DELETE` 请求（无 JSON body 时）会作为表单字段发送；对 `GET` 请求会拼到 URL 作为查询参数。                                              |
+| retry                         | Int    | 否       | -      | 当 HTTP 请求返回 `IOException` 时的最大重试次数。                                                                                                |
+| retry_backoff_multiplier_ms   | Int    | 否       | 100    | 失败重试时回退时间（毫秒）的乘数。                                                                                                                  |
+| retry_backoff_max_ms          | Int    | 否       | 10000  | 失败重试时回退时间（毫秒）的上限。                                                                                                                  |
+| array_mode                    | Boolean| 否       | false  | 为 true 时，多条数据会被合并为 JSON 数组发送；为 false 时（默认）每条数据单独作为 JSON 对象发送。                                                              |
+| batch_size                    | Int    | 否       | 1      | 单个 HTTP 请求最多发送的数据条数。仅在 `array_mode = true` 时生效。                                                                                  |
+| request_interval_ms           | Int    | 否       | 0      | 两次 HTTP 请求之间的间隔毫秒数，用于避免请求过于频繁。                                                                                                |
+| multi_table_sink_replica      | Int    | 否       | -      | 多表写入时使用的 Sink 副本数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。                                                       |
+| common-options                |        | 否       | -      | Sink 插件常用参数，详情请参考 [Sink 常用选项](../common-options/sink-common-options.md)。                                                              |
+
+### url
+
+Webhook 接收端的 HTTP URL。可以把静态的查询参数直接写在 URL 中，例如
+`http://localhost/test/webhook?source=seatunnel`。
+
+### params
+
+`params` 是附加 HTTP 请求参数最灵活的方式：
+
+- 对 `POST`/`PUT`/`DELETE` 请求（无 JSON body 时）会作为 `application/x-www-form-urlencoded` 表单字段发送。
+- 对 `GET` 请求会拼到 URL 上作为查询参数。
+
+当请求方法为 `POST` 且上游行本身是 JSON 对象时，JSON 体作为请求主体发送，`params` 作为额外的表单字段一同发送。
+
+### 重试行为
+
+只有遇到 `IOException` 才会触发重试。第一次重试等待 `retry_backoff_multiplier_ms`（默认 100 ms），
+之后每次等待时间为 `min(上次等待 * retry_backoff_multiplier_ms, retry_backoff_max_ms)`，直到重试
+成功或达到 `retry` 设置的次数上限。
+
+### array_mode 与 batch_size
+
+当 `array_mode = false`（默认）时，Http Sink 每条数据发送一次请求。设置为 `array_mode = true`
+后会按批次发送；`batch_size` 控制每个 JSON 数组请求最多包含多少条数据，`request_interval_ms` 用
+于在相邻批次之间增加延迟。
 
 ## 示例
 
-Http Sink 固定发送 `POST` 请求。每条上游数据会被转换成 JSON 作为请求体；当 `array_mode = true` 时，会先把多条数据攒成 JSON 数组再发送，`batch_size` 控制单次请求最多包含多少条数据。
-
-简单示例:
+### 简单示例
 
 ```hocon
-Http {
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 1
+    schema = {
+      fields {
+        age = "int"
+        name = "string"
+      }
+    }
+  }
+}
+
+sink {
+  Http {
     url = "http://localhost/test/webhook"
     headers {
-        token = "9e32e859ef044462a257e1fc76730066"
+      token = "9e32e859ef044462a257e1fc76730066"
     }
+  }
 }
 ```
 
 ### 带批处理的示例
 
 ```hocon
-Http {
+sink {
+  Http {
     url = "http://localhost/test/webhook"
     headers {
-        token = "9e32e859ef044462a257e1fc76730066"
-        Content-Type = "application/json"
+      token = "9e32e859ef044462a257e1fc76730066"
+      Content-Type = "application/json"
     }
     array_mode = true
     batch_size = 50
     request_interval_ms = 500
+  }
+}
+```
+
+### 带重试和表单参数的示例
+
+```hocon
+sink {
+  Http {
+    url = "http://localhost/test/webhook"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
+    params {
+      source = "seatunnel"
+      channel = "cdc"
+    }
+    retry = 3
+    retry_backoff_multiplier_ms = 200
+    retry_backoff_max_ms = 5000
+  }
+}
+```
+
+### 多表写入
+
+在 URL 中使用 `${database_name}` 和 `${table_name}` 占位符，把不同上游表的数据路由到不同的 Webhook 地址。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 5000
+}
+
+source {
+  MySQL-CDC {
+    url = "jdbc:mysql://127.0.0.1:3306/seatunnel"
+    username = "root"
+    password = "******"
+
+    table-names = ["seatunnel.role", "seatunnel.user", "galileo.Bucket"]
+  }
+}
+
+transform {
+}
+
+sink {
+  Http {
+    url = "http://localhost/test/${database_name}_test/${table_name}_test"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
+  }
+}
+```
+
+如果上游是带有 schema 限定的表列表（例如 Oracle），可以使用 `${schema_name}` 代替 `${database_name}`：
+
+```hocon
+source {
+  Jdbc {
+    driver = oracle.jdbc.driver.OracleDriver
+    url = "jdbc:oracle:thin:@localhost:1521/XE"
+    username = "testUser"
+    password = "testPassword"
+
+    table_list = [
+      {
+        table_path = "TESTSCHEMA.TABLE_1"
+      },
+      {
+        table_path = "TESTSCHEMA.TABLE_2"
+      }
+    ]
+  }
+}
+
+transform {
+}
+
+sink {
+  Http {
+    url = "http://localhost/test/${schema_name}_test/${table_name}_test"
+    headers {
+      token = "9e32e859ef044462a257e1fc76730066"
+    }
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/SftpFile.md
+++ b/docs/zh/connectors/sink/SftpFile.md
@@ -2,32 +2,43 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 
 # SftpFile
 
-> Sftp file Sink 连接器
+> Sftp File Sink 连接器
+
+## 支持引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
 
 ## 描述
 
-将数据输出到Sftp。
+通过 SFTP 将数据写入远程目录。连接器支持多种文件格式（`text`、`csv`、`parquet`、`orc`、
+`json`、`excel`、`xml`、`binary`、`canal_json`、`debezium_json`、`maxwell_json`），支持按
+字段分区、自定义文件名以及 CDC 管道运行时的结构变更。
 
-:::提示
+:::tip
 
-如果你使用spark/flink，为了使用这个连接器，你必须确保你的spark/flink集群已经集成了hadoop。测试的hadoop版本是2.x。
+如果使用 Spark/Flink，请确保集群已集成 Hadoop，测试版本为 Hadoop 2.x。
 
-如果你使用SeaTunnel引擎，当你下载并安装SeaTunnel引擎时，它会自动集成hadoop jar包。您可以在${SEATUNNEL_HOME}/lib下找到jar包。
+如果使用 SeaTunnel Engine，安装包中已包含 Hadoop JAR，可在 `${SEATUNNEL_HOME}/lib` 下确认。
 
+连接器同时支持密码认证（`password`）和公钥认证（`keyfile`）。
+
+:::
 
 ## 主要特性
 
 - [x] [多模态](../../introduction/concepts/connector-v2-features.md#多模态multimodal)
 
-  使用二进制文件格式读取和写入任何格式的文件，例如视频、图片等。简而言之，任何文件都可以同步到目标位置。
+  使用二进制文件格式读写任意格式的文件，例如视频、图片等。简而言之，任何文件都可以同步到目标位置。
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 
-  默认情况下，我们使用2PC commit来确保`精确一次`
+  默认使用 2PC 提交保证 `精确一次`。
 
-- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
-- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+  在 `path` 中使用 `${database_name}` 与 `${table_name}` 占位符，把不同上游表的数据路由到不同的输出目录。
 
 - [x] 文件格式类型
   - [x] text
@@ -44,257 +55,137 @@ import ChangeLog from '../changelog/connector-file-sftp.md';
 
 ## 参数
 
-| 名称                                    | 类型      | 是否必填 | 默认值                                        | 备注                                                        |
-|---------------------------------------|---------|------|--------------------------------------------|-----------------------------------------------------------|
-| host                                  | string  | 是    | -                                          |                                                           |
-| port                                  | int     | 是    | -                                          |                                                           |
-| user                                  | string  | 是    | -                                          |                                                           |
-| password                              | string  | 否    | -                                          | 未配置 `keyfile` 时需要配置。                                      |
-| keyfile                               | string  | 否    | -                                          | 用于 SFTP 公钥认证的私钥文件路径。                                    |
-| path                                  | string  | 是    | -                                          |                                                           |
-| tmp_path                              | string  | 是    | /tmp/seatunnel                             | 结果文件将首先写入临时路径，然后使用`mv`将临时目录剪切到目标目录。需要一个FTP目录。             |
-| custom_filename                       | boolean | 否    | false                                      | 是否需要自定义文件名                                                |
-| file_name_expression                  | string  | 否    | "${transactionId}"                         | 仅在custom_filename为true时使用                                 |
-| filename_time_format                  | string  | 否    | "yyyy.MM.dd"                               | 仅在custom_filename为true时使用                                 |
-| file_format_type                      | string  | 否    | "csv"                                      |                                                           |
-| field_delimiter                       | string  | 否    | '\001'                                     | 仅当file_format_type为text时使用                                |
-| row_delimiter                         | string  | 否    | "\n"                                       | 仅当file_format_type为 `text`、`csv`、`json` 时使用               |
-| have_partition                        | boolean | 否    | false                                      | 是否需要处理分区。                                                 |
-| partition_by                          | array   | 否    | -                                          | 只有在have_partition为true时才使用                                |
-| partition_dir_expression              | string  | 否    | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/" | 只有在have_partition为true时才使用                                |
-| is_partition_field_write_in_file      | boolean | 否    | false                                      | 只有在have_partition为true时才使用                                |
-| sink_columns                          | array   | 否    |                                            | 当此参数为空时，所有字段都是sink列                                       |
-| is_enable_transaction                 | boolean | 否    | true                                       |                                                           |
-| batch_size                            | int     | 否    | 1000000                                    |                                                           |
-| compress_codec                        | string  | 否    | none                                       |                                                           |
-| common-options                        | object  | 否    | -                                          |                                                           |
-| max_rows_in_memory                    | int     | 否    | -                                          | 仅当file_format_type为excel时使用。                              |
-| sheet_max_rows                         | int     | 否    | 1048576                                    | 仅当 `file_format_type` 为 `excel` 时使用；每个工作表允许写入的最大行数。 |
-| sheet_name                            | string  | 否    | Sheet${Random number}                      | 仅当file_format_type为excel时使用。                              |
-| csv_string_quote_mode                 | enum    | 否    | MINIMAL                                    | 仅当file_format_type为csv时使用。                                |
-| xml_root_tag                          | string  | 否    | RECORDS                                    | 仅当file_format_type为xml时使用                                 |
-| xml_row_tag                           | string  | 否    | RECORD                                     | 仅当file_format_type为xml时使用                                 |
-| xml_use_attr_format                   | boolean | 否    | -                                          | 仅当file_format_type为xml时使用                                 |
-| single_file_mode                      | boolean | 否    | false                                      | 每个并行处理只会输出一个文件。启用此参数后，batch_size将不会生效。输出文件名没有文件块后缀。       |
-| create_empty_file_when_no_data        | boolean | 否    | false                                      | 当上游没有数据同步时，仍然会生成相应的数据文件。                                  |
-| parquet_avro_write_timestamp_as_int96 | boolean | 否    | false                                      | 仅当file_format_type为parquet时使用                             |
-| enable_header_write                   | boolean | 否    | false                                      | 仅当file_format_type为text、csv时使用<br/>false：不写标头，true：写标头。   |
-| parquet_avro_write_fixed_as_int96     | array   | 否    | -                                          | 仅当file_format_type为parquet时使用                             |
-| encoding                              | string  | 否    | "UTF-8"                                    | 仅当file_format_type为json、text、csv、xml时使用。                  |
-| schema_evolution_enabled              | boolean | 否    | false                                      | 开启 Schema 演变支持，适用于 CDC 管道。为 true 时，来自上游的 ADD/DROP/RENAME/MODIFY 列事件无需重启作业即可应用到 Sink。不支持 binary 格式。 |
-| schema_save_mode                      | string  | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST               | 现有目录处理方式                                                  |
-| data_save_mode                        | string  | 否    | APPEND_DATA                                | 现有数据处理方式                                                  |
-| merge_update_event                    | boolean | 否    | false                                      | 仅当file_format_type为canal_json、debezium_json、maxwell_json. |
-
-### host [string]
-
-目标sftp主机，必填。
-
-### port [int]
-
-目标sftp端口，必填。
-
-### user [string]
-
-目标sftp用户，必填。
-
-### password [string]
-
-目标sftp密码。未配置 `keyfile` 时需要配置。
-
-### keyfile [string]
-
-用于 SFTP 公钥认证的私钥文件路径。
-
-### path [string]
-
-目标目录路径，必填。
-
-### custom_filename [boolean]
-
-是否自定义文件名
+| 名称                                    | 类型      | 是否必填 | 默认值                                          | 描述                                                                                                                                                |
+|---------------------------------------|---------|------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| host                                  | string  | 是    | -                                            | 目标 SFTP 服务器地址。                                                                                                                                |
+| port                                  | int     | 是    | -                                            | 目标 SFTP 端口，通常为 `22`。                                                                                                                          |
+| user                                  | string  | 是    | -                                            | SFTP 登录用户名。                                                                                                                                    |
+| password                              | string  | 否    | -                                            | SFTP 登录密码。未配置 `keyfile` 时需要配置。                                                                                                              |
+| keyfile                               | string  | 否    | -                                            | 用于 SFTP 公钥认证的私钥文件路径。                                                                                                                       |
+| path                                  | string  | 是    | -                                            | SFTP 服务端的目标目录。                                                                                                                                |
+| tmp_path                              | string  | 是    | /tmp/seatunnel                               | SFTP 服务端的临时目录；写入时会先把输出文件写到这里，检查点完成后再 `mv` 到 `path`。                                                                              |
+| custom_filename                       | boolean | 否    | false                                        | 是否需要自定义文件名。                                                                                                                                  |
+| file_name_expression                  | string  | 否    | "${transactionId}"                           | 仅在 `custom_filename = true` 时使用。                                                                                                                |
+| filename_time_format                  | string  | 否    | "yyyy.MM.dd"                                 | 仅在 `custom_filename = true` 时使用。                                                                                                                |
+| file_format_type                      | string  | 否    | "csv"                                        | 支持 `text`、`csv`、`parquet`、`orc`、`json`、`excel`、`xml`、`binary`、`canal_json`、`debezium_json`、`maxwell_json`。                                          |
+| filename_extension                    | string  | 否    | -                                            | 用自定义后缀覆盖默认后缀，例如 `.xml`、`.json`、`dat`、`.customtype`。                                                                                       |
+| field_delimiter                       | string  | 否    | '\001' for text and ',' for csv              | 列分隔符，仅在 `file_format_type` 为 `text` 或 `csv` 时生效。                                                                                             |
+| row_delimiter                         | string  | 否    | "\n"                                         | 行分隔符，仅在 `file_format_type` 为 `text`、`csv` 或 `json` 时生效。                                                                                      |
+| have_partition                        | boolean | 否    | false                                        | 是否按上游字段值分区输出。                                                                                                                              |
+| partition_by                          | array   | 否    | -                                            | 仅在 `have_partition = true` 时使用。                                                                                                                  |
+| partition_dir_expression              | string  | 否    | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"   | 仅在 `have_partition = true` 时使用。                                                                                                                  |
+| is_partition_field_write_in_file      | boolean | 否    | false                                        | 仅在 `have_partition = true` 时使用。                                                                                                                  |
+| sink_columns                          | array   | 否    |                                              | 实际写入文件的列；为空时写入全部上游列。                                                                                                                    |
+| is_enable_transaction                 | boolean | 否    | true                                         | 预留参数，目前仅支持 `true`（也是默认行为）。                                                                                                              |
+| batch_size                            | int     | 否    | 1000000                                      | 单个文件最大行数，达到后滚动生成新文件。                                                                                                                    |
+| compress_codec                        | string  | 否    | none                                         | 压缩编码，详见下方说明。                                                                                                                                |
+| common-options                        | object  | 否    | -                                            | Sink 插件通用参数，详情请参考 [Sink Common Options](../common-options/sink-common-options.md)。                                                          |
+| max_rows_in_memory                    | int     | 否    | -                                            | 仅在 `file_format_type` 为 `excel` 时使用。                                                                                                            |
+| sheet_max_rows                        | int     | 否    | 1048576                                      | 仅在 `file_format_type` 为 `excel` 时使用。                                                                                                            |
+| sheet_name                            | string  | 否    | Sheet${Random number}                        | 仅在 `file_format_type` 为 `excel` 时使用。                                                                                                            |
+| csv_string_quote_mode                 | enum    | 否    | MINIMAL                                      | 仅在 `file_format_type` 为 `csv` 时使用。                                                                                                              |
+| xml_root_tag                          | string  | 否    | RECORDS                                      | 仅在 `file_format_type` 为 `xml` 时使用。                                                                                                              |
+| xml_row_tag                           | string  | 否    | RECORD                                       | 仅在 `file_format_type` 为 `xml` 时使用。                                                                                                              |
+| xml_use_attr_format                   | boolean | 否    | -                                            | 仅在 `file_format_type` 为 `xml` 时使用。                                                                                                              |
+| single_file_mode                      | boolean | 否    | false                                        | 每个并行度只输出一个文件；开启后 `batch_size` 不再生效，文件名也不带分块后缀。                                                                              |
+| create_empty_file_when_no_data        | boolean | 否    | false                                        | 上游没有数据时仍生成对应的空文件。                                                                                                                        |
+| parquet_avro_write_timestamp_as_int96 | boolean | 否    | false                                        | 仅在 `file_format_type` 为 `parquet` 时使用。                                                                                                          |
+| parquet_avro_write_fixed_as_int96     | array   | 否    | -                                            | 仅在 `file_format_type` 为 `parquet` 时使用。                                                                                                          |
+| enable_header_write                   | boolean | 否    | false                                        | 仅在 `file_format_type` 为 `text` 或 `csv` 时使用；为 true 时写入表头行。                                                                                |
+| encoding                              | string  | 否    | "UTF-8"                                      | 仅在 `file_format_type` 为 `json`、`text`、`csv` 或 `xml` 时使用。                                                                                     |
+| schema_evolution_enabled              | boolean | 否    | false                                        | 启用 CDC 结构变更（ADD/DROP/RENAME/MODIFY）支持，无需重启任务；`binary` 不支持，详见下方说明。                                                            |
+| schema_save_mode                      | string  | 否    | CREATE_SCHEMA_WHEN_NOT_EXIST                 | 任务启动时对目标目录的处理方式。                                                                                                                          |
+| data_save_mode                        | string  | 否    | APPEND_DATA                                  | 任务启动时对目录中已有数据文件的处理方式。                                                                                                                  |
+| merge_update_event                    | boolean | 否    | false                                        | 仅在 `file_format_type` 为 `canal_json`、`debezium_json` 或 `maxwell_json` 时使用。为 true 时，UPDATE_AFTER 和 UPDATE_BEFORE 会合并为单个 UPDATE 事件。    |
 
 ### file_name_expression [string]
 
-仅在`custom_filename`为`true`时使用。
+仅在 `custom_filename = true` 时使用。
 
-`file_name_expression`描述了将在`path`中创建的文件表达式。我们可以在`file_name_expression`中添加变量`${now}`或`${uuid}`，类似于`test_${uuid}_${now}`，
-`${now}`表示当前时间，其格式可以通过指定选项`filename_time_format`来定义。
+`file_name_expression` 描述 `path` 内创建文件的命名规则。支持在表达式中嵌入 `${now}` 或
+`${uuid}`，例如 `test_${uuid}_${now}`。`${now}` 表示当前时间，时间格式可通过
+`filename_time_format` 指定。
 
-请注意，如果`is_enable_transaction`为`true`，我们将自动添加`${transactionId}_`在文件的开头。
-
-### filename_time_format [string]
-
-仅在`custom_filename`为`true`时使用。
-
-当`file_name_expression`参数中的格式为`xxxx-${now}`时，`filename_time_format`可以指定路径的时间格式，默认值为`yyyy.MM.dd`。常用的时间格式如下：
-
-| Symbol |    Description     |
-|--------|--------------------|
-| y      | Year               |
-| M      | Month              |
-| d      | Day of month       |
-| H      | Hour in day (0-23) |
-| m      | Minute in hour     |
-| s      | Second in minute   |
-
-### file_format_type [string]
-
-我们支持以下文件类型：
-
-`text` `csv` `parquet` `orc` `json` `excel` `xml` `binary` `canal_json` `debezium_json` `maxwell_json`
-
-请注意，最终文件名将以file_format_type的后缀结尾，文本文件的后缀为`txt`。
-
-### field_delimiter [string]
-
-数据行中列之间的分隔符。仅在`text`文件格式中需要。
-
-### row_delimiter [string]
-
-文件中行之间的分隔符。仅在 `text`、`csv`、`json` 文件格式中需要。
-
-### have_partition [boolean]
-
-是否需要处理分区。
-
-### partition_by [array]
-
-仅在`have_partition`为`true`时使用。
-
-根据所选字段对数据进行分区。
-
-### partition_dir_expression [string]
-
-仅在`have_partition`为`true`时使用。
-
-如果指定了`partition_by`，我们将根据分区信息生成相应的分区目录，并将最终文件放置在分区目录中。
-
-默认的`partition_dir_expression`是`${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/`。`k0`是第一个分区字段，`v0`是第一个划分字段的值。
-
-### is_partition_field_write_in_file [boolean]
-
-仅在`have_partition`为`true`时使用。
-
-如果`is_partition_field_write_in_file`为`true`，则分区字段及其值将写入数据文件。
-例如，如果你想写一个Hive数据文件，它的值应该是`false`。
-
-### sink_columns [array]
-
-哪些列需要写入文件，默认值是从`Transform`或`Source`获取的所有列。
-字段的顺序决定了文件实际写入的顺序。
-
-### is_enable_transaction [boolean]
-
-如果`is_enable_transaction`为`true`，我们将确保数据在写入目标目录时不会丢失或重复。
-
-请注意，如果`is_enable_transaction`为`true`，我们将自动添加`${transactionId}_`在文件的开头。
-
-现在只支持`true`。
-
-### batch_size [int]
-
-文件中的最大行数。对于SeaTunnel引擎，文件中的行数由`batch_size`和`checkpoint.interval`共同决定。如果`checkpoint.interval`的值足够大，sink writer将在文件中写入行，直到文件中的行大于`batch_size`。如果`checkpoint.interval`较小，则接收器写入程序将在新的检查点触发时创建一个新文件。
+注意：当 `is_enable_transaction = true` 时，文件名会自动加上前缀 `${transactionId}_`。
 
 ### compress_codec [string]
 
-文件的压缩编解码器和支持的详细信息如下所示：
+输出文件的压缩编码，支持以下组合：
 
-- txt: `lzo` `none`
-- json: `lzo` `none`
-- csv: `lzo` `none`
-- orc: `lzo` `snappy` `lz4` `zlib` `none`
-- parquet: `lzo` `snappy` `lz4` `gzip` `brotli` `zstd` `none`
+- `text` / `json` / `csv`：`lzo`、`none`
+- `orc`：`lzo`、`snappy`、`lz4`、`zlib`、`none`
+- `parquet`：`lzo`、`snappy`、`lz4`、`gzip`、`brotli`、`zstd`、`none`
 
-提示：excel类型不支持任何压缩格式
+`excel` 不支持任何压缩编码。
 
-### common options
-
-Sink插件常用参数，请参考[Sink common Options](../common-options/sink-common-options.md)了解详细信息。
-
-### max_rows_in_memory
-
-当文件格式为Excel时，内存中可以缓存的最大数据项数。
-
-### sheet_max_rows [int]
-
-仅当 `file_format_type` 为 `excel` 时使用。该选项限制每个工作表可以写入的最大行数，默认值为 `1048576`。
-
-### sheet_name
-
-编写工作簿的工作表
-
-### csv_string_quote_mode [string]
-
-当文件格式为CSV时，CSV的字符串引用模式。
-
-- ALL：所有字符串字段都将被引用。
-- MINIMAL：包含特殊字符的引号字段，如字段分隔符、引号字符或行分隔符字符串中的任何字符。
-- NONE：从不引用字段。当分隔符出现在数据中时，打印机会用转义符作为前缀。如果未设置转义符，格式验证将抛出异常。
-
-### xml_root_tag [string]
-
-指定XML文件中根元素的标记名。
-
-### xml_row_tag [string]
-
-指定XML文件中数据行的标记名称。
-
-### xml_use_attr_format [boolean]
-
-指定是否使用标记属性格式处理数据。
-
-### parquet_avro_write_timestamp_as_int96 [boolean]
-
-支持从时间戳写入Parquet INT96，仅适用于parquet文件。
-
-### parquet_avro_write_fixed_as_int96 [array]
-
-支持从12-byte字段写入Parquet INT96，仅适用于parquet文件。
-
-### enable_header_write [boolean]
-
-仅当file_format_type为text、csv时使用。false：不写标头，true：写标头。
-
-### encoding [string]
-
-仅当file_format_type为json、text、csv、xml时使用。
-要写入的文件的编码。此参数将由`Charset.forName(encoding)`解析。
 ### schema_save_mode [string]
 
-现有的目录处理方法。
+任务启动时对目标目录的处理方式：
 
-- RECREATE_SCHEMA：当目录不存在时创建，当目录存在时删除并重新创建
-- CREATE_SCHEMA_WHEN_NOT_EXIST：当目录不存在时创建，当目录存在时跳过
-- ERROR_WHEN_SCHEMA_NOT_EXIST：当目录不存在时，将报告错误
-- IGNORE：忽略对表的处理
+- `CREATE_SCHEMA_WHEN_NOT_EXIST`（默认）：目录不存在时创建，存在则跳过。
+- `RECREATE_SCHEMA`：目录存在时先删除再重建。
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`：目录不存在时立即报错。
+- `IGNORE`：不做任何处理。
 
 ### data_save_mode [string]
 
-现有的数据处理方法。
+任务启动时对目录中已有数据文件的处理方式：
 
--DROP_DATA:保留目录并删除数据文件
--APPEND_DATA：保留目录，保留数据文件
--ERROR_WHEN_DATA_EXISTS：当有数据文件时，会报告错误
+- `APPEND_DATA`（默认）：保留目录与已有文件，继续追加。
+- `DROP_DATA`：保留目录，删除已有数据文件。
+- `ERROR_WHEN_DATA_EXISTS`：目录下存在数据文件时立即报错。
 
+### schema_evolution_enabled [boolean]
 
-### merge_update_event [boolean]
+当设置为 `true` 时，SFTP 文件 Sink 会在不重启任务的情况下处理上游 CDC 结构变更事件
+（ADD COLUMN、DROP COLUMN、RENAME COLUMN、MODIFY COLUMN）。每次结构变更会先关闭当前输出
+文件，再用新结构打开新文件。
 
-仅当file_format_type为canal_json、debezium_json、maxwell_json时使用.
-设置成true,序列化数据时,UPDATE_AFTER 和 UPDATE_BEFORE 会合并成 UPDATE;
-设置成false,序列化数据时,UPDATE_AFTER 和 UPDATE_BEFORE 不会合并;
+**支持的格式：** 除 `binary` 外的全部文件格式。与 `file_format_type = binary` 同时启用会在
+任务启动时因配置校验失败。
+
+**分区约束：** 当 `have_partition = true` 时，不允许 DROP `partition_by` 中列出的字段，
+否则会立即报错。分区列在结构变更前后必须保持稳定。
+
+**当 `schema_evolution_enabled = false`（默认）时：** 如果上游 CDC 源开启了
+`schema-changes.enabled = true` 并且有 `AlterTableEvent` 进入 Sink，任务会立即失败并给出明确
+错误：
+
+> `Received AlterTableEvent but schema_evolution_enabled=false at this sink. Either set schema_evolution_enabled=true to handle schema changes, or set schema-changes.enabled=false at the CDC source to suppress them.`
+
+使用默认 CDC 源配置（`schema-changes.enabled = false`）的用户完全不受影响。
+
+**已知限制：** 结构变更与检查点不是原子的。如果任务恰好在文件滚动与结构元数据更新之间的
+短暂窗口崩溃，恢复后写入的行可能仍使用变更前的结构。该架构性限制与其他 SeaTunnel Sink 相同。
 
 ## 示例
 
-对于具有`have_partition`、`custom_filename`和`sink_columns`的文本文件格式
+### 带分区与自定义文件名的 Text 格式
 
-```bash
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
 
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+source {
+  FakeSource {
+    row.num = 100
+    schema = {
+      fields {
+        name = "string"
+        age = "int"
+      }
+    }
+  }
+}
+
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "password"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/seatunnel/job1"
     tmp_path = "/data/sftp/seatunnel/tmp"
     file_format_type = "text"
@@ -307,20 +198,23 @@ SftpFile {
     custom_filename = true
     file_name_expression = "${transactionId}_${now}"
     filename_time_format = "yyyy.MM.dd"
-    sink_columns = ["name","age"]
+    sink_columns = ["name", "age"]
     is_enable_transaction = true
+  }
 }
-
 ```
 
-当我们的源端是多个表，并且希望不同的表达式到不同的目录时，我们可以这样配置
+### 多表写入
+
+当上游覆盖多张表，并且希望每张表落到各自目录时，可在 `path` 中使用 `${table_name}` 占位符。
 
 ```hocon
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "password"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/seatunnel/job1/${table_name}"
     tmp_path = "/data/sftp/seatunnel/tmp"
     file_format_type = "text"
@@ -333,41 +227,47 @@ SftpFile {
     custom_filename = true
     file_name_expression = "${transactionId}_${now}"
     filename_time_format = "yyyy.MM.dd"
-    sink_columns = ["name","age"]
+    sink_columns = ["name", "age"]
     is_enable_transaction = true
-    schema_save_mode=RECREATE_SCHEMA
-    data_save_mode=DROP_DATA
+    schema_save_mode = "RECREATE_SCHEMA"
+    data_save_mode = "DROP_DATA"
+  }
 }
-
-
 ```
 
-### schema_evolution_enabled [boolean]
-
-设置为 `true` 时，文件 Sink 可在运行时处理 CDC Schema 变更事件（ADD COLUMN、DROP COLUMN、RENAME COLUMN、MODIFY COLUMN 类型），无需重启作业。每次 Schema 变更时，当前输出文件会被关闭，并以新 Schema 打开一个新文件。
-
-**支持的格式：** 除 `binary` 外的所有文件格式。将此选项与 `file_format_type = binary` 一起使用时，作业启动时会抛出配置校验错误。
-
-**分区约束：** 当 `have_partition = true` 时，不允许删除 `partition_by` 中列出的列，违反时会立即抛出异常。分区列在 Schema 变更过程中必须保持稳定。
-
-**当 `schema_evolution_enabled = false`（默认值）时：** 若上游 CDC Source 配置了 `schema-changes.enabled = true` 且 Sink 收到 `AlterTableEvent`，作业会立即抛出如下错误：
-> `Received AlterTableEvent but schema_evolution_enabled=false at this sink. Either set schema_evolution_enabled=true to handle schema changes, or set schema-changes.enabled=false at the CDC source to suppress them.`
-
-使用默认 CDC Source 配置（`schema-changes.enabled = false`）的用户不受影响。
-
-**已知限制：** Schema 变更与 Checkpoint 不是原子操作。若作业在文件轮转与 Schema 元数据更新之间的窗口期崩溃，恢复后写入的数据行可能使用变更前的 Schema。这是与其他 SeaTunnel Sink 共同存在的已知架构限制。完整的重启后 DDL 正确性支持需要配套的 CDC Source 修复（另行跟踪）。
-
-CDC 管道中的使用示例：
+### CDC 结构变更
 
 ```hocon
-SftpFile {
-    host = "xxx.xxx.xxx.xxx"
+sink {
+  SftpFile {
+    host = "sftp.example.com"
     port = 22
-    user = "username"
-    password = "xxxxxxxxxxxxxxxxx"
+    user = "seatunnel"
+    password = "********"
     path = "/data/sftp/cdc/${table_name}"
+    tmp_path = "/data/sftp/cdc/tmp"
     file_format_type = "parquet"
     schema_evolution_enabled = true
+    have_partition = true
+    partition_by = ["updated_at_month"]
+  }
+}
+```
+
+### Parquet + 公钥认证
+
+```hocon
+sink {
+  SftpFile {
+    host = "sftp.example.com"
+    port = 22
+    user = "seatunnel"
+    keyfile = "/home/seatunnel/.ssh/id_rsa"
+    path = "/data/sftp/seatunnel/parquet"
+    tmp_path = "/data/sftp/seatunnel/tmp"
+    file_format_type = "parquet"
+    sink_columns = ["name", "age"]
+  }
 }
 ```
 

--- a/docs/zh/connectors/sink/SqlServer.md
+++ b/docs/zh/connectors/sink/SqlServer.md
@@ -16,7 +16,10 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过 JDBC 写入数据。支持批处理和流处理模式，支持并发写入，支持精确一次语义（使用 XA 事务保证）。
+通过 JDBC 将数据写入 SQL Server。本连接器继承了 [Jdbc 接收器连接器](./Jdbc.md) 的全部选项，并使用 Microsoft SQL Server JDBC 驱动。
+
+支持批处理和流处理模式、并发写入以及精确一次语义（使用 XA 事务保证）。在配置了
+`primary_keys` 和 `generate_sink_sql` 时，也支持接收上游的 CDC 变更事件。
 
 ## 使用依赖
 
@@ -39,9 +42,9 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 支持的数据源信息
 
-| 数据源    | 支持的版本               | 驱动类名                                      | URL 格式                                   | Maven 依赖                                                                                   |
-|-----------|--------------------------|-----------------------------------------------|--------------------------------------------|---------------------------------------------------------------------------------------------|
-| SQL Server | 支持版本 >= 2008        | com.microsoft.sqlserver.jdbc.SQLServerDriver  | jdbc:sqlserver://localhost:1433            | [下载](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc)               |
+| 数据源     | 支持的版本               | 驱动类名                                      | URL 格式                            | Maven 依赖                                                                  |
+|------------|--------------------------|-----------------------------------------------|-------------------------------------|-----------------------------------------------------------------------------|
+| SQL Server | 支持版本 >= 2008         | com.microsoft.sqlserver.jdbc.SQLServerDriver  | jdbc:sqlserver://localhost:1433     | [下载](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc) |
 
 ## 数据库依赖
 
@@ -50,99 +53,105 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 数据类型映射
 
-| SQL Server 数据类型                     | SeaTunnel 数据类型                                                                                   |
-|-----------------------------------------|------------------------------------------------------------------------------------------------------|
-| BIT                                     | BOOLEAN                                                                                             |
-| TINYINT<br/>SMALLINT                    | SHORT                                                                                               |
-| INTEGER                                 | INT                                                                                                 |
-| BIGINT                                  | LONG                                                                                                |
-| DECIMAL<br />NUMERIC<br />MONEY<br />SMALLMONEY | DECIMAL((获取指定列的列大小)+1,<br/>(获取指定列的小数点右侧的位数)))                                |
-| REAL                                    | FLOAT                                                                                               |
-| FLOAT                                   | DOUBLE                                                                                              |
-| CHAR<br />NCHAR<br />VARCHAR<br />NTEXT<br />NVARCHAR<br />TEXT | STRING                                                                                              |
-| DATE                                    | LOCAL_DATE                                                                                          |
-| TIME                                    | LOCAL_TIME                                                                                          |
-| DATETIME<br />DATETIME2<br />SMALLDATETIME<br />DATETIMEOFFSET | LOCAL_DATE_TIME                                                                                     |
-| TIMESTAMP<br />BINARY<br />VARBINARY<br />IMAGE<br />UNKNOWN | 尚未支持                                                                                            |
+| SQL Server 数据类型                                              | SeaTunnel 数据类型                                                                              |
+|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| BIT                                                              | BOOLEAN                                                                                          |
+| TINYINT<br/>SMALLINT                                             | SHORT                                                                                            |
+| INTEGER                                                          | INT                                                                                              |
+| BIGINT                                                           | LONG                                                                                             |
+| DECIMAL<br />NUMERIC<br />MONEY<br />SMALLMONEY                  | DECIMAL((获取指定列的列大小)+1,<br/>(获取指定列的小数点右侧的位数)))                              |
+| REAL                                                             | FLOAT                                                                                            |
+| FLOAT                                                            | DOUBLE                                                                                           |
+| CHAR<br />NCHAR<br />VARCHAR<br />NTEXT<br />NVARCHAR<br />TEXT | STRING                                                                                           |
+| DATE                                                             | LOCAL_DATE                                                                                       |
+| TIME                                                             | LOCAL_TIME                                                                                       |
+| DATETIME<br />DATETIME2<br />SMALLDATETIME<br />DATETIMEOFFSET   | LOCAL_DATE_TIME                                                                                  |
+| TIMESTAMP<br />BINARY<br />VARBINARY<br />IMAGE<br />UNKNOWN     | 尚未支持                                                                                         |
 
 ## 接收器选项
 
-| 名称                           | 类型    | 是否必填 | 默认值  | 描述                                                                                                                                                                                                 |
-|------------------------------|---------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                          | String  | 是       | -       | JDBC 连接的 URL。参考示例：`jdbc:sqlserver://localhost:1433;databaseName=mydatabase`                                                                                                                |
-| driver                       | String  | 是       | -       | 用于连接远程数据源的 JDBC 类名，如果使用 SQL Server，值为 `com.microsoft.sqlserver.jdbc.SQLServerDriver`。                                                                                           |
-| username                     | String  | 否       | -       | 连接实例的用户名                                                                                                                                                                                     |
-| password                     | String  | 否       | -       | 连接实例的密码                                                                                                                                                                                       |
-| query                        | String  | 否       | -       | 使用此 SQL 将上游输入数据写入数据库。例如 `INSERT ...`，`query` 优先级更高。                                                                                                                         |
-| database                     | String  | 否       | -       | 使用此 `database` 和 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。此选项与 `query` 互斥，且优先级更高。                                                                                   |
-| table                        | String  | 否       | -       | 使用 `database` 和此 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。此选项与 `query` 互斥，且优先级更高。                                                                                   |
-| primary_keys                 | Array    | 否       | -       | 此选项用于在自动生成 SQL 时支持 `insert`、`delete` 和 `update` 等操作。                                                                                                                              |
-| connection_check_timeout_sec | Int    | 否       | 30      | 用于验证连接完成的数据库操作的等待时间（秒）。                                                                                                                                                       |
-| max_retries                  | Int    | 否       | 0       | 提交失败（executeBatch）的重试次数。                                                                                                                                                                 |
-| batch_size                   | Int    | 否       | 1000    | 对于批量写入，当缓冲记录数达到 `batch_size` 时，数据会刷新到数据库。如果 `batch_interval_ms` 大于 0，经过指定时间也会触发刷新。                                                                         |
-| batch_interval_ms            | Long   | 否       | 0       | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 0 时，写入器会在每条记录写入时检查间隔，达到间隔后同步刷新。                                                                              |
-| is_exactly_once              | Boolean  | 否       | false   | 是否启用精确一次语义，将使用 Xa 事务。如果启用，需要设置 `xa_data_source_class_name`。                                                                                                               |
-| generate_sink_sql            | Boolean  | 否       | false   | 根据要写入的数据库表生成 SQL 语句。                                                                                                                                                                  |
-| xa_data_source_class_name    | String  | 否       | -       | 数据库驱动的 XA 数据源类名，例如 SQL Server 为 `com.microsoft.sqlserver.jdbc.SQLServerXADataSource`，其他数据源请参考附录。                                                                          |
-| max_commit_attempts          | Int    | 否       | 3       | 事务提交失败的重试次数。                                                                                                                                                                             |
-| transaction_timeout_sec      | Int    | 否       | -1      | 事务打开后的超时时间，默认为 -1（永不超时）。注意：设置超时可能会影响精确一次语义。                                                                                                                  |
-| auto_commit                  | Boolean  | 否       | true    | 默认启用自动事务提交。                                                                                                                                                                               |
-| properties                   | Map      | 否       | -       | 额外的 JDBC 连接参数。当 `properties` 和 URL 中存在相同参数时，优先级由 SQL Server JDBC 驱动决定。                                                                                                     |
-| common-options               |         | 否       | -       | 接收器插件通用参数，详情请参考 [Sink Common Options](../common-options/sink-common-options.md)。                                                                                                                    |
-| schema_save_mode             | Enum     | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST | 同步任务启动前，控制目标表结构的处理方式。                                                                                                                   |
-| data_save_mode               | Enum     | 否       | APPEND_DATA | 同步任务启动前，控制目标表已有数据的处理方式。                                                                                                                   |
-| custom_sql                   | String   | 否       | -       | 当 `data_save_mode` 为 `CUSTOM_PROCESSING` 时，填写同步任务启动前需要执行的 SQL。                                                                                                                    |
-| enable_upsert                | Boolean  | 否       | true    | 通过主键存在启用 upsert。如果任务中没有键重复数据，将此参数设置为 `false` 可以加快数据导入速度。                                                                                                     |
-| multi_table_sink_replica     | Int      | 否       | 1       | 多表写入时使用的 Sink Writer 副本数量。                                                                                                     |
+本连接器使用的选项与 [Jdbc 接收器连接器](./Jdbc.md) 完全一致。下表列出了 SQL Server 相关选项中
+与通用 JDBC 选项有差异的部分；其他通用选项请参考链接页面中的权威描述。
 
-## 提示
+| 名称                          | 类型    | 是否必填 | 默认值                       | 描述                                                                                                                                                                                              |
+|-------------------------------|---------|----------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                           | String  | 是       | -                            | JDBC 连接的 URL。参考示例：`jdbc:sqlserver://localhost:1433;databaseName=mydatabase`，其中 `databaseName` 指定连接的默认数据库。                                                                  |
+| driver                        | String  | 是       | -                            | 用于连接远程数据源的 JDBC 类名，SQL Server 使用 `com.microsoft.sqlserver.jdbc.SQLServerDriver`。                                                                                                |
+| username                      | String  | 是       | -                            | 连接实例的用户名。同时接受 `user` 作为 `username` 的别名。                                                                                                                                          |
+| password                      | String  | 是       | -                            | 连接实例的密码。                                                                                                                                                                                  |
+| query                         | String  | 否       | -                            | 使用此 SQL 将上游输入数据写入数据库。例如 `INSERT ...`，`query` 优先级更高。                                                                                                                       |
+| database                      | String  | 否       | -                            | 使用此 `database` 和 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。此选项与 `query` 互斥，且优先级更高。                                                                                  |
+| table                         | String  | 否       | -                            | 使用 `database` 和此 `table-name` 自动生成 SQL 并接收上游输入数据写入数据库。此选项与 `query` 互斥，且优先级更高。                                                                                  |
+| primary_keys                  | Array   | 否       | -                            | 此选项用于在自动生成 SQL 时支持 `insert`、`delete` 和 `update` 等操作。                                                                                                                            |
+| connection_check_timeout_sec  | Int     | 否       | 30                           | 用于验证连接完成的数据库操作的等待时间（秒）。                                                                                                                                                     |
+| max_retries                   | Int     | 否       | 0                            | 提交失败（executeBatch）的重试次数。                                                                                                                                                               |
+| batch_size                    | Int     | 否       | 1000                         | 对于批量写入，当缓冲记录数达到 `batch_size` 时，数据会刷新到数据库。如果 `batch_interval_ms` 大于 0，经过指定时间也会触发刷新。                                                                       |
+| batch_interval_ms             | Long    | 否       | 0                            | 写入触发的定时刷新间隔，单位毫秒。`0` 表示关闭定时刷新；大于 0 时，写入器会在每条记录写入时检查间隔，达到间隔后同步刷新。                                                                            |
+| is_exactly_once               | Boolean | 否       | false                        | 是否启用精确一次语义，将使用 Xa 事务。如果启用，需要设置 `xa_data_source_class_name`。                                                                                                              |
+| generate_sink_sql             | Boolean | 否       | false                        | 根据要写入的数据库表生成 SQL 语句。                                                                                                                                                                |
+| xa_data_source_class_name     | String  | 否       | -                            | 数据库驱动的 XA 数据源类名，例如 SQL Server 为 `com.microsoft.sqlserver.jdbc.SQLServerXADataSource`，其他数据源请参考 [Jdbc 选项附录](./Jdbc.md#sink-options)。                                   |
+| max_commit_attempts           | Int     | 否       | 3                            | 事务提交失败的重试次数。                                                                                                                                                                           |
+| transaction_timeout_sec       | Int     | 否       | -1                           | 事务打开后的超时时间，默认为 -1（永不超时）。注意：设置超时可能会影响精确一次语义。                                                                                                                  |
+| auto_commit                   | Boolean | 否       | true                         | 默认启用自动事务提交。                                                                                                                                                                             |
+| properties                    | Map     | 否       | -                            | 额外的 JDBC 连接参数。当 `properties` 和 URL 中存在相同参数时，优先级由 SQL Server JDBC 驱动决定。                                                                                                 |
+| common-options                |         | 否       | -                            | 接收器插件通用参数，详情请参考 [Sink Common Options](../common-options/sink-common-options.md)。                                                                                                    |
+| schema_save_mode              | Enum    | 否       | CREATE_SCHEMA_WHEN_NOT_EXIST  | 同步任务启动前，控制目标表结构的处理方式。                                                                                                                                                          |
+| data_save_mode                | Enum    | 否       | APPEND_DATA                  | 同步任务启动前，控制目标表已有数据的处理方式。                                                                                                                                                      |
+| custom_sql                    | String  | 否       | -                            | 当 `data_save_mode` 为 `CUSTOM_PROCESSING` 时，填写同步任务启动前需要执行的 SQL。                                                                                                                  |
+| enable_upsert                 | Boolean | 否       | true                         | 通过主键存在启用 upsert。如果任务中没有键重复数据，将此参数设置为 `false` 可以加快数据导入速度。                                                                                                   |
+| multi_table_sink_replica      | Int     | 否       | 1                            | 多表写入时使用的 Sink Writer 副本数量。                                                                                                                                                            |
 
-> 如果未设置 `partition_column`，将以单并发运行；如果设置了 `partition_column`，将根据任务的并发度并行执行。
+### Schema Save Mode（结构保存模式）
+
+`schema_save_mode` 控制任务启动前对目标表结构的处理方式：
+
+- `CREATE_SCHEMA_WHEN_NOT_EXIST`（默认）：目标表不存在时自动创建；存在则跳过。
+- `RECREATE_SCHEMA`：目标表存在时先删除，再用上游结构重建。
+- `ERROR_WHEN_SCHEMA_NOT_EXIST`：目标表不存在时立即报错。
+- `IGNORE`：不做任何处理，由下游自行管理。
+
+### Data Save Mode（数据保存模式）
+
+`data_save_mode` 控制任务启动前对目标表已有数据的处理方式：
+
+- `APPEND_DATA`（默认）：保留已有数据，向表中追加新行。
+- `DROP_DATA`：保留表结构，删除已有数据。
+- `CUSTOM_PROCESSING`：执行用户通过 `custom_sql` 提供的预处理 SQL。
+- `ERROR_WHEN_DATA_EXISTS`：目标表已有数据时立即报错。
 
 ## 任务示例
 
 ### 简单示例
 
-> 这是一个读取 SQL Server 数据并直接插入到另一个表的示例
+> 从 SQL Server 读取数据并直接写入另一张表。
 
-```
+```hocon
 env {
-  # 可以在此设置引擎配置
-  parallelism = 10
+  parallelism = 1
+  job.mode = "BATCH"
 }
 
 source {
-  # 这是一个示例源插件，**仅用于测试和演示功能**
   Jdbc {
     driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
     url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-    username = SA
+    username = "SA"
     password = "Y.sa123456"
-    query = "select * from column_type_test.dbo.full_types_jdbc"
-    # 并行分片读取字段
-    partition_column = "id"
-    # 分片数量
-    partition_num = 10
+    query = "select id, name, age from column_type_test.dbo.full_types_jdbc"
   }
-  # 如果想了解更多关于如何配置 SeaTunnel 的信息，并查看完整的源插件列表，
-  # 请访问 https://seatunnel.apache.org/docs/connectors/source/Jdbc
 }
 
 transform {
-  # 如果想了解更多关于如何配置 SeaTunnel 的信息，并查看完整的转换插件列表，
-  # 请访问 https://seatunnel.apache.org/docs/transforms/sql
 }
 
 sink {
   Jdbc {
     driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
     url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-    username = SA
+    username = "SA"
     password = "Y.sa123456"
-    query = "insert into full_types_jdbc_sink( id, val_char, val_varchar, val_text, val_nchar, val_nvarchar, val_ntext, val_decimal, val_numeric, val_float, val_real, val_smallmoney, val_money, val_bit, val_tinyint, val_smallint, val_int, val_bigint, val_date, val_time, val_datetime2, val_datetime, val_smalldatetime ) values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
+    query = "insert into full_types_jdbc_sink(id, name, age) values(?, ?, ?)"
   }
-  # 如果想了解更多关于如何配置 SeaTunnel 的信息，并查看完整的接收器插件列表，
-  # 请访问 https://seatunnel.apache.org/docs/connectors/sink/Jdbc
 }
 ```
 
@@ -150,39 +159,80 @@ sink {
 
 > 我们也支持 CDC 变更数据。在这种情况下，需要配置 `database`、`table` 和 `primary_keys`。
 
-```
-Jdbc {
-  plugin_input = "customers"
-  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
-  url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-  username = SA
-  password = "Y.sa123456"
-  generate_sink_sql = true
-  database = "column_type_test"
-  table = "dbo.full_types_sink"
-  batch_size = 100
-  primary_keys = ["id"]
+```hocon
+sink {
+  Jdbc {
+    plugin_input = "customers_cdc"
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "column_type_test"
+    table = "dbo.full_types_sink"
+    batch_size = 100
+    primary_keys = ["id"]
+  }
 }
 ```
 
 ### 精确一次接收器
 
-> 事务性写入可能较慢，但数据更准确
+> 事务性写入可能较慢，但数据更准确。
 
-```
-Jdbc {
-  driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
-  url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
-  username = SA
-  password = "Y.sa123456"
-  max_retries = 0
-  query = "insert into full_types_jdbc_sink( id, val_char, val_varchar, val_text, val_nchar, val_nvarchar, val_ntext, val_decimal, val_numeric, val_float, val_real, val_smallmoney, val_money, val_bit, val_tinyint, val_smallint, val_int, val_bigint, val_date, val_time, val_datetime2, val_datetime, val_smalldatetime ) values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
-  is_exactly_once = "true"
-  xa_data_source_class_name = "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"
+```hocon
+sink {
+  Jdbc {
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
+    username = "SA"
+    password = "Y.sa123456"
+    max_retries = 0
+    query = "insert into full_types_jdbc_sink(id, name, age) values(?, ?, ?)"
+    is_exactly_once = true
+    xa_data_source_class_name = "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"
+  }
 }
+```
 
-# 如果想了解更多关于如何配置 SeaTunnel 的信息，并查看完整的接收器插件列表，
-# 请访问 https://seatunnel.apache.org/docs/connectors/sink/Jdbc
+### Save Mode 示例
+
+> 每次运行时重建目标表，并清空已有数据后再写入。
+
+```hocon
+sink {
+  Jdbc {
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=column_type_test"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "column_type_test"
+    table = "dbo.full_types_sink"
+    schema_save_mode = "RECREATE_SCHEMA"
+    data_save_mode = "DROP_DATA"
+  }
+}
+```
+
+### 多表写入
+
+> 在 URL 中使用 `${database_name}` 和 `${table_name}` 占位符，把不同上游表的数据路由到对应的目标表。
+
+```hocon
+sink {
+  Jdbc {
+    driver = com.microsoft.sqlserver.jdbc.SQLServerDriver
+    url = "jdbc:sqlserver://localhost:1433;databaseName=${database_name}"
+    username = "SA"
+    password = "Y.sa123456"
+    generate_sink_sql = true
+    database = "${database_name}"
+    table = "${table_name}"
+    primary_keys = ["id"]
+    multi_table_sink_replica = 2
+  }
+}
 ```
 
 ## 变更日志

--- a/docs/zh/connectors/source/Mysql.md
+++ b/docs/zh/connectors/source/Mysql.md
@@ -2,15 +2,19 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 # MySQL
 
-> JDBC Mysql 源连接器
+> JDBC MySQL 源连接器
 
 ## 描述
 
-通过 JDBC 读取外部数据源数据。
+通过 JDBC 读取 MySQL 数据。本连接器继承了 [Jdbc 源连接器](./Jdbc.md) 的全部选项，使用官方
+MySQL 驱动（`com.mysql.cj.jdbc.Driver`）。
 
-## 支持 Mysql 版本
+支持批处理模式（基于拆分键的并行读取）。如需增量快照或变更数据捕获语义，请使用
+[MySQL-CDC 源连接器](./MySQL-CDC.md)。
 
-- 5.5/5.6/5.7/8.0/8.1/8.2/8.3/8.4
+## 支持的 MySQL 版本
+
+- 5.5 / 5.6 / 5.7 / 8.0 / 8.1 / 8.2 / 8.3 / 8.4
 
 ## 支持的引擎
 
@@ -28,215 +32,170 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/mysql/mysql-connector-java) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
 
-## 主要功能
+## 主要特性
 
 - [x] [批处理](../../introduction/concepts/connector-v2-features.md)
 - [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
-- [x] [支持用户定义的拆分](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持用户自定义拆分](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
 
-> 支持 SQL 查询，并能实现列投影效果
+> 支持 SQL 查询，并能实现列投影效果。如需变更数据捕获，请使用 [MySQL-CDC 连接器](./MySQL-CDC.md)。
 
 ## 支持的数据源信息
 
-| 数据源 |                    支持的版本                   |          驱动器          |                  网址                  | Maven下载链接                                                           |
-|-----|---------------------------------------------------------|--------------------------|---------------------------------------|---------------------------------------------------------------------|
-| Mysql | 不同的依赖版本具有不同的驱动程序类。 | com.mysql.cj.jdbc.Driver | jdbc:mysql://localhost:3306/test | [下载](https://mvnrepository.com/artifact/mysql/mysql-connector-java) |
+| 数据源 | 支持的版本                                       | 驱动类                  | URL                                | Maven 下载                                                                       |
+|--------|--------------------------------------------------|-------------------------|------------------------------------|----------------------------------------------------------------------------------|
+| MySQL  | 不同的依赖版本对应不同的驱动类。                 | com.mysql.cj.jdbc.Driver | jdbc:mysql://localhost:3306/test   | [下载](https://mvnrepository.com/artifact/mysql/mysql-connector-java)              |
 
 ## 数据类型映射
 
-| Mysql 数据类型                                                                                  |                                                                 SeaTunnel 数据类型                                                             |
-|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| BIT(1)<br/>TINYINT(1)                                                                       | BOOLEAN                                                                                                                                         |
-| TINYINT                                                                                     | BYTE                                                                                                                                            |
-| TINYINT UNSIGNED<br/>SMALLINT                                                               | SMALLINT                                                                                                                                        |
-| SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR         | INT                                                                                                                                             |
-| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                | BIGINT                                                                                                                                          |
-| BIGINT UNSIGNED                                                                             | DECIMAL(20,0)                                                                                                                                   |
-| DECIMAL(x,y)(获取指定列的列大小<38)                                                                  | DECIMAL(x,y)                                                                                                                                    |
-| DECIMAL(x,y)(获取指定列的列大小>38)                                                                  | DECIMAL(38,18)                                                                                                                                  |
-| DECIMAL UNSIGNED                                                                            | DECIMAL((获取指定列的列大小)+1,<br/>(获取指定列的小数点右侧的位数)) |
-| FLOAT<br/>FLOAT UNSIGNED                                                                    | FLOAT                                                                                                                                           |
-| DOUBLE<br/>DOUBLE UNSIGNED                                                                  | DOUBLE                                                                                                                                          |
-| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON<br/>ENUM        | STRING                                                                                                                                          |
-| DATE                                                                                        | DATE                                                                                                                                            |
-| TIME(s)                                                                                     | TIME(s)                                                                                                                                         |
-| DATETIME<br/>TIMESTAMP(s)                                                                   | TIMESTAMP(s)                                                                                                                                    |
-| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINAR<br/>BIT(n)<br/>GEOMETRY | BYTES                                                                                                                                           |
+| MySQL 数据类型                                                                                | SeaTunnel 数据类型                                                                                |
+|-----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| BIT(1)<br/>TINYINT(1)                                                                         | BOOLEAN                                                                                            |
+| TINYINT                                                                                       | BYTE                                                                                               |
+| TINYINT UNSIGNED<br/>SMALLINT                                                                 | SMALLINT                                                                                           |
+| SMALLINT UNSIGNED<br/>MEDIUMINT<br/>MEDIUMINT UNSIGNED<br/>INT<br/>INTEGER<br/>YEAR           | INT                                                                                                |
+| INT UNSIGNED<br/>INTEGER UNSIGNED<br/>BIGINT                                                  | BIGINT                                                                                             |
+| BIGINT UNSIGNED                                                                               | DECIMAL(20,0)                                                                                      |
+| DECIMAL(x,y)（列大小 < 38）                                                                   | DECIMAL(x,y)                                                                                       |
+| DECIMAL(x,y)（列大小 > 38）                                                                   | DECIMAL(38,18)                                                                                     |
+| DECIMAL UNSIGNED                                                                              | DECIMAL((获取指定列的列大小)+1,<br/>(获取指定列的小数点右侧的位数))                                    |
+| FLOAT<br/>FLOAT UNSIGNED                                                                      | FLOAT                                                                                              |
+| DOUBLE<br/>DOUBLE UNSIGNED                                                                    | DOUBLE                                                                                             |
+| CHAR<br/>VARCHAR<br/>TINYTEXT<br/>MEDIUMTEXT<br/>TEXT<br/>LONGTEXT<br/>JSON<br/>ENUM          | STRING                                                                                             |
+| DATE                                                                                          | DATE                                                                                               |
+| TIME(s)                                                                                       | TIME(s)                                                                                            |
+| DATETIME<br/>TIMESTAMP(s)                                                                     | TIMESTAMP(s)                                                                                       |
+| TINYBLOB<br/>MEDIUMBLOB<br/>BLOB<br/>LONGBLOB<br/>BINARY<br/>VARBINAR<br/>BIT(n)<br/>GEOMETRY | BYTES                                                                                              |
 
-## 数据源参数
+## 源选项
 
-| 名称                                         | 类型         | 是否必填 | 默认值   | 描述                                                                                                                                                                                                                     |
-|--------------------------------------------|------------|------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| url                                        | String     | 是    | -     | JDBC 连接的 URL。参见示例: <br/>`jdbc:mysql://localhost:3306/test`。                                                                                                                                                            |
-| driver                                     | String     | 是    | -     | 用于连接远程数据源的 JDBC 类名，<br/>如果使用 MySQL，值为 `com.mysql.cj.jdbc.Driver`。                                                                                                                                                      |
-| username                                   | String     | 否    | -     | 连接实例用户名。                                                                                                                                                                                                               |
-| password                                   | String     | 否    | -     | 连接实例密码。                                                                                                                                                                                                                |
-| query                                      | String     | 否    | -     | 查询语句。当未配置 `table_path` 和 `table_list` 时必填。                                                                                                                                                                       |
-| connection_check_timeout_sec               | Int        | 否    | 30    | 验证数据库连接所使用的操作完成的等待时间（秒）。                                                                                                                                                                                               |
-| partition_column                           | String     | 否    | -     | 用于并行度分区的列名，仅支持数字类型，仅支持数字类型的主键，并且只能配置一列。                                                                                                                                                                                |
-| partition_lower_bound                      | BigDecimal | 否    | -     | 扫描时 `partition_column` 的最小值，如果未设置，`SeaTunnel` 将查询数据库以获取最小值。                                                                                                                                                            |
-| partition_upper_bound                      | BigDecimal | 否    | -     | 扫描时 `partition_column` 的最大值，如果未设置，`SeaTunnel` 将查询数据库以获取最大值。                                                                                                                                                            |
-| partition_num                              | Int        | 否    | 作业并行度 | 分区数量，仅支持正整数。<br/>默认值为作业并行度。                                                                                                                                                                                            |
-| fetch_size                                 | Int        | 否    | 0     | 对于返回大量对象的查询，可以配置查询的行提取大小，以通过减少满足选择条件所需的数据库访问次数来提高性能。<br/>设置为零表示使用 `JDBC` 的默认值。                                                                                                                                         |
-| properties                                 | Map        | 否    | -     | 额外的连接配置参数，当属性和 URL 中有相同的参数时，优先级由驱动程序的具体实现决定。<br/>例如，在 MySQL 中，属性优先于 URL。                                                                                                                                               |
-| use_regex                                  | Boolean    | 否    | false | 控制表路径的正则表达式匹配。当设置为true时，table_path 将被视为正则表达式模式。当设置为false或未指定时，table_path 将被视为精确路径（不进行正则匹配）。                                                                                                                            |
-| table_path                                 | String     | 否    | -     | 表的完整路径，您可以使用此配置代替 `query`。<br/>示例：<br/>"testdb.table1"                                  |
-| table_list                                 | Array      | 否    | -     | 要读取的表的列表，您可以使用此配置代替 `table_path`，示例如下： ```[{ table_path = "testdb.table1"}, {table_path = "testdb.table2", query = "select id, name from testdb.table2"}]```                                                           |
-| where_condition                            | String     | 否    | -     | 所有表/查询的通用行过滤条件，必须以 `where` 开头。例如 `where id > 100`。                                                                                                                                                                     |
-| split.size                                 | Int        | 否    | 8096  | 表的分割大小（行数），当读取表时，捕获的表会被分割成多个分片。                                                                                                                                                                                        |
-| split.even-distribution.factor.lower-bound | Double     | 否    | 0.05  | 分片键分布因子的下限。该因子用于判断表数据的分布是否均匀。如果计算得到的分布因子大于或等于该下限（即，(MAX(id) - MIN(id) + 1) / 行数），则会对表的分片进行优化，以确保数据的均匀分布。反之，如果分布因子较低，则表数据将被视为分布不均匀。如果估算的分片数量超过 `sample-sharding.threshold` 所指定的值，则会采用基于采样的分片策略。默认值为 0.05。               |
-| split.even-distribution.factor.upper-bound | Double     | 否    | 100   | 分片键分布因子的上限。该因子用于判断表数据的分布是否均匀。如果计算得到的分布因子小于或等于该上限（即，(MAX(id) - MIN(id) + 1) / 行数），则会对表的分片进行优化，以确保数据的均匀分布。反之，如果分布因子较大，则表数据将被视为分布不均匀，并且如果估算的分片数量超过 `sample-sharding.threshold` 所指定的值，则会采用基于采样的分片策略。默认值为 100.0。            |
-| split.sample-sharding.threshold            | Int        | 否    | 1000  | 此配置指定了触发样本分片策略的估算分片数阈值。当分布因子超出由 `chunk-key.even-distribution.factor.upper-bound` 和 `chunk-key.even-distribution.factor.lower-bound` 指定的范围，并且估算的分片数量（计算方法为大致行数 / 分片大小）超过此阈值时，将使用样本分片策略。此配置有助于更高效地处理大型数据集。默认值为 1000 个分片。 |
-| split.allow-sampling                       | Boolean    | 否    | true  | 是否允许对分布不均匀的分片键使用采样分片策略。设置为 `false` 时，SeaTunnel 会退回到迭代式不均匀分片。                                                                                                            |
-| use_select_count                           | Boolean    | 否    | false | 是否使用 `select count(*)` 在分片前估算表行数。                                                                                                                                                                                        |
-| skip_analyze                               | Boolean    | 否    | false | 是否跳过分片前的表行数分析。                                                                                                                                                                                                       |
-| split.inverse-sampling.rate                | Int        | 否    | 1000  | 样本分片策略中使用的采样率的倒数。例如，如果该值设置为 1000，则表示在采样过程中应用 1/1000 的采样率。此选项提供了灵活性，可以控制采样的粒度，从而影响最终的分片数量。特别适用于处理非常大的数据集，在这种情况下通常会选择较低的采样率。默认值为 1000。                                                                                   |
-| int_type_narrowing                         | Boolean    | 否    | true  | Int类型收窄，如果为 true，则 tinyint(1) 类型将被收窄为 boolean 类型（如果没有精度损失）。目前仅支持 MySQL。                                                                                                                                                |
-| common-options                             |            | 否    | -     | 源插件的常见参数，请参阅 [源常见参数](../common-options/source-common-options.md) 了解详细信息。                                                                                                                                                              |
+本连接器使用的选项与 [Jdbc 源连接器](./Jdbc.md#source-options) 相同。下表给出了本连接器
+暴露的全部选项；未列出项请参考通用 JDBC 源的说明。
+
+| 名称                                          | 类型       | 是否必填 | 默认值         | 描述                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|-----------------------------------------------|------------|----------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| url                                           | String     | 是       | -              | JDBC 连接 URL。示例：`jdbc:mysql://localhost:3306/test`。较大数据量读取时建议附带 `serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true`。                                                                                                                                                                                                                                                                                                                                  |
+| driver                                        | String     | 是       | -              | 用于连接远程数据源的 JDBC 类名。MySQL 使用 `com.mysql.cj.jdbc.Driver`。                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| username                                      | String     | 是       | -              | 连接实例的用户名。同时接受 `user` 作为 `username` 的别名。                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| password                                      | String     | 是       | -              | 连接实例的密码。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| query                                         | String     | 否       | -              | 查询语句。当未配置 `table_path` 和 `table_list` 时必填。                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| connection_check_timeout_sec                  | Int        | 否       | 30             | 验证数据库连接完成所需等待的秒数。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| partition_column                              | String     | 否       | -              | 用于并行度分区的列名，仅支持数字类型的主键，且只能配置一列。                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| partition_lower_bound                         | BigDecimal | 否       | -              | 扫描时 `partition_column` 的最小值；未设置时 SeaTunnel 会查询数据库获取最小值。                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| partition_upper_bound                         | BigDecimal | 否       | -              | 扫描时 `partition_column` 的最大值；未设置时 SeaTunnel 会查询数据库获取最大值。                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| partition_num                                 | Int        | 否       | 作业并行度      | 分区数量，仅支持正整数；默认与作业并行度一致。                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| fetch_size                                    | Int        | 否       | 0              | 对返回大量对象的查询，配置行获取大小以减少满足选择条件所需的数据库访问次数。设置为 0 表示使用 JDBC 驱动默认值。                                                                                                                                                                                                                                                                                                                                                                                                     |
+| properties                                    | Map        | 否       | -              | 额外的连接配置参数。当 `properties` 和 URL 存在相同参数时，优先级由驱动决定；在 MySQL 中，`properties` 优先于 URL。                                                                                                                                                                                                                                                                                                                                                                                                |
+| use_regex                                     | Boolean    | 否       | false          | 控制 `table_path` 是否按正则匹配。`true` 时按正则模式匹配；`false` 或未设置时按精确路径匹配（不进行正则匹配）。                                                                                                                                                                                                                                                                                                                                                                                                    |
+| table_path                                    | String     | 否       | -              | 表的完整路径，可代替 `query`。示例：`"testdb.table1"`。                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| table_list                                    | Array      | 否       | -              | 需要读取的表列表，可代替 `table_path`。示例：`[{table_path = "testdb.table1"}, {table_path = "testdb.table2", query = "select id, name from testdb.table2"}]`。                                                                                                                                                                                                                                                                                                                                                    |
+| where_condition                               | String     | 否       | -              | 对所有表/查询生效的通用行过滤条件，必须以 `where` 开头，例如 `where id > 100`。                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| split.size                                    | Int        | 否       | 8096           | 单个分片的行数；捕获到的表在读取时会被拆分为多个分片。                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| split.even-distribution.factor.lower-bound    | Double     | 否       | 0.05           | 分片键分布因子的下限。用于判断表数据是否均匀分布。当分布因子 `(MAX(id) - MIN(id) + 1) / row count` 大于等于该下限时，表分片会被优化为均匀分布；否则视为不均匀分布，当估算分片数超过 `sample-sharding.threshold` 时启用采样分片策略。                                                                                                                                                                                                                                                                            |
+| split.even-distribution.factor.upper-bound    | Double     | 否       | 100.0          | 分片键分布因子的上限。当分布因子小于等于该上限时，表分片会被优化为均匀分布；否则视为不均匀分布，当估算分片数超过 `sample-sharding.threshold` 时启用采样分片策略。                                                                                                                                                                                                                                                                                                                                                    |
+| split.sample-sharding.threshold               | Int        | 否       | 1000           | 触发采样分片策略的估算分片数阈值。当分布因子落在 `split.even-distribution.factor.upper-bound` 与 `split.even-distribution.factor.lower-bound` 之外，且估算分片数（大致行数 / split.size）超过该阈值时启用采样分片策略。                                                                                                                                                                                                                                                                                       |
+| split.allow-sampling                          | Boolean    | 否       | true           | 是否允许对分布不均匀的分片键使用采样分片策略。`false` 时 SeaTunnel 回退到迭代式不均匀分片。                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| use_select_count                              | Boolean    | 否       | false          | 是否在分片前使用 `select count(*)` 估算表行数。                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| skip_analyze                                  | Boolean    | 否       | false          | 是否跳过分片前的表行数分析。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| split.inverse-sampling.rate                   | Int        | 否       | 1000           | 采样分片策略中采样率的倒数。例如设置为 1000 表示采样率为 1/1000。处理超大数据集时调高此值可降低采样率。                                                                                                                                                                                                                                                                                                                                                                                                            |
+| int_type_narrowing                            | Boolean    | 否       | true           | 整型收窄。当为 `true` 且无精度损失时，`tinyint(1)` 会被收窄为 `boolean`。目前仅 MySQL 支持。                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| common-options                                |            | 否       | -              | 源插件通用参数，详情请参考 [Source Common Options](../common-options/source-common-options.md)。                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### int_type_narrowing
 
-Int类型收窄，如果为 true，则 tinyint(1) 类型将被收窄为 boolean 类型（如果没有精度损失）。目前仅支持 MySQL。
+`int_type_narrowing` 控制 MySQL 的 `tinyint(1)` 映射到 SeaTunnel 类型的方式：
 
-例：
+- `int_type_narrowing = true`（默认）：`tinyint(1)` → `boolean`。
+- `int_type_narrowing = false`：`tinyint(1)` → `tinyint`。
 
-int_type_narrowing = true
+## 并行读取
 
-| MySQL      | SeaTunnel |
-|------------|-----------|
-| TINYINT(1) | Boolean   |
+JDBC 源连接器支持并行读取表数据。SeaTunnel 按照一定规则拆分数据并交给读取器处理，读取器
+数量由 `parallelism` 决定。
 
-int_type_narrowing = false
+**拆分键规则：**
 
-| MySQL      | SeaTunnel |
-|------------|-----------|
-| TINYINT(1) | TINYINT   |
+1. 如果 `partition_column` 不为空，则使用该列进行拆分；该列必须属于下面的**支持拆分数据类型**。
+2. 如果 `partition_column` 为空，SeaTunnel 会读取表结构并选取主键或唯一索引。当主键或唯一索引
+   包含多列时，按顺序选取第一列属于**支持拆分数据类型**的列进行拆分。例如表的主键为
+   `(guid, name varchar)`，其中 `guid` 不属于支持拆分数据类型，则使用 `name` 列进行拆分。
 
+**支持拆分数据类型：**
 
-## 并行读取器
-
-JDBC 源连接器支持从表中并行读取数据。SeaTunnel 将使用特定规则将表中的数据进行分割，然后将这些数据交给读取器进行读取。读取器的数量由 `parallelism` 选项决定。
-**拆分键规则:**
-
-1. 如果 `partition_column` 不为空，它将用于计算数据的分片。该列必须属于 **支持的分片数据类型**。
-2. 如果 partition_column 为空，SeaTunnel 将从表中读取模式并获取主键和唯一索引。如果主键和唯一索引中有多个列，则会选择第一个属于 **支持的分片数据类型** 的列来进行数据分片。例如，如果表的主键是 `(nn guid, name varchar)`，因为 `guid` 不属于 **支持的分片数据类型**，所以会选择列 `name` 来进行数据分片。
-
-**支持的拆分数据类型:**
-* String
-* Number(int, bigint, decimal, ...)
-* Date
-
-### 与拆分相关的参数
-
-#### split.size
-
-每个分片中的行数，捕获的表在读取时会被分成多个分片。
-
-#### split.even-distribution.factor.lower-bound
-
-> 不推荐使用
-
-分片键分布因子的下限。该因子用于判断表数据是否均匀分布。如果计算出的分布因子大于或等于此下限（即，(最大(id) - 最小(id) + 1)/ 行数），则表的分片将被优化为均匀分布。否则，如果分布因子较小，则表的数据将被认为是不均匀分布的。如果估算的分片数量超过 `sample-sharding.threshold` 所指定的值，将使用基于采样的分片策略。默认值为 0.05。
-
-#### split.even-distribution.factor.upper-bound
-
-> 不推荐使用
-
-分片键分布因子的上限。该因子用于判断表数据是否均匀分布。如果计算出的分布因子小于或等于此上限（即，(最大(id) - 最小(id) + 1）/ 行数)，则表的分片将被优化为均匀分布。否则，如果分布因子较大，则表的数据将被认为是不均匀分布的。如果估算的分片数量超过 `sample-sharding.threshold` 所指定的值，将使用基于采样的分片策略。默认值为 100.0。
-
-#### split.sample-sharding.threshold
-
-此配置指定了触发采样分片策略的估算分片数量阈值。当分布因子超出 `chunk-key.even-distribution.factor.upper-bound` 和 `chunk-key.even-distribution.factor.lower-bound` 指定的范围，并且估算的分片数量（按大致行数除以分片大小计算）超过该阈值时，将使用采样分片策略。这有助于更高效地处理大数据集。默认值为 1000 个分片。
-
-#### split.inverse-sampling.rate
-
-采样分片策略中使用的采样率的倒数。例如，如果此值设置为 1000，则意味着在采样过程中应用 1/1000 的采样率。此选项提供了灵活性，可以控制采样的粒度，从而影响最终的分片数量。在处理非常大的数据集时，较低的采样率通常是首选。默认值为 1000。
-
-#### partition_column [string]
-
-拆分数据的列名称。
-
-#### partition_upper_bound [BigDecimal]
-
-扫描时 `partition_column` 的最大值。如果未设置，SeaTunnel 将查询数据库以获取最大值。
-
-#### partition_lower_bound [BigDecimal]
-
-扫描时 `partition_column` 的最小值。如果未设置，SeaTunnel 将查询数据库以获取最小值。
-
-#### partition_num [int]
-
-> 不推荐使用，正确的方法是通过 `split.size` 来控制分片的数量。
-
-需要拆分成多少个分片，只支持正整数。默认值为作业并行度。
+- String
+- Number（`int`、`bigint`、`decimal` 等）
+- Date
 
 ## 提示
 
-
-> 如果表无法拆分（例如，表没有主键或唯一索引，且未设置 `partition_column`），则将以单线程并发方式运行。
+> 如果表无法拆分（例如表没有主键或唯一索引，且 `partition_column` 未设置），将以单并发方式运行。
 >
-> 使用 `table_path` 替代 `query` 来进行单表读取。如果需要读取多个表，请使用 `table_list`。
-> 当基于 `query` 推断主键时，主键继承自结果集中第一列所在的底层表；如果 `query` 包含多表 JOIN 或同时从多张表读取，该主键对整个 JOIN 结果集的唯一性不作严格保证。
+> 单表读取时可使用 `table_path` 代替 `query`；读取多张表时使用 `table_list`。
+>
+> 当基于 `query` 推断主键时，主键继承自结果集中第一列所在的底层表；如果 `query` 包含 JOIN
+> 或同时从多张表读取，该主键对整个 JOIN 结果集的唯一性不作严格保证。
+>
+> 如需增量快照或变更数据捕获语义，请使用 [MySQL-CDC 源连接器](./MySQL-CDC.md)。
 
 ## 任务示例
 
-### 简单的例子
+### 简单示例
 
-> 这个示例以单线程并行的方式查询测试数据库中 `type_bin` 为 'table' 的16条数据，并查询所有字段。你也可以指定查询哪些字段，并将最终结果输出到控制台。
+> 以单线程并行方式查询测试库中 `type_bin` 表的 16 条数据，并选择全部字段；也可以指定输出到
+> 控制台的列。
 
-```
-# 定义运行时环境
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
 }
-source{
-    Jdbc {
-        url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        query = "select * from type_bin limit 16"
-    }
+
+source {
+  Jdbc {
+    url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin limit 16"
+  }
 }
 
 transform {
-    # 如果您想了解更多关于如何配置 SeaTunnel 的信息，并查看完整的转换插件列表，
-    # 请访问 https://seatunnel.apache.org/docs/transforms/sql
 }
 
 sink {
-    Console {}
+  Console {}
 }
 ```
 
 ### 按 `partition_column` 并行
 
-```
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
 }
+
 source {
-    Jdbc {
-        url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        query = "select * from type_bin"
-        partition_column = "id"
-        split.size = 10000
-        # Read start boundary
-        #partition_lower_bound = ...
-        # Read end boundary
-        #partition_upper_bound = ...
-    }
+  Jdbc {
+    url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin"
+    partition_column = "id"
+    split.size = 10000
+    # 起始边界；不填则由 SeaTunnel 查询数据库获取最小值
+    # partition_lower_bound = ...
+    # 结束边界；不填则由 SeaTunnel 查询数据库获取最大值
+    # partition_upper_bound = ...
+  }
 }
 
 sink {
@@ -246,24 +205,25 @@ sink {
 
 ### 按主键或唯一索引并行
 
-> 配置 `table_path` 将启用自动拆分，您可以配置 `split.*` 来调整拆分策略
+> 配置 `table_path` 会自动开启拆分。可通过 `split.*` 选项调整拆分策略。
 
-```
+```hocon
 env {
   parallelism = 4
   job.mode = "BATCH"
 }
+
 source {
-    Jdbc {
-        url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        table_path = "testdb.table1"
-        query = "select * from testdb.table1"
-        split.size = 10000
-    }
+  Jdbc {
+    url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    table_path = "testdb.table1"
+    query = "select * from testdb.table1"
+    split.size = 10000
+  }
 }
 
 sink {
@@ -271,42 +231,49 @@ sink {
 }
 ```
 
-### 并行的同时指定边界
+### 指定上下边界的并行读取
 
-> 指定数据的上下边界查询会更加高效。根据您配置的上下边界读取数据源会更高效。 
+> 同时指定查询范围的上下边界是驱动并行读取最高效的方式。
 
-```
+```hocon
+env {
+  parallelism = 4
+  job.mode = "BATCH"
+}
+
 source {
-    Jdbc {
-        url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
-        driver = "com.mysql.cj.jdbc.Driver"
-        connection_check_timeout_sec = 100
-        username = "root"
-        password = "123456"
-        # Define query logic as required
-        query = "select * from type_bin"
-        partition_column = "id"
-        # Read start boundary
-        partition_lower_bound = 1
-        # Read end boundary
-        partition_upper_bound = 500
-        partition_num = 10
-        properties {
-         useSSL=false
-        }
+  Jdbc {
+    url = "jdbc:mysql://localhost:3306/test?serverTimezone=GMT%2b8&useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true"
+    driver = "com.mysql.cj.jdbc.Driver"
+    connection_check_timeout_sec = 100
+    username = "root"
+    password = "123456"
+    query = "select * from type_bin"
+    partition_column = "id"
+    partition_lower_bound = 1
+    partition_upper_bound = 500
+    partition_num = 10
+    properties {
+      useSSL = "false"
     }
+  }
+}
+
+sink {
+  Console {}
 }
 ```
 
 ### 多表读取
 
-***配置 `table_list` 将启用自动拆分，您可以配置 `split.*` 来调整拆分策略***
+> 配置 `table_list` 会自动开启拆分。可通过 `split.*` 选项调整拆分策略。
 
 ```hocon
 env {
   job.mode = "BATCH"
   parallelism = 4
 }
+
 source {
   Jdbc {
     url = "jdbc:mysql://localhost/test?serverTimezone=GMT%2b8"
@@ -321,16 +288,16 @@ source {
       },
       {
         table_path = "testdb.table2"
-        # Use query filetr rows & columns
+        # 使用 query 过滤行和列
         query = "select id, name from testdb.table2 where id > 100"
       }
     ]
-    #where_condition= "where id > 100"
-    #split.size = 8096
-    #split.even-distribution.factor.upper-bound = 100
-    #split.even-distribution.factor.lower-bound = 0.05
-    #split.sample-sharding.threshold = 1000
-    #split.inverse-sampling.rate = 1000
+    # where_condition = "where id > 100"
+    # split.size = 8096
+    # split.even-distribution.factor.upper-bound = 100
+    # split.even-distribution.factor.lower-bound = 0.05
+    # split.sample-sharding.threshold = 1000
+    # split.inverse-sampling.rate = 1000
   }
 }
 


### PR DESCRIPTION
## Purpose

Improves five connector documentation pages that have not received docs-only PRs in the last 7 days. Each page is updated in both English and Chinese, with consistent structure, accurate required/optional flags, and concrete examples sourced from existing E2E tests.

## Scope

**Sink docs**
- `docs/en/connectors/sink/SqlServer.md` + `docs/zh/connectors/sink/SqlServer.md`
- `docs/en/connectors/sink/Cloudberry.md` + `docs/zh/connectors/sink/Cloudberry.md`
- `docs/en/connectors/sink/Http.md` + `docs/zh/connectors/sink/Http.md`
- `docs/en/connectors/sink/SftpFile.md` + `docs/zh/connectors/sink/SftpFile.md`

**Source docs**
- `docs/en/connectors/source/Mysql.md` + `docs/zh/connectors/source/Mysql.md`

## What changed

- **SqlServer sink**: corrected `username` / `password` to `Yes` required, added dedicated `schema_save_mode` and `data_save_mode` sections, added a Save Mode example, a Multi Table Sink example, and tagged every HOCON snippet with the `hocon` fence.
- **Cloudberry sink**: added `support multiple table write` and `timer flush` to the Key Features list (they were previously missing), tightened the connection option table, made the connection options independent of PostgreSQL instead of relying on text-only references, and added a Multi Table Sink example.
- **Http sink**: replaced the misleading single-sentence `params` description with concrete behaviour for `POST` / `PUT` / `DELETE` (form fields) and `GET` (query string), added a retry + form-params example, and added a Multi Tables section that covers both `${database_name}` and `${schema_name}` placeholder patterns.
- **SftpFile sink**: added a `Support Those Engines` section, documented the `keyfile` / public-key authentication option, restructured the `schema_save_mode` / `data_save_mode` explanations, deduplicated the `schema_evolution_enabled` block that previously appeared both in the options table and at the bottom, and rewrote every example with the `hocon` fence (some used `bash`).
- **MySQL source**: corrected `username` / `password` to `Yes` required, linked the MySQL-CDC connector for incremental reads, tagged every example with the `hocon` fence, expanded the `int_type_narrowing` description, and consolidated the parallel-reader split options.

## Verification

This PR only touches documentation. Build, CI, and Connector-V2 behaviour are unaffected.